### PR TITLE
Updated load_cert to use the proper key identifier

### DIFF
--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -203,11 +203,11 @@ static int load_cert(const char * cert_id, const char * cert_file,
 
 	switch (buf[0]) {
 		case 0x9a: sc_format_path("0101",&path); break;
-		case 0x9b: sc_format_path("0500",&path); break;
 		case 0x9c: sc_format_path("0100",&path); break;
 		case 0x9d: sc_format_path("0102",&path); break;
+		case 0x9e: sc_format_path("0500",&path); break;
 		default:
-			fprintf(stderr,"cert must be 9A, 9B, 9C or 9D\n");
+			fprintf(stderr,"cert must be 9A, 9C, 9D or 9E\n");
 			return 2;
 	}
 


### PR DESCRIPTION
```
/*
 * Copyright (c) 2010 Raytheon BBN Technologies.
 *
 * PERMISSION
 *
 * This material is based upon work supported by the Defense Advanced
 * Research Projects Agency and Space and Naval Warfare Systems
 * Center, Pacific, under Contract No. N66001-09-C-2073.
 * Approved for Public Release, Distribution Unlimited
 */
```

I missed a change in my last pull request to update the load_cert function to also use the 0x9E key instead of the 0x9B key.  According to the SP800-73-3 Table 6, Part 1 the container ID for the 0x9E key is still 0x0500 so I just needed to update the key reference identifier.
