### PR TITLE
pkcs11-tool: Choose ECDSA signature format

### DIFF
--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -73,9 +73,7 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 	FILE		*outf = NULL;
 	int		n;
 
-	assert(ctx != NULL);
-
-	if (ctx->debug < level)
+	if (!ctx || ctx->debug < level)
 		return;
 
 	p = buf;
@@ -167,9 +165,7 @@ void sc_hex_dump(struct sc_context *ctx, int level, const u8 * in, size_t count,
 	char *p = buf;
 	int lines = 0;
 
-	assert(ctx != NULL);
-
-	if (ctx->debug < level)
+	if (!ctx || ctx->debug < level)
 		return;
 
 	assert(buf != NULL && (in != NULL || count == 0));


### PR DESCRIPTION
This PR allows the user to choose the format of ECDSA signatures like in pkcs15-crypt. In order to achieve this, OpenSC log functions were modified so that they are more defensive if the sc_context parameter is NULL. This allows `sc_asn1_sig_value_rs_to_sequence()` (along with other functions) to be used when no reference to ctx is available.