### PR TITLE
Remove 'hacked' mode of PKCS#11 module

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -209,14 +209,14 @@ app default {
 	# PIV cards need an entry similar to this one:
 	# card_atr 3B:7D:96:00:00:80:31:80:65:B0:83:11:00:AC:83:00:90:00 {
 		# name = "PIV-II";
-	 	# driver = "piv";
+		# driver = "piv";
 	# }
 
 	# Estonian ID card and Micardo driver sometimes only play together with T=0
 	# In theory only the 'cold' ATR should be specified, as T=0 will
 	# be the preferred protocol once you boot it up with T=0, but be
 	# paranoid.
-	# 
+	#
 	# Warm ATR v1
 	card_atr 3b:6e:00:ff:45:73:74:45:49:44:20:76:65:72:20:31:2e:30 {
 		force_protocol = t0;
@@ -262,7 +262,7 @@ app default {
 	card_atr 3b:ff:11:00:ff:80:b1:fe:45:1f:03:00:68:d2:76:00:00:28:ff:05:1e:31:80:00:90:00:a6 {
 		force_protocol = t0;
 	}
-	
+
 	# IAS/ECC cards
 	#card_atr 3B:7F:96:00:00:00:31:B9:64:40:70:14:10:73:94:01:80:82:90:00 {
         #        type = 25001;
@@ -318,7 +318,7 @@ app default {
 		#
 		# Default: no
 		# try_emulation_first = yes;
-		
+
 		# Enable builtin emulators.
 		# Default: yes
 		# enable_builtin_emulation = no;
@@ -381,19 +381,19 @@ app opensc-pkcs11 {
 		# (which may be possible because you have already authenticated
 		# with the card). This setting is not very secure.
 		#
-		# Also, if your card is not locked, you can enconter problems 
-		# due to limitation of the OpenSC framework, that still is not 
+		# Also, if your card is not locked, you can enconter problems
+		# due to limitation of the OpenSC framework, that still is not
 		# thoroughly tested in the multi threads environment.
 		#
-		# Your settings will be more secure if you choose to lock your 
-		# card. Nevertheless this behavior is a known violation of PKCS#11 
-		# specification. Now once one application has started using your 
-		# card with C_Login, no other application can use it, until 
-		# the first is done and calls C_Logout or C_Finalize. In the case 
-		# of many PKCS#11 application this does not happen until you exit 
+		# Your settings will be more secure if you choose to lock your
+		# card. Nevertheless this behavior is a known violation of PKCS#11
+		# specification. Now once one application has started using your
+		# card with C_Login, no other application can use it, until
+		# the first is done and calls C_Logout or C_Finalize. In the case
+		# of many PKCS#11 application this does not happen until you exit
 		# the application.
-		# Thus it is impossible to use several smart card aware applications 
-		# at the same time, e.g. you cannot run both Firefox and Thunderbird at 
+		# Thus it is impossible to use several smart card aware applications
+		# at the same time, e.g. you cannot run both Firefox and Thunderbird at
 		# the same time, if both are configured to use your smart card.
 		#
 		# Default: false
@@ -424,8 +424,8 @@ app opensc-pkcs11 {
 		# create_puk_slot = true;
 
 		# Report as 'zero' the CKA_ID attribute of CA certificate
-		# For the unknown reason the middleware of the manufacturer of gemalto (axalto, gemplus) 
-		# card reports as '0' the CKA_ID of CA cartificates. 
+		# For the unknown reason the middleware of the manufacturer of gemalto (axalto, gemplus)
+		# card reports as '0' the CKA_ID of CA cartificates.
 		# Maybe someone else will need it. (Would be nice to know who and what for -- VTA)
 		#
 		# Default: false
@@ -437,6 +437,27 @@ app opensc-pkcs11 {
 		#
 		# Default: empty
 		# ignored_readers = "CardMan 1021", "SPR 532";
+
+                # Symbolic names of PINs for which slots are created
+                # Card can contain more then one PINs or more then one on-card application with
+                #   its own PINs. Normally, to access all of them with the PKCS#11 API a slot has to be
+                #   created for all of them. Many slots could be ennoying for some of widely used application,
+                #   like FireFox. This configuration parameter allows to select the PINs or on-card application
+                #   for which PKCS#11 slot will be created.
+                # Actually recognised following symbolic names:
+                #  'user', 'sign', 'application', all
+                # Only PINs initialised, non-SoPIN, non-unblocking are associated with symbolic name.
+                # 'user' is identified as first global or first local PIN.
+                # 'sign' is identified as second PIN: first local, second global or second local.
+                # 'application' slot created for each on-card application,
+                #   even if they use a common global PIN.
+                # 'all' slot created for all non-sopin, non-unblocking PINs,
+                #   optionally for PUK (see option 'create_puk_slot')
+                #
+                # Default: all
+                # create_slots_for_pins = "user,sign";
+                # create_slots_for_pins = application;
+                # create_slots_for_pins = "application,sign";
 	}
 }
 
@@ -458,8 +479,8 @@ app tokend {
 
 # XXX: remove cardmod pseudodriver
 app cardmod {
-	# cardmod app name use special pcsc reader subset 
-	# fix options for this reader driver here. 
+	# cardmod app name use special pcsc reader subset
+	# fix options for this reader driver here.
 
 	reader_driver cardmod {
 		# Enable pinpad if detected (PC/SC v2.0.2 Part 10)

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -4,7 +4,7 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 EXTRA_DIST = Makefile.mak
 
 dist_noinst_SCRIPTS = opensc_pkcs11_install.js
-lib_LTLIBRARIES = opensc-pkcs11.la pkcs11-spy.la onepin-opensc-pkcs11.la
+lib_LTLIBRARIES = opensc-pkcs11.la pkcs11-spy.la
 
 AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(PTHREAD_CFLAGS)
 INCLUDES = -I$(top_srcdir)/src
@@ -20,15 +20,9 @@ OPENSC_PKCS11_LIBS = \
 	$(top_builddir)/src/common/libcompat.la \
 	$(OPTIONAL_OPENSSL_LIBS) $(PTHREAD_LIBS)
 
-opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC) hack-disabled.c
+opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC)
 opensc_pkcs11_la_LIBADD = $(OPENSC_PKCS11_LIBS)
 opensc_pkcs11_la_LDFLAGS = $(AM_LDFLAGS) \
-	-export-symbols "$(srcdir)/opensc-pkcs11.exports" \
-	-module -shared -avoid-version -no-undefined
-
-onepin_opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC) hack-enabled.c
-onepin_opensc_pkcs11_la_LIBADD = $(OPENSC_PKCS11_LIBS)
-onepin_opensc_pkcs11_la_LDFLAGS = $(AM_LDFLAGS) \
 	-export-symbols "$(srcdir)/opensc-pkcs11.exports" \
 	-module -shared -avoid-version -no-undefined
 
@@ -43,7 +37,6 @@ pkcs11_spy_la_LDFLAGS = $(AM_LDFLAGS) \
 
 if WIN32
 opensc_pkcs11_la_SOURCES += $(top_builddir)/win32/versioninfo.rc
-onepin_opensc_pkcs11_la_SOURCES += $(top_builddir)/win32/versioninfo.rc
 pkcs11_spy_la_SOURCES += $(top_builddir)/win32/versioninfo.rc
 endif
 
@@ -59,7 +52,7 @@ pkcs11-jar: jar-dir
 if WIN32
 install-exec-hook:
 	$(mkdir_p) "$(DESTDIR)$(libdir)"
-	for l in opensc-pkcs11.dll onepin-opensc-pkcs11.dll pkcs11-spy.dll; do \
+	for l in opensc-pkcs11.dll pkcs11-spy.dll; do \
 		mv "$(DESTDIR)$(libdir)/$$l" "$(DESTDIR)$(bindir)/$$l"; \
 	done
 else
@@ -71,7 +64,7 @@ PKCS11_SUFFIX=.so
 endif
 install-exec-hook:
 	$(mkdir_p) "$(DESTDIR)$(pkcs11dir)"
-	for l in opensc-pkcs11$(PKCS11_SUFFIX) onepin-opensc-pkcs11$(PKCS11_SUFFIX) pkcs11-spy$(PKCS11_SUFFIX); do \
+	for l in opensc-pkcs11$(PKCS11_SUFFIX) pkcs11-spy$(PKCS11_SUFFIX); do \
 		rm -f "$(DESTDIR)$(pkcs11dir)/$$l"; \
 		$(LN_S) ../$$l "$(DESTDIR)$(pkcs11dir)/$$l"; \
 	done

--- a/src/pkcs11/Makefile.mak
+++ b/src/pkcs11/Makefile.mak
@@ -1,6 +1,5 @@
 TOPDIR = ..\..
 
-TARGET0                 = onepin-opensc-pkcs11.dll
 TARGET1                 = opensc-pkcs11.dll
 TARGET3			= pkcs11-spy.dll
 
@@ -15,18 +14,11 @@ all: $(TOPDIR)\win32\versioninfo.res $(TARGET0) $(TARGET1) $(TARGET3)
 
 !INCLUDE $(TOPDIR)\win32\Make.rules.mak
 
-$(TARGET0): $(OBJECTS) hack-enabled.obj ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
+$(TARGET1): $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
 	echo LIBRARY $* > $*.def
 	echo EXPORTS >> $*.def
 	type opensc-pkcs11.exports >> $*.def
-	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET0) $(OBJECTS) hack-enabled.obj  ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib $(OPENSSL_LIB) gdi32.lib
-	if EXIST $(TARGET0).manifest mt -manifest $(TARGET0).manifest -outputresource:$(TARGET0);2
-
-$(TARGET1): $(OBJECTS) hack-disabled.obj ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
-	echo LIBRARY $* > $*.def
-	echo EXPORTS >> $*.def
-	type opensc-pkcs11.exports >> $*.def
-	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET1) $(OBJECTS) hack-disabled.obj ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib $(OPENSSL_LIB) gdi32.lib
+	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET1) $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib $(OPENSSL_LIB) gdi32.lib
 	if EXIST $(TARGET1).manifest mt -manifest $(TARGET1).manifest -outputresource:$(TARGET1);2
 
 $(TARGET3): $(OBJECTS3) ..\libopensc\opensc.lib

--- a/src/pkcs11/hack-disabled.c
+++ b/src/pkcs11/hack-disabled.c
@@ -1,2 +1,0 @@
-extern int hack_enabled;
-int hack_enabled = 0;

--- a/src/pkcs11/hack-enabled.c
+++ b/src/pkcs11/hack-enabled.c
@@ -1,2 +1,0 @@
-extern int hack_enabled;
-int hack_enabled = 1;

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -51,6 +51,11 @@ extern "C" {
 #define SC_PKCS11_PIN_UNBLOCK_SCONTEXT_SETPIN   2
 #define SC_PKCS11_PIN_UNBLOCK_SO_LOGGED_INITPIN 3
 
+#define SC_PKCS11_SLOT_FOR_PIN_USER     1
+#define SC_PKCS11_SLOT_FOR_PIN_SIGN     2
+#define SC_PKCS11_SLOT_FOR_APPLICATION  4
+#define SC_PKCS11_SLOT_CREATE_ALL       8
+
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
 
@@ -80,6 +85,7 @@ struct sc_pkcs11_config {
 	unsigned int pin_unblock_style;
 	unsigned int create_puk_slot;
 	unsigned int zero_ckaid_for_ca_certs;
+	 unsigned int create_slots_flags;
 };
 
 /*

--- a/win32/OpenSC.wxs.in
+++ b/win32/OpenSC.wxs.in
@@ -46,9 +46,6 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <!-- Install critical DLL-s to system folder. NB! Id-s can not contain "-" characters! -->
       <Directory Id="$(var.PlatformSystemFolder)" Name=".">
-        <Component Id="onepin_opensc_pkcs11.dll" Guid="*" Win64="$(var.Win64YesNo)">
-          <File Source="$(var.SOURCE_DIR)\src\pkcs11\onepin-opensc-pkcs11.dll" Vital="yes"/>
-        </Component>
         <Component Id="opensc_pkcs11.dll" Guid="*" Win64="$(var.Win64YesNo)">
           <File Source="$(var.SOURCE_DIR)\src\pkcs11\opensc-pkcs11.dll" Vital="yes"/>
         </Component>
@@ -152,7 +149,6 @@
         <ComponentRef Id="opensc.conf"/>
       </Feature>
       <Feature Id="OpenSC_pkcs11" Level="1" Title="OpenSC PKCS#11 module" Description="PKCS#11 module usd by most open source and cross-platform software (like Firefox, Putty, TrueCrypt, OpenVPN etc)" TypicalDefault="install">
-        <ComponentRef Id="onepin_opensc_pkcs11.dll"/>
         <ComponentRef Id="opensc_pkcs11.dll"/>
       </Feature>
       <!-- Minidriver is only installed if selected via Custom install (level == 4) -->


### PR DESCRIPTION
The 'hacked' version of the opensc-pkcs11 module can be obtained 
with the help of new OpenSC configuration options.('create_slot_flags').

No need to package two versions of so, dll, ...
