### PR TITLE
Comment field, RFC 4716 format for ssh public keys

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -70,7 +70,7 @@ fi
 test -L OpenSC.tokend/build/opensc-src || ln -sf ${BUILDPATH}/src OpenSC.tokend/build/opensc-src
 
 # Build and copy OpenSC.tokend
-xcodebuild -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj
+xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj
 
 # Prepare target root
 # Copy Tokend

--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -185,7 +185,21 @@
 					</term>
 					<listitem><para>Reads the public key with id <replaceable>id</replaceable>,
 					writing the output in format suitable for
-					<filename>$HOME/.ssh/authorized_keys</filename>.</para></listitem>
+					<filename>$HOME/.ssh/authorized_keys</filename>.</para> 
+
+					<para>The key label, if any will be shown in the 'Comment' field.</para>
+
+
+					<varlistentry>
+						<term>
+							<option>--rfc4716</option>
+						</term>
+						<listitem><para>When used in conjunction with option <option>--read-ssh-key</option> the
+						output format of the public key follows rfc4716.</para></listitem>
+					</varlistentry>
+					<para></para>
+					<para> The default output format is a single line (openssh).</para>
+					</listitem>
 				</varlistentry>
 
 				<varlistentry>


### PR DESCRIPTION
Small improvement for large scale key management in conjunction with (open)SSH.

Allow for the key label to appear in the comment field of the SSH key. 

Support the RFC 4716 public key format. Thus supporting the new crop of (mobile/windows) SSH tools.