### PR TITLE
epass2003: support stricter privkey/pubkey ACLs

### DIFF
--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -507,6 +507,12 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		 sc_print_path(&file->path));
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "private key_info path: %s",
 		 sc_print_path(&(key_info->path)));
+
+	r = sc_pkcs15init_authenticate(profile, p15card, file,
+				       SC_AC_OP_DELETE);
+	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r,
+		    "generate key: pkcs15init_authenticate(SC_AC_OP_DELETE) failed");
+
 	r = sc_delete_file(p15card->card, &file->path);
 	/* create */
 	r = sc_pkcs15init_create_file(profile, p15card, file);
@@ -558,6 +564,11 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	r = sc_select_file(p15card->card, &pukf->path, NULL);
 	/* if exist, delete */
 	if (r == SC_SUCCESS) {
+		r = sc_pkcs15init_authenticate(profile, p15card, pukf,
+		       SC_AC_OP_DELETE);
+		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r,
+		    "generate key - pubkey: pkcs15init_authenticate(SC_AC_OP_DELETE) failed");
+
 		r = sc_pkcs15init_delete_by_path(profile, p15card, &pukf->path);
 		if (r != SC_SUCCESS) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
@@ -572,6 +583,11 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 			 "generate key: pukf create file failed\n");
 		goto failed;
 	}
+
+	r = sc_pkcs15init_authenticate(profile, p15card, pukf,
+				       SC_AC_OP_UPDATE);
+	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r,
+		    "generate key - pubkey: pkcs15init_authenticate(SC_AC_OP_UPDATE) failed");
 
 	/* generate key pair */
 	fidl = (file->id & 0xff) * FID_STEP;


### PR DESCRIPTION
The patch allows to use ACLs requring PIN for deleting and updating private and public keys for epass2003. Currently default epass2003 profile has `ACL = *= NONE` for both private and public key files.

Privkey import worked before this patch, but generating failed. 

**Testcase:**
1. In `/usr/share/opensc/epass2003.profile`, change ACL to require PIN for deleting and updating private and public key files 2900, 3000. E.g. by applying this diff to the profile:
   
   ```
   --- epass2003.profile   2013-03-22 14:27:33.815532234 +0100
   +++ epass2003.profile.new       2013-03-22 16:42:16.321706060 +0100
   @@ -164,13 +164,13 @@
    #type  = internal-ef;
                                           structure = 0xA3;
    #ACL = READ=CHV1,UPDATE=CHV1,CRYPTO=CHV1;
   -                                       ACL = *=NONE;
   +                                       ACL = *=NONE,UPDATE=$PIN,DELETE=$PIN;
                                   }
   
                           EF public-key {
                       file-id       = 3000;
                                           structure = transparent;
   -                                       ACL      = *=NONE;
   +                                       ACL                        = *=NEVER,READ=NONE,UPDATE=$PIN,WRITE=$PIN,DELETE=$PIN;
                           }
   
                           # Certificate template
   ```
2. Erase card, initialize with onepin profile, generate keypair:
   
   ```
   pkcs15-init -E
   pkcs15-init --create-pkcs15 --profile pkcs15+onepin --label "Generated" --pin 1234 --puk 000000
   pkcs15-init --generate-key rsa/2048 --auth-id 01 -u sign
   ```

Generating should now complete successfully. Deleting/updating 29xx and 30xx keyfiles will not be possible without PIN authorization. It can be checked via opensc-explorer's `rm` and `put` commands.
