### PR TITLE
Reduce indicated maximum PIN length to 15 to support more PIN pad readers

### DIFF
--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -838,9 +838,9 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 	pin_info.attrs.pin.reference = 0x81;
 	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_LOCAL|SC_PKCS15_PIN_FLAG_INITIALIZED|SC_PKCS15_PIN_FLAG_UNBLOCK_DISABLED|SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA;
 	pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC;
-	pin_info.attrs.pin.min_length = 4;
+	pin_info.attrs.pin.min_length = 6;
 	pin_info.attrs.pin.stored_length = 0;
-	pin_info.attrs.pin.max_length = 16;
+	pin_info.attrs.pin.max_length = 15;
 	pin_info.attrs.pin.pad_char = '\0';
 	pin_info.tries_left = 3;
 	pin_info.max_tries = 3;


### PR DESCRIPTION
Some PIN PAD reader only support a PIN length up to 15 characters (Most notably REINER SCT Cyberjack readers). The SmartCard-HSM support a PIN in the range 6 to 16 characters, however the PIN range indicated to the reader leads to an error returned in pcsc_pin_cmd().

The proposed patch reduces the advertised maximum PIN length to 15, effectively preventing this problem with affected readers. Please note, that the SmartCard-HSM up to version 1.2 allows changing the PIN size only during initialization.
