### PR TITLE
Fixed issue with building dnie-tool bash_completion script

### DIFF
--- a/doc/tools/dnie-tool.1.xml
+++ b/doc/tools/dnie-tool.1.xml
@@ -3,20 +3,22 @@
 	<refmeta>
 		<refentrytitle>dnie-tool</refentrytitle>
 		<manvolnum>1</manvolnum>
-		<refmiscinfo>opensc</refmiscinfo>
+		<refmiscinfo class="productname">OpenSC</refmiscinfo>
+		<refmiscinfo class="manual">OpenSC Tools</refmiscinfo>
+		<refmiscinfo class="source">opensc</refmiscinfo>
 	</refmeta>
 
 	<refnamediv>
 		<refname>dnie-tool</refname>
 		<refpurpose>displays information about DNIe based security tokens</refpurpose>
 	</refnamediv>
-
-	<refsect1>
-		<title>Synopsis</title>
-		<para>
-			<command>dnie-tool</command> [OPTIONS]
-		</para>
-	</refsect1>
+	
+	<refsynopsisdiv>
+		<cmdsynopsis>
+			<command>dnie-tool</command>
+			<arg choice="opt"><replaceable class="option">OPTIONS</replaceable></arg>
+		</cmdsynopsis>
+	</refsynopsisdiv>
 
 	<refsect1>
 		<title>Description</title>
@@ -30,33 +32,49 @@
 		<para>
 			<variablelist>
 				<varlistentry>
-					<term><option>--idesp, -i </option></term>
-					<listitem><para>Show the DNIe IDESP value.
-					</para></listitem>
+					<term>
+						<option>--idesp</option>,
+						<option>-i</option>
+					</term>
+					<listitem><para>Show the DNIe IDESP value.</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--data, -d </option></term>
+					<term>
+						<option>--data</option>,
+						<option>-d</option>
+					</term>
 					<listitem><para>Show DNIe personal information.
 					Reads and print DNIe number and User Name and SurName</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--all, -a </option></term>
+					<term>
+						<option>--all</option>,
+						<option>-a</option>
+					</term>
 					<listitem><para>Displays every available information.
-					This command is equivalent to -d -i -s 
-					</para></listitem>
+					This command is equivalent to -d -i -s</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--serial, -s </option></term>
+					<term>
+						<option>--serial</option>,
+						<option>-s</option>
+					</term>
 					<listitem><para>Displays DNIe Serial Number
 					</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--version, -V </option></term>
+					<term>
+						<option>--version</option>,
+						<option>-V</option>
+					</term>
 					<listitem><para>Show DNIe sw version.
 					Displays sofware version for in-card DNIe OS</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--pin</option> <replaceable>pin</replaceable>, <option>-p</option> <replaceable>pin</replaceable></term>
+					<term>
+						<option>--pin</option> <replaceable>pin</replaceable>,
+						<option>-p</option> <replaceable>pin</replaceable>
+					</term>
 					<listitem><para>Specify the user pin <replaceable>pin</replaceable> to use.
 					If set to env:<replaceable>VARIABLE</replaceable>, the
 					value of the environment variable
@@ -64,22 +82,34 @@
 					The default is do not enter pin</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--reader</option> <replaceable>number</replaceable>, <option>-r</option> <replaceable>number</replaceable></term>
+					<term>
+						<option>--reader</option> <replaceable>number</replaceable>,
+						<option>-r</option> <replaceable>number</replaceable>
+					</term>
 					<listitem><para>Specify the reader <replaceable>number</replaceable> to use.
 					The default is reader 0.</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--driver</option> <replaceable>driver</replaceable>, <option>-c</option> <replaceable>driver</replaceable></term>
+					<term>
+						<option>--driver</option> <replaceable>driver</replaceable>,
+						<option>-c</option> <replaceable>driver</replaceable>
+					</term>
 					<listitem><para>Specify the card driver <replaceable>driver</replaceable> to use.
 					Default is use driver from configuration file, or auto-detect if absent</para></listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--wait, -w</option></term>
+					<term>
+						<option>--wait</option>, 
+						<option>-w</option>
+					</term>
 					<listitem><para>Causes <command>dnie-tool</command> to wait for the token to be inserted into reader.</para>
 					</listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>--verbose, -v</option></term>
+					<term>
+						<option>--verbose</option>,
+						<option>-v</option>
+					</term>
 					<listitem><para>Causes <command>dnie-tool</command> to be more verbose. 
 					Specify this flag several times
 to enable debug output in the opensc library.</para></listitem>


### PR DESCRIPTION
Fixed an issue where the dnie-tool was not generated correctly form bash_completion.

The XML formatting caused the Makefile to not generate the proper arguments for /etc/bash_completion.d/dnie-tool
