### PR TITLE
Call dlclose() only when having a valid handle.

### DIFF
--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -74,7 +74,7 @@ C_UnloadModule(void *module)
 	if (!mod || mod->_magic != MAGIC)
 		return CKR_ARGUMENTS_BAD;
 
-	if (sc_dlclose(mod->handle) < 0)
+	if (mod->handle != NULL && sc_dlclose(mod->handle) < 0)
 		return CKR_FUNCTION_FAILED;
 
 	memset(mod, 0, sizeof(*mod));


### PR DESCRIPTION
This fixes issue where calling pks11-tool with a module that does not exist causes a segmentation fault.

Signed-off-by: Nikos Mavrogiannopoulos nmav@redhat.com
