### PR TITLE
Fixed error in padding for pkcs15, it would fail due to incorrect flags.

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -447,7 +447,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	if (pad_flags != 0) {
 		size_t tmplen = sizeof(buf);
 
-		r = sc_pkcs1_encode(ctx, pad_flags, tmp, inlen, tmp, &tmplen, modlen);
+		r = sc_pkcs1_encode(ctx, flags, tmp, inlen, tmp, &tmplen, modlen);
 		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, r, "Unable to add padding");
 
 		inlen = tmplen;


### PR DESCRIPTION
The file pkcs15-sec contains (probably) a simple error:
On line 450 the pkcs1 encoding function is called with pad_flags, while the
pkcs1_encode function also requires information about the hashing algorithm. Using
the pad_flags variable instead of the flags variable results in an error when
a specific hash function is specified by for instance the command
"pkcs11-tool --module opensc-pkcs11.so -s -m SHA256-RSA-PKCS -l -i test.dat".

Switching to 'flags' instead of 'pad_flags' provides the information required.

Another option would be to include the algo->flags in the call but since the entire flags uint is bitwise encoded it should not be a problem.
