### PR TITLE
Update of Mac OSX build scripts for Mac OSX Mountain Lion (10.8.X)

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -67,7 +67,7 @@ if [ "${BUILDTOKEND}" == "true" ]; then
 	fi
 
 # Fetch binary dependencies
-	curl -O --insecure https://www.opensc-project.org/downloads/build-10.6.tar.gz
+	curl -O https://www.opensc-project.org/downloads/build-10.6.tar.gz
 
 # Unpack the binary building components
 	if ! test -e OpenSC.tokend/build; then


### PR DESCRIPTION
This update adds a switch in build-package.in so that it checks the Mac OSX version and points to the correct SDK for Mountain Lion. It should also be possible to add SDK for 10.7, but I don't have access to that, so I can't test it.
