### PR TITLE
Add support for ACOS5-64 cards.

### DIFF
--- a/src/libopensc/card-acos5.c
+++ b/src/libopensc/card-acos5.c
@@ -26,6 +26,8 @@
 #include "cardctl.h"
 
 static struct sc_atr_table acos5_atrs[] = {
+	{"3b:be:96:00:00:41:05:20:00:00:00:00:00:00:00:00:00:90:00", NULL, NULL,
+	SC_CARD_TYPE_ACOS5_GENERIC, 0, NULL},
 	{"3b:be:18:00:00:41:05:10:00:00:00:00:00:00:00:00:00:90:00", NULL, NULL,
 	 SC_CARD_TYPE_ACOS5_GENERIC, 0, NULL},
 	{NULL, NULL, NULL, 0, 0, NULL}


### PR DESCRIPTION
The ACOS5-64 cards have a different ATR than the original
ACOS5-32 cards. This change simply adds this ATR so that it
will be recognized properly.