### PR TITLE
Use-after-free in pkcs15_pubkey_release()

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3824,14 +3824,12 @@ static void
 pkcs15_pubkey_release(void *object)
 {
 	struct pkcs15_pubkey_object *pubkey = (struct pkcs15_pubkey_object*) object;
+	struct sc_pkcs15_pubkey *key_data = pubkey->pub_data;
+	if (key_data)
+		sc_pkcs15_free_pubkey(key_data);
+	pubkey->pub_data = NULL;
 
-	if (__pkcs15_release_object((struct pkcs15_any_object *) object) == 0)   {
-		struct sc_pkcs15_pubkey *key_data = pubkey->pub_data;
-
-		if (key_data)
-			sc_pkcs15_free_pubkey(key_data);
-		pubkey->pub_data = NULL;
-	}
+	__pkcs15_release_object((struct pkcs15_any_object *) object);
 }
 
 


### PR DESCRIPTION
While tracking down nasty segfaults that happened when closing the PKCS #11 module, I found a use-after-free bug; the fix seems to work for me!
