### PR TITLE
Staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ stamp-h*
 *.css
 *.out
 *.tmp
+*.o
+*.obj
 ChangeLog
 opensc.conf
 xsl-stylesheets

--- a/configure.ac
+++ b/configure.ac
@@ -597,7 +597,7 @@ if test "${enable_pedantic}" = "yes"; then
 	CFLAGS="${CFLAGS} -pedantic"
 fi
 if test "${enable_strict}" = "yes"; then
-	CFLAGS="${CFLAGS} -Wall -Wextra"
+	CFLAGS="${CFLAGS} -Wall -Wextra -Wno-unused-parameter"
 fi
 if test "$GCC" = "yes"; then
 	# This should be resolved not ignored.

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -9,7 +9,7 @@ dist_noinst_DATA = \
 	compat_getopt_main.c \
 	README.compat_strlcpy compat_strlcpy.3
 
-INCLUDES = -I$(top_srcdir)/src
+AM_CPPFLAGS = -I$(top_srcdir)/src
 
 libcompat_la_SOURCES = \
 	compat_dummy.c \

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1001,7 +1001,7 @@ static int asn1_decode_se_info(sc_context_t *ctx, const u8 *obj, size_t objlen,
 	ret = SC_SUCCESS;
 err:
 	if (ret != SC_SUCCESS) {
-		int i;
+		size_t i;
 		for (i = 0; i < idx; i++)
 			if (ses[i])
 				free(ses[i]);

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1411,7 +1411,7 @@ authentic_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 	rv = authentic_pin_get_policy(card, pin_cmd);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
-	if (pin_cmd->pin1.len > (int)pin_cmd->pin1.max_length)
+	if (pin_cmd->pin1.len > pin_cmd->pin1.max_length)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_PIN_LENGTH, "PIN policy check failed");
 
 	pin_cmd->pin1.tries_left = -1;
@@ -1492,7 +1492,7 @@ authentic_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 		LOG_FUNC_RETURN(ctx, rv);
 	}
 
-	if (card->max_send_size && (data->pin1.len + data->pin2.len > (int)card->max_send_size))
+	if (card->max_send_size && (data->pin1.len + data->pin2.len > card->max_send_size))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_PIN_LENGTH, "APDU transmit failed");
 
 	memset(pin_data, data->pin1.pad_char, sizeof(pin_data));

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -117,8 +117,10 @@ static int iasecc_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *
 static int iasecc_get_free_reference(struct sc_card *card, struct iasecc_ctl_get_free_reference *ctl_data);
 static int iasecc_sdo_put_data(struct sc_card *card, struct iasecc_sdo_update *update);
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int _iasecc_sm_read_binary(struct sc_card *card, unsigned int offs, unsigned char *buf, size_t count);
 static int _iasecc_sm_update_binary(struct sc_card *card, unsigned int offs, const unsigned char *buff, size_t count);
+#endif
 
 static int
 iasecc_chv_cache_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
@@ -680,6 +682,7 @@ iasecc_erase_binary(struct sc_card *card, unsigned int offs, size_t count, unsig
 }
 
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int
 _iasecc_sm_read_binary(struct sc_card *card, unsigned int offs,
 		unsigned char *buff, size_t count)
@@ -747,7 +750,7 @@ _iasecc_sm_update_binary(struct sc_card *card, unsigned int offs,
 
 	LOG_FUNC_RETURN(ctx, 0);
 }
-
+#endif
 
 static int
 iasecc_emulate_fcp(struct sc_context *ctx, struct sc_apdu *apdu)
@@ -2215,12 +2218,14 @@ iasecc_keyset_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 
 	update.fields[0].parent_tag = IASECC_SDO_KEYSET_TAG;
 	update.fields[0].tag = IASECC_SDO_KEYSET_TAG_MAC;
-	update.fields[0].value = data->pin2.data;
+        /* Avoid warnings about qualifiers being discarded */
+	memcpy(update.fields[0].value, data->pin2.data, sizeof(update.fields[0].value));
 	update.fields[0].size = 16;
 
 	update.fields[1].parent_tag = IASECC_SDO_KEYSET_TAG;
 	update.fields[1].tag = IASECC_SDO_KEYSET_TAG_ENC;
-	update.fields[1].value = data->pin2.data + 16;
+        /* Avoid warnings about qualifiers being discarded */
+	memcpy(update.fields[1].value, data->pin2.data + 16, sizeof(update.fields[1].value));
 	update.fields[1].size = 16;
 
 	rv = iasecc_sm_sdo_update(card, (scb & IASECC_SCB_METHOD_MASK_REF), &update);

