### PR TITLE
pkcs11-tool: Add support for creating EC privkey

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1716,7 +1716,7 @@ do_read_private_key(unsigned char *data, size_t data_len, EVP_PKEY **key)
 
 	mem = BIO_new(BIO_s_mem());
 	BIO_set_mem_buf(mem, &buf_mem, BIO_NOCLOSE);
-	if (!strstr((char *)data, "-----BEGIN PRIVATE KEY-----"))
+	if (!strstr((char *)data, "-----BEGIN PRIVATE KEY-----") && !strstr((char *)data, "-----BEGIN EC PRIVATE KEY-----"))
 		*key = d2i_PrivateKey_bio(mem, NULL);
 	else
 		*key = PEM_read_bio_PrivateKey(mem, NULL, NULL, NULL);
@@ -1895,7 +1895,8 @@ static int write_object(CK_SESSION_HANDLE session)
 			rv = parse_rsa_private_key(&rsa, contents, contents_len);
 		}
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
-		else if (evp_key->type == NID_id_GostR3410_2001)   {
+		else if (evp_key->type == NID_id_GostR3410_2001 || evp_key->type == EVP_PKEY_EC)   {
+			/* parsing ECDSA is identical to GOST */
 			rv = parse_gost_private_key(evp_key, &gost);
 		}
 #endif
@@ -1998,6 +1999,16 @@ static int write_object(CK_SESSION_HANDLE session)
 			n_privkey_attr++;
 		}
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+		else if (evp_key->type == EVP_PKEY_EC)   {
+			type = CKK_EC;
+
+			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_KEY_TYPE, &type, sizeof(type));
+			n_privkey_attr++;
+			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_EC_PARAMS, gost.param_oid.value, gost.param_oid.len);
+			n_privkey_attr++;
+			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_VALUE, gost.private.value, gost.private.len);
+			n_privkey_attr++;
+		}
 		else if (evp_key->type == NID_id_GostR3410_2001)   {
 			type = CKK_GOSTR3410;
 


### PR DESCRIPTION
  * This patch allows to create EC private keys. The feature re-use the GOST
  parsing function as instanciating an ECDSA key is the same as a GOST key.
  This way we can import existing ECDSA keys on a token using pkcs11-tool.