### PR TITLE
piv-tool -s not sending APDU - missing code

### DIFF
--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -390,6 +390,15 @@ static int send_apdu(void)
 		apdu.resp = rbuf;
 		apdu.resplen = sizeof(rbuf);
 
+		printf("Sending: ");
+		for (r = 0; r < len0; r++)
+			printf("%02X ", buf[r]);
+		printf("\n");
+		r = sc_transmit_apdu(card, &apdu);
+		if (r) {
+			fprintf(stderr, "APDU transmit failed: %s\n", sc_strerror(r));
+			return 1;
+		}
 		printf("Received (SW1=0x%02X, SW2=0x%02X)%s\n", apdu.sw1, apdu.sw2,
 		       apdu.resplen ? ":" : "");
 		if (apdu.resplen)


### PR DESCRIPTION
The code to send the APDU to the piv card when using
piv-tool -s xx:xx:xx... was inadvertently removed
on 2011-04-26 02:29:53 by: 1cdb3fa9716bf287387020f06892a5f45cde98fc
APDU parsing: switch to Frank Morgner's implementation

The missing code is replaced.

The -s option is infrequently used, so the problem
was not spotted earlier.
