### PR TITLE
Iso7816 cleanups for staging

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -770,13 +770,10 @@ static int iso7816_restore_security_env(sc_card_t *card, int se_num)
 {
 	sc_apdu_t apdu;
 	int r;
-	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
 	
 	assert(card != NULL);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_1, 0x22, 0xF3, se_num);
-	apdu.resplen = sizeof(rbuf) > 250 ? 250 : sizeof(rbuf);
-	apdu.resp = rbuf;
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");
 	return sc_check_sw(card, apdu.sw1, apdu.sw2);


### PR DESCRIPTION
Hi,

please pull the iso-for-staging branch into opensc/staging.

It contains the following improvements:
- iso7816.c: clean up iso7816_restore_security_env()
  No need for response buffers for APDUs of the APDU_CASE_1 type.
  This should fix OpenSC Ticket #299.
- iso7816.c: slightly clean up iso7816_delete_file()
  Only set the APDU's data element for the APDU_CASE3_SHORT type;
  no need to do it for the APDU_CASE_1 type.

These commits are part of the testing branch, which is used for Jenkings.
So you can check easily verify that the changes compile without problems.

Thanks for your support
Peter
