### PR TITLE
Honour key capabilities for signing and decryption

### DIFF
--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -237,6 +237,7 @@ sc_pkcs15emu_add_ec_prkey
 sc_pkcs15emu_add_ec_pubkey
 sc_pkcs15emu_add_x509_cert
 sc_pkcs15emu_object_add
+sc_pkcs15_bind_internal
 sc_print_path
 sc_put_data
 sc_read_binary

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -969,7 +969,7 @@ sc_pkcs15_get_application_by_type(struct sc_card * card, char *app_type)
 }
 
 
-static int
+int
 sc_pkcs15_bind_internal(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 {
 	struct sc_path tmppath;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -668,6 +668,7 @@ int sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 /* sc_pkcs15_unbind:  Releases a PKCS #15 card object, and frees any
  * memory allocations done on the card object. */
 int sc_pkcs15_unbind(struct sc_pkcs15_card *card);
+int sc_pkcs15_bind_internal(struct sc_pkcs15_card *p15card, struct sc_aid *aid);
 
 int sc_pkcs15_get_objects(struct sc_pkcs15_card *card, unsigned int type,
 			  struct sc_pkcs15_object **ret, size_t ret_count);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3494,6 +3494,9 @@ static int test_signature(CK_SESSION_HANDLE sess)
 
 	ck_mech.mechanism = firstMechType;
 	rv = p11->C_SignInit(sess, &ck_mech, privKeyObject);
+	/* mechanism not implemented, don't test */
+	if (rv == CKR_MECHANISM_INVALID)
+		return errors;
 	if (rv != CKR_OK)
 		p11_fatal("C_SignInit", rv);
 


### PR DESCRIPTION
I solved the problem from #419 by creating a PKCS#15 emulator and assigning specific capabilities to the signature and decryption keys. Now only the supported configurations can be triggered by the application via `C_SignInit`.