### PR TITLE
Fix for ePass2003 smart card token concurrency issues

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -450,7 +450,9 @@ epass2003_refresh(struct sc_card *card)
 	int r = SC_SUCCESS;
 
 	if (g_sm) {
+		card->sm_ctx.sm_mode = 0;		
 		r = mutual_auth(card, g_init_key_enc, g_init_key_mac);
+		card->sm_ctx.sm_mode = SM_MODE_TRANSMIT;
 		LOG_TEST_RET(card->ctx, r, "mutual_auth failed");
 	}
 
@@ -947,9 +949,7 @@ epass2003_init(struct sc_card *card)
 	card->name = "epass2003";
 	card->cla = 0x00;
 	card->drv_data = NULL;
-/* VT
-	card->ctx->use_sm = 1;
-*/
+//	card->ctx->use_sm = 1;
 
 	g_sm = SM_SCP01;
 	/* g_sm = SM_PLAIN; */

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -334,6 +334,8 @@ int sc_lock(sc_card_t *card)
 				/* invalidate cache */
 				memset(&card->cache, 0, sizeof(card->cache));
 				card->cache.valid = 0;
+				if (card->sm_ctx.ops.open)
+					card->sm_ctx.ops.open(card);
 				r = card->reader->ops->lock(card->reader);
 			}
 		}


### PR DESCRIPTION
Please see issue #364 for discussion of original problem and explanation of changes. 