### PR TITLE
sc-hsm: Added fallback for readers that do not support extended length. ...

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -153,14 +153,25 @@ static int sc_hsm_list_files(sc_card_t *card, u8 * buf, size_t buflen)
 {
 	sc_apdu_t apdu;
 	u8 recvbuf[MAX_EXT_APDU_LENGTH];
+	sc_hsm_private_data_t *priv = (sc_hsm_private_data_t *) card->drv_data;
 	int r;
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_EXT, 0x58, 0, 0);
+	if (priv->noExtLength) {
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0x58, 0, 0);
+	} else {
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_2_EXT, 0x58, 0, 0);
+	}
 	apdu.cla = 0x80;
 	apdu.resp = recvbuf;
 	apdu.resplen = sizeof(recvbuf);
 	apdu.le = 0;
 	r = sc_transmit_apdu(card, &apdu);
+
+	if ((r == SC_ERROR_TRANSMIT_FAILED) && (!priv->noExtLength)) {
+		sc_log(card->ctx, "No extended length support ? Trying fall-back to short APDUs, probably breaking support for RSA 2048 operations");
+		priv->noExtLength = 1;
+		return sc_hsm_list_files(card, buf, buflen);
+	}
 	LOG_TEST_RET(card->ctx, r, "ENUMERATE OBJECTS APDU transmit failed");
 
 	memcpy(buf, recvbuf, buflen);

--- a/src/libopensc/card-sc-hsm.h
+++ b/src/libopensc/card-sc-hsm.h
@@ -47,6 +47,7 @@
 typedef struct sc_hsm_private_data {
 	const sc_security_env_t *env;
 	u8 algorithm;
+	int noExtLength;
 	char *serialno;
 } sc_hsm_private_data_t;
 


### PR DESCRIPTION
...Without extended length, RSA 2048 bit operations will not work.
