### PR TITLE
Onepin profile stopped to work after commit 10e1ad001d

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -341,13 +341,13 @@ sc_pkcs15init_bind(struct sc_card *card, const char *name, const char *profile_o
 				profile->options[i++] = strdup(s);
 		}
 	}
-#if 0
+
 	r = sc_pkcs15init_read_info(card, profile);
 	if (r < 0) {
 		sc_profile_free(profile);
 		LOG_TEST_RET(ctx, r, "Read info error");
 	}
-#endif
+
 	/* Check the config file for a profile name.
 	 * If none is defined, use the default profile name.
 	 */


### PR DESCRIPTION
Cards formatted with one-pin profile can not be used (for modification
of the data on the card with pkcs15-init -X for example) after this
commit, which prevent the reading of 5015/4946 (containing the
profile).

The part of the code was simply commented out without comment.
Maybe it was used for testing purposes, and not removed for
the commit ?
