### PR TITLE
libopensc:   'init', 'format', 'compare', 'is-valid' OID procedures

### DIFF
--- a/src/libopensc/ef-atr.c
+++ b/src/libopensc/ef-atr.c
@@ -95,9 +95,14 @@ sc_parse_ef_atr_content(struct sc_card *card, unsigned char *buf, size_t buflen)
 	}
 
 	tag = sc_asn1_find_tag(ctx, buf, buflen, ISO7816_TAG_II_ALLOCATION_SCHEME, &taglen);
-	if (tag && taglen < sizeof(ef_atr.allocation_oid))   {
-		sc_log(ctx, "EF.ATR: OID %s", sc_dump_hex(tag, sizeof(taglen)));
-		memcpy(ef_atr.allocation_oid.value, tag, taglen);
+	if (tag)   {
+		sc_log(ctx, "EF.ATR: DER encoded OID %s", sc_dump_hex(tag, taglen));
+		tag = sc_asn1_find_tag(ctx, tag, taglen, SC_ASN1_TAG_OBJECT, &taglen);
+		if (tag)   {
+			sc_log(ctx, "EF.ATR: OID %s", sc_dump_hex(tag, taglen));
+			if(sc_asn1_decode_object_id(tag, taglen, &ef_atr.allocation_oid))
+				LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ASN1_OBJECT);
+		}
 	}
 
 	if (category == ISO7816_II_CATEGORY_TLV)   {

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -101,6 +101,9 @@ sc_format_apdu
 sc_bytes2apdu
 sc_format_asn1_entry
 sc_format_oid
+sc_init_oid
+sc_compare_oid
+sc_valid_oid
 sc_format_path
 sc_free_apps
 sc_free_ef_atr

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -174,7 +174,7 @@ typedef struct sc_security_env {
 
 struct sc_algorithm_id {
 	unsigned int algorithm;
-	struct sc_object_id obj_id;
+	struct sc_object_id oid;
 	void *params;
 };
 
@@ -1216,6 +1216,12 @@ const sc_path_t *sc_get_mf_path(void);
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen);
 int sc_bin_to_hex(const u8 *, size_t, char *, size_t, int separator);
 scconf_block *sc_get_conf_block(sc_context_t *ctx, const char *name1, const char *name2, int priority);
+
+/**
+ * Initializes a given OID
+ * @param  oid  sc_object_id object to be initialized
+ */
+void sc_init_oid(struct sc_object_id *oid);
 /**
  * Converts a given OID in ascii form to a internal sc_object_id object
  * @param  oid  OUT sc_object_id object for the result
@@ -1230,6 +1236,11 @@ int sc_format_oid(struct sc_object_id *oid, const char *in);
  * @return 1 if the oids are equal and a non-zero value otherwise
  */
 int sc_compare_oid(const struct sc_object_id *oid1, const struct sc_object_id *oid2);
+/**
+ * Validates a given OID
+ * @param  oid  sc_object_id object to be validated
+ */
+int sc_valid_oid(const struct sc_object_id *oid);
 
 /* Base64 encoding/decoding functions */
 int sc_base64_encode(const u8 *in, size_t inlen, u8 *out, size_t outlen,

--- a/src/libopensc/pkcs15-algo.c
+++ b/src/libopensc/pkcs15-algo.c
@@ -335,131 +335,122 @@ asn1_free_ec_params(void *params)
 static struct sc_asn1_pkcs15_algorithm_info algorithm_table[] = {
 #ifdef SC_ALGORITHM_SHA1
 	/* hmacWithSHA1 */
-	{ SC_ALGORITHM_SHA1, {{ 1, 2, 840, 113549, 2, 7 }}, NULL, NULL, NULL },
-	{ SC_ALGORITHM_SHA1, {{ 1, 3, 6, 1, 5, 5, 8, 1, 2 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_SHA1, {{ 1, 2, 840, 113549, 2, 7, -1}}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_SHA1, {{ 1, 3, 6, 1, 5, 5, 8, 1, 2, -1}}, NULL, NULL, NULL },
 	/* SHA1 */
-	{ SC_ALGORITHM_SHA1, {{ 1, 3, 14, 3, 2, 26, }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_SHA1, {{ 1, 3, 14, 3, 2, 26, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_MD5
-	{ SC_ALGORITHM_MD5, {{ 1, 2, 840, 113549, 2, 5, }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_MD5, {{ 1, 2, 840, 113549, 2, 5, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_DSA
-	{ SC_ALGORITHM_DSA, {{ 1, 2, 840, 10040, 4, 3 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_DSA, {{ 1, 2, 840, 10040, 4, 3, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_RSA /* really rsaEncryption */
-	{ SC_ALGORITHM_RSA, {{ 1, 2, 840, 113549, 1, 1, 1 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_RSA, {{ 1, 2, 840, 113549, 1, 1, 1, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_DH
-	{ SC_ALGORITHM_DH, {{ 1, 2, 840, 10046, 2, 1 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_DH, {{ 1, 2, 840, 10046, 2, 1, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_RC2_WRAP /* from CMS */
-	{ SC_ALGORITHM_RC2_WRAP,  {{ 1, 2, 840, 113549, 1, 9, 16, 3, 7 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_RC2_WRAP,  {{ 1, 2, 840, 113549, 1, 9, 16, 3, 7, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_RC2 /* CBC mode */
-	{ SC_ALGORITHM_RC2, {{ 1, 2, 840, 113549, 3, 2 }},
+	{ SC_ALGORITHM_RC2, {{ 1, 2, 840, 113549, 3, 2, -1}},
 			asn1_decode_rc2_params,
 			asn1_encode_rc2_params },
 #endif
 #ifdef SC_ALGORITHM_DES /* CBC mode */
-	{ SC_ALGORITHM_DES, {{ 1, 3, 14, 3, 2, 7 }},
+	{ SC_ALGORITHM_DES, {{ 1, 3, 14, 3, 2, 7, -1}},
 			asn1_decode_des_params,
 			asn1_encode_des_params,
 			free },
 #endif
 #ifdef SC_ALGORITHM_3DES_WRAP /* from CMS */
-	{ SC_ALGORITHM_3DES_WRAP, {{ 1, 2, 840, 113549, 1, 9, 16, 3, 6 }}, NULL, NULL, NULL },
+	{ SC_ALGORITHM_3DES_WRAP, {{ 1, 2, 840, 113549, 1, 9, 16, 3, 6, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_3DES /* EDE CBC mode */
-	{ SC_ALGORITHM_3DES, {{ 1, 2, 840, 113549, 3, 7 }},
+	{ SC_ALGORITHM_3DES, {{ 1, 2, 840, 113549, 3, 7, -1}},
 			asn1_decode_des_params,
 			asn1_encode_des_params,
 			free },
 #endif
 #ifdef SC_ALGORITHM_GOST /* EDE CBC mode */
-	{ SC_ALGORITHM_GOST, {{ 1, 2, 4434, 66565, 3, 7 }},
-			NULL,
-			NULL,
-			NULL },
+	{ SC_ALGORITHM_GOST, {{ 1, 2, 4434, 66565, 3, 7, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_GOSTR3410
-	{ SC_ALGORITHM_GOSTR3410, {{ 1, 2, 643, 2, 2, 19 }},
+	{ SC_ALGORITHM_GOSTR3410, {{ 1, 2, 643, 2, 2, 19, -1}},
 			asn1_decode_gostr3410_params,
 			asn1_encode_gostr3410_params,
 			NULL },
 #endif
 /* We do not support PBES1 because the encryption is weak */
 #ifdef SC_ALGORITHM_PBKDF2
-	{ SC_ALGORITHM_PBKDF2, {{ 1, 2, 840, 113549, 1, 5, 12 }},
+	{ SC_ALGORITHM_PBKDF2, {{ 1, 2, 840, 113549, 1, 5, 12, -1}},
 			asn1_decode_pbkdf2_params,
 			asn1_encode_pbkdf2_params,
 			free },
 #endif
 #ifdef SC_ALGORITHM_PBES2
-	{ SC_ALGORITHM_PBES2, {{ 1, 2, 840, 113549, 1, 5, 13 }},
+	{ SC_ALGORITHM_PBES2, {{ 1, 2, 840, 113549, 1, 5, 13, -1}},
 			asn1_decode_pbes2_params,
 			asn1_encode_pbes2_params,
 			asn1_free_pbes2_params },
 #endif
 
 #ifdef SC_ALGORITHM_EC
-	{ SC_ALGORITHM_EC, {{ 1, 2, 840, 10045, 2, 1 }},
-			asn1_decode_ec_params, asn1_encode_ec_params, asn1_free_ec_params },
+	{ SC_ALGORITHM_EC, {{ 1, 2, 840, 10045, 2, 1, -1}},
+			asn1_decode_ec_params,
+			asn1_encode_ec_params,
+			asn1_free_ec_params },
 #endif
 /* TODO: -DEE Not clear of we need the next five or not */
 #ifdef SC_ALGORITHM_ECDSA_SHA1
 	/* Note RFC 3279 says no ecParameters */
-	{ SC_ALGORITHM_ECDSA_SHA1, {{ 1, 2, 840, 10045, 4, 1 }}, NULL, NULL, NULL}, 
+	{ SC_ALGORITHM_ECDSA_SHA1, {{ 1, 2, 840, 10045, 4, 1, -1}}, NULL, NULL, NULL},
 #endif
 #ifdef SC_ALGORITHM_ECDSA_SHA224
 /* These next 4 are defined in RFC 5758 */
-	{ SC_ALGORITHM_ECDSA_SHA224, {{ 1, 2, 840, 10045, 4, 3, 1 }}, 
-			asn1_decode_ec_params, asn1_encode_ec_params, asn1_free_ec_params },
+	{ SC_ALGORITHM_ECDSA_SHA224, {{ 1, 2, 840, 10045, 4, 3, 1, -1}},
+			asn1_decode_ec_params,
+			asn1_encode_ec_params,
+			asn1_free_ec_params },
 #endif
 #ifdef SC_ALGORITHM_ECDSA_SHA256
-	{ SC_ALGORITHM_ECDSA_SHA256, {{ 1, 2, 840, 10045, 4, 3, 2 }},
-			asn1_decode_ec_params, asn1_encode_ec_params, asn1_free_ec_params },
+	{ SC_ALGORITHM_ECDSA_SHA256, {{ 1, 2, 840, 10045, 4, 3, 2, -1}},
+			asn1_decode_ec_params,
+			asn1_encode_ec_params,
+			asn1_free_ec_params },
 #endif
 #ifdef SC_ALGORITHM_ECDSA_SHA384
-	{ SC_ALGORITHM_ECDSA_SHA384, {{ 1, 2, 840, 10045, 4, 3, 3 }},
-			asn1_decode_ec_params, asn1_encode_ec_params, asn1_free_ec_params },
+	{ SC_ALGORITHM_ECDSA_SHA384, {{ 1, 2, 840, 10045, 4, 3, 3, -1}},
+			asn1_decode_ec_params,
+			asn1_encode_ec_params,
+			asn1_free_ec_params },
 #endif
 #ifdef SC_ALGORITHM_ECDSA_SHA512
-	{ SC_ALGORITHM_ECDSA_SHA512, {{ 1, 2, 840, 10045, 4, 3, 4 }},
-			asn1_decode_ec_params, asn1_encode_ec_params, asn1_free_ec_params },
+	{ SC_ALGORITHM_ECDSA_SHA512, {{ 1, 2, 840, 10045, 4, 3, 4, -1}},
+			asn1_decode_ec_params,
+			asn1_encode_ec_params,
+			asn1_free_ec_params },
 #endif
 	{ -1, {{ -1 }}, NULL, NULL, NULL }
 };
 
+
 static struct sc_asn1_pkcs15_algorithm_info *
 sc_asn1_get_algorithm_info(const struct sc_algorithm_id *id)
 {
-	struct sc_asn1_pkcs15_algorithm_info *aip;
+	struct sc_asn1_pkcs15_algorithm_info *aip = NULL;
 
-	aip = algorithm_table;
-	if ((int) id->algorithm < 0) {
-		while (aip->id >= 0) {
-			const int	*oid1, *oid2;
-			int		m;
-			
-			oid1 = aip->oid.value;
-	                oid2 = id->obj_id.value;
-			for (m = 0; m < SC_MAX_OBJECT_ID_OCTETS; m++) {
-				if (oid1[m] == oid2[m])
-					continue;
-				if (oid1[m] > 0 || oid2[m] > 0)
-					break;
-				/* We have a match */
-				return aip;
-			}
-			aip++;
-		}
-	} else {
-		while (aip->id >= 0) {
-			if (aip->id == (int)id->algorithm)
-				return aip;
-			aip++;
-		}
+	for (aip = algorithm_table; aip->id >= 0; aip++)   {
+		if ((int) id->algorithm < 0 && sc_compare_oid(&id->oid, &aip->oid))
+			return aip;
+
+		if (aip->id == (int)id->algorithm)
+			return aip;
 	}
+
 	return NULL;
 }
 
@@ -479,7 +470,7 @@ sc_asn1_decode_algorithm_id(sc_context_t *ctx, const u8 *in,
 	int r;
 
 	sc_copy_asn1_entry(c_asn1_alg_id, asn1_alg_id);
-	sc_format_asn1_entry(asn1_alg_id + 0, &id->obj_id, NULL, 0);
+	sc_format_asn1_entry(asn1_alg_id + 0, &id->oid, NULL, 0);
 
 	memset(id, 0, sizeof(*id));
 	r = _sc_asn1_decode(ctx, asn1_alg_id, in, len, &in, &len, 0, depth + 1);
@@ -492,8 +483,8 @@ sc_asn1_decode_algorithm_id(sc_context_t *ctx, const u8 *in,
 	if ((alg_info = sc_asn1_get_algorithm_info(id)) != NULL) {
 		id->algorithm = alg_info->id;
 		if (alg_info->decode) {
-/* TODO: -DEE  why the test for SC_ASN1_PRESENT? 
- * If it looking for SC_ASN1_NULL, thats valid for EC, in some cases 
+/* TODO: -DEE  why the test for SC_ASN1_PRESENT?
+ * If it looking for SC_ASN1_NULL, thats valid for EC, in some cases
  */
 			if (asn1_alg_id[1].flags & SC_ASN1_PRESENT) {
 				sc_debug( ctx,SC_LOG_DEBUG_NORMAL,"SC_ASN1_PRESENT was set, so invalid");
@@ -522,20 +513,19 @@ sc_asn1_encode_algorithm_id(sc_context_t *ctx,
 
 	alg_info = sc_asn1_get_algorithm_info(id);
 	if (alg_info == NULL) {
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Cannot encode unknown algorithm %u.\n",
-				id->algorithm);
+		sc_log(ctx, "Cannot encode unknown algorithm %u", id->algorithm);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
 	/* Set the oid if not yet given */
-	if (id->obj_id.value[0] <= 0) {
+	if (!sc_valid_oid(&id->oid)) {
 		temp_id = *id;
-		temp_id.obj_id = alg_info->oid;
+		temp_id.oid = alg_info->oid;
 		id = &temp_id;
 	}
 
 	sc_copy_asn1_entry(c_asn1_alg_id, asn1_alg_id);
-	sc_format_asn1_entry(asn1_alg_id + 0, (void *) &id->obj_id, NULL, 1);
+	sc_format_asn1_entry(asn1_alg_id + 0, (void *) &id->oid, NULL, 1);
 
 	/* no parameters, write NULL tag */
 	if (!id->params || !alg_info->encode)

--- a/src/libopensc/pkcs15-data.c
+++ b/src/libopensc/pkcs15-data.c
@@ -107,7 +107,7 @@ int sc_pkcs15_decode_dodf_entry(struct sc_pkcs15_card *p15card,
 
 	/* Fill in defaults */
 	memset(&info, 0, sizeof(info));
-	info.app_oid.value[0] = -1;
+	sc_init_oid(&info.app_oid);
 
 	r = sc_asn1_decode(ctx, asn1_data, *buf, *buflen, buf, buflen);
 	if (r == SC_ERROR_ASN1_END_OF_CONTENTS)
@@ -152,14 +152,12 @@ int sc_pkcs15_encode_dodf_entry(sc_context_t *ctx,
 	sc_copy_asn1_entry(c_asn1_type_data_attr, asn1_type_data_attr);
 	sc_copy_asn1_entry(c_asn1_data, asn1_data);
 
-	if (label_len) {
-		sc_format_asn1_entry(asn1_com_data_attr + 0,
-				&info->app_label, &label_len, 1);
-	}
-	if (info->app_oid.value[0] != -1) {
-		sc_format_asn1_entry(asn1_com_data_attr + 1,
-				&info->app_oid, NULL, 1);
-	}
+	if (label_len)
+		sc_format_asn1_entry(asn1_com_data_attr + 0, &info->app_label, &label_len, 1);
+
+	if (sc_valid_oid(&info->app_oid))
+		sc_format_asn1_entry(asn1_com_data_attr + 1, &info->app_oid, NULL, 1);
+
 	sc_format_asn1_entry(asn1_type_data_attr + 0, &info->path, NULL, 1);
 	sc_format_asn1_entry(asn1_data + 0, &data_obj, NULL, 1);
 

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1055,7 +1055,7 @@ sc_pkcs15_fix_ec_parameters(struct sc_context *ctx, struct sc_pkcs15_ec_paramete
 			sc_log(ctx, "Curve name: '%s'", ecparams->named_curve);
 		}
 
-		if (ecparams->id.value[0] <=0 || ecparams->id.value[1] <=0)
+		if (!sc_valid_oid(&ecparams->id))
 			sc_format_oid(&ecparams->id, ec_curve_infos[ii].oid_str);
 
 		ecparams->field_length = ec_curve_infos[ii].size;
@@ -1081,7 +1081,7 @@ sc_pkcs15_fix_ec_parameters(struct sc_context *ctx, struct sc_pkcs15_ec_paramete
 			LOG_TEST_RET(ctx, rv, "Cannot encode object ID");
 		}
 	}
-	else if (ecparams->id.value[0] > 0 && ecparams->id.value[1] > 0)  {
+	else if (sc_valid_oid(&ecparams->id))  {
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_IMPLEMENTED, "EC parameters has to be presented as a named curve or explicit data");
 	}
 

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -354,13 +354,13 @@ sc_pkcs15_encode_tokeninfo(sc_context_t *ctx, sc_pkcs15_tokeninfo_t *ti,
 	}
 	sc_format_asn1_entry(asn1_toki_attrs + 12, NULL, NULL, 0);
 
-	if (ti->profile_indication.oid.value[0] > 0)   {
-        	sc_format_asn1_entry(asn1_profile_indication + 0, &ti->profile_indication.oid, NULL, 1);
+	if (sc_valid_oid(&ti->profile_indication.oid))   {
+		sc_format_asn1_entry(asn1_profile_indication + 0, &ti->profile_indication.oid, NULL, 1);
 		sc_format_asn1_entry(asn1_toki_attrs + 13, asn1_profile_indication, NULL, 1);
 	}
 	else if (ti->profile_indication.name)   {
 		pi_len = strlen(ti->profile_indication.name);
-        	sc_format_asn1_entry(asn1_profile_indication + 1, ti->profile_indication.name, &pi_len, 1);
+		sc_format_asn1_entry(asn1_profile_indication + 1, ti->profile_indication.name, &pi_len, 1);
 		sc_format_asn1_entry(asn1_toki_attrs + 13, asn1_profile_indication, NULL, 1);
 	}
 	else    {
@@ -713,7 +713,7 @@ struct sc_pkcs15_card * sc_pkcs15_card_new(void)
 		return NULL;
 	}
 
-	p15card->tokeninfo->profile_indication.oid.value[0] = -1;
+	sc_init_oid(&p15card->tokeninfo->profile_indication.oid);
 
 	p15card->magic = SC_PKCS15_CARD_MAGIC;
 	return p15card;

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -45,9 +45,9 @@ typedef unsigned char u8;
 #define SC_MAX_CRTS_IN_SE		12
 #define SC_MAX_SE_NUM			8
 
-/* When changing this value, pay attention to the initialization of the ASN1 
- * static variables that use this macro, like, for example, 
- * 'c_asn1_supported_algorithms' in src/libopensc/pkcs15.c 
+/* When changing this value, pay attention to the initialization of the ASN1
+ * static variables that use this macro, like, for example,
+ * 'c_asn1_supported_algorithms' in src/libopensc/pkcs15.c
  */
 #define SC_MAX_SUPPORTED_ALGORITHMS	8
 

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -1384,7 +1384,7 @@ iasecc_md_gemalto_set_default(struct sc_pkcs15_card *p15card, struct sc_profile 
 
 	if (!data_obj)   {
 		memset(&data_args, 0, sizeof(data_args));
-		data_args.app_oid.value[0] = -1;
+		sc_init_oid(&data_args.app_oid);
 		data_args.label = "Default Key Container";
 		data_args.app_label = "CSP";
 		data_args.der_encoded.value = (unsigned char *)guid;
@@ -1493,7 +1493,7 @@ iasecc_md_gemalto_new_prvkey(struct sc_pkcs15_card *p15card, struct sc_profile *
 	data[offs++] = 0x01;
 
 	memset(&data_args, 0, sizeof(data_args));
-	data_args.app_oid.value[0] = -1;
+	sc_init_oid(&data_args.app_oid);
 	data_args.label = guid;
 	data_args.app_label = "CSP";
         data_args.der_encoded.value = data;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -63,6 +63,7 @@
 #include "libopensc/pkcs15.h"
 #include "libopensc/log.h"
 #include "libopensc/cards.h"
+#include "libopensc/asn1.h"
 #include "pkcs15init/pkcs15-init.h"
 #include "pkcs15init/profile.h"
 #include "util.h"
@@ -1189,7 +1190,7 @@ do_store_data_object(struct sc_profile *profile)
 	int	r=0;
 
 	memset(&args, 0, sizeof(args));
-	args.app_oid.value[0] = -1;
+	sc_init_oid(&args.app_oid);
 
 	if (opt_objectid)
 		sc_pkcs15_format_id(opt_objectid, &args.id);


### PR DESCRIPTION
In a reason of number of bugs(*) that concern the OID management, the general usage OID procedures 'init', 'format', 'compare', 'is-valid' are introduced.

These procedures are to be used by all actors: libopensc, pkcs15, pkcs11, tools, ....

(*)
This bug reported by Andreas Schwier :
https://github.com/OpenSC/OpenSC/commit/8e75d971cb7eadfef9b5b50adb3cb6d18e641ed2#commitcomment-1792477

In pkcs15-algo sc_asn1_get_algorithm_info() can return the OID not full length and without ending '-1' value:
https://github.com/OpenSC/OpenSC/blob/staging/src/libopensc/pkcs15-algo.c#L452
https://github.com/OpenSC/OpenSC/blob/staging/src/libopensc/pkcs15-algo.c#L459
