### PR TITLE
Fix bug in verbose flag handling.

### DIFF
--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -75,6 +75,19 @@ static const char *option_help[] = {
 static sc_context_t *ctx = NULL;
 static sc_card_t *card = NULL;
 
+static int check_apdu(const sc_apdu_t *apdu)
+{
+	if (apdu->sw1 != 0x90 || apdu->sw2 != 00 || verbose) {
+		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
+			apdu->sw1, apdu->sw2, apdu->resplen ? ":" : "");
+		if (apdu->resplen)
+			util_hex_dump_asc(stdout, apdu->resp, apdu->resplen, -1);
+		if (apdu->sw1 != 0x90 || apdu->sw2 != 0x00)
+			return 1;
+	}
+	return 0;
+}
+
 static int cardos_info(void)
 {
 	sc_apdu_t apdu;
@@ -107,13 +120,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	printf("Info : %s\n", apdu.resp);
 
 	apdu.p2 = 0x82;
@@ -124,16 +132,11 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resp[0] == 0xc9)
 		is_cardos5 = 1;
-	
+
 	apdu.p2 = 0x81;
 	apdu.resplen = sizeof(rbuf);
 	r = sc_transmit_apdu(card, &apdu);
@@ -142,15 +145,10 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (is_cardos5)	{
-		printf("Serial number: %02x %02x %02x %02x %02x %02x %02x %02x\n",	
+		printf("Serial number: %02x %02x %02x %02x %02x %02x %02x %02x\n",
 			apdu.resp[0], apdu.resp[1], apdu.resp[2], apdu.resp[3],
 			apdu.resp[4], apdu.resp[5], apdu.resp[6], apdu.resp[7]);
 	} else	{
@@ -162,7 +160,7 @@ static int cardos_info(void)
 		if (apdu.resplen)
 			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
 	}
-	
+
 	apdu.p2 = 0x82;
 	apdu.resplen = sizeof(rbuf);
 	r = sc_transmit_apdu(card, &apdu);
@@ -171,13 +169,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	printf("OS Version: %d.%d", apdu.resp[0], apdu.resp[1]);
 	if (apdu.resp[0] == 0xc8 && apdu.resp[1] == 0x02) {
 		printf(" (that's CardOS M4.0)\n");
@@ -211,14 +204,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 0x00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
-
 
 	printf("Current life cycle: ");
 	if (rbuf[0] == 0x34) {
@@ -252,13 +239,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("Security Status of current DF:\n");
 	util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
@@ -271,13 +253,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("Free memory : %d\n", rbuf[0]<<8|rbuf[1]);
 
@@ -289,13 +266,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	if (rbuf[0] == 0x00) {
 		printf("ATR Status: 0x%d ROM-ATR\n",rbuf[0]);
@@ -313,13 +285,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("Packages installed:\n");
 	util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
@@ -332,17 +299,12 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	if (is_cardos5)
 		printf("Ram size: %d, Eeprom size: %d, cpu type: %x, chip config: %d, chip manufacturer: %d\n",
-			rbuf[0]<<8|rbuf[1], rbuf[2]<<8|rbuf[3], rbuf[4], rbuf[6], rbuf[7]);	
+			rbuf[0]<<8|rbuf[1], rbuf[2]<<8|rbuf[3], rbuf[4], rbuf[6], rbuf[7]);
 	else
 		printf("Ram size: %d, Eeprom size: %d, cpu type: %x, chip config: %d\n",
 			rbuf[0]<<8|rbuf[1], rbuf[2]<<8|rbuf[3], rbuf[4], rbuf[5]);
@@ -355,13 +317,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	if (is_cardos5)
 		printf("Free eeprom memory: %d\n", rbuf[0]<<24|rbuf[1]<<16|rbuf[2]<<8|rbuf[3]);
@@ -376,13 +333,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("Current Maximum Data Field Length: %d\n", rbuf[0]<<8|rbuf[1]);
 
@@ -395,18 +347,13 @@ static int cardos_info(void)
 				sc_strerror(r));
 			return 1;
 		}
-		if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-			fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-				apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-			if (apdu.resplen)
-				util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+		if (check_apdu(&apdu))
 			return 1;
-		}
-	
+
 		printf("Complete chip production data:\n");
 		util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
 	}
-	
+
 	apdu.p2 = 0x96;
 	apdu.resplen = sizeof(rbuf);
 	r = sc_transmit_apdu(card, &apdu);
