### PR TITLE
Regression in e35febe: compute cert length

### DIFF
--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -171,7 +171,7 @@ sc_pkcs15_read_certificate(struct sc_pkcs15_card *p15card, const struct sc_pkcs1
 		return SC_ERROR_INVALID_ASN1_OBJECT;
 	}
 
-	cert->data = der;
+	cert->data.value = der.value;
 	*cert_out = cert;
 	return SC_SUCCESS;
 }


### PR DESCRIPTION
Apparently, a regression was introduced in e35febe.

The change breaks the cases where the certificate is stored in the card in a fixed-size EF (e.g. a 2048 byte file) and is padded with zeros in the end.

While we should try to use the available content before reading the file, if we do read it, then we should keep looking at the certificate length as computed by `parse_x509_cert()`.
