### PR TITLE
Introduce EC curve OID into internal algorithm info data

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1804,7 +1804,7 @@ sc_encode_oid (struct sc_context *ctx, struct sc_object_id *id,
 		unsigned char **out, size_t *size)
 {
 	static const struct sc_asn1_entry c_asn1_object_id[2] = {
-        	{ "oid", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, SC_ASN1_ALLOC, NULL, NULL },
+		{ "oid", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, SC_ASN1_ALLOC, NULL, NULL },
 		{ NULL, 0, 0, 0, NULL, NULL }
 	};
 	struct sc_asn1_entry asn1_object_id[2];

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -119,9 +119,9 @@ static int myeid_init(struct sc_card *card)
     flags |= SC_ALGORITHM_ECDSA_RAW;
 	ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES; 
 
-	_sc_card_add_ec_alg(card, 192, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 224, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 256, flags, ext_flags);
+	_sc_card_add_ec_alg(card, 192, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 224, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);
 #endif
         
 	/* State that we have an RNG */

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2882,8 +2882,8 @@ static int piv_init(sc_card_t *card)
 	flags = SC_ALGORITHM_ECDSA_RAW;
 	ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
-	_sc_card_add_ec_alg(card, 256, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 384, flags, ext_flags);
+	_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 384, flags, ext_flags, NULL);
 
 	card->caps |= SC_CARD_CAP_RNG;
 

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1053,10 +1053,10 @@ static int sc_hsm_init(struct sc_card *card)
 			SC_ALGORITHM_EXT_EC_NAMEDCURVE|
 			SC_ALGORITHM_EXT_EC_UNCOMPRESES|
 			SC_ALGORITHM_ONBOARD_KEY_GEN;
-	_sc_card_add_ec_alg(card, 192, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 224, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 256, flags, ext_flags);
-	_sc_card_add_ec_alg(card, 320, flags, ext_flags);
+	_sc_card_add_ec_alg(card, 192, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 224, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);
+	_sc_card_add_ec_alg(card, 320, flags, ext_flags, NULL);
 
 	card->caps |= SC_CARD_CAP_RNG|SC_CARD_CAP_APDU_EXT;
 

--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -121,7 +121,8 @@ int _sc_card_add_algorithm(struct sc_card *card, const struct sc_algorithm_info 
 int _sc_card_add_rsa_alg(struct sc_card *card, unsigned int key_length,
 			 unsigned long flags, unsigned long exponent);
 int _sc_card_add_ec_alg(struct sc_card *card, unsigned int key_length,
-			 unsigned long flags, unsigned long ext_flags);
+			 unsigned long flags, unsigned long ext_flags,
+			 struct sc_object_id *curve_oid);
 
 /********************************************************************/
 /*                 pkcs1 padding/encoding functions                 */

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -191,10 +191,23 @@ struct sc_pbes2_params {
 	struct sc_algorithm_id key_encr_alg;
 };
 
-struct sc_ec_params {
+/*
+ * The ecParameters can be presented as
+ * - name of curve;
+ * - OID of named curve;
+ * - implicit parameters.
+ *
+ * type - type(choice) of 'EC domain parameters' as it present in CKA_EC_PARAMS (PKCS#11).
+          Recommended value '1' -- namedCurve.
+ * field_length - EC key size in bits.
+ */
+struct sc_ec_parameters {
+	char *named_curve;
+	struct sc_object_id id;
+	struct sc_lv_data der;
+
 	int type;
-	u8 * der;
-	size_t der_len;
+	size_t field_length;
 };
 
 typedef struct sc_algorithm_info {
@@ -208,6 +221,7 @@ typedef struct sc_algorithm_info {
 		} _rsa;
 		struct sc_ec_info {
 			unsigned ext_flags;
+			struct sc_ec_parameters params;
 		} _ec;
 	} u;
 } sc_algorithm_info_t;
