### PR TITLE
EC key storing: make sure algorithm params are available

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -1503,8 +1503,10 @@ sc_pkcs15init_store_public_key(struct sc_pkcs15_card *p15card, struct sc_profile
 		break;
 	case SC_ALGORITHM_EC:
 		type = SC_PKCS15_TYPE_PUBKEY_EC;
+		/* if key does not have curve... */
+		if (!key.u.ec.params.named_curve)
+			key.u.ec.params = keyargs->params.ec;
 
-		key.u.ec.params = keyargs->params.ec;
 		sc_pkcs15_fix_ec_parameters(ctx, &key.u.ec.params);
 
 		keybits = key.u.ec.params.field_length;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -100,7 +100,6 @@ static int	do_sanity_check(struct sc_profile *profile);
 
 static int	init_keyargs(struct sc_pkcs15init_prkeyargs *);
 static void	init_gost_params(struct sc_pkcs15init_keyarg_gost_params *, EVP_PKEY *);
-static void	init_ec_params(struct sc_pkcs15_ec_parameters *, EVP_PKEY *);
 static int	get_pin_callback(struct sc_profile *profile,
 			int id, const struct sc_pkcs15_auth_info *info,
 			const char *label,
@@ -888,8 +887,11 @@ do_store_private_key(struct sc_profile *profile)
 	r = sc_pkcs15_convert_prkey(&args.key, pkey);
 	if (r < 0)
 		return r;
+	if (args.key.algorithm == SC_ALGORITHM_EC) {
+		sc_pkcs15_fix_ec_parameters(ctx, &args.key.u.ec.params);
+		args.params.ec = args.key.u.ec.params;
+	}
 	init_gost_params(&args.params.gost, pkey);
-	init_ec_params(&args.params.ec, pkey);
 
 	if (ncerts) {
 		unsigned int	usage;
@@ -1042,10 +1044,8 @@ do_store_public_key(struct sc_profile *profile, EVP_PKEY *pkey)
 		r = do_read_public_key(opt_infile, opt_format, &pkey);
 	if (r >= 0) {
 		r = sc_pkcs15_convert_pubkey(&args.key, pkey);
-		if (r >= 0) {
+		if (r >= 0)
 			init_gost_params(&args.params.gost, pkey);
-			init_ec_params(&args.params.ec, pkey);
-		}
 	}
 	if (r >= 0)
 		r = sc_pkcs15init_store_public_key(p15card, profile, &args, &dummy);
@@ -1582,41 +1582,6 @@ init_gost_params(struct sc_pkcs15init_keyarg_gost_params *params, EVP_PKEY *pkey
 #else
 	(void)params, (void)pkey; /* no warning */
 #endif
-}
-
-
-static void
-init_ec_params(struct sc_pkcs15_ec_parameters *params, EVP_PKEY *pkey)
-{
-#if defined(ENABLE_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
-	EC_KEY *key;
-
-	assert(pkey);
-	if (pkey->type == EVP_PKEY_EC) {
-		const EC_GROUP *grp = NULL;
-		int nid;
-
-		key = EVP_PKEY_get0(pkey);
-		assert(key);
-		assert(params);
-
-		grp = EC_KEY_get0_group(key);
-		assert(grp);
-
-		/* get curve name */
-		nid = EC_GROUP_get_curve_name(grp);
-		if(nid != 0) {
-			const char *name = OBJ_nid2sn(nid);
-			if(sizeof(name) > 0)
-				params->named_curve = strdup(name);
-		}
-
-		sc_pkcs15_fix_ec_parameters(ctx, params);
-	}
-#else
-	(void)params, (void)pkey; /* no warning */
-#endif
-
 }
 
 /*


### PR DESCRIPTION
When trying to import EC keys onto a card with pkcs15-init, the
params.ec of sc_pkcs15init_prkeyargs or pubkeyargs had not been
initialized. This commit fixes that by reading the curve name from the
EVP_KEY and initializing the parameters.

Also, in sc_pkcs15_encode_pubkey_as_spki, this commit adds code that
tries to construct the EC algorithm params from the key itself. This
prevents a NULL parameter in the SPKI/ASN1 encoding.