### PR TITLE
3 GOST-related commits

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1793,16 +1793,16 @@ pkcs15_create_private_key(struct sc_pkcs11_slot *slot, struct sc_profile *profil
 			args.key.algorithm = SC_ALGORITHM_RSA;
 			rsa = &args.key.u.rsa;
 			break;
-		case CKK_EC:
-			args.key.algorithm = SC_ALGORITHM_EC;
-			ec = &args.key.u.ec;
-			/* TODO: -DEE Do not have PKCS15 card with EC to test this */
-			/* fall through */
 		case CKK_GOSTR3410:
 			set_gost_params(&args.params.gost, NULL, pTemplate, ulCount, NULL, 0);
 			args.key.algorithm = SC_ALGORITHM_GOSTR3410;
 			gost = &args.key.u.gostr3410;
 			break;
+		case CKK_EC:
+			args.key.algorithm = SC_ALGORITHM_EC;
+			ec = &args.key.u.ec;
+			/* TODO: -DEE Do not have PKCS15 card with EC to test this */
+			/* fall through */
 		default:
 			return CKR_ATTRIBUTE_VALUE_INVALID;
 	}


### PR DESCRIPTION
Hi,

While testing GOSTR3410 key generation I noticed that:
- CKM_GOSTR3410_KEY_PAIR_GEN mechanism wasn't listed even when the card supports it.
- CKK_GOSTR3410 was required in the template, and that is not consistent with RSA and EC.
- The EC code has a switch/case block that falls through into a GOST block which doesn't seem to be the intended behavior.

I made 3 patches to fix those issues. Feel free to criticize them or merge them.
## Sincerely,

Mathias
