### PR TITLE
Display the flags argument of C_Initialize()

### DIFF
--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -365,6 +365,16 @@ C_Initialize(CK_VOID_PTR pInitArgs)
 
 	enter("C_Initialize");
 	print_ptr_in("pInitArgs", pInitArgs);
+
+	if (pInitArgs) {
+		CK_C_INITIALIZE_ARGS *ptr = pInitArgs;
+		fprintf(spy_output, "     flags: %ld\n", ptr->flags);
+		if (ptr->flags & CKF_LIBRARY_CANT_CREATE_OS_THREADS)
+			fprintf(spy_output, "       CKF_LIBRARY_CANT_CREATE_OS_THREADS\n");
+		if (ptr->flags & CKF_OS_LOCKING_OK)
+			fprintf(spy_output, "       CKF_OS_LOCKING_OK\n");
+	}
+
 	rv = po->C_Initialize(pInitArgs);
 	return retne(rv);
 }


### PR DESCRIPTION
The the pInitArgs argument of C_Initialize() is not NULL it is a pointer
to a CK_C_INITIALIZE_ARGS structure.
This structure contains a flags bitfield with possible values:
- CKF_LIBRARY_CANT_CREATE_OS_THREADS
- CKF_OS_LOCKING_OK

This flags parameter is now parsed and displayed.
