### PR TITLE
PKCS#11: Improve compliance for public keys.

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2274,18 +2274,18 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 			bn = &rsa->modulus; break;
 		case CKA_PUBLIC_EXPONENT:
 			bn = &rsa->exponent; break;
-        case CKA_VERIFY:
-            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFY);
-            break;
-        case CKA_VERIFY_RECOVER:
-            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER);
-            break;
-        case CKA_ENCRYPT:
-            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_ENCRYPT);
-            break;
-        case CKA_WRAP:
-            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_WRAP);
-            break;
+		case CKA_VERIFY:
+			args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFY);
+			break;
+		case CKA_VERIFY_RECOVER:
+			args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER);
+			break;
+		case CKA_ENCRYPT:
+			args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_ENCRYPT);
+			break;
+		case CKA_WRAP:
+			args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_WRAP);
+			break;
 		default:
 			/* ignore unknown attrs, or flag error? */
 			continue;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2274,6 +2274,18 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 			bn = &rsa->modulus; break;
 		case CKA_PUBLIC_EXPONENT:
 			bn = &rsa->exponent; break;
+        case CKA_VERIFY:
+            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFY);
+            break;
+        case CKA_VERIFY_RECOVER:
+            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER);
+            break;
+        case CKA_ENCRYPT:
+            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_ENCRYPT);
+            break;
+        case CKA_WRAP:
+            args.usage |= pkcs15_check_bool_cka(attr, SC_PKCS15_PRKEY_USAGE_WRAP);
+            break;
 		default:
 			/* ignore unknown attrs, or flag error? */
 			continue;


### PR DESCRIPTION
  * Key usage required when calling C_CreateObject for public key were not used.
    This adds the logic to convert from PKCS#11 attributes to PKCS#15 in the
    structure that is sent to underlying _store_pubkey functions.