### PR TITLE
Issue 395. Commenting a couple of needed free statements in order to avoid failures...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ doc/tools/pkcs15-init
 doc/tools/pkcs15-tool
 doc/tools/sc-hsm-tool
 doc/tools/westcos-tool
+doc/tools/dnie-tool
 
 etc/opensc.conf.win
 etc/opensc.conf

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -324,7 +324,7 @@ static int cwa_parse_tlv(sc_card_t * card,
 		/* set index to next Tag to jump to */
 		next = tlv->buflen;
 	}
-	free(buffer);
+/*	free(buffer); temporary fix. TODO: free this buffer correctly */
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);	/* mark no error */
 }
 
@@ -1601,7 +1601,7 @@ encode_end:
 	free(msgbuf);
 	free(cryptbuf);
 	free(ccbuf);
-	free(apdubuf);
+/*	free(apdubuf); Temporary fix. TODO: free this buffer correctly */
 	LOG_FUNC_RETURN(ctx, res);
 }
 


### PR DESCRIPTION
This changes propose to skip to required free statements for now, in order to avoid failures since the memory is used later in the code. Rewriting will be required in order to free all allocated memory.
There is a tiny non-related change of adding dnie-tool to .gitignore.