### PR TITLE
use a default file size

### DIFF
--- a/src/libopensc/ef-atr.c
+++ b/src/libopensc/ef-atr.c
@@ -145,7 +145,7 @@ int sc_parse_ef_atr(struct sc_card *card)
 	rv = sc_read_binary(card, 0, buf, file->size, 0);
 	LOG_TEST_RET(ctx, rv, "Cannot read EF(ATR) file");
 	
-	rv = sc_parse_ef_atr_content(card, buf, file->size);
+	rv = sc_parse_ef_atr_content(card, buf, rv);
 	LOG_TEST_RET(ctx, rv, "EF(ATR) parse error");
 
 	free(buf);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -552,7 +552,7 @@ sc_pkcs15_get_lastupdate(struct sc_pkcs15_card *p15card)
 	if (!p15card->tokeninfo->last_update.path.len)
 		return NULL;
 
-        r = sc_select_file(p15card->card, &p15card->tokeninfo->last_update.path, &file);
+	r = sc_select_file(p15card->card, &p15card->tokeninfo->last_update.path, &file);
 	if (r < 0)
 		return NULL;
 


### PR DESCRIPTION
applications use the file size to allocate the memory. if a card doesn't
return the file size on select, this breaks the application. so we
choose a default file size of 1024 which hopefully is big enough.
