### PR TITLE
Mention that create_slots_for_pins can be used to get opensc-onepin behaviour

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -625,6 +625,10 @@ app opensc-pkcs11 {
 		# create_slots_for_pins = "user,sign";
 		# create_slots_for_pins = application;
 		# create_slots_for_pins = "application,sign";
+		#
+		# For the module to simulate the opensc-onepin module behavior the following option
+		# must be set:
+		# create_slots_for_pins = "user"
 	}
 }
 


### PR DESCRIPTION
The previously available text, didn't make clear to users of the library what option they should use to get a compatible with opensc-onepin module.
