### PR TITLE
Fix

### DIFF
--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -322,7 +322,7 @@ static CK_RV gostr3410_verify_data(const unsigned char *pubkey, int pubkey_len,
 		unsigned char *signat, int signat_len)
 {
 	EVP_PKEY *pkey;
-	EVP_PKEY_CTX *pkey_ctx;
+	EVP_PKEY_CTX *pkey_ctx = NULL;
 	EC_POINT *P;
 	BIGNUM *X, *Y;
 	ASN1_OCTET_STRING *octet;


### PR DESCRIPTION
openssl.c: In function 'sc_pkcs11_verify_data':
openssl.c:384:19: warning: 'pkey_ctx' may be used uninitialized in this function [-Wuninitialized]
openssl.c:325:16: note: 'pkey_ctx' was declared here
