### PR TITLE
C_Digest  does not handle size query correctly Issue #327

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -195,6 +195,25 @@ done:
 }
 
 CK_RV
+sc_pkcs11_md_size(struct sc_pkcs11_session *session,
+			CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
+{
+	sc_pkcs11_operation_t *op;
+	CK_RV rv;
+
+	rv = session_get_operation(session, SC_PKCS11_OPERATION_DIGEST, &op);
+	if (rv != CKR_OK)
+		LOG_FUNC_RETURN(context, rv);
+
+	rv = op->type->md_size(op, pData, pulDataLen);
+	if (rv == CKR_BUFFER_TOO_SMALL || rv == CKR_OK)
+		LOG_FUNC_RETURN(context, rv);
+
+	session_stop_operation(session, SC_PKCS11_OPERATION_DIGEST);
+	LOG_FUNC_RETURN(context, rv);
+}
+
+CK_RV
 sc_pkcs11_md_final(struct sc_pkcs11_session *session,
 			CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -37,6 +37,7 @@ static sc_pkcs11_mechanism_type_t find_mechanism = {
 	NULL,		/* md_init */
 	NULL,		/* md_update */
 	NULL,		/* md_final */
+	NULL,           /* md_size */
 	NULL,		/* sign_init */
 	NULL,		/* sign_update */
 	NULL,		/* sign_final */
@@ -520,6 +521,13 @@ C_Digest(CK_SESSION_HANDLE hSession,		/* the session's handle */
 	rv = get_session(hSession, &session);
 	if (rv != CKR_OK)
 		goto out;
+
+	/*
+	 * Issue #327 PKCS#11 2.20 11.2 Must check size before doing the update
+	 */
+	rv  = sc_pkcs11_md_size(session, pDigest, pulDigestLen);
+	if (rv == CKR_BUFFER_TOO_SMALL || !pDigest)
+	    return rv;
 
 	rv = sc_pkcs11_md_update(session, pData, ulDataLen);
 	if (rv == CKR_OK)

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -250,6 +250,8 @@ struct sc_pkcs11_mechanism_type {
 					CK_BYTE_PTR, CK_ULONG);
 	CK_RV		  (*md_final)(sc_pkcs11_operation_t *,
 					CK_BYTE_PTR, CK_ULONG_PTR);
+	CK_RV             (*md_size)(sc_pkcs11_operation_t *,
+	                                CK_BYTE_PTR, CK_ULONG_PTR);
 
 	CK_RV		  (*sign_init)(sc_pkcs11_operation_t *,
 					struct sc_pkcs11_object *);
@@ -382,6 +384,7 @@ CK_RV sc_pkcs11_get_mechanism_info(struct sc_pkcs11_card *, CK_MECHANISM_TYPE,
 CK_RV sc_pkcs11_md_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR);
 CK_RV sc_pkcs11_md_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 CK_RV sc_pkcs11_md_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV sc_pkcs11_md_size(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_sign_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR,
 				struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
 CK_RV sc_pkcs11_sign_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);


### PR DESCRIPTION
Code added to allow C_Digest to handle buffer size querry and CKR_BUFFER_TOO_SMALL
before doing the md_update function.
