### PR TITLE
opensc: fix spurious gcc overflow warning

### DIFF
--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -168,13 +168,13 @@ cardos_select_pin_reference(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	} else {
 		preferred = current;
 		/* PINs are even numbered, PUKs are odd */
+		if (preferred >= 125)
+			return SC_ERROR_TOO_MANY_OBJECTS;
 		if (!(preferred & 1))
 			preferred++;
-		if (preferred >= 126)
-			return SC_ERROR_TOO_MANY_OBJECTS;
 	}
 
-	if (current > preferred || preferred > CARDOS_PIN_ID_MAX)
+	if (preferred > CARDOS_PIN_ID_MAX)
 		return SC_ERROR_TOO_MANY_OBJECTS;
 	auth_info->attrs.pin.reference = preferred;
 	return 0;

--- a/src/pkcs15init/pkcs15-incrypto34.c
+++ b/src/pkcs15init/pkcs15-incrypto34.c
@@ -187,13 +187,13 @@ incrypto34_select_pin_reference(sc_profile_t *profile, sc_pkcs15_card_t *p15card
 	} else {
 		preferred = current;
 		/* PINs are even numbered, PUKs are odd */
+		if (preferred >= 125)
+			return SC_ERROR_TOO_MANY_OBJECTS;
 		if (!(preferred & 1))
 			preferred++;
-		if (preferred >= 126)
-			return SC_ERROR_TOO_MANY_OBJECTS;
 	}
 
-	if (current > preferred || preferred > INCRYPTO34_PIN_ID_MAX)
+	if (preferred > INCRYPTO34_PIN_ID_MAX)
 		return SC_ERROR_TOO_MANY_OBJECTS;
 	auth_info->attrs.pin.reference = preferred;
 	return 0;


### PR DESCRIPTION
On some architectures (ppc & s390) gcc produces these warnings
  pkcs15-cardos.c: In function 'cardos_select_pin_reference':
  pkcs15-cardos.c:177:5: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]

  pkcs15-incrypto34.c: In function 'incrypto34_select_pin_reference':
  pkcs15-incrypto34.c:196:5: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]

Remove this warning by reordering test (there is no real bug anyway).

Signed-off-by: Milan Broz mbroz@redhat.com