--- a/src/libopensc/card-jcop.c
+++ b/src/libopensc/card-jcop.c
@@ -642,7 +642,8 @@ static int jcop_set_security_env(sc_card_t *card,
                 if (tmp.algorithm_flags & SC_ALGORITHM_RSA_HASH_MD5)
                         tmp.algorithm_ref |= 0x20;
 
-		memcpy(env, &tmp, sizeof(struct sc_security_env));
+                /* NOTE: Have to break env's const-ness here to update the environment (???) */
+		memcpy((struct sc_security_env *) env, &tmp, sizeof(struct sc_security_env));
 	}
 	
         sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0xC1, 0);
@@ -696,6 +697,7 @@ static int jcop_set_security_env(sc_card_t *card,
 	drvdata->invalid_senv=0;
 	return 0;
 }
+
 static int jcop_compute_signature(sc_card_t *card,
 				  const u8 * data, size_t datalen,
 				  u8 * out, size_t outlen) {

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -549,7 +549,6 @@ pgp_set_blob(struct blob *blob, const u8 *data, size_t len)
 static void
 pgp_attach_acl(sc_card_t *card, sc_file_t *file, struct do_info *info)
 {
-	sc_acl_entry_t *acl;
 	unsigned int method = SC_AC_NONE;
 	unsigned long key_ref = SC_AC_KEY_REF_NONE;
 
@@ -649,7 +648,7 @@ pgp_new_blob(sc_card_t *card, struct blob *parent, unsigned int file_id,
 			u8 id_str[2];
 
 			/* no parent: set file's path = file's id */
-			sc_format_path(ushort2bebytes(id_str, file_id), &blob->file->path);
+			sc_format_path((char *) ushort2bebytes(id_str, file_id), &blob->file->path);
 		}
 
 		/* find matching DO info: set file type depending on it */
@@ -1673,11 +1672,10 @@ static int
 pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
                                 sc_cardctl_openpgp_keygen_info_t *key_info)
 {
-	unsigned int blob_id;
 	time_t ctime = 0;
 	u8 *in = data;
-	u8 *modulus;
-	u8 *exponent;
+	u8 *modulus = NULL;     /* supresses uninitialized usage warnings */
+	u8 *exponent = NULL;    /* supresses uninitialized usage warnings */
 	int r;
 	LOG_FUNC_CALLED(card->ctx);
 
@@ -1686,7 +1684,7 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 	LOG_TEST_RET(card->ctx, r, "Cannot store creation time");
 
 	/* Parse response. Ref: pgp_enumerate_blob() */
-	while (data_len > (in - data)) {
+	while (data + data_len > in) {
 		unsigned int cla, tag, tmptag;
 		size_t		len;
 		u8	*part = in;
@@ -1769,10 +1767,8 @@ static int pgp_update_card_algorithms(sc_card_t *card, sc_cardctl_openpgp_keygen
  **/
 static int pgp_gen_key(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_info)
 {
-	struct pgp_priv_data *priv = DRVDATA(card);
-	struct blob *algo_blob;
+        /* struct pgp_priv_data *priv = DRVDATA(card); */
 	sc_apdu_t apdu;
-	unsigned int modulus_bitlen;
 	/* Temporary variables to hold APDU params */
 	u8 apdu_case;
 	u8 *apdu_data;
@@ -1783,12 +1779,12 @@ static int pgp_gen_key(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_in
 
 	/* Set Control Reference Template for key */
 	if (key_info->keytype == SC_OPENPGP_KEY_SIGN)
-		apdu_data = "\xb6";
+                apdu_data = (u8 *) "\xb6";
 		/* As a string, apdu_data will end with '\0' (B6 00) */
 	else if (key_info->keytype == SC_OPENPGP_KEY_ENCR)
-		apdu_data = "\xb8";
+                apdu_data = (u8 *) "\xb8";
 	else if (key_info->keytype == SC_OPENPGP_KEY_AUTH)
-		apdu_data = "\xa4";
+                apdu_data = (u8 *) "\xa4";
 	else {
 		sc_log(card->ctx, "Unknown key type %X.", key_info->keytype);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
@@ -1918,7 +1914,7 @@ static int
 pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info,
                                u8 **result, size_t *resultlen)
 {
-	struct pgp_priv_data *priv = DRVDATA(card);
+        /* struct pgp_priv_data *priv = DRVDATA(card); */
 	sc_context_t *ctx = card->ctx;
 	/* The Cardholder private key template (7F48) part */
 	const size_t max_prtem_len = 7*(1 + 3);     /* 7 components */
@@ -2075,11 +2071,11 @@ out2:
  **/
 static int pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 {
-	struct pgp_priv_data *priv = DRVDATA(card);
+        /* struct pgp_priv_data *priv = DRVDATA(card); */
 	sc_context_t *ctx = card->ctx;
 	sc_cardctl_openpgp_keygen_info_t pubkey;
-	u8 *data;
-	size_t len;
+	u8 *data = NULL;        /* supresses uninitialized usage warnings */
+	size_t len = 0;         /* supresses uninitialized usage warnings */
 	int r;
 
 	LOG_FUNC_CALLED(ctx);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2011,7 +2011,7 @@ static int piv_compute_signature(sc_card_t *card,
 	piv_private_data_t * priv = PIV_DATA(card);
 	int r;
 	int i;
-	int nLen;
+	size_t nLen;
 	u8 rbuf[128]; /* For EC conversions  384 will fit */
 	size_t rbuflen = sizeof(rbuf);
 	const u8 * body;
@@ -2031,7 +2031,7 @@ static int piv_compute_signature(sc_card_t *card,
 
 	if (priv->alg_id == 0x11 || priv->alg_id == 0x14 ) {
 		nLen = (priv->key_size + 7) / 8;
-		if (outlen < 2*nLen) {
+		if (outlen < 2l * nLen) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL," output too small for EC signature %d < %d", outlen, 2*nLen);
 			r = SC_ERROR_INVALID_DATA;
 			goto err;
@@ -2603,7 +2603,7 @@ static int piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 	 */
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	if (data->cmd == SC_PIN_CMD_CHANGE) {
-		int i = 0;
+		size_t i = 0;
 		if (data->pin2.len < 6) {
 			return SC_ERROR_INVALID_PIN_LENGTH;
 		}

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -239,7 +239,8 @@ static int sc_hsm_decode_ecdsa_signature(sc_card_t *card,
 					const u8 * data, size_t datalen,
 					u8 * out, size_t outlen) {
 
-	int fieldsizebytes, i, r;
+        size_t fieldsizebytes;
+        int i, r;
 	const u8 *body, *tag;
 	size_t bodylen, taglen;
 
@@ -258,7 +259,7 @@ static int sc_hsm_decode_ecdsa_signature(sc_card_t *card,
 
 	sc_log(card->ctx, "Field size %d, signature buffer size %d", fieldsizebytes, outlen);
 
-	if (outlen < (fieldsizebytes * 2)) {
+	if (outlen < (fieldsizebytes * 2l)) {
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_DATA, "output too small for EC signature");
 	}
 	memset(out, 0, outlen);
@@ -331,9 +332,12 @@ static int sc_hsm_compute_signature(sc_card_t *card,
 
 		if ((priv->algorithm & 0xF0) == ALGO_EC_RAW) {
 			len = sc_hsm_decode_ecdsa_signature(card, apdu.resp, apdu.resplen, out, outlen);
+#if 0
+                        /* size_t is unsigned, so this test is nonsensical */
 			if (len < 0) {
 				LOG_FUNC_RETURN(card->ctx, len);
 			}
+#endif
 		} else {
 			len = apdu.resplen > outlen ? outlen : apdu.resplen;
 			memcpy(out, apdu.resp, len);
@@ -412,7 +416,7 @@ static int sc_hsm_get_serialnr(sc_card_t *card, sc_serial_number_t *serial)
 	}
 
 	serial->len = strlen(priv->serialno);
-	strncpy(serial->value, priv->serialno, sizeof(serial->value));
+	memcpy(serial->value, priv->serialno, serial->len + 1);
 	return 0;
 }
 

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -42,7 +42,7 @@ static int sc_card_sm_check(sc_card_t *card);
 
 int sc_check_sw(sc_card_t *card, unsigned int sw1, unsigned int sw2)
 {
-	if (card == NULL)
+	if (card == NULL || card->ops == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	if (card->ops->check_sw == NULL)
 		return SC_ERROR_NOT_SUPPORTED;

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -84,12 +84,12 @@ sm_restore_sc_context(struct sc_card *card, struct sm_info *sm_info)
 }
 #endif
 
+#ifdef ENABLE_SM
 static int
 iasecc_sm_transmit_apdus(struct sc_card *card, struct sc_remote_data *rdata,
 		unsigned char *out, size_t *out_len)
 {
 	struct sc_context *ctx = card->ctx;
-#ifdef ENABLE_SM
 	struct sc_remote_apdu *rapdu = rdata->data;
 	int rv = SC_SUCCESS, offs = 0;
 
@@ -119,20 +119,21 @@ iasecc_sm_transmit_apdus(struct sc_card *card, struct sc_remote_data *rdata,
 		*out_len = offs;
 
 	LOG_FUNC_RETURN(ctx, rv);
-#else
+#if 0
 	LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "built without support of SM and External Authentication");
 	return SC_ERROR_NOT_SUPPORTED;
 #endif
 }
+#endif
 
 
+#ifdef ENABLE_SM
 /* Big TODO: do SM release in all handles, clean the saved card context -- current DF, EF, etc. */
 static int
 sm_release (struct sc_card *card, struct sc_remote_data *rdata,
 		unsigned char *out, size_t out_len)
 {
 	struct sc_context *ctx = card->ctx;
-#ifdef ENABLE_SM
 	struct sm_info *sm_info = &card->sm_ctx.info;
 	int rv;
 
@@ -144,11 +145,12 @@ sm_release (struct sc_card *card, struct sc_remote_data *rdata,
 
 	sm_restore_sc_context(card, sm_info);
 	LOG_FUNC_RETURN(ctx, rv);
-#else
+#if 0
 	LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "built without support of SM and External Authentication");
 	return SC_ERROR_NOT_SUPPORTED;
 #endif
 }
+#endif
 
 
 int
@@ -221,11 +223,11 @@ iasecc_sm_external_authentication(struct sc_card *card, unsigned skey_ref, int *
 }
 
 
+#ifdef ENABLE_SM
 static int
 iasecc_sm_se_mutual_authentication(struct sc_card *card, unsigned se_num)
 {
 	struct sc_context *ctx = card->ctx;
-#ifdef ENABLE_SM
 	struct sm_info *sm_info = &card->sm_ctx.info;
 	struct iasecc_se_info se;
 	struct sc_crt *crt =  &sm_info->session.cwa.params.crt_at;
@@ -268,13 +270,14 @@ iasecc_sm_se_mutual_authentication(struct sc_card *card, unsigned se_num)
 	LOG_TEST_RET(ctx, rv, "SM set SE mutual auth.: set SE error");
 
 	LOG_FUNC_RETURN(ctx, rv);
-#else
+#if 0
 	LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "built without support of Secure-Messaging");
 	return SC_ERROR_NOT_SUPPORTED;
 #endif
 }
+#endif
 
-
+#if ENABLE_SM
 static int
 iasecc_sm_get_challenge(struct sc_card *card, unsigned char *out, size_t len)
 {
@@ -298,6 +301,7 @@ iasecc_sm_get_challenge(struct sc_card *card, unsigned char *out, size_t len)
 
 	LOG_FUNC_RETURN(ctx, apdu.resplen);
 }
+#endif
 
 
 int
@@ -363,13 +367,13 @@ iasecc_sm_initialize(struct sc_card *card, unsigned se_num, unsigned cmd)
 }
 
 
+#ifdef ENABLE_SM
 static int
 iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 {
 #define AUTH_SM_APDUS_MAX 12
 #define ENCODED_APDUS_MAX_LENGTH (AUTH_SM_APDUS_MAX * (SC_MAX_APDU_BUFFER_SIZE * 2 + 64) + 32)
 	struct sc_context *ctx = card->ctx;
-#ifdef ENABLE_SM
 	struct sm_info *sm_info = &card->sm_ctx.info;
 	struct sm_cwa_session *session = &sm_info->session.cwa;
 	struct sc_remote_apdu *rapdu = NULL;
@@ -404,11 +408,12 @@ iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 	}
 
 	LOG_FUNC_RETURN(ctx, rv);
-#else
+#if 0
 	LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "built without support of Secure-Messaging");
 	return SC_ERROR_NOT_SUPPORTED;
 #endif
 }
+#endif
 
 
 int

--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -91,7 +91,7 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 	gettimeofday (&tv, NULL);
 	tm = localtime (&tv.tv_sec);
 	strftime (time_string, sizeof(time_string), "%H:%M:%S", tm);
-	r = snprintf(p, left, "0x%lx %s.%03ld ", (unsigned long)pthread_self(), time_string, tv.tv_usec / 1000);
+	r = snprintf(p, left, "0x%lx %s.%03ld ", (unsigned long)pthread_self(), time_string, tv.tv_usec / 1000l);
 #endif
 	p += r;
 	left -= r;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -317,11 +317,13 @@ typedef struct sc_reader {
 #define SC_PIN_ENCODING_BCD	1
 #define SC_PIN_ENCODING_GLP	2 /* Global Platform - Card Specification v2.0.1 */
 
+#define SC_PIN_GET_PIN_PAD      ((size_t) -1)
+
 struct sc_pin_cmd_pin {
 	const char *prompt;	/* Prompt to display */
 
 	const u8 *data;		/* PIN, if given by the appliction */
-	int len;		/* set to -1 to get pin from pin pad */
+	size_t len;		/* set to -1 to get pin from pin pad */
 
 	size_t min_length;	/* min/max length of PIN */
 	size_t max_length;

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -125,7 +125,8 @@ static int piv_get_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_o
 	struct sc_pkcs15_id  id;
 	unsigned char guid_bin[SC_PKCS15_MAX_ID_SIZE + SC_MAX_SERIALNR];
 	size_t bin_size, offs, tlen;
-	int r, i;
+	int r;
+        size_t i;
 	unsigned char fbit, fbits, fbyte, fbyte2, fnibble;
 	unsigned char *f5p, *f8p;
 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -172,7 +172,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 	LOG_TEST_RET(card->ctx, r, "Could not select SmartCard-HSM application");
 
 	// Read device certificate to determine serial number
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, "\x2F\x02", 2, 0, 0);
+	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, (u8 *) "\x2F\x02", 2, 0, 0);
 	r = sc_select_file(card, &path, &file);
 	sc_file_free(file);
 	LOG_TEST_RET(card->ctx, r, "Could not select EF.C_DevAut");

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -31,6 +31,7 @@
 #include "internal.h"
 #include "pkcs15.h"
 #include "asn1.h"
+#include <common/libscdl.h>
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/sha.h>

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -154,6 +154,24 @@ static unsigned int pcsc_proto_to_opensc(DWORD proto)
 	}
 }
 
+static const char *pcsc_proto_to_string(unsigned int proto) {
+  switch (proto) {
+  case SC_PROTO_T0:
+    return "T0 protocol";
+    break;
+  case SC_PROTO_T1:
+    return "T1 protocol";
+    break;
+  case SC_PROTO_RAW:
+    return "RAW protocol";
+    break;
+  default:
+    break;
+  }
+
+  return "!!INVALID!! protocol";
+}
+
 static DWORD opensc_proto_to_pcsc(unsigned int proto)
 {
 	switch (proto) {
@@ -476,7 +494,7 @@ static int pcsc_connect(sc_reader_t *reader)
 	reader->active_protocol = pcsc_proto_to_opensc(active_proto);
 	priv->pcsc_card = card_handle;
 
-	sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "Initial protocol: %s", reader->active_protocol == SC_PROTO_T1 ? "T=1" : "T=0");
+	sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "Initial protocol: %s", pcsc_proto_to_string(reader->active_protocol));
 
 	/* Check if we need a specific protocol. refresh_attributes above already sets the ATR */
 	if (check_forced_protocol(reader->ctx, &reader->atr, &tmp)) {
@@ -1708,9 +1726,8 @@ static int transform_pace_input(
         struct establish_pace_channel_input *pace_input,
         u8 *sbuf, size_t *scount)
 {
-	char dbuf[SC_MAX_APDU_BUFFER_SIZE * 3];
     u8 *p = sbuf;
-    uint16_t lengthInputData, lengthCertificateDescription;
+    size_t lengthInputData, lengthCertificateDescription;
     uint8_t lengthCHAT, lengthPIN;
 
     if (!pace_input || !sbuf || !scount)

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -256,7 +256,7 @@ enter(const char *function)
 	gettimeofday (&tv, NULL);
 	tm = localtime (&tv.tv_sec);
 	strftime (time_string, sizeof(time_string), "%F %H:%M:%S", tm);
-	fprintf(spy_output, "%s.%03ld\n", time_string, tv.tv_usec / 1000);
+	fprintf(spy_output, "%s.%03ld\n", time_string, tv.tv_usec / 1000l);
 #endif
 
 }

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -181,7 +181,8 @@ CK_RV card_detect(sc_reader_t *reader)
 {
 	struct sc_pkcs11_card *p11card = NULL;
 	int rc, rv;
-	unsigned int i, j;
+	unsigned int i;
+       int j;
 
 	rv = CKR_OK;
 

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -324,7 +324,8 @@ iasecc_file_convert_acls(struct sc_context *ctx, struct sc_profile *profile, str
 	int ii;
 
 	for (ii=0; ii<SC_MAX_AC_OPS;ii++)   {
-		struct sc_acl_entry *acl = sc_file_get_acl_entry(file, ii);
+                /* NOTE: const qualifier stripped from function return value */
+                struct sc_acl_entry *acl = (struct sc_acl_entry *) sc_file_get_acl_entry(file, ii);
 
 		if (acl)   {
 			switch (acl->method)   {
@@ -1314,8 +1315,8 @@ iasecc_pkcs15_delete_object (struct sc_profile *profile, struct sc_pkcs15_card *
 
 	switch(object->type & SC_PKCS15_TYPE_CLASS_MASK)   {
 	case SC_PKCS15_TYPE_PUBKEY:
-		sc_log(ctx, "Ignore delete of SDO-PubKey(ref:%X) '%s', path %s", key_ref, object->label, sc_print_path(path));
 		key_ref = ((struct sc_pkcs15_pubkey_info *)object->data)->key_reference;
+		sc_log(ctx, "Ignore delete of SDO-PubKey(ref:%X) '%s', path %s", key_ref, object->label, sc_print_path(path));
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 	case SC_PKCS15_TYPE_PRKEY:
 		sc_log(ctx, "delete PrivKey '%s', path %s", object->label, sc_print_path(path));
@@ -1788,12 +1789,14 @@ iasecc_emu_store_data(struct sc_pkcs15_card *p15card, struct sc_profile *profile
 }
 
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int
 iasecc_emu_update_tokeninfo(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		struct sc_pkcs15_tokeninfo *tinfo)
 {
 	LOG_FUNC_RETURN(p15card->card->ctx, SC_SUCCESS);
 }
+#endif
 
 
 static struct sc_pkcs15init_operations

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -125,9 +125,11 @@ static int	sc_pkcs15init_qualify_pin(struct sc_card *, const char *,
 	       		unsigned int, struct sc_pkcs15_auth_info *);
 static struct sc_pkcs15_df * find_df_by_type(struct sc_pkcs15_card *,
 			unsigned int);
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int	sc_pkcs15init_read_info(struct sc_card *card, struct sc_profile *);
 static int	sc_pkcs15init_parse_info(struct sc_card *, const unsigned char *, size_t,
 			struct sc_profile *);
+#endif
 static int	sc_pkcs15init_write_info(struct sc_pkcs15_card *, struct sc_profile *,
 			struct sc_pkcs15_object *);
 
@@ -3725,6 +3727,7 @@ sc_pkcs15init_qualify_pin(struct sc_card *card, const char *pin_name,
 }
 
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 /*
  * Get the list of options from the card, if it specifies them
  */
@@ -3759,8 +3762,10 @@ sc_pkcs15init_read_info(struct sc_card *card, struct sc_profile *profile)
 		free(mem);
 	return r;
 }
+#endif
 
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int
 set_info_string(char **strp, const u8 *p, size_t len)
 {
@@ -3775,7 +3780,9 @@ set_info_string(char **strp, const u8 *p, size_t len)
 	*strp = s;
 	return SC_SUCCESS;
 }
+#endif
 
+#if I_AM_ACTUALLY_USED_SOMEDAY
 /*
  * Parse OpenSC Info file. We rudely clobber any information
  * given on the command line.
@@ -3787,7 +3794,7 @@ set_info_string(char **strp, const u8 *p, size_t len)
  */
 static int
 sc_pkcs15init_parse_info(struct sc_card *card,
-		const unsigned char *p, size_t len, struct sc_profile *profile)
+                         const unsigned char *p, size_t len, struct sc_profile *profile)
 {
 	unsigned char	tag;
 	const unsigned char *end;
@@ -3838,6 +3845,7 @@ error:
 	sc_log(card->ctx, "OpenSC info file corrupted");
 	return SC_ERROR_PKCS15INIT;
 }
+#endif
 
 
 static int

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -592,7 +592,7 @@ static int cardos_format(const char *opt_startkey)
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -953,7 +953,7 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1048,7 +1048,7 @@ change_startkey:
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -32,6 +32,7 @@
 #include "libopensc/asn1.h"
 #include "libopensc/cards.h"
 #include "libopensc/cardctl.h"
+#include "libopensc/log.h"
 #include "util.h"
 
 #define	OPT_RAW		256
@@ -55,8 +56,10 @@ static char *prettify_gender(char *str);
 static void display_data(const struct ef_name_map *mapping, char *value);
 static int decode_options(int argc, char **argv);
 static int do_userinfo(sc_card_t *card);
+#if I_AM_ACTUALLY_USED_SOMEDAY
 static int read_transp(sc_card_t *card, const char *pathstring, unsigned char *buf, int buflen);
 static void bintohex(char *buf, int len);
+#endif
 
 /* define global variables */
 static int actions = 0;
@@ -215,8 +218,12 @@ static void display_data(const struct ef_name_map *mapping, char *value)
 				}
 			} else {
 				const char *label = mapping->name;
+                                size_t labelLen = strlen(label);
 
-				printf("%s:%*s%s\n", label, 10-strlen(label), "", value);
+                                if (labelLen > 10)
+                                  labelLen = 10;
+
+				printf("%s:%*s%s\n", label, 10 - (int) labelLen, "", value);
 			}
 		}
 	}
@@ -340,7 +347,7 @@ static int do_userinfo(sc_card_t *card)
 		buf[file->size] = '\0';
 
 		if (file->size > 0) {
-			display_data(openpgp_data + i, buf);
+                  display_data(openpgp_data + i, (char *) buf);
 		}
 	}
 
@@ -348,6 +355,7 @@ static int do_userinfo(sc_card_t *card)
 }
 
 
+#if I_AM_ACUTALLY_USED_SOMEDAY
 /* Select and read a transparent EF */
 static int read_transp(sc_card_t *card, const char *pathstring, unsigned char *buf, int buflen)
 {
@@ -381,6 +389,8 @@ static void bintohex(char *buf, int len)
 		buf[2 * i] = hextable[c / 16];
 	}
 }
+#endif
+
 
 int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 {
@@ -415,7 +425,7 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 	return 0;
 }
 
-int do_verify(sc_card_t *card, u8 *type, u8* pin)
+int do_verify(sc_card_t *card, char *type, char *pin)
 {
 	struct sc_pin_cmd_data data;
 	int tries_left;
@@ -423,7 +433,8 @@ int do_verify(sc_card_t *card, u8 *type, u8* pin)
 	if (!type || !pin)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
-	if (strncasecmp("CHV", type, 3) != 0) {
+        /* type has to be cast to char * for strncasecmp */
+	if (strncasecmp("CHV", (char *) type, 3) != 0) {
 		printf("Invalid PIN type. Please use CHV1, CHV2 or CHV3.\n");
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
@@ -437,7 +448,7 @@ int do_verify(sc_card_t *card, u8 *type, u8* pin)
 	data.cmd = SC_PIN_CMD_VERIFY;
 	data.pin_type = SC_AC_CHV;
 	data.pin_reference = type[3] - '0';
-	data.pin1.data = pin;
+	data.pin1.data = (u8 *) pin;
 	data.pin1.len = strlen(pin);
 	r = sc_pin_cmd(card, &data, &tries_left);
 	return r;
@@ -499,7 +510,7 @@ int main(int argc, char **argv)
 		exit_status |= do_userinfo(card);
 
 	if (opt_verify && opt_pin) {
-		exit_status |= do_verify(card, verifytype, pin);
+          exit_status |= do_verify(card, verifytype, pin);
 	}
 
 	if (opt_genkey)


### PR DESCRIPTION
Fix various warnings encountered when configured with "--enable-strict", such as integer conversions, unused locals and unused static functions. Also add "-Wno-unused-parameter" to the compiler's command line to reduce unused parameter warnings to a dull roar.

Unused static functions are clearly marked with "#if I_AM_ACTUALLY_USED_SOMEDAY" -- if these functions should be deprecated, then they are clearly marked and easy to remove.

There are also a few places where const qualifiers are clearly violated and commented as such in the code. This requires some thinking as to whether the function prototype and function pointer prototype need to be updated to allow mutability.

Yeah, it's a little bit of a code audit.
