### PR TITLE
iso7816: allow extended length APDUs

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -831,6 +831,9 @@ iso7816_compute_signature(struct sc_card *card,
 	apdu.datalen = datalen;
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
+		LOG_FUNC_RETURN(card->ctx, apdu.resplen);
+	}
 
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "Card returned error");


### PR DESCRIPTION
Other card drivers typically use `sc_get_iso7816_driver()->ops` for initialisation. With the proposed change the ISO ops can be reused when the card (driver) that builds upon it allows using extended length APDUs.
