### PR TITLE
opensc-explorer: allow filename-pattern as argument to 'ls'

### DIFF
--- a/doc/tools/opensc-explorer.1.xml
+++ b/doc/tools/opensc-explorer.1.xml
@@ -276,9 +276,12 @@
 
 			<varlistentry>
 				<term>
-					<command>ls</command>
+					<command>ls</command> [<replaceable>pattern</replaceable> ...]
 				</term>
-				<listitem><para>List all files in the current DF</para></listitem>
+				<listitem><para>List files in the current DF.
+				If no <replaceable>pattern</replaceable> is given, then all files are listed.
+				If one ore more <replaceable>pattern</replaceable>s are given, only files matching
+				at least one <replaceable>pattern</replaceable> are listed.</para></listitem>
 			</varlistentry>
 
 			<varlistentry>


### PR DESCRIPTION
Make ls more flexible and more similar to the UNIX ls.

This time without fnmatch().
Instead, a self-written pattern matching function named pattern_match() is used.

This should fix the issue with fnmatch() not available on Windows.

It would be great if this version made it into opensc's upstream for the next release.

Best
Peter