@@ -1282,7 +1296,7 @@ void sc_print_cache(struct sc_card *card);
 struct sc_algorithm_info * sc_card_find_rsa_alg(struct sc_card *card,
 		unsigned int key_length);
 struct sc_algorithm_info * sc_card_find_ec_alg(struct sc_card *card,
-		unsigned int field_length);
+		unsigned int field_length, struct sc_object_id *curve_oid);
 struct sc_algorithm_info * sc_card_find_gostr3410_alg(struct sc_card *card,
 		unsigned int key_length);
 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -374,7 +374,7 @@ static int sc_pkcs15emu_sc_hsm_get_rsa_public_key(struct sc_context *ctx, sc_cvc
 
 static int sc_pkcs15emu_sc_hsm_get_ec_public_key(struct sc_context *ctx, sc_cvc_t *cvc, struct sc_pkcs15_pubkey *pubkey)
 {
-	struct sc_ec_params *ecp;
+	struct sc_ec_parameters *ecp;
 	const struct sc_lv_data *oid;
 	int r;
 
@@ -384,18 +384,18 @@ static int sc_pkcs15emu_sc_hsm_get_ec_public_key(struct sc_context *ctx, sc_cvc_
 	if (r != SC_SUCCESS)
 		return r;
 
-	ecp = calloc(1, sizeof(struct sc_ec_params));
+	ecp = calloc(1, sizeof(struct sc_ec_parameters));
 	if (!ecp)
 		return SC_ERROR_OUT_OF_MEMORY;
 
-	ecp->der_len = oid->len + 2;
-	ecp->der = calloc(ecp->der_len, 1);
-	if (!ecp->der)
+	ecp->der.len = oid->len + 2;
+	ecp->der.value = calloc(ecp->der.len, 1);
+	if (!ecp->der.value)
 		return SC_ERROR_OUT_OF_MEMORY;
 
-	ecp->der[0] = 0x06;
-	ecp->der[1] = (u8)oid->len;
-	memcpy(ecp->der + 2, oid->value, oid->len);
+	*(ecp->der.value + 0) = 0x06;
+	*(ecp->der.value + 1) = (u8)oid->len;
+	memcpy(ecp->der.value + 2, oid->value, oid->len);
 	ecp->type = 1;		// Named curve
 
 	pubkey->alg_id = (struct sc_algorithm_id *)calloc(1, sizeof(struct sc_algorithm_id));
@@ -411,11 +411,11 @@ static int sc_pkcs15emu_sc_hsm_get_ec_public_key(struct sc_context *ctx, sc_cvc_
 	memcpy(pubkey->u.ec.ecpointQ.value, cvc->publicPoint, cvc->publicPointlen);
 	pubkey->u.ec.ecpointQ.len = cvc->publicPointlen;
 
-	pubkey->u.ec.params.der.value = malloc(ecp->der_len);
+	pubkey->u.ec.params.der.value = malloc(ecp->der.len);
 	if (!pubkey->u.ec.params.der.value)
 		return SC_ERROR_OUT_OF_MEMORY;
-	memcpy(pubkey->u.ec.params.der.value, ecp->der, ecp->der_len);
-	pubkey->u.ec.params.der.len = ecp->der_len;
+	memcpy(pubkey->u.ec.params.der.value, ecp->der.value, ecp->der.len);
+	pubkey->u.ec.params.der.len = ecp->der.len;
 
 	sc_pkcs15_fix_ec_parameters(ctx, &pubkey->u.ec.params);
 

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -212,7 +212,7 @@ int sc_pkcs15_derive(struct sc_pkcs15_card *p15card,
 
 	switch (obj->type) {
 		case SC_PKCS15_TYPE_PRKEY_EC:
-			alg_info = sc_card_find_ec_alg(p15card->card, prkey->field_length);
+			alg_info = sc_card_find_ec_alg(p15card->card, prkey->field_length, NULL);
 			if (alg_info == NULL) {
 				sc_log(ctx, "Card does not support EC with field_size %d", prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
@@ -352,7 +352,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 
 		case SC_PKCS15_TYPE_PRKEY_EC:
 			modlen = ((prkey->field_length +7) / 8) * 2;  /* 2*nLen */ 
-			alg_info = sc_card_find_ec_alg(p15card->card, prkey->field_length);
+			alg_info = sc_card_find_ec_alg(p15card->card, prkey->field_length, NULL);
 			if (alg_info == NULL) {
 				sc_log(ctx, "Card does not support EC with field_size %d", prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -200,19 +200,6 @@ struct sc_pkcs15_prkey_dsa {
 	sc_pkcs15_bignum_t priv;
 };
 
-/*
- * The ecParameters can be presented as
- * - named curve;
- * - OID of named curve;
- * - implicit parameters.
- */
-struct sc_pkcs15_ec_parameters {
-	char *named_curve;
-	struct sc_object_id id;
-	struct sc_pkcs15_der der;
-	size_t field_length; /* in bits */
-};
-
 struct sc_pkcs15_gost_parameters {
 	struct sc_object_id key;
 	struct sc_object_id hash;
@@ -220,12 +207,12 @@ struct sc_pkcs15_gost_parameters {
 };
 
 struct sc_pkcs15_pubkey_ec {
-	struct sc_pkcs15_ec_parameters params;
+	struct sc_ec_parameters params;
 	struct sc_pkcs15_u8 ecpointQ; /* This is NOT DER, just value and length */
 };
 
 struct sc_pkcs15_prkey_ec {
-	struct sc_pkcs15_ec_parameters params;
+	struct sc_ec_parameters params;
 	sc_pkcs15_bignum_t	privateD; /* note this is bignum */
 	struct sc_pkcs15_u8		ecpointQ; /* This is NOT DER, just value and length */
 };
@@ -964,7 +951,7 @@ struct sc_supported_algo_info *sc_pkcs15_get_supported_algo(struct sc_pkcs15_car
 int sc_pkcs15_add_supported_algo_ref(struct sc_pkcs15_object *,
 		struct sc_supported_algo_info *);
 
-int sc_pkcs15_fix_ec_parameters(struct sc_context *, struct sc_pkcs15_ec_parameters *);
+int sc_pkcs15_fix_ec_parameters(struct sc_context *, struct sc_ec_parameters *);
 
 /* Convert the OpenSSL key data type into the OpenSC key */
 int sc_pkcs15_convert_bignum(sc_pkcs15_bignum_t *dst, const void *bignum);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2763,7 +2763,7 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 		/* TODO: check allowed values of keybits */
 	}
 	else if (keytype == CKK_EC)   {
-		struct sc_pkcs15_der *der = &keygen_args.prkey_args.key.u.ec.params.der;
+		struct sc_lv_data *der = &keygen_args.prkey_args.key.u.ec.params.der;
 
 		der->len = sizeof(struct sc_object_id);
 		rv = attr_find_ptr(pPubTpl, ulPubCnt, CKA_EC_PARAMS, (void **)&der->value, &der->len);
@@ -4379,7 +4379,7 @@ get_public_exponent(struct sc_pkcs15_pubkey *key, CK_ATTRIBUTE_PTR attr)
 static CK_RV
 get_ec_pubkey_params(struct sc_pkcs15_pubkey *key, CK_ATTRIBUTE_PTR attr)
 {
-	struct sc_ec_params * ecp;
+	struct sc_ec_parameters *ecp;
 
 	if (key == NULL)
 		return CKR_ATTRIBUTE_TYPE_INVALID;
@@ -4396,10 +4396,10 @@ get_ec_pubkey_params(struct sc_pkcs15_pubkey *key, CK_ATTRIBUTE_PTR attr)
 			return CKR_OK;
 		}
 
-		ecp = (struct sc_ec_params *) key->alg_id->params;
-		if (ecp && ecp->der && ecp->der_len)   {
-			check_attribute_buffer(attr, ecp->der_len);
-			memcpy(attr->pValue, ecp->der, ecp->der_len);
+		ecp = (struct sc_ec_parameters *) key->alg_id->params;
+		if (ecp && ecp->der.value && ecp->der.len)   {
+			check_attribute_buffer(attr, ecp->der.len);
+			memcpy(attr->pValue, ecp->der.value, ecp->der.len);
 			return CKR_OK;
 		}
 	}

--- a/src/pkcs15init/pkcs15-sc-hsm.c
+++ b/src/pkcs15init/pkcs15-sc-hsm.c
@@ -173,7 +173,7 @@ static int sc_hsm_encode_gakp_rsa(struct sc_pkcs15_card *p15card, sc_cvc_t *cvc,
 
 static int sc_hsm_encode_gakp_ec(struct sc_pkcs15_card *p15card, sc_cvc_t *cvc, struct sc_pkcs15_prkey_info *key_info) {
 	struct sc_object_id ecdsaWithSHA256 = { { 0,4,0,127,0,7,2,2,2,2,3,-1 } };
-	struct sc_pkcs15_ec_parameters *ecparams = (struct sc_pkcs15_ec_parameters *)key_info->params.data;
+	struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
 	struct ec_curve *curve = NULL;
 	u8 *curveoid;
 	int curveoidlen,r;


### PR DESCRIPTION
It's needed to store information about EC curve supported by card.
Primary usage is, when importing/generating key,  to get know if particular curve is supported by card.