### PR TITLE
EC field_length changes for non-multiple of 8 bits curves

### DIFF
--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -705,12 +705,16 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 		memcpy(dst->ecpointQ.value, buf, buflen);
 		dst->ecpointQ.len = buflen;
 
-		/* calculate the field length */
-		dst->params.field_length = (buflen - 1) / 2 * 8;
+		/*
+		 * In OpenSC the field_length is in bits. Not all curves are a mutiple of 8.
+		 * EC_POINT_point2oct handles this and returns octstrings that can handle
+		 * these curves. Get real field_length from OpenSSL. 
+		 */
+		dst->params.field_length = EC_GROUP_get_degree(grp);
 
 		/* Octetstring may need leading zeros if BN is to short */
-		if (dst->privateD.len < dst->params.field_length/8)   {
-			size_t d = dst->params.field_length/8 - dst->privateD.len;
+		if (dst->privateD.len < (dst->params.field_length + 7) / 8)   {
+			size_t d = (dst->params.field_length + 7) / 8 - dst->privateD.len;
 
 			dst->privateD.data = realloc(dst->privateD.data, dst->privateD.len + d);
 			if (!dst->privateD.data)

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -721,6 +721,11 @@ sc_pkcs15_decode_pubkey_ec(sc_context_t *ctx,
 	key->ecpointQ.len = ecpoint_len;
 	key->ecpointQ.value = ecpoint_data;
 
+	/*
+	 * Only get here if raw point is stored in pkcs15 without curve name
+	 * spki has the curvename, so we can get the field_length
+	 * Following only true for curves that are multiple of 8 
+	 */
 	key->params.field_length = (ecpoint_len - 1)/2 * 8;
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -1296,6 +1301,12 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 
 	if (pk_alg.algorithm == SC_ALGORITHM_EC)   {
 		/* EC public key is not encapsulated into BIT STRING -- it's a BIT STRING */
+		/*
+		 * sc_pkcs15_fix_ec_parameters below will set field_length from curve.
+		 * if no alg_id->params, assume field_length is multiple of 8 
+		 */
+		pubkey->u.ec.params.field_length = (pk.len - 1) / 2 * 8;
+
 		if (pubkey->alg_id->params) {
 			struct sc_ec_parameters *ecp = (struct sc_ec_parameters *)pubkey->alg_id->params;
 
@@ -1309,7 +1320,6 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 			LOG_TEST_RET(ctx, r, "failed to fix EC parameters");
 		}
 
-		pubkey->u.ec.params.field_length = (pk.len - 1)/2 * 8;
 		pubkey->u.ec.ecpointQ.value = malloc(pk.len);
 		if (pubkey->u.ec.ecpointQ.value == NULL)
 			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -518,6 +518,7 @@ static int sc_pkcs15emu_sc_hsm_add_pubkey(sc_pkcs15_card_t *p15card, sc_pkcs15_p
 		pubkey_info.modulus_length = pubkey.u.rsa.modulus.len << 3;
 		r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
 	} else {
+		/* TODO fix if support of non multiple of 8 curves are added */
 		pubkey_info.field_length = cvc.primeOrModuluslen << 3;
 		r = sc_pkcs15emu_add_ec_pubkey(p15card, &pubkey_obj, &pubkey_info);
 	}

--- a/src/pkcs15init/pkcs15-isoApplet.c
+++ b/src/pkcs15init/pkcs15-isoApplet.c
@@ -485,7 +485,7 @@ isoApplet_generate_key_ec(const sc_pkcs15_prkey_info_t *key_info, sc_card_t *car
 	args.pubkey.ec.params.coFactor.len			= curve->coFactor.len;
 	/* The length of the public key point will be:
 	 * Uncompressed tag + 2 * field length in bytes. */
-	args.pubkey.ec.ecPointQ.len = 1 + 2 * key_info->field_length / 8;
+	args.pubkey.ec.ecPointQ.len = 1 + 2 * (key_info->field_length + 7) / 8;
 	args.pubkey.ec.ecPointQ.value = malloc(args.pubkey.ec.ecPointQ.len);
 	if(!args.pubkey.ec.ecPointQ.value)
 	{

--- a/src/pkcs15init/pkcs15-isoApplet.c
+++ b/src/pkcs15init/pkcs15-isoApplet.c
@@ -485,7 +485,7 @@ isoApplet_generate_key_ec(const sc_pkcs15_prkey_info_t *key_info, sc_card_t *car
 	args.pubkey.ec.params.coFactor.len			= curve->coFactor.len;
 	/* The length of the public key point will be:
 	 * Uncompressed tag + 2 * field length in bytes. */
-	args.pubkey.ec.ecPointQ.len = 1 + 2 * (key_info->field_length + 7) / 8;
+	args.pubkey.ec.ecPointQ.len = 1 + (key_info->field_length + 7) / 8 * 2;
 	args.pubkey.ec.ecPointQ.value = malloc(args.pubkey.ec.ecPointQ.len);
 	if(!args.pubkey.ec.ecPointQ.value)
 	{


### PR DESCRIPTION
THIS CODE NEEDS TO BE TESTED. 

While reviewing #438 questions about the OpenSC EC field_length came up. Most curve names have the number of bits in the name.  Early code in OpenSC made the assumption that tey were always a multiple of 8, but this is not the case. When getting memory to hold the X, Y, privateD or other curve parameters, the number of bytes need to hold number = (field_length + 7) / 8 to allow for an extra byte for the odd bits. 


In OpenSC the EC field_length is the number of bits in the field.
Most curves have a field_length which is a multiple of 8 bits
but there are many that are not.

The X and Y points and privateD are stored in octetstrings
so there may need to be an extra byte in the octetstring.

An OpenSSL BIGNUM will drop leading zero bytes, so its size can not be used
to determine the field_length.