### PR TITLE
pkcs15init: superpluous 'ec-params' in init data

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2751,7 +2751,7 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 		/* TODO: check allowed values of keybits */
 	}
 	else if (keytype == CKK_EC)   {
-		struct sc_pkcs15_der *der = &keygen_args.prkey_args.params.ec.der;
+		struct sc_pkcs15_der *der = &keygen_args.prkey_args.key.u.ec.params.der;
 
 		der->len = sizeof(struct sc_object_id);
 		rv = attr_find_ptr(pPubTpl, ulPubCnt, CKA_EC_PARAMS, (void **)&der->value, &der->len);

--- a/src/pkcs15init/pkcs15-init.h
+++ b/src/pkcs15init/pkcs15-init.h
@@ -216,7 +216,6 @@ struct sc_pkcs15init_prkeyargs {
 
 	union {
 		struct sc_pkcs15init_keyarg_gost_params gost;
-		struct sc_pkcs15_ec_parameters ec;
 	} params;
 
 	struct sc_pkcs15_prkey	key;
@@ -236,7 +235,6 @@ struct sc_pkcs15init_pubkeyargs {
 
 	union {
 		struct sc_pkcs15init_keyarg_gost_params gost;
-		struct sc_pkcs15_ec_parameters ec;
 	} params;
 
 	struct sc_pkcs15_pubkey	key;

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -1214,8 +1214,8 @@ sc_pkcs15init_init_prkdf(struct sc_pkcs15_card *p15card, struct sc_profile *prof
 		keyinfo_gostparams->gost28147 = keyargs->params.gost.gost28147;
 	}
 	else if (key->algorithm == SC_ALGORITHM_EC)  {
-		struct sc_pkcs15_ec_parameters *ecparams = &keyargs->params.ec;
-		key_info->params.data = &keyargs->params.ec;
+		struct sc_pkcs15_ec_parameters *ecparams = &keyargs->key.u.ec.params;
+		key_info->params.data = &keyargs->key.u.ec.params;
 		key_info->params.free_params = sc_pkcs15init_empty_callback;
 		key_info->field_length = ecparams->field_length;
 	}
@@ -1317,7 +1317,7 @@ sc_pkcs15init_generate_key(struct sc_pkcs15_card *p15card, struct sc_profile *pr
 	if (keygen_args->prkey_args.key.algorithm == SC_ALGORITHM_GOSTR3410)
 		pubkey_args.params.gost = keygen_args->prkey_args.params.gost;
 	else if (keygen_args->prkey_args.key.algorithm == SC_ALGORITHM_EC)
-		pubkey_args.params.ec = keygen_args->prkey_args.params.ec;
+		pubkey_args.key.u.ec.params = keygen_args->prkey_args.key.u.ec.params;
 
 	/* Generate the private key on card */
 	r = profile->ops->create_key(profile, p15card, object);
@@ -1504,8 +1504,9 @@ sc_pkcs15init_store_public_key(struct sc_pkcs15_card *p15card, struct sc_profile
 	case SC_ALGORITHM_EC:
 		type = SC_PKCS15_TYPE_PUBKEY_EC;
 
-		key.u.ec.params = keyargs->params.ec;
-		sc_pkcs15_fix_ec_parameters(ctx, &key.u.ec.params);
+		key.u.ec.params = keyargs->key.u.ec.params;
+		r = sc_pkcs15_fix_ec_parameters(ctx, &key.u.ec.params);
+		LOG_TEST_RET(ctx, r, "Failed to fix EC public key parameters");
 
 		keybits = key.u.ec.params.field_length;
 		break;
@@ -1972,7 +1973,7 @@ check_keygen_params_consistency(struct sc_card *card, struct sc_pkcs15init_keyge
 	int i, rv;
 
 	if (alg == SC_ALGORITHM_EC)   {
-		struct sc_pkcs15_ec_parameters *ecparams = &params->prkey_args.params.ec;
+		struct sc_pkcs15_ec_parameters *ecparams = &params->prkey_args.key.u.ec.params;
 
 		rv = sc_pkcs15_fix_ec_parameters(ctx, ecparams);
 		LOG_TEST_RET(ctx, rv, "Cannot fix EC parameters");
@@ -2150,9 +2151,12 @@ prkey_bits(struct sc_pkcs15_card *p15card, struct sc_pkcs15_prkey *key)
 		}
 		return SC_PKCS15_GOSTR3410_KEYSIZE;
 	case SC_ALGORITHM_EC:
-		/* calculation returns one bit too small, add one bu default */
-		sc_log(ctx, "Private EC key length %u", sc_pkcs15init_keybits(&key->u.ec.privateD) + 1);
-		return sc_pkcs15init_keybits(&key->u.ec.privateD) + 1;
+		sc_log(ctx, "Private EC key length %u", key->u.ec.params.field_length);
+		if (key->u.ec.params.field_length == 0)   {
+			sc_log(ctx, "Invalid EC key length");
+			return SC_ERROR_OBJECT_NOT_VALID;
+		}
+		return key->u.ec.params.field_length;
 	}
 	sc_log(ctx, "Unsupported key algorithm.");
 	return SC_ERROR_NOT_SUPPORTED;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1524,7 +1524,7 @@ do_generate_key(struct sc_profile *profile, const char *spec)
 
 	if (*spec)   {
 		if (isalpha(*spec) && keygen_args.prkey_args.key.algorithm == SC_ALGORITHM_EC)   {
-			keygen_args.prkey_args.params.ec.named_curve = strdup(spec);
+			keygen_args.prkey_args.key.u.ec.params.named_curve = strdup(spec);
 			keybits = 0;
 		}
 		else {


### PR DESCRIPTION
Pkcs15init data, used to import/generate key objects with <I>pkcs15-init</i> tool,
include twice the same <i>EC parameters</i> data:
 - explicit <i>params</i> member in <i>pkcs15init-args</i> data
 - part of <i>sc_pkcs15_pubkey/sc_pkcs15_prkey</i>

Explicit <i>params</i> is removed.