### PR TITLE
register mechanisms more precisely

### DIFF
--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -233,9 +233,10 @@ isoApplet_init(sc_card_t *card)
 		 * driver. */
 		flags = 0;
 		flags |= SC_ALGORITHM_ECDSA_RAW;
+		flags |= SC_ALGORITHM_ECDSA_HASH_NONE;
 		flags |= SC_ALGORITHM_ONBOARD_KEY_GEN;
-		flags |= SC_ALGORITHM_EXT_EC_UNCOMPRESES;
-		ext_flags =  SC_ALGORITHM_EXT_EC_NAMEDCURVE;
+		ext_flags = SC_ALGORITHM_EXT_EC_UNCOMPRESES;
+		ext_flags |=  SC_ALGORITHM_EXT_EC_NAMEDCURVE;
 		ext_flags |= SC_ALGORITHM_EXT_EC_F_P;
 		for (i=0; ec_curves[i].oid.value[0] >= 0; i++)
 		{

--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -233,7 +233,7 @@ isoApplet_init(sc_card_t *card)
 		 * driver. */
 		flags = 0;
 		flags |= SC_ALGORITHM_ECDSA_RAW;
-		flags |= SC_ALGORITHM_ECDSA_HASH_NONE;
+		flags |= SC_ALGORITHM_ECDSA_HASH_SHA1;
 		flags |= SC_ALGORITHM_ONBOARD_KEY_GEN;
 		ext_flags = SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 		ext_flags |=  SC_ALGORITHM_EXT_EC_NAMEDCURVE;

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -158,7 +158,7 @@ static int myeid_init(struct sc_card *card)
 			card->version.fw_major >= 4)   {
 		int i;
 
-	        flags |= SC_ALGORITHM_ECDSA_RAW;
+		flags |= SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
 		for (i=0; ec_curves[i].curve_name != NULL; i++)

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -158,7 +158,8 @@ static int myeid_init(struct sc_card *card)
 			card->version.fw_major >= 4)   {
 		int i;
 
-		flags |= SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW;
+		flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW | SC_ALGORITHM_ONBOARD_KEY_GEN;
+		flags |= SC_ALGORITHM_ECDSA_HASH_NONE | SC_ALGORITHM_ECDSA_HASH_SHA1;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
 		for (i=0; ec_curves[i].curve_name != NULL; i++)

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2879,7 +2879,7 @@ static int piv_init(sc_card_t *card)
 	_sc_card_add_rsa_alg(card, 2048, flags, 0); /* optional */
 	_sc_card_add_rsa_alg(card, 3072, flags, 0); /* optional */
 
-	flags = SC_ALGORITHM_ECDSA_RAW;
+	flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW;
 	ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
 	_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2879,7 +2879,7 @@ static int piv_init(sc_card_t *card)
 	_sc_card_add_rsa_alg(card, 2048, flags, 0); /* optional */
 	_sc_card_add_rsa_alg(card, 3072, flags, 0); /* optional */
 
-	flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW;
+	flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW | SC_ALGORITHM_ECDSA_HASH_NONE;
 	ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
 	_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1042,6 +1042,7 @@ static int sc_hsm_init(struct sc_card *card)
 	_sc_card_add_rsa_alg(card, 2048, flags, 0);
 
 	flags = SC_ALGORITHM_ECDSA_RAW|
+		SC_ALGORITHM_ECDH_CDH_RAW|
 		SC_ALGORITHM_ECDSA_HASH_NONE|
 		SC_ALGORITHM_ECDSA_HASH_SHA1|
 		SC_ALGORITHM_ECDSA_HASH_SHA224|

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4700,11 +4700,11 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
-	}
 
-	/* We support PKCS1 padding in software */
-	/* either the card supports it or OpenSC does */
-	rsa_flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+		/* We support PKCS1 padding in software */
+		/* either the card supports it or OpenSC does */
+		rsa_flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+	}
 
 #ifdef ENABLE_OPENSSL
 		/* all our software hashes are in OpenSSL */

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4573,7 +4573,7 @@ static int register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	if (rc != CKR_OK)
 		return rc;
 
-#if ENABLE_OPENSSL
+#ifdef ENABLE_OPENSSL
 	mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1,
 		&mech_info, CKK_EC, NULL);
 	if (!mt)
@@ -4585,22 +4585,24 @@ static int register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 
 	/* ADD ECDH mechanisms */
 	/* The PIV uses curves where CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE produce the same results */
-	mech_info.flags &= ~CKF_SIGN;
-	mech_info.flags |= CKF_DERIVE;
+	if(flags & SC_ALGORITHM_ECDH_CDH_RAW) {
+		mech_info.flags &= ~CKF_SIGN;
+		mech_info.flags |= CKF_DERIVE;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL);
-	if (!mt)
-		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
-	if (rc != CKR_OK)
-	    return rc;
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL);
+		if (!mt)
+			return CKR_HOST_MEMORY;
+		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		if (rc != CKR_OK)
+			return rc;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC, NULL);
-	if (!mt)
-		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
-	if (rc != CKR_OK)
-	    return rc;
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC, NULL);
+		if (!mt)
+			return CKR_HOST_MEMORY;
+		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		if (rc != CKR_OK)
+			return rc;
+	}
 
 	if (flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_HW | CKF_GENERATE_KEY_PAIR;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4566,21 +4566,25 @@ static int register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	mech_info.ulMinKeySize = min_key_size;
 	mech_info.ulMaxKeySize = max_key_size;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA, &mech_info, CKK_EC, NULL);
-	if (!mt)
-		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
-	if (rc != CKR_OK)
-		return rc;
+	if(flags & SC_ALGORITHM_ECDSA_HASH_NONE) {
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA, &mech_info, CKK_EC, NULL);
+		if (!mt)
+			return CKR_HOST_MEMORY;
+		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		if (rc != CKR_OK)
+			return rc;
+	}
 
 #ifdef ENABLE_OPENSSL
-	mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1,
-		&mech_info, CKK_EC, NULL);
-	if (!mt)
-		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
-	if (rc != CKR_OK)
-		return rc;
+	if(flags & SC_ALGORITHM_ECDSA_HASH_SHA1) {
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1,
+			&mech_info, CKK_EC, NULL);
+		if (!mt)
+			return CKR_HOST_MEMORY;
+		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		if (rc != CKR_OK)
+			return rc;
+	}
 #endif
 
 	/* ADD ECDH mechanisms */


### PR DESCRIPTION
**This PR should be reviewed carefully, it might affect cards that I can not test with**

In a nutshell, this PR addresses the following:

  - support different flags for different key types
  - register ECDH mechanisms only if card driver indicates support with SC_ALGORITHM_ECDH_CDH_RAW

It touches card driver code for piv (@dengert), sc-hsm (@cardcontact) and myeid (who is the maintainer?), only to keep the existing behavior: It adds the SC_ALGORITHM_ECDH_CDH_RAW flag, because the cards/drivers seem to support ECDH.

How exactly is the SC_ALGORITHM_ECDH_CDH_RAW flag defined? Do we need a seperate flag for ECDH with cofactor multiplication (for curves with a cofactor=1 it should produce the same result)?

I don't have a way to test how the change (seperation of flags for different algorithms) affects GOSTR. The rtcep card seems to call _sc_card_add_algorithm for GOSTR with seperate flags. The change does not look like it will affect the existing behavior.
