### PR TITLE
Add possibility to execute PACE on the reader (tested with Reiner SCT RFID standard/komfort)

### DIFF
--- a/src/libopensc/internal-winscard.h
+++ b/src/libopensc/internal-winscard.h
@@ -172,6 +172,16 @@ typedef LONG (PCSC_API *SCardGetAttrib_t)(SCARDHANDLE hCard, DWORD dwAttrId,\
 #define FEATURE_IFD_DISPLAY_PROPERTIES   0x11
 #define FEATURE_GET_TLV_PROPERTIES       0x12
 #define FEATURE_CCID_ESC_COMMAND         0x13
+#define FEATURE_EXECUTE_PACE             0x20
+
+#define PACE_FUNCTION_GetReaderPACECapabilities 0x01
+#define PACE_FUNCTION_EstablishPACEChannel      0x02
+#define PACE_FUNCTION_DestroyPACEChannel        0x03
+
+#define PACE_CAPABILITY_eSign                   0x10
+#define PACE_CAPABILITY_eID                     0x20
+#define PACE_CAPABILITY_generic                 0x40
+#define PACE_CAPABILITY_DestroyPACEChannel      0x80
 
 /* properties returned by FEATURE_GET_TLV_PROPERTIES */
 #define PCSCv2_PART10_PROPERTY_wLcdLayout 1

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -292,3 +292,4 @@ sc_card_find_rsa_alg
 sc_print_cache
 sc_find_app
 sc_remote_data_init
+sc_perform_pace

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -270,6 +270,10 @@ struct sc_reader_driver {
 /* reader capabilities */
 #define SC_READER_CAP_DISPLAY	0x00000001
 #define SC_READER_CAP_PIN_PAD	0x00000002
+#define SC_READER_CAP_PACE_GENERIC         0x00000003
+#define SC_READER_CAP_PACE_EID             0x00000004
+#define SC_READER_CAP_PACE_ESIGN           0x00000008
+#define SC_READER_CAP_PACE_DESTROY_CHANNEL 0x00000010
 
 typedef struct sc_reader {
 	struct sc_context *ctx;
@@ -339,6 +343,72 @@ struct sc_pin_cmd_data {
 	struct sc_apdu *apdu;		/* APDU of the PIN command */
 };
 
+
+#define PACE_PIN_ID_MRZ 0x01
+#define PACE_PIN_ID_CAN 0x02
+#define PACE_PIN_ID_PIN 0x03
+#define PACE_PIN_ID_PUK 0x04
+/** 
+ * Input data for EstablishPACEChannel()
+ */
+struct establish_pace_channel_input {
+    /** Type of secret (CAN, MRZ, PIN or PUK). */
+    unsigned char pin_id;
+
+    /** Length of \a chat */
+    size_t chat_length;
+    /** Card holder authorization template */
+    const unsigned char *chat;
+
+    /** Length of \a pin */
+    size_t pin_length;
+    /** Secret */
+    const unsigned char *pin;
+
+    /** Length of \a certificate_description */
+    size_t certificate_description_length;
+    /** Certificate description */
+    const unsigned char *certificate_description;
+};
+
+/** 
+ * Output data for EstablishPACEChannel()
+ */
+struct establish_pace_channel_output {
+    /** PACE result (TR-03119) */
+    unsigned int result;
+
+    /** MSE: Set AT status byte */
+    unsigned char mse_set_at_sw1;
+    /** MSE: Set AT status byte */
+    unsigned char mse_set_at_sw2;
+
+    /** Length of \a ef_cardaccess */
+    size_t ef_cardaccess_length;
+    /** EF.CardAccess */
+    unsigned char *ef_cardaccess;
+
+    /** Length of \a recent_car */
+    size_t recent_car_length;
+    /** Most recent certificate authority reference */
+    unsigned char *recent_car;
+
+    /** Length of \a previous_car */
+    size_t previous_car_length;
+    /** Previous certificate authority reference */
+    unsigned char *previous_car;
+
+    /** Length of \a id_icc */
+    size_t id_icc_length;
+    /** ICC identifier */
+    unsigned char *id_icc;
+
+    /** Length of \a id_pcd */
+    size_t id_pcd_length;
+    /** PCD identifier */
+    unsigned char *id_pcd;
+};
+
 struct sc_reader_operations {
 	/* Called during sc_establish_context(), when the driver
 	 * is loaded */
@@ -365,6 +435,9 @@ struct sc_reader_operations {
 	/* Pin pad functions */
 	int (*display_message)(struct sc_reader *, const char *);
 	int (*perform_verify)(struct sc_reader *, struct sc_pin_cmd_data *);
+	int (*perform_pace)(struct sc_reader *reader,
+            struct establish_pace_channel_input *,
+            struct establish_pace_channel_output *);
 
 	/* Wait for an event */
 	int (*wait_for_event)(struct sc_context *ctx, unsigned int event_mask, sc_reader_t **event_reader, unsigned int *event, 
@@ -1193,6 +1266,10 @@ extern const char *sc_get_version(void);
 	}
 
 extern sc_card_driver_t *sc_get_iso7816_driver(void);
+
+int sc_perform_pace(sc_card_t *card,
+        struct establish_pace_channel_input *pace_input,
+        struct establish_pace_channel_output *pace_output);
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/reader-ctapi.c
+++ b/src/libopensc/reader-ctapi.c
@@ -562,6 +562,7 @@ struct sc_reader_driver * sc_get_ctapi_driver(void)
 	ctapi_ops.connect = ctapi_connect;
 	ctapi_ops.disconnect = ctapi_disconnect;
 	ctapi_ops.perform_verify = ctbcs_pin_cmd;
+	ctapi_ops.perform_pace = NULL;
 	ctapi_ops.use_reader = NULL;
 	
 	return &ctapi_drv;

--- a/src/libopensc/reader-openct.c
+++ b/src/libopensc/reader-openct.c
@@ -448,6 +448,7 @@ struct sc_reader_driver *sc_get_openct_driver(void)
 	openct_ops.disconnect = openct_reader_disconnect;
 	openct_ops.transmit = openct_reader_transmit;
 	openct_ops.perform_verify = openct_reader_perform_verify;
+	openct_ops.perform_pace = NULL;
 	openct_ops.lock = openct_reader_lock;
 	openct_ops.unlock = openct_reader_unlock;
 	openct_ops.use_reader = NULL;

--- a/src/libopensc/sec.c
+++ b/src/libopensc/sec.c
@@ -279,3 +279,127 @@ int sc_build_pin(u8 *buf, size_t buflen, struct sc_pin_cmd_pin *pin, int pad)
 
 	return i;
 }
+
+int sc_perform_pace(sc_card_t *card,
+        struct establish_pace_channel_input *pace_input,
+        struct establish_pace_channel_output *pace_output)
+{
+    int r = SC_ERROR_NOT_SUPPORTED;
+    u8 buf[0xffff];
+
+    assert(card != NULL && pace_input != NULL && pace_output != NULL);
+    SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_NORMAL);
+
+    switch (pace_input->pin_id) {
+        case PACE_PIN_ID_MRZ:
+            sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Initiating PACE with MRZ");
+            break;
+        case PACE_PIN_ID_CAN:
+            sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Initiating PACE with CAN");
+            break;
+        case PACE_PIN_ID_PIN:
+            sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Initiating PACE with PIN");
+            break;
+        case PACE_PIN_ID_PUK:
+            sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Initiating PACE with PUK");
+            break;
+        default:
+            sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Initiating PACE with unknown PACE secret type");
+            break;
+    }
+
+    if (pace_input->chat_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_input->chat,
+                pace_input->chat_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "CHAT (%d bytes):\n%s",
+                pace_input->chat_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "CHAT (0 bytes)");
+    }
+
+    if (pace_input->certificate_description_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_input->certificate_description,
+                pace_input->certificate_description_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Certificate description (%d bytes):\n%s",
+                pace_input->certificate_description_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Certificate description (0 bytes)");
+    }
+
+    if (card->reader
+            && card->reader->ops
+            && card->reader->ops->perform_pace
+            && card->reader->capabilities & SC_READER_CAP_PACE_GENERIC) {
+        r = card->reader->ops->perform_pace(card->reader, pace_input,
+                pace_output);
+    } else {
+        /* TODO Add EstablishPACEChannel using a normal reader here */
+        /* see for example http://vsmartcard.sourceforge.net/npa/README.html */
+        sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "PACE currently only supported via reader.");
+    }
+
+    sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+            "EstablishPACEChannel Result is 0x%08X",
+            pace_output->result);
+
+    sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+            "MSE:Set AT Statusbytes: %02X %02X",
+            pace_output->mse_set_at_sw1, pace_output->mse_set_at_sw2);
+
+
+    if (pace_output->ef_cardaccess_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_output->ef_cardaccess,
+                pace_output->ef_cardaccess_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "EF.CardAccess (%d bytes):\n%s",
+                pace_output->ef_cardaccess_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "EF.CardAccess (0 bytes)");
+    }
+
+    if (pace_output->recent_car_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_output->recent_car,
+                pace_output->recent_car_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Most recent certificate authority reference (%d bytes):\n%s",
+                pace_output->recent_car_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Most recent certificate authority reference (0 bytes)");
+    }
+
+    if (pace_output->previous_car_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_output->previous_car,
+                pace_output->previous_car_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Previous certificate authority reference (%d bytes):\n%s",
+                pace_output->previous_car_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Previous certificate authority reference (0 bytes)");
+    }
+
+    if (pace_output->id_icc_length) {
+        sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
+                pace_output->id_icc,
+                pace_output->id_icc_length, buf, sizeof buf);
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Ephemeral PACE public key of the ICC (ID ICC, %d bytes):\n%s",
+                pace_output->id_icc_length, buf);
+    } else {
+        sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+                "Ephemeral PACE public key of the ICC (ID ICC, 0 bytes)");
+    }
+
+    SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
+}


### PR DESCRIPTION
Implements PC/SC interface to PACE-enabled readers defined in PC/SC
pt. 10 AMD 1 and BSI TR-03119.

PACE can be started using `sc_perform_pace`. This function currently
calls the new `perform_pace` from `struct sc_reader_operations`, if the
reader has the needed capabilities. `sc_perform_pace` could also be
extended with a stand-alone implementation of PACE (code could be
imported from here http://vsmartcard.sourceforge.net/npa/README.html).

Note that the reader's PACE capabilities are correctly determined by
calling GetReaderPACECapabilities.

OpenSC's new PACE capabilities can be tested using the `npa-tool` from
the Virtual Smart Card Architecture (see link above).
