### PR TITLE
Fix error when signing with Swedish BankID card

### DIFF
--- a/src/libopensc/card-setcos.c
+++ b/src/libopensc/card-setcos.c
@@ -618,7 +618,9 @@ static int setcos_set_security_env2(sc_card_t *card,
 		memcpy(p, env->file_ref.value, env->file_ref.len);
 		p += env->file_ref.len;
 	}
-	if (env->flags & SC_SEC_ENV_KEY_REF_PRESENT) {
+	if (env->flags & SC_SEC_ENV_KEY_REF_PRESENT &&
+	    !(card->type == SC_CARD_TYPE_SETCOS_NIDEL ||
+	      card->type == SC_CARD_TYPE_SETCOS_FINEID_V2_2048)) {
 		if (env->flags & SC_SEC_ENV_KEY_REF_ASYMMETRIC)
 			*p++ = 0x83;
 		else


### PR DESCRIPTION
Some Swedish BankID cards (at least card type 6006 and probably 6005) have key reference 0, but SC_SEC_ENV_KEY_REF_PRESENT should not be set since this causes an error when creating a signature (using fribid on Ubuntu x64). Also see http://en.it-usenet.org/thread/11873/12745/. This commit fixes #265 
