### PR TITLE
Disable card reading during initialization of the library.

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -381,8 +381,10 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 		hotplug_slot->id--;
 		sc_ctx_detect_readers(context);
 	}
-
-	card_detect_all();
+	
+	if (!sc_pkcs11_conf.plug_and_play) {
+		card_detect_all();
+	}
 
 	found = malloc(list_size(&virtual_slots) * sizeof(CK_SLOT_ID));
 
@@ -477,6 +479,10 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 		return rv;
 
 	sc_log(context, "C_GetSlotInfo(0x%lx)", slotID);
+
+	if (sc_pkcs11_conf.plug_and_play) {
+		card_detect_all();
+	}
 
 	rv = slot_get_slot(slotID, &slot);
 	if (rv == CKR_OK){

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -128,7 +128,7 @@ CK_RV initialize_reader(sc_reader_t *reader)
 			return rv;
 	}
 
-	if (sc_detect_card_presence(reader)) {
+	if (!sc_pkcs11_conf.plug_and_play && sc_detect_card_presence(reader)) {
 		card_detect(reader);
 	}
 


### PR DESCRIPTION
This prevents a slowdown of PKCS #11 C_Initialize when cards
are present. This results to faster startup of programs that
initialize PKCS #11 but not use any smart card operations, and
removes slowdowns in forking servers that follow PKCS #11
and call C_Initialize after each fork().
