### PR TITLE
Fix a crash when trying to list objects via opensc-pkcs11

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3147,6 +3147,9 @@ get_bignum_bits(sc_pkcs15_bignum_t *bn, CK_ATTRIBUTE_PTR attr)
 {
 	CK_ULONG	bits, mask;
 
+	if (bn->len == 0 || bn->data == NULL) {
+		return CKR_OK;
+	}
 	bits = bn->len * 8;
 	for (mask = 0x80; mask; mask >>= 1, bits--) {
 		if (bn->data[0] & mask)


### PR DESCRIPTION
When listing objects on uninitialized CryptoStick, I saw opensc-pkcs11 crash when trying to get Modulus_bits of pubkey:

```
    $ pkcs11-tool --module=/usr/lib/opensc-pkcs11.so -O -l
    Using slot 1 with a present token (0x1)
    Logging in to "OpenPGP Card (Signature PIN)".
    Please enter User PIN: 
    Private Key Object; RSA 
      label:      Signature key
      ID:         01
      Usage:      sign
    Segmentation fault
```

After fix:

```
    $ pkcs11-tool --module=/usr/lib/opensc-pkcs11.so -O -l
    Using slot 1 with a present token (0x1)
    Logging in to "OpenPGP Card (Signature PIN)".
    Please enter User PIN: 
    Private Key Object; RSA 
      label:      Signature key
      ID:         01
      Usage:      sign
    Public Key Object; RSA 0 bits
      label:      Signature key
      ID:         01
      Usage:      verify
```
