### PR TITLE
Allow PKCS15 cache to work with PIV cards (if enabled)

### DIFF
--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -735,11 +735,13 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		ckis[i].cert_found = 1;
 		/* cache it using the PKCS15 emulation objects */
 		/* as it does not change */
-               	if (cert_der.value) {
-               	 	cert_info.value.value = cert_der.value;
-                       	cert_info.value.len = cert_der.len;
-                       	cert_info.path.len = 0; /* use in mem cert from now on */
-               	}
+		if (cert_der.value) {
+			cert_info.value.value = cert_der.value;
+			cert_info.value.len = cert_der.len;
+			if (!p15card->opts.use_file_cache) {
+				cert_info.path.len = 0; /* use in mem cert from now on */
+			}
+		}
 		/* following will find the cached cert in cert_info */
 		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
 		if (r < 0 || cert_out->key == NULL) {


### PR DESCRIPTION
These changes simply allow the use of the file cache if it is enabled. More specifically, it allows the file cache to actually be created properly in the first place. Once the cache files are created properly then they are used.

If `use_file_cache` is not enabled, then the behavior continues as normal, fetching all certificates every time. The big win is that if it can fetch a certificate from a file instead of from the card, it will do so.