### PR TITLE
pkcs11-tool bug

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1783,6 +1783,7 @@ static int write_object(CK_SESSION_HANDLE session)
 	struct rsakey_info rsa;
 	struct gostkey_info gost;
 	EVP_PKEY *evp_key = NULL;
+	CK_KEY_TYPE type = CKK_RSA;
 
 	memset(&cert, 0, sizeof(cert));
 	memset(&rsa,  0, sizeof(rsa));
@@ -1918,7 +1919,6 @@ static int write_object(CK_SESSION_HANDLE session)
 			n_privkey_attr++;
 		}
 		if (evp_key->type == EVP_PKEY_RSA)   {
-			CK_KEY_TYPE type = CKK_RSA;
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_KEY_TYPE, &type, sizeof(type));
 			n_privkey_attr++;
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_MODULUS, rsa.modulus, rsa.modulus_len);


### PR DESCRIPTION
fixed filling key type attr on writing object

pointer refers to local variable from destroyed stack frame

/usr/local/bin/pkcs11-tool --module /usr/lib/opensc-pkcs11.so -w deckey.der -y privkey -d 45 -l -v
Using slot 1 with a present token (0x1)
Logging in to "Rutoken ECP (User PIN)".
Please enter User PIN: 
error: PKCS11 function C_CreateObject failed: rv = CKR_ATTRIBUTE_VALUE_INVALID (0x13)

Aborting.
