### PR TITLE
use sc_debug_hex for hexdump

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -169,23 +169,6 @@ static int sc_apdu2bytes(sc_context_t *ctx, const sc_apdu_t *apdu,
 	return SC_SUCCESS;
 }
 
-void sc_apdu_log(sc_context_t *ctx, int level, const u8 *data, size_t len, int is_out)
-{
-	size_t blen = len * 5 + 128;
-	char   *buf = malloc(blen);
-	if (buf == NULL)
-		return;
-
-	sc_hex_dump(ctx, level, data, len, buf, blen);
-
-	sc_debug(ctx, level, "\n%s APDU data [%5u bytes] =====================================\n"
-		"%s"
-		"======================================================================\n",
-		is_out != 0 ? "Outgoing" : "Incoming", len,
-		buf);
-	free(buf);
-}
-
 int sc_apdu_get_octets(sc_context_t *ctx, const sc_apdu_t *apdu, u8 **buf,
 	size_t *len, unsigned int proto)
 {

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -539,10 +539,9 @@ static int select_file_id(sc_card_t *card, const u8 *buf, size_t buflen,
 	sc_apdu_t apdu;
         u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
         sc_file_t *file;
-	char	debug_buf[32];
 
-	sc_bin_to_hex(buf, buflen, debug_buf, sizeof(debug_buf), 0);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "called, p1=%u, path=%s\n", p1, debug_buf);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "called, p1=%u\n", p1);
+	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "path", buf, buflen);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, p1, 0);
 	apdu.resp = rbuf;

--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -239,8 +239,8 @@ int sc_apdu_set_resp(sc_context_t *ctx, sc_apdu_t *apdu, const u8 *buf,
  * @param  len          length of the APDU
  * @param  is_outgoing  != 0 if the data is send to the card
  */
-void sc_apdu_log(sc_context_t *ctx, int level, const u8 *data, size_t len,
-	int is_outgoing);
+#define sc_apdu_log(ctx, level, data, len, is_outgoing) \
+	sc_debug_hex(ctx, level, is_outgoing != 0 ? "Outgoing APDU" : "Incoming APDU", data, len)
 
 extern struct sc_reader_driver *sc_get_pcsc_driver(void);
 extern struct sc_reader_driver *sc_get_ctapi_driver(void);

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -84,6 +84,7 @@ sc_disconnect_card
 sc_do_log
 sc_do_log_noframe
 _sc_debug
+_sc_debug_hex
 sc_enum_apps
 sc_encode_oid
 sc_parse_ef_atr

--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -156,6 +156,28 @@ void _sc_log(struct sc_context *ctx, const char *format, ...)
 	va_end(ap);
 }
 
+void _sc_debug_hex(sc_context_t *ctx, int type, const char *file, int line,
+        const char *func, const char *label, const u8 *data, size_t len)
+{
+	size_t blen = len * 5 + 128;
+	char *buf = malloc(blen);
+	if (buf == NULL)
+		return;
+
+    sc_hex_dump(ctx, type, data, len, buf, blen);
+
+    if (label)
+        sc_do_log(ctx, type, file, line, func,
+                "\n%s (%u byte%s):\n%s",
+                label, (unsigned int) len, len==1?"":"s", buf);
+    else
+        sc_do_log(ctx, type, file, line, func,
+                "%u byte%s:\n%s",
+                (unsigned int) len, len==1?"":"s", buf);
+
+	free(buf);
+}
+
 /* Although not used, we need this for consistent exports */
 void sc_hex_dump(struct sc_context *ctx, int level, const u8 * in, size_t count, char *buf, size_t len)
 {
@@ -167,7 +189,7 @@ void sc_hex_dump(struct sc_context *ctx, int level, const u8 * in, size_t count,
 	if (ctx->debug < level)
 		return;
 
-	assert(buf != NULL && in != NULL);
+	assert(buf != NULL && (in != NULL || count == 0));
 	buf[0] = 0;
 	if ((count * 5) > len)
 		return;

--- a/src/libopensc/log.h
+++ b/src/libopensc/log.h
@@ -57,6 +57,31 @@ void sc_do_log(struct sc_context *ctx, int level, const char *file, int line, co
 void sc_do_log_noframe(sc_context_t *ctx, int level, const char *format, va_list args);
 void _sc_debug(struct sc_context *ctx, int level, const char *format, ...);
 void _sc_log(struct sc_context *ctx, const char *format, ...);
+/** 
+ * @brief Log binary data to a sc context
+ * 
+ * @param[in] ctx   Context for logging
+ * @param[in] level
+ * @param[in] label Label to prepend to the buffer
+ * @param[in] data  Binary data
+ * @param[in] len   Length of \a data
+ */
+#define sc_debug_hex(ctx, level, label, data, len) \
+    _sc_debug_hex(ctx, level, __FILE__, __LINE__, __FUNCTION__, label, data, len)
+/** 
+ * @brief Log binary data
+ *
+ * @param[in] ctx   Context for logging
+ * @param[in] type  Debug level
+ * @param[in] file  File name to be prepended
+ * @param[in] line  Line to be prepended
+ * @param[in] func  Function to be prepended
+ * @param[in] label label to prepend to the buffer
+ * @param[in] data  binary data
+ * @param[in] len   length of \a data
+ */
+void _sc_debug_hex(struct sc_context *ctx, int level, const char *file, int line,
+        const char *func, const char *label, const u8 *data, size_t len);
 
 void sc_hex_dump(struct sc_context *ctx, int level, const u8 * buf, size_t len, char *out, size_t outlen);
 char * sc_dump_hex(const u8 * in, size_t count);

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1605,7 +1605,6 @@ pcsc_pin_cmd(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 {
 	struct pcsc_private_data *priv = GET_PRIV_DATA(reader);
 	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE], sbuf[SC_MAX_APDU_BUFFER_SIZE];
-	char dbuf[SC_MAX_APDU_BUFFER_SIZE * 3];
 	size_t rcount = sizeof(rbuf), scount = 0;
 	int r;
 	DWORD ioctl = 0;
@@ -1651,8 +1650,7 @@ pcsc_pin_cmd(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 	/* If PIN block building failed, we fail too */
 	SC_TEST_RET(reader->ctx, SC_LOG_DEBUG_NORMAL, r, "PC/SC v2 pinpad block building failed!");
 	/* If not, debug it, just for fun */
-	sc_bin_to_hex(sbuf, scount, dbuf, sizeof(dbuf), ':');
-	sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "PC/SC v2 pinpad block: %s", dbuf);
+	sc_debug_hex(reader->ctx, SC_LOG_DEBUG_NORMAL, "PC/SC v2 pinpad block", sbuf, scount);
 
 	r = pcsc_internal_transmit(reader, sbuf, scount, rbuf, &rcount, ioctl);
 


### PR DESCRIPTION
use a single code base everywhere.

rebased to current HEAD and fixed sc_debug_hex's definition.
