### PR TITLE
Fix-up changes caused by Coverity scan See #366

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1557,7 +1557,8 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 
 	r = sc_lock(card);
 	if (r != SC_SUCCESS)
-		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "sc_lock failed\n");
+		goto err; /* cleanup */
 	locked = 1;
 
 	p = sbuf;
@@ -1827,7 +1828,8 @@ static int piv_general_external_authenticate(sc_card_t *card,
 
 	r = sc_lock(card);
 	if (r != SC_SUCCESS)
-		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "sc_lock failed\n");
+		goto err; /* cleanup */
 	locked = 1;
 
 	p = sbuf;

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -494,8 +494,8 @@ int main(int argc, char * const argv[])
 			action_count++;
 			break;
 		case 'Z':
-			/* fall through */
 			compress_cert = 1;
+			/* fall through */
 		case 'C':
 			do_load_cert = 1;
 			cert_id = optarg;

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -494,10 +494,7 @@ int main(int argc, char * const argv[])
 			action_count++;
 			break;
 		case 'Z':
-			/*
-			-Z is the same as -C but -Z says the cert is compressed.
-			https://github.com/OpenSC/OpenSC/commit/3a92bf7af5aaa85fdbc0434d0a55393e68e0f98d#commitcomment-9636487
-			*/
+			/* fall through */
 			compress_cert = 1;
 		case 'C':
 			do_load_cert = 1;


### PR DESCRIPTION
piv-tool.c add  /* fall through */ to avoif false warning
card-piv.c - clean up if sc_lock fails.