### PR TITLE
pkcs15-tool: initialize 'opt_auth_id' consistently.

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -45,7 +45,7 @@ static const char *app_name = "pkcs15-tool";
 
 static int opt_wait = 0;
 static int opt_no_cache = 0;
-static char * opt_auth_id;
+static char * opt_auth_id = NULL;
 static char * opt_reader = NULL;
 static char * opt_cert = NULL;
 static char * opt_data = NULL;


### PR DESCRIPTION
All the other option values are initialized to NULL, so do the same to
opt_auth_id.

(Although, as they're all static globals, they should be set to 0 at
runtime anyway, I think...)

Signed-Off-By: Anthony Foiani anthony.foiani@gmail.com
