### PR TITLE
iasecc: Fix log output is always displayed

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -3385,7 +3385,7 @@ iasecc_read_public_key(struct sc_card *card, unsigned type,
 
 	iasecc_sdo_free_fields(card, &sdo);
 
-	SC_FUNC_RETURN(ctx, SC_SUCCESS, rv);
+	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, rv);
 }
 
 


### PR DESCRIPTION
  * iasecc_read_public_key function uses SC_SUCCESS instead of log level
  value, hence the log output is always displayed. This uses
  SC_LOG_DEBUG_NORMAL instead.