### PR TITLE
For opensc accessflags fix

### DIFF
--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -886,6 +886,11 @@ do_store_private_key(struct sc_profile *profile)
 		args.x509_usage = opt_x509_usage? opt_x509_usage : usage;
 	}
 
+	args.access_flags |= 
+		  SC_PKCS15_PRKEY_ACCESS_SENSITIVE 
+		| SC_PKCS15_PRKEY_ACCESS_ALWAYSSENSITIVE 
+		| SC_PKCS15_PRKEY_ACCESS_NEVEREXTRACTABLE;
+
 	r = sc_pkcs15init_store_private_key(p15card, profile, &args, NULL);
 
 	if (r < 0)


### PR DESCRIPTION
Adding default accessflags to the do_store_private_key function in the same way do_generate_key has those accessflags

This seems the right thing to do, when you look at the initial commit which added the flags in do_generate_key and the ticket http://www.opensc-project.org/opensc/ticket/198

Currently when storing a key, the accessflags are not set
