### PR TITLE
Issue 395. Avoiding a couple of memory leaks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ doc/tools/pkcs15-init
 doc/tools/pkcs15-tool
 doc/tools/sc-hsm-tool
 doc/tools/westcos-tool
+doc/tools/dnie-tool
 
 etc/opensc.conf.win
 etc/opensc.conf

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -43,6 +43,23 @@
 
 #include "cwa14890.h"
 
+/**
+ * Structure used to compose BER-TLV encoded data
+ * according to iso7816-4 sect 5.2.2.
+ *
+ * Notice that current implementation does not handle properly
+ * multibyte tag id. Just asume that tag is 1-byte length
+ * Also, encodings for data length longer than 0x01000000 bytes
+ * are not supported (tag 0x84)
+ */
+typedef struct cwa_tlv_st {
+        u8 *buf;                /** local copy of TLV byte array */
+        size_t buflen;          /** lengt of buffer */
+        unsigned int tag;       /** tag ID */
+        size_t len;             /** length of data field */
+        u8 *data;               /** pointer to start of data in buf buffer */
+} cwa_tlv_t;
+
 /*********************** utility functions ************************/
 
 /**
@@ -242,13 +259,13 @@ static int cwa_compose_tlv(sc_card_t * card,
  * @return SC_SUCCESS if OK; else error code
  */
 static int cwa_parse_tlv(sc_card_t * card,
-			 u8 * data, size_t datalen, cwa_tlv_t tlv_array[]
+			 u8 * buffer, size_t datalen,
+			 cwa_tlv_t tlv_array[]
     )
 {
 	size_t n = 0;
 	size_t next = 0;
 	sc_context_t *ctx = NULL;
-	u8 *buffer = NULL;
 
 	/* preliminary checks */
 	if (!card || !card->ctx)
@@ -257,14 +274,9 @@ static int cwa_parse_tlv(sc_card_t * card,
 	ctx = card->ctx;
 
 	LOG_FUNC_CALLED(ctx);
-	if (!data || !tlv_array)
+	if (!tlv_array)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	/* create buffer and copy data into */
-	buffer = calloc(datalen, sizeof(u8));
-	if (!buffer)
-		LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
-	memcpy(buffer, data, datalen);
 	for (n = 0; n < datalen; n += next) {
 		cwa_tlv_t *tlv = NULL;	/* pointer to TLV structure to store info */
 		size_t j = 2;	/* TLV has at least two bytes */
@@ -324,7 +336,6 @@ static int cwa_parse_tlv(sc_card_t * card,
 		/* set index to next Tag to jump to */
 		next = tlv->buflen;
 	}
-	free(buffer);
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);	/* mark no error */
 }
 
@@ -1592,16 +1603,20 @@ int cwa_encode_apdu(sc_card_t * card,
 			goto encode_end;
 		}
 	}
+
 	/* that's all folks */
 	res = SC_SUCCESS;
+	goto encode_end_apdu_valid;
 
 encode_end:
+	if (apdubuf)
+		free(apdubuf);
+encode_end_apdu_valid:
 	if (msg)
 		sc_log(ctx, msg);
 	free(msgbuf);
 	free(cryptbuf);
 	free(ccbuf);
-	free(apdubuf);
 	LOG_FUNC_RETURN(ctx, res);
 }
 
@@ -1629,6 +1644,7 @@ int cwa_decode_response(sc_card_t * card,
 	cwa_tlv_t *e_tlv = &tlv_array[1];	/* to store pad encoded data (Tag 0x87) */
 	cwa_tlv_t *m_tlv = &tlv_array[2];	/* to store mac CC (Tag 0x8E) */
 	cwa_tlv_t *s_tlv = &tlv_array[3];	/* to store sw1-sw2 status (Tag 0x99) */
+	u8 *buffer = NULL;	/* buffer for data. pointers to this buffer are in tlv_array */
 	u8 *ccbuf = NULL;	/* buffer for mac CC calculation */
 	size_t cclen = 0;	/* ccbuf len */
 	u8 macbuf[8];		/* where to calculate mac */
@@ -1692,8 +1708,16 @@ int cwa_decode_response(sc_card_t * card,
 
 	/* parse response to find TLV's data and check results */
 	memset(tlv_array, 0, 4 * sizeof(cwa_tlv_t));
+	/* create buffer and copy data into */
+	buffer = calloc(from->resplen, sizeof(u8));
+	if (!buffer) {
+		msg = "Cannot allocate space for response buffer";
+		res = SC_ERROR_OUT_OF_MEMORY;
+		goto response_decode_end;
+	}
+	memcpy(buffer, from->resp, from->resplen);
 
-	res = cwa_parse_tlv(card, from->resp, from->resplen, tlv_array);
+	res = cwa_parse_tlv(card, buffer, from->resplen, tlv_array);
 	if (res != SC_SUCCESS) {
 		msg = "Error in TLV parsing";
 		goto response_decode_end;
@@ -1794,7 +1818,7 @@ int cwa_decode_response(sc_card_t * card,
 	if (to->resp) {		/* if response apdu provides buffer, try to use it */
 		if (to->resplen < resplen) {
 			msg =
-			    "Provided buffer has not enought size to store response";
+			    "Provided buffer has not enough size to store response";
 			res = SC_ERROR_OUT_OF_MEMORY;
 			goto response_decode_end;
 		}
@@ -1862,7 +1886,7 @@ int cwa_decode_response(sc_card_t * card,
 		res = provider->cwa_decode_post_ops(card, provider, from, to);
 		if (res != SC_SUCCESS) {
 			sc_log(ctx, "Decode APDU: provider post_ops() failed");
-			LOG_FUNC_RETURN(ctx, res);
+			goto response_decode_end;
 		}
 	}
 
@@ -1870,6 +1894,8 @@ int cwa_decode_response(sc_card_t * card,
 	res = SC_SUCCESS;
 
  response_decode_end:
+	if (buffer)
+		free(buffer);
 	if (ccbuf)
 		free(ccbuf);
 	if (msg) {

--- a/src/libopensc/cwa14890.h
+++ b/src/libopensc/cwa14890.h
@@ -52,23 +52,6 @@
 #include <openssl/des.h>
 
 /**
- * Structure used to compose BER-TLV encoded data
- * according to iso7816-4 sect 5.2.2.
- *
- * Notice that current implementation does not handle properly
- * multibyte tag id. Just asume that tag is 1-byte lenght
- * Also, encodings for data lenght longer than 0x01000000 bytes
- * are not supported (tag 0x84)
- */
-typedef struct cwa_tlv_st {
-	u8 *buf;		/** local copy of TLV byte array */
-	size_t buflen;		/** lengt of buffer */
-	unsigned int tag;	/** tag ID */
-	size_t len;		/** lenght of data field */
-	u8 *data;		/** pointer to start of data in buf buffer */
-} cwa_tlv_t;
-
-/**
  * Structure used to handle keys and sequence counter once SM session
  * is stablished
  */


### PR DESCRIPTION
Would this way forward be acceptable?
The buffers are freed now in all cases, except when apdubuf is assigned to the data pointer in the apdu.
This will happen often, I think.
And without digging too much, I have seen a few other places where pointers seem to be overwritten or left out of scope without being properly freed. I would work on fixing this, but it will take some time and I would prefer to do it in several steps. Is that ok?
If someone is willing to help, I would be very happy.