### PR TITLE
openpgp-tool: Return EXIT_SUCCESS if no error occurs

### DIFF
--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -410,7 +410,7 @@ int main(int argc, char **argv)
 	sc_card_t *card = NULL;
 	int r;
 	int argind = 0;
-	int exit_status = EXIT_FAILURE;
+	int exit_status = EXIT_SUCCESS;
 
 	/* decode options */
 	argind = decode_options(argc, argv);


### PR DESCRIPTION
exit_status is either set directly or a function return is ORed with it,
in which case EXIT_SUCCESS can never be returned if the initial value is !=
0;