@@ -415,13 +362,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("System keys: PackageLoadKey (version 0x%02x, retries %d)\n",
 			rbuf[0], rbuf[1]);
@@ -436,14 +378,8 @@ static int cardos_info(void)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Unable to determine current DF:\n");
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("Path to current DF:\n");
 	util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
@@ -624,13 +560,8 @@ static int cardos_format(const char *opt_startkey)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen != 0x02) {
 		printf("did not receive version info, aborting\n");
 		return 1;
@@ -663,13 +594,8 @@ static int cardos_format(const char *opt_startkey)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen < 0x04) {
 		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
 		printf("aborting\n");
@@ -689,7 +615,7 @@ static int cardos_format(const char *opt_startkey)
 
 	/* first run GET DATA for lifecycle	 00 CA 01 83
 	 * returns 34 MANUFACTURING 20 ADMINISTRATION 10 OPERATIONAL
-	 * 26 INITIALITATION, 23 PERSINALIZATION 3f DEATH
+	 * 26 INITIALIZATION, 23 PERSONALIZATION 3f DEATH
 	 * 29 ERASE IN PROGRESS
  	 * */
 
@@ -709,13 +635,8 @@ static int cardos_format(const char *opt_startkey)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	if (apdu.resp[0] == 0x34) {
 		printf("card in manufacturing state\n");
@@ -724,7 +645,7 @@ static int cardos_format(const char *opt_startkey)
 		/* we can leave manufacturing mode with FORMAT,
  		 * but before we do that, we need to change the secret
  		 * siemens start key to the default 0xff start key.
- 		 * we know the APDU for that, but it is secreat and
+ 		 * we know the APDU for that, but it is secret and
  		 * siemens so far didn't allow us to publish it.
  		 */
 	}
@@ -743,7 +664,7 @@ static int cardos_format(const char *opt_startkey)
 	}
 	printf("card in operational state, need to switch to admin state\n");
 
-	/* PHASE CONTORL 80 10 00 00 */
+	/* PHASE CONTROL 80 10 00 00 */
 
 	memset(&apdu, 0, sizeof(apdu));
 	apdu.cla = 0x80;
@@ -760,15 +681,10 @@ static int cardos_format(const char *opt_startkey)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
-	/* use GET DATA for lifecacle one more */
+	/* use GET DATA for lifecycle once more */
 
 	memset(&apdu, 0, sizeof(apdu));
 	apdu.cla = 0x00;
@@ -786,13 +702,8 @@ static int cardos_format(const char *opt_startkey)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resp[0] != 0x20) {
 		printf("card not in administrative state, failed\n");
 		printf("aborting\n");
@@ -823,13 +734,8 @@ admin_state:
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen != 0x00) {
 		printf("card has packages installed.\n");
 		printf("you would loose those, and we can't re-install them.\n");
@@ -867,13 +773,8 @@ admin_state:
 				sc_strerror(r));
 			return 1;
 		}
-		if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-			fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-				apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-			if (apdu.resplen)
-				util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+		if (check_apdu(&apdu))
 			return 1;
-		}
 	}
 
 erase_state:
@@ -921,13 +822,8 @@ erase_state:
 				sc_strerror(r));
 			return 1;
 		}
-		if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-			fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-				apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-			if (apdu.resplen)
-				util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+		if (check_apdu(&apdu))
 			return 1;
-		}
 	}
 	return 0;
 }
@@ -983,13 +879,8 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen != 0x02) {
 		printf("did not receive version info, aborting\n");
 		return 1;
@@ -1024,13 +915,8 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen < 0x04) {
 		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
 		printf("aborting\n");
@@ -1089,13 +975,8 @@ change_startkey:
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 
 	printf("change startkey command issued with success\n");
 
@@ -1119,13 +1000,8 @@ change_startkey:
 			sc_strerror(r));
 		return 1;
 	}
-	if (apdu.sw1 != 0x90 || apdu.sw2 != 00 || verbose) {
-		fprintf(stderr, "Received (SW1=0x%02X, SW2=0x%02X)%s\n",
-			apdu.sw1, apdu.sw2, apdu.resplen ? ":" : "");
-		if (apdu.resplen)
-			util_hex_dump_asc(stdout, apdu.resp, apdu.resplen, -1);
+	if (check_apdu(&apdu))
 		return 1;
-	}
 	if (apdu.resplen < 0x04) {
 		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %u\n", apdu.resplen);
 		printf("aborting\n");


### PR DESCRIPTION
Using the verbose flag was causing cardos-tool to return as if an error
had occured.
