### PR TITLE
Fix Lc byte in VERIFY PIN block for PC/SC PIN PAD reader

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -217,6 +217,12 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 	}
+
+	data->pin1.offset = 5;
+	data->pin1.length_offset = 4;
+	data->pin2.offset = 5;
+	data->pin2.length_offset = 4;
+
 	return (*iso_ops->pin_cmd)(card, data, tries_left);
 }
 


### PR DESCRIPTION
The SmartCard-HSM uses a variable-length PIN, whose length is indicated in Lc.

This patch changes the PC/SC PIN Block used for PIN PAD reader and removes the Lc byte, which is automatically added by the reader.

This patch partially fixes #309, however while PIN verification now works on Windows, PIN modify fails with this reader on Linux. The issue is related to a firmware bug confirmed by Identiv.
