### PR TITLE
Allows OpenSC to survive an UNICODE built.

### DIFF
--- a/src/common/libscdl.c
+++ b/src/common/libscdl.c
@@ -28,12 +28,12 @@
 #include <windows.h>
 void *sc_dlopen(const char *filename)
 {
-	return (void *)LoadLibrary(filename);
+	return (void *)LoadLibraryA(filename);
 }
 
 void *sc_dlsym(void *handle, const char *symbol)
 {
-	return GetProcAddress((HANDLE)handle, symbol);
+	return GetProcAddress((HMODULE)handle, symbol);
 }
 
 const char *sc_dlerror()
@@ -43,7 +43,7 @@ const char *sc_dlerror()
 
 int sc_dlclose(void *handle)
 {
-	return FreeLibrary((HANDLE)handle);
+	return FreeLibrary((HMODULE)handle);
 }
 #else
 #include <dlfcn.h>

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -1183,20 +1183,20 @@ sc_card_sm_load(struct sc_card *card, const char *module_path, const char *in_mo
 
 #ifdef _WIN32
 	if (!module_path) {
-		rc = RegOpenKeyEx( HKEY_CURRENT_USER, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
+		rc = RegOpenKeyExA( HKEY_CURRENT_USER, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
 		if( rc == ERROR_SUCCESS ) {
 			temp_len = PATH_MAX;
-			rc = RegQueryValueEx( hKey, "SmDir", NULL, NULL, (LPBYTE) temp_path, &temp_len);
+			rc = RegQueryValueExA( hKey, "SmDir", NULL, NULL, (LPBYTE) temp_path, &temp_len);
 			if( (rc == ERROR_SUCCESS) && (temp_len < PATH_MAX) )
 				module_path = temp_path;
 			RegCloseKey( hKey );
 		}
 	}
 	if (!module_path) {
-		rc = RegOpenKeyEx( HKEY_LOCAL_MACHINE, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
+		rc = RegOpenKeyExA( HKEY_LOCAL_MACHINE, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
 		if( rc == ERROR_SUCCESS ) {
 			temp_len = PATH_MAX;
-			rc = RegQueryValueEx( hKey, "SmDir", NULL, NULL, (LPBYTE) temp_path, &temp_len);
+			rc = RegQueryValueExA( hKey, "SmDir", NULL, NULL, (LPBYTE) temp_path, &temp_len);
 			if(rc == ERROR_SUCCESS && temp_len < PATH_MAX)
 				module_path = temp_path;
 			RegCloseKey( hKey );

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -245,7 +245,7 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 	if (val)   {
 #ifdef _WIN32
 		expanded_len = PATH_MAX;
-		expanded_len = ExpandEnvironmentStrings(val, expanded_val, expanded_len);
+		expanded_len = ExpandEnvironmentStringsA(val, expanded_val, expanded_len);
 		if (expanded_len > 0)
 			val = expanded_val;
 #endif
@@ -552,7 +552,7 @@ static void process_config_file(sc_context_t *ctx, struct _sc_ctx_options *opts)
 #ifdef _WIN32
 	conf_path = getenv("OPENSC_CONF");
 	if (!conf_path) {
-		rc = RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey);
+		rc = RegOpenKeyExA(HKEY_CURRENT_USER, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey);
 		if (rc == ERROR_SUCCESS) {
 			temp_len = PATH_MAX;
 			rc = RegQueryValueEx( hKey, "ConfigFile", NULL, NULL, (LPBYTE) temp_path, &temp_len);
@@ -563,7 +563,7 @@ static void process_config_file(sc_context_t *ctx, struct _sc_ctx_options *opts)
 	}
 
 	if (!conf_path) {
-		rc = RegOpenKeyEx( HKEY_LOCAL_MACHINE, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
+		rc = RegOpenKeyExA( HKEY_LOCAL_MACHINE, "Software\\OpenSC Project\\OpenSC", 0, KEY_QUERY_VALUE, &hKey );
 		if (rc == ERROR_SUCCESS) {
 			temp_len = PATH_MAX;
 			rc = RegQueryValueEx( hKey, "ConfigFile", NULL, NULL, (LPBYTE) temp_path, &temp_len);
@@ -874,7 +874,7 @@ int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize)
 	/* If USERPROFILE isn't defined, assume it's a single-user OS
 	 * and put the cache dir in the Windows dir (usually C:\\WINDOWS) */
 	if (homedir == NULL || homedir[0] == '\0') {
-		GetWindowsDirectory(temp_path, sizeof(temp_path));
+		GetWindowsDirectoryA(temp_path, sizeof(temp_path));
 		homedir = temp_path;
 	}
 #endif

--- a/src/libopensc/internal-winscard.h
+++ b/src/libopensc/internal-winscard.h
@@ -20,6 +20,13 @@ typedef unsigned __int8 uint8_t;
 #ifdef __APPLE__
 #include <wintypes.h>
 #endif
+// allow unicode built where SCARD_READERSTATE is defined as SCARD_READERSTATEW and SCardGetStatusChange renamed to SCardGetStatusChangeW
+#ifdef WIN32
+#ifdef UNICODE
+#define SCARD_READERSTATE SCARD_READERSTATEA
+#undef SCardGetStatusChange
+#endif
+#endif
 #else
 /* mingw32 does not have winscard.h */
 

--- a/src/libopensc/user-interface.c
+++ b/src/libopensc/user-interface.c
@@ -35,7 +35,11 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+
+#ifndef UNICODE
 #define UNICODE
+#endif
+
 #include <windows.h>
 #endif
 #ifdef __APPLE__

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3345,7 +3345,7 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 		}
 		else
 		{
-			// %S enable the use of UNICODE string inside an ANSI string
+			// %S enable the use of UNICODE string (wsPinContext) inside an ANSI string (buf)
 			snprintf(buf, sizeof(buf), "Please enter PIN %S", vs->wszPinContext);
 		}
 		logprintf(pCardData, 7, "About to display message box for external PIN verification\n");


### PR DESCRIPTION
UNICODE is set by default by Visual Studio (but can be deactivated)

The trick is to force ANSI version by appending a A to some function calls.

Vincent LE TOUX
---
http://www.mysmartlogon.com