### PR TITLE
base64 decoding: Do not assume that char is signed.

### DIFF
--- a/src/libopensc/base64.c
+++ b/src/libopensc/base64.c
@@ -73,7 +73,7 @@ static int from_base64(const char *in, unsigned int *out, int *skip)
 		u8 b;
 		int k = *in;
 		
-		if (k < 0)
+		if (k < 0 || k >= (int)sizeof(bin_table))
 			return -1;
 		if (k == 0 && c == 0)
 			return 0;


### PR DESCRIPTION
In the systems where char is unsigned by default the base64 decoding
would crash.
