### PR TITLE
working on the minidriver (branch minidriver-cmck-issue-i426)

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3180,8 +3180,16 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __in PCARD_SIGNING_INFO pIn
 				opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA1;
 			else if (wcscmp(pinf->pszAlgId, L"SHAMD5") == 0)
 				opt_hash_flags = SC_ALGORITHM_RSA_HASH_MD5_SHA1;
+			else if (wcscmp(pinf->pszAlgId, L"SHA224") == 0)
+				opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA224;
 			else if (wcscmp(pinf->pszAlgId, L"SHA256") == 0)
 				opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA256;
+			else if (wcscmp(pinf->pszAlgId, L"SHA384") == 0)
+				opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA384;
+			else if (wcscmp(pinf->pszAlgId, L"SHA512") == 0)
+				opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA512;
+			else if (wcscmp(pinf->pszAlgId, L"RIPEMD160") == 0)
+				opt_hash_flags = SC_ALGORITHM_RSA_HASH_RIPEMD160;
 			else
 						{
 				logprintf(pCardData, 0,"unknown AlgId %S\n",NULLWSTR(pinf->pszAlgId));
@@ -3205,6 +3213,12 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __in PCARD_SIGNING_INFO pIn
 			opt_hash_flags = SC_ALGORITHM_RSA_HASH_MD5_SHA1;
 		else if (hashAlg == CALG_SHA_256)
 			opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA256;
+		else if (hashAlg == CALG_SHA_384)
+			opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA384;
+		else if (hashAlg == CALG_SHA_512)
+			opt_hash_flags = SC_ALGORITHM_RSA_HASH_SHA512;
+		else if (hashAlg == (ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_RIPEMD160))
+			opt_hash_flags = SC_ALGORITHM_RSA_HASH_RIPEMD160;
 		else if (hashAlg !=0)
 			return SCARD_E_UNSUPPORTED_FEATURE;
 	}

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3181,6 +3181,16 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __in PCARD_SIGNING_INFO pIn
 		else if (hashAlg !=0)
 			return SCARD_E_UNSUPPORTED_FEATURE;
 	}
+	
+	if (pInfo->dwSigningFlags & CARD_PADDING_NONE)
+	{
+		/* do not add the digest info when called from CryptSignHash(CRYPT_NOHASHOID)
+
+		Note: SC_ALGORITHM_RSA_HASH_MD5_SHA1 aka CALG_SSL3_SHAMD5 do not have a digest info to be added
+		      CryptSignHash(CALG_SSL3_SHAMD5,CRYPT_NOHASHOID) is the same than CryptSignHash(CALG_SSL3_SHAMD5)
+		*/
+		opt_hash_flags = 0;
+	}
 
 	/* From sc-minidriver_specs_v7.docx pp.76:
 	 * 'The Base CSP/KSP performs the hashing operation on the data before passing it

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3241,7 +3241,13 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __in PCARD_SIGNING_INFO pIn
 		logprintf(pCardData, 2, "sc_pkcs15_compute_signature return %d\n", r);
 		if(r < 0)   {
 			logprintf(pCardData, 2, "sc_pkcs15_compute_signature erreur %s\n", sc_strerror(r));
-			return SCARD_F_INTERNAL_ERROR;
+			switch (r)
+			{
+			case SC_ERROR_NOT_SUPPORTED:
+				return SCARD_E_UNSUPPORTED_FEATURE;
+			default:
+				return SCARD_F_INTERNAL_ERROR;
+			}
 		}
 
 		pInfo->cbSignedData = r;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3432,8 +3432,7 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 				MB_OKCANCEL | MB_ICONINFORMATION);
 		if (IDCANCEL == r) {
 			logprintf(pCardData, 2, "User canceled PIN verification\n");
-			/* @TODO: is this the right code to return? */
-			return SCARD_E_INVALID_PARAMETER;
+			return ERROR_CANCELLED;
 		}
 	}
 
@@ -3827,7 +3826,7 @@ DWORD WINAPI CardSetProperty(__in   PCARD_DATA pCardData,
 	if (dwFlags)
 		return SCARD_E_INVALID_PARAMETER;
 
-	if (!pbData || !cbDataLen)
+	if (!cbDataLen)
 		return SCARD_E_INVALID_PARAMETER;
 
 	/* the following properties cannot be set according to the minidriver specifications */
@@ -3858,7 +3857,7 @@ DWORD WINAPI CardSetProperty(__in   PCARD_DATA pCardData,
 	 * CardAuthenticateEx if the PIN required is declared of type ExternalPinType.
 	 */
 	if (wcscmp(CP_PARENT_WINDOW, wszProperty) == 0) {
-		if (cbDataLen != sizeof(HWND))   {
+		if (cbDataLen != sizeof(HWND) || !pbData)   {
 			return SCARD_E_INVALID_PARAMETER;
 		}
 		else   {


### PR DESCRIPTION
* Digital signature without digestinfo is now working with CryptSignHash(CRYPT_NOHASHOID) (SHAMD5 was already working)
* regression when Pinpad authentication fixed (message can be NULL)
* all memory leaks found by the quality testing tool (the virtual filesystem was not freed + in some cases). 
* better parameter checking for a few functions
* add some hash algorithm (such as SHA512) to CryptSignHash
* better error reporting if a card does not support a feature ("not supported" instead of "internal error")