### PR TITLE
Fixed most const warnings and added pragmas to ignore false warnings

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -605,7 +605,7 @@ int sc_transmit_apdu(sc_card_t *card, sc_apdu_t *apdu)
 				plen = len;
 				last = 1;
 			}
-			tapdu.data    = buf;
+			tapdu.data    = (u8 *) buf;
 			tapdu.datalen = tapdu.lc = plen;
 
 			r = sc_check_apdu(card, &tapdu);
@@ -693,7 +693,7 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 				sc_log(ctx, "APDU too short (need %lu more bytes)", (unsigned long) apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
-			apdu->data = p;
+			apdu->data = (u8 *) p;
 			apdu->datalen = apdu->lc;
 			len -= apdu->lc;
 			p += apdu->lc;
@@ -731,7 +731,7 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 				sc_log(ctx, "APDU too short (need %lu more bytes)", (unsigned long) apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
-			apdu->data = p;
+			apdu->data = (u8 *) p;
 			apdu->datalen = apdu->lc;
 			len -= apdu->lc;
 			p += apdu->lc;

--- a/src/libopensc/card-akis.c
+++ b/src/libopensc/card-akis.c
@@ -86,7 +86,7 @@ select_file(sc_card_t *card, sc_apdu_t *apdu, const sc_path_t *path,
 	apdu->resp = rbuf;
 	apdu->resplen = sizeof(rbuf);
 	apdu->datalen = path->len;
-	apdu->data = path->value;
+	apdu->data = (u8 *) path->value;
 	apdu->lc = path->len;
 	apdu->le = 256;
 
@@ -324,7 +324,7 @@ akis_delete_file(sc_card_t *card, const sc_path_t *path)
         apdu.cla = 0x80;
 	apdu.lc = buflen;
 	apdu.datalen = buflen;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");

--- a/src/libopensc/card-asepcos.c
+++ b/src/libopensc/card-asepcos.c
@@ -429,7 +429,7 @@ static int asepcos_set_sec_attributes(sc_card_t *card, const u8 *data, size_t le
 	apdu.cla    |= 0x80;
 	apdu.lc      = len;
 	apdu.datalen = len;
-	apdu.data    = data;
+	apdu.data    = (u8 *) data;
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");
 	return sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -515,7 +515,7 @@ static int asepcos_decipher(sc_card_t *card, const u8 * crgram, size_t crgram_le
 	 * always have Le <= crgram_len) */
 	apdu.le      = (outlen >= 256 && crgram_len < 256) ? 256 : outlen;
 	
-	apdu.data    = crgram;
+	apdu.data    = (u8 *)crgram;
 	apdu.lc      = crgram_len;
 	apdu.datalen = crgram_len;
 	r = sc_transmit_apdu(card, &apdu);
@@ -546,7 +546,7 @@ static int asepcos_compute_signature(sc_card_t *card, const u8 *data, size_t dat
 	apdu.cla    |= 0x80;
 	apdu.lc      = datalen;
 	apdu.datalen = datalen;
-	apdu.data    = data;
+	apdu.data    = (u8 *) data;
 	apdu.resp    = rbuf;
 	apdu.resplen = sizeof(rbuf);
 	apdu.le      = 256;
@@ -893,7 +893,7 @@ static int asepcos_change_key(sc_card_t *card, sc_cardctl_asepcos_change_key_t *
 	sc_format_apdu(card, &apdu, atype, 0x24, 0x01, 0x80);
 	apdu.lc      = p->datalen;
 	apdu.datalen = p->datalen;
-	apdu.data    = p->data;
+	apdu.data    = (u8 *) p->data;
 
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");

--- a/src/libopensc/card-atrust-acos.c
+++ b/src/libopensc/card-atrust-acos.c
@@ -874,7 +874,7 @@ static int atrust_acos_logout(struct sc_card *card)
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
 	apdu.le = 0;
 	apdu.lc = 2;
-	apdu.data    = mf_buf;
+	apdu.data    = (u8 *) mf_buf;
 	apdu.datalen = 2;
 	apdu.resplen = 0;
 	

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -967,7 +967,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 		sc_format_apdu(card, cur_apdu, SC_APDU_CASE_3_SHORT, 0xD0, (idx >> 8) & 0x7F, idx & 0xFF);
 		cur_apdu->lc = sz;
 		cur_apdu->datalen = sz;
-		cur_apdu->data = buf + count - rest;
+		cur_apdu->data = (u8 *) (buf + count - rest);
 
 		idx += sz;
 		rest -= sz;
@@ -1016,7 +1016,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 		sc_format_apdu(card, cur_apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
 		cur_apdu->lc = sz;
 		cur_apdu->datalen = sz;
-		cur_apdu->data = buf + count - rest;
+		cur_apdu->data = (u8 *) ( buf + count - rest );
 
 		idx += sz;
 		rest -= sz;
@@ -1243,7 +1243,7 @@ authentic_delete_file(struct sc_card *card, const struct sc_path *path)
 
 	for (ii=0, p1 = 0x02; ii<2; ii++, p1 = 0x01)   {
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xE4, p1, 0x00);
-		apdu.data = path->value + path->len - 2;
+		apdu.data = (u8 *) (path->value + path->len - 2);
 		apdu.datalen = 2;
 		apdu.lc = 2;
 
@@ -2103,7 +2103,7 @@ authentic_decipher(struct sc_card *card, const unsigned char *in, size_t in_len,
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x80, 0x86);
 	apdu.flags |= SC_APDU_FLAGS_CHAINING;
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.datalen = in_len;
 	apdu.lc = in_len;
 	apdu.resp = resp;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -815,7 +815,7 @@ do_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
 	apdu.le      = outlen;
 	apdu.resplen = outlen;
 
-	apdu.data    = data;
+	apdu.data    = (u8 *) data;
 	apdu.lc      = datalen;
 	apdu.datalen = datalen;
 	r = sc_transmit_apdu(card, &apdu);
@@ -1031,7 +1031,7 @@ cardos_put_data_oci(sc_card_t *card,
 	apdu.p1  = 0x01;
 	apdu.p2  = 0x6e;
 	apdu.lc  = args->len;
-	apdu.data = args->data;
+	apdu.data = (u8 *) args->data;
 	apdu.datalen = args->len;
 
 	r = sc_transmit_apdu(card, &apdu);
@@ -1057,7 +1057,7 @@ cardos_put_data_seci(sc_card_t *card,
 	apdu.p1  = 0x01;
 	apdu.p2  = 0x6d;
 	apdu.lc  = args->len;
-	apdu.data = args->data;
+	apdu.data = (u8 *) args->data;
 	apdu.datalen = args->len;
 
 	r = sc_transmit_apdu(card, &apdu);

--- a/src/libopensc/card-default.c
+++ b/src/libopensc/card-default.c
@@ -42,7 +42,7 @@ default_match_card(struct sc_card *card)
 static int
 default_init(struct sc_card *card)
 {
-	int r;
+	/* int r; */ // unsused, avoid warnings at all cost (this is security software)
 
 	LOG_FUNC_CALLED(card->ctx);
 

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -951,7 +951,10 @@ static int dnie_select_file(struct sc_card *card,
 	char pbuf[SC_MAX_PATH_STRING_SIZE];
         u8 *path = pathbuf;
 	size_t pathlen;
-        int cached=0;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+    int cached = 0;
+#pragma GCC diagnostic pop
 
 	sc_file_t *file = NULL;
 	int res = SC_SUCCESS;
@@ -2141,6 +2144,7 @@ static int dnie_sm_wrap_apdu(struct sc_card *card, struct sc_apdu *plain, struct
 
 static int dnie_sm_get_wrapped_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t **sm_apdu)
 {
+
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu *apdu = NULL;
 	int rv;
@@ -2177,7 +2181,10 @@ static int dnie_sm_unwrap_apdu(sc_card_t *card, sc_apdu_t *wrapped, sc_apdu_t *p
 {
 	int res = SC_SUCCESS;
     struct sc_context *ctx = card->ctx;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 	cwa_provider_t *provider = NULL;
+#pragma GCC diagnostic pop
 
     LOG_FUNC_CALLED(ctx);
 

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -412,7 +412,7 @@ static int entersafe_update_binary(sc_card_t *card,
 	apdu.cla=idx > 0x7fff ? 0x80:0x00;
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = entersafe_transmit_apdu(card, &apdu,0,0,0,0);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -546,7 +546,7 @@ static int select_file_id(sc_card_t *card, const u8 *buf, size_t buflen,
 	apdu.resp = rbuf;
 	apdu.resplen = sizeof(rbuf);
 	apdu.datalen = buflen;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 	apdu.lc = buflen;
 	apdu.le = 252;
 
@@ -724,7 +724,7 @@ static int flex_delete_file(sc_card_t *card, const sc_path_t *path)
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xE4, 0x00, 0x00);
 	if (!IS_CYBERFLEX(card))
 		apdu.cla = 0xF0;	/* Override CLA byte */
-	apdu.data = path->value;
+	apdu.data = (u8 *) path->value;
 	apdu.lc = 2;
 	apdu.datalen = 2;
 	
@@ -1079,7 +1079,7 @@ cyberflex_compute_signature(sc_card_t *card, const u8 *data,
 
 	apdu.lc = data_len;
 	apdu.datalen = data_len;
-	apdu.data = data;
+	apdu.data = (u8 *) data;
 	apdu.resplen = outlen;
 	apdu.resp = out;
 	r = sc_transmit_apdu(card, &apdu);

--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -119,7 +119,7 @@ static int gp_select_applet(sc_card_t *card, const u8 *aid, size_t aid_len)
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xa4, 0x04, 0x00);
 	apdu.lc      = aid_len;
-	apdu.data    = aid;
+	apdu.data    = (u8 *) aid;
 	apdu.datalen = aid_len;
 	apdu.resp    = buf;
 	apdu.le      = 256;
@@ -497,7 +497,7 @@ static int gemsafe_decipher(struct sc_card *card, const u8 * crgram,
 	apdu.resplen = sizeof(rbuf);
 	apdu.le      = crgram_len;
 
-	apdu.data = crgram;
+	apdu.data = (u8 *) crgram;
 	apdu.lc   = crgram_len;
 	apdu.datalen = crgram_len;
 	r = sc_transmit_apdu(card, &apdu);

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -528,7 +528,7 @@ gpk_select(sc_card_t *card, int kind,
 	apdu.ins = 0xA4;
 	apdu.p1 = kind;
 	apdu.p2 = 0;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 	apdu.datalen = buflen;
 	apdu.lc = apdu.datalen;
 
@@ -1340,7 +1340,7 @@ gpk_decipher(sc_card_t *card, const u8 *in, size_t inlen,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x1C, 0x00, 0x00);
 	apdu.cla |= 0x80;
 	apdu.lc   = inlen;
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.datalen = inlen;
 	apdu.le   = 256;		/* give me all you got :) */
 	apdu.resp = buffer;

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -1791,7 +1791,7 @@ iasecc_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd,
 	}
 	else if (pin_cmd->pin1.data && pin_cmd->pin1.len)   {
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x20, 0, pin_cmd->pin_reference);
-		apdu.data = pin_cmd->pin1.data;
+		apdu.data = (u8 *) pin_cmd->pin1.data;
 		apdu.datalen = pin_cmd->pin1.len;
 		apdu.lc = pin_cmd->pin1.len;
 	}
@@ -2219,12 +2219,12 @@ iasecc_keyset_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 
 	update.fields[0].parent_tag = IASECC_SDO_KEYSET_TAG;
 	update.fields[0].tag = IASECC_SDO_KEYSET_TAG_MAC;
-	update.fields[0].value = data->pin2.data;
+	update.fields[0].value = (u8 *) data->pin2.data;
 	update.fields[0].size = 16;
 
 	update.fields[1].parent_tag = IASECC_SDO_KEYSET_TAG;
 	update.fields[1].tag = IASECC_SDO_KEYSET_TAG_ENC;
-	update.fields[1].value = data->pin2.data + 16;
+	update.fields[1].value = (u8 *) (data->pin2.data + 16);
 	update.fields[1].size = 16;
 
 	rv = iasecc_sm_sdo_update(card, (scb & IASECC_SCB_METHOD_MASK_REF), &update);
@@ -2356,7 +2356,7 @@ iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_
 
 	if (data->pin2.len)   {
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x2C, 0x02, reference);
-		apdu.data = data->pin2.data;
+		apdu.data = (u8 *) data->pin2.data;
 		apdu.datalen = data->pin2.len;
 		apdu.lc = apdu.datalen;
 
@@ -3208,7 +3208,7 @@ iasecc_compute_signature_at(struct sc_card *card,
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x88, 0x00, 0x00);
 	apdu.datalen = in_len;
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.lc = in_len;
 	apdu.resp = rbuf;
 	apdu.resplen = sizeof(rbuf);
@@ -3270,7 +3270,7 @@ iasecc_compute_signature(struct sc_card *card,
 
 static int
 iasecc_read_public_key(struct sc_card *card, unsigned type,
-		struct sc_path *key_path, unsigned ref, size_t size,
+		struct sc_path *key_path, unsigned ref, unsigned size,
 		unsigned char **out, size_t *out_len)
 {
 	struct sc_context *ctx = card->ctx;

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -769,7 +769,7 @@ do_select(sc_card_t * card, u8 kind,
 	if (kind == MCRD_SEL_DF) p2 = 0x0C;
 
 	sc_format_apdu(card, &apdu, buflen?SC_APDU_CASE_4_SHORT:SC_APDU_CASE_2_SHORT, 0xA4, kind, p2);
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 	apdu.datalen = buflen;
 	apdu.lc = apdu.datalen;
 	apdu.resp = resbuf;
@@ -1349,7 +1349,7 @@ static int mcrd_compute_signature(sc_card_t * card,
 
 	}
 	apdu.lc = datalen;
-	apdu.data = data;
+	apdu.data = (u8 *) data;
 	apdu.datalen = datalen;
 	apdu.le = 0x80;
 	apdu.resp = out;

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -1134,7 +1134,7 @@ auth_compute_signature(struct sc_card *card, const unsigned char *in, size_t ile
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x9E, 0x9A);
 	apdu.datalen = ilen;
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.lc = ilen;
 	apdu.le = olen > 256 ? 256 : olen;
 	apdu.resp = resp;
@@ -1181,7 +1181,7 @@ auth_decipher(struct sc_card *card, const unsigned char *in, size_t inlen,
 	_inlen = inlen;
 	if (_inlen == 256)   {
 		apdu.cla |= 0x10;
-		apdu.data = in;
+		apdu.data = (u8 *) in;
 		apdu.datalen = 8;
 		apdu.resp = resp;
 		apdu.resplen = SC_MAX_APDU_BUFFER_SIZE;
@@ -1211,7 +1211,7 @@ auth_decipher(struct sc_card *card, const unsigned char *in, size_t inlen,
 		break;
 #endif
 
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.datalen = _inlen;
 	apdu.resp = resp;
 	apdu.resplen = SC_MAX_APDU_BUFFER_SIZE;

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1201,7 +1201,7 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 		if (((card->caps & SC_CARD_CAP_APDU_EXT) == 0) && (priv->ext_caps & EXT_CAP_CHAINING))
 			apdu.flags |= SC_APDU_FLAGS_CHAINING;
 
-		apdu.data = buf;
+		apdu.data = (u8 *) buf;
 		apdu.datalen = buf_len;
 		apdu.lc = buf_len;
 	}
@@ -1352,7 +1352,7 @@ pgp_compute_signature(sc_card_t *card, const u8 *data,
 	}
 
 	apdu.lc = data_len;
-	apdu.data = data;
+	apdu.data = (u8 *) data;
 	apdu.datalen = data_len;
 	apdu.le = ((outlen >= 256) && !(card->caps & SC_CARD_CAP_APDU_EXT)) ? 256 : outlen;
 	apdu.resp    = out;
@@ -1410,7 +1410,7 @@ pgp_decipher(sc_card_t *card, const u8 *in, size_t inlen,
 	}
 
 	apdu.lc = inlen;
-	apdu.data = in;
+	apdu.data = (u8 *) in;
 	apdu.datalen = inlen;
 	apdu.le = ((outlen >= 256) && !(card->caps & SC_CARD_CAP_APDU_EXT)) ? 256 : outlen;
 	apdu.resp = out;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -471,7 +471,7 @@ static int piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 
 	apdu.lc = sendbuflen;
 	apdu.datalen = sendbuflen;
-	apdu.data = sendbuf;
+	apdu.data = (u8 *) sendbuf;
 
 	if (recvbuf) {
 		apdu.resp = rbuf;
@@ -683,7 +683,7 @@ static int piv_select_aid(sc_card_t* card, u8* aid, size_t aidlen, u8* response,
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
 	apdu.lc = aidlen;
-	apdu.data = aid;
+	apdu.data = (u8 *) aid;
 	apdu.datalen = aidlen;
 	apdu.resp = response;
 	apdu.resplen = responselen ? *responselen : 0;

--- a/src/libopensc/card-rtecp.c
+++ b/src/libopensc/card-rtecp.c
@@ -296,7 +296,7 @@ static int rtecp_verify(sc_card_t *card, unsigned int type, int ref_qualifier,
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT,
 				0x20, 0, ref_qualifier);
 		apdu.lc = data_len;
-		apdu.data = data;
+		apdu.data = (u8 *) data;
 		apdu.datalen = data_len;
 		r = sc_transmit_apdu(card, &apdu);
 		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -642,7 +642,7 @@ static int rutoken_verify(sc_card_t *card, unsigned int type, int ref_qualifier,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x20, 0x00, ref_qualifier);
 	apdu.lc = data_len;
 	apdu.datalen = data_len;
-	apdu.data = data;
+	apdu.data = (u8 *) data;
 	ret = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "APDU transmit failed");
 	ret = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -693,7 +693,7 @@ static int rutoken_change_reference_data(sc_card_t *card, unsigned int type,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x24, 0x01, ref_qualifier);
 	apdu.lc = newlen;
 	apdu.datalen = newlen;
-	apdu.data = newref;
+	apdu.data = (u8 *) newref;
 	ret = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "APDU transmit failed");
 	ret = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -767,7 +767,7 @@ static int rutoken_set_security_env(sc_card_t *card,
 	/*  select component  */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 1, 0);
 	apdu.lc = apdu.datalen = sizeof(data);
-	apdu.data = data;
+	apdu.data = (u8 *) data;
 	switch (env->operation)
 	{
 		case SC_SEC_OPERATION_AUTHENTICATE:
@@ -990,7 +990,7 @@ static int rutoken_cipher_p(sc_card_t *card, const u8 * crgram, size_t crgram_le
 		len = (crgram_len > sizeof(buf)) ? sizeof(buf) : crgram_len;
 		apdu.lc = len;
 		apdu.datalen = len;
-		apdu.data = crgram;
+		apdu.data = (u8 *) crgram;
 		crgram += len;
 		crgram_len -= len;
 
@@ -1071,7 +1071,7 @@ static int rutoken_compute_mac_gost(sc_card_t *card,
 		len = (ilen > signing_chunk) ? signing_chunk : ilen;
 		apdu.lc = len;
 		apdu.datalen = len;
-		apdu.data = in;
+		apdu.data = (u8 *) in;
 		in += len;
 		ilen -= len;
 		if (ilen == 0)

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1325,7 +1325,7 @@ static int starcos_logout(sc_card_t *card)
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
 	apdu.le = 0;
 	apdu.lc = 2;
-	apdu.data    = mf_buf;
+	apdu.data    = (u8 *) mf_buf;
 	apdu.datalen = 2;
 	apdu.resplen = 0;
 	

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -1117,7 +1117,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 		
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x00, mode);
 		apdu.datalen = data_len;
-		apdu.data = data;
+		apdu.data = (u8 *) data;
 		apdu.lc = data_len;
 		apdu.le = outlen > 240 ? 240 : outlen;
 		apdu.resp = out;

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -427,7 +427,7 @@ static int cwa_verify_cvc_certificate(sc_card_t * card,
 
 	/* compose apdu for Perform Security Operation (Verify cert) cmd */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x2A, 0x00, 0xAE);
-	apdu.data = cert;
+	apdu.data = (u8 *) cert;
 	apdu.datalen = len;
 	apdu.lc = len;
 	apdu.le = 0;

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -690,7 +690,11 @@ iasecc_sm_delete_file(struct sc_card *card, unsigned se_num, unsigned int file_i
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_DELETE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_delete_file() SM INITIALIZE failed");
 
+    /* probably correct so we push gcc ignore flags */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
 	sm_info->cmd_data = (void *)file_id;
+#pragma GCC diagnostic pop
 
 	sc_remote_data_init(&rdata);
 	rv = iasecc_sm_cmd(card, &rdata);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -198,7 +198,7 @@ iso7816_write_record(struct sc_card *card, unsigned int rec_nr,
 
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
@@ -226,7 +226,7 @@ iso7816_append_record(struct sc_card *card,
 
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
@@ -255,7 +255,7 @@ iso7816_update_record(struct sc_card *card, unsigned int rec_nr,
 
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
@@ -284,7 +284,7 @@ iso7816_write_binary(struct sc_card *card,
 		       (idx >> 8) & 0x7F, idx & 0xFF);
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
@@ -312,7 +312,7 @@ iso7816_update_binary(struct sc_card *card,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
 	apdu.lc = count;
 	apdu.datalen = count;
-	apdu.data = buf;
+	apdu.data = (u8 *) buf;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -553,7 +553,8 @@ sc_pkcs15init_delete_by_path(struct sc_profile *profile, struct sc_pkcs15_card *
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_file *parent = NULL, *file = NULL;
 	struct sc_path path;
-	int rv, file_type = SC_FILE_TYPE_DF;
+	int rv;
+    /* int file_type = SC_FILE_TYPE_DF; */
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx, "trying to delete '%s'", sc_print_path(file_path));
@@ -582,7 +583,7 @@ sc_pkcs15init_delete_by_path(struct sc_profile *profile, struct sc_pkcs15_card *
 	}
 	else    {
 		sc_log(ctx, "Try to get the parent's 'DELETE' access");
-		file_type = file->type;
+		/* file_type = file->type; */
 		if (file_path->len >= 2) {
 			/* Select the parent DF */
 			path.len -= 2;

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -671,7 +671,7 @@ static int cardos_format(const char *opt_startkey)
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", (unsigned int ) apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1032,7 +1032,7 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", (unsigned int) apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1127,7 +1127,7 @@ change_startkey:
 		return 1;
 	}
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", (unsigned int) apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -215,7 +215,7 @@ static void display_data(const struct ef_name_map *mapping, char *value)
 			} else {
 				const char *label = mapping->name;
 
-				printf("%s:%*s%s\n", label, 10-strlen(label), "", value);
+				printf("%s:%*s%s\n", label, (int) 10-strlen(label), "", value);
 			}
 		}
 	}

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -417,7 +417,10 @@ static int cleanUpShares(secret_share_t *shares, unsigned char n)
 
 void clearScreen()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
 	if (system( "clear" )) system( "cls" );
+#pragma GCC diagnostic pop
 }
 
 
@@ -600,7 +603,10 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 	printf("\nPlease remember to present the share id as well as the share value.");
 	printf("\n\nPlease enter prime: ");
 	memset(inbuf, 0, sizeof(inbuf));
-	fgets(inbuf, sizeof(inbuf), stdin);
+#pragma GCC diagnostic push	
+#pragma GCC diagnostic ignored "-Wunused-result"
+    fgets(inbuf, sizeof(inbuf), stdin);
+#pragma GCC diagnostic pop
 	binlen = 64;
 	sc_hex_to_bin(inbuf, bin, &binlen);
 	BN_bin2bn(bin, binlen, &prime);
@@ -621,13 +627,19 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 
 		printf("Please enter share ID: ");
 		memset(inbuf, 0, sizeof(inbuf));
-		fgets(inbuf, sizeof(inbuf), stdin);
+#pragma GCC diagnostic push	
+#pragma GCC diagnostic ignored "-Wunused-result"
+        fgets(inbuf, sizeof(inbuf), stdin);
+#pragma GCC diagnostic pop
 		p = &(sp->x);
 		BN_hex2bn(&p, inbuf);
 
 		printf("Please enter share value: ");
 		memset(inbuf, 0, sizeof(inbuf));
+#pragma GCC diagnostic push	
+#pragma GCC diagnostic ignored "-Wunused-result"
 		fgets(inbuf, sizeof(inbuf), stdin);
+#pragma GCC diagnostic pop
 		binlen = 64;
 		sc_hex_to_bin(inbuf, bin, &binlen);
 		BN_bin2bn(bin, binlen, &(sp->y));

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -860,7 +860,11 @@ int main(int argc, char *argv[])
 		memset(b, 0, file->size);
 
 		fp = fopen(put_filename, "rb");
-		fread(b, 1, file->size, fp);
+		r = fread(b, 1, file->size, fp);
+        if (r < 0) {
+            printf("Error reading file.\n");
+            goto out; // ??
+        }
 		fclose(fp);
 
 		r = sc_update_binary(card, 0, b, file->size, 0);


### PR DESCRIPTION
Im using the OpenSC project to do some tests with smartcards and got annoyed by continuous warnings about const casts:

The OpenSC project master creates quite some warning concerning due to cons u8 \* conversions to u8 *. These are correct but should be properly cast. There are some unused variables which also cause warnings. I simply got tired of them and wanted to avoid most (if not all) warnings as possible. Some are invalid and I added pragma statements to ignore the warnings. 
