### PR TITLE
Set output buffer len variable if padding removed.

### DIFF
--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -166,9 +166,10 @@ sc_pkcs1_strip_02_padding(sc_context_t *ctx, const u8 *data, size_t len, u8 *out
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
 	/* Now move decrypted contents to head of buffer */
-	if (*out_len < len -  n)
+	if (*out_len < len - n)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
-	memmove(out, data + n, len - n);
+	*out_len = len - n;
+	memmove(out, data + n, *out_len);
 
 	sc_log(ctx, "stripped output(%i): %s", len - n, sc_dump_hex(out, len - n));
 	LOG_FUNC_RETURN(ctx, len - n);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2712,7 +2712,6 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 					logprintf(pCardData, 2, "Cannot strip PKCS1 padding: %i\n", r);
 					return SCARD_F_INTERNAL_ERROR;
 				}
-				pInfo->cbData = r;
 			}
 			else if (pInfo->dwPaddingType == CARD_PADDING_OAEP)   {
 				/* TODO: Handle OAEP padding if present - can call PFN_CSP_UNPAD_DATA */


### PR DESCRIPTION
This patch makes the implementation of sc_pkcs1_strip_02_padding in padding.c actually match the implied behaviour of its signature (and how it was used by the Windows minidirver in the 0.13.0 release).  Specifically, on input, *out_len is the length of the buffer pointed to by "out" parameter, and on return, *out_len is set to the length of unpadded data copied to "out" parameter.

It also removes the "fix" for this lack of consistency that was added to minidriver.c in the master branch because with the change described above, pinfo->cbData is already set to the unpadded data len in minidriver.c.
