### PR TITLE
Formatting with spaces and returns in hex dump.

### DIFF
--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -60,7 +60,7 @@ void sc_do_log_noframe(sc_context_t *ctx, int level, const char *format, va_list
 
 static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int line, const char *func, const char *format, va_list args)
 {
-	char	buf[1836], *p;
+	char	buf[4096], *p;
 	int	r;
 	size_t	left;
 #ifdef _WIN32
@@ -211,14 +211,15 @@ sc_dump_hex(const u8 * in, size_t count)
 
 	for (ii=0; ii<count; ii++) {
 		if (!(ii%16))   {
-			if (!(ii%48))
+			if ((ii)&&(!(ii%48)))
 				snprintf(dump_buf + offs, size - offs, "\n");
-			else
+			else if (ii)
 				snprintf(dump_buf + offs, size - offs, " ");
+			offs = strlen(dump_buf);
 		}
 
 		snprintf(dump_buf + offs, size - offs, "%02X", *(in + ii));
-		offs = strlen(dump_buf);
+		offs += 2;
 
 		if (offs > size)
             		break;


### PR DESCRIPTION
There are two changes, both only related to logging:
- Increase the buffer size in sc_do_log_va to 4096.
- Fix formatting in sc_hex_dump so that it prints an space every 16 bytes and one return every 48. That helps when comparing large objects. This seems to be the original intention, but the spaces and returns were overwritten by the following characters.
