### PR TITLE
Fix to allow exponents other than 65537 for Feitian ePass 2003

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -1003,10 +1003,10 @@ epass2003_init(struct sc_card *card)
 
 	flags = SC_ALGORITHM_ONBOARD_KEY_GEN | SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_HASH_NONE;
 
-	_sc_card_add_rsa_alg(card, 512, flags, 0x10001);
-	_sc_card_add_rsa_alg(card, 768, flags, 0x10001);
-	_sc_card_add_rsa_alg(card, 1024, flags, 0x10001);
-	_sc_card_add_rsa_alg(card, 2048, flags, 0x10001);
+	_sc_card_add_rsa_alg(card, 512, flags, 0);
+	_sc_card_add_rsa_alg(card, 768, flags, 0);
+	_sc_card_add_rsa_alg(card, 1024, flags, 0);
+	_sc_card_add_rsa_alg(card, 2048, flags, 0);
 
 	card->caps = SC_CARD_CAP_RNG | SC_CARD_CAP_APDU_EXT;
 


### PR DESCRIPTION
This fix will allow importing RSA keys with public exponents other than 65537. 

It was tested on actual Feitian ePass 2003. RSA keys with exponents 3 or 0x23 (generated by older OpenSSH) now can be imported and work. Tests pass and those keys are also usable for logging via ssh after exporting with `pkcs15-tool --read-ssh-key`.

Testcase:

```
openssl genrsa -3 -out privtest.pem 2048
pkcs15-init --reader 0 --auth-id 01 --key-usage sign --format PEM --store-private-key privtest.pem
# test
pkcs11-tool --login --test --module /usr/lib64/opensc-pkcs11.so
```
