### PR TITLE
RSA: PKCS1 for signature, RAW for decryption

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4701,11 +4701,12 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	/* Check if we support raw RSA */
 	if (flags & SC_ALGORITHM_RSA_RAW) {
+		mech_info.flags &= ~CKF_SIGN;
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
-
+		mech_info.flags |= CKF_SIGN;
 	}
 
 	/* We support PKCS1 padding in software */
@@ -4729,6 +4730,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	/* No need to Check for PKCS1  We support it in software and turned it on above so always added it */
 	if (flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
+		mech_info.flags &= ~CKF_DECRYPT;
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
@@ -4770,6 +4772,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 				return rc;
 		}
 #endif /* ENABLE_OPENSSL */
+		mech_info.flags |= CKF_DECRYPT;
 	}
 
 	/* TODO support other padding mechanisms */


### PR DESCRIPTION
Hi!

I am using a card that supports RSA PKCS#1 for signature only and RAW input for decryption only. currently the card's capabilities flag is used for both operations which is also what is exorted from the PKCS#11 module. This PR changes this behavior, but I am not sure if this breaks some other card or application.

From the comments in the PKCS#11 module I can see that there are many deficits. What would be the correct(tm) way of implementing method (i.e. signature/decryption) dependant card capabilities? Is PKCS#1 even used for decryption (or RAW input for signature) in some application?

Thanks for comments.