### PR TITLE
Reset return code to success if pubkey read from cert.

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2101,8 +2101,10 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 		logprintf(pCardData, 1, "now read certificate '%s'\n", cont->cert_obj->label);
 		rv = sc_pkcs15_read_certificate(vs->p15card, (struct sc_pkcs15_cert_info *)(cont->cert_obj->data), &cert);
 		if(!rv)   {
-			if(cert->key->algorithm == SC_ALGORITHM_RSA)
+			if(cert->key->algorithm == SC_ALGORITHM_RSA) {
 				sc_der_copy(&pubkey_der, &cert->key->data);
+				ret = SCARD_S_SUCCESS;
+			}
 			else
 				ret = SCARD_E_UNSUPPORTED_FEATURE;
 			sc_pkcs15_free_certificate(cert);


### PR DESCRIPTION
In CardGetContainerInfo(), the return value is set to SCARD_E_FILE_NOT_FOUND if unable to read the public key from the token.  It then tries to read the public key from the certificate.  However, even if this succeeds, the function returns with a failure code because the return value is not reset to SCARD_S_SUCCESS.

This patch fixes the problem.
