### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/libopensc/card-tcos.c
+++ b/src/libopensc/card-tcos.c
@@ -402,6 +402,7 @@ static int tcos_select_file(sc_card_t *card,
 
 	file = sc_file_new();
 	if (file == NULL) SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_OUT_OF_MEMORY);
+	*file_out = file;
 	file->path = *in_path;
 
 	for(i=2; i+1<apdu.resplen && i+1+apdu.resp[i+1]<apdu.resplen; i+=2+apdu.resp[i+1]){
@@ -440,7 +441,6 @@ static int tcos_select_file(sc_card_t *card,
 		}
 	}
 	file->magic = SC_FILE_MAGIC;
-	*file_out = file;
 
 	parse_sec_attr(card, file, file->sec_attr, file->sec_attr_len);
 

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -764,15 +764,14 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 	sdo = calloc(1, sizeof(struct iasecc_sdo));
 	if (!sdo)
 		return SC_ERROR_OUT_OF_MEMORY;
+	*out = sdo;
 
 	sdo->sdo_class = *(data + 1) & 0x7F;
 	sdo->sdo_ref = *(data + 2) & 0x3F;
 
 	sc_log(ctx, "sdo_class 0x%X, sdo_ref 0x%X", sdo->sdo_class, sdo->sdo_ref);
-	if (data_len == 3)   {
-		*out = sdo;
+	if (data_len == 3)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
-	}
 
 	size_size = iasecc_parse_size(data + 3, &size);
 	LOG_TEST_RET(ctx, size_size, "parse error: invalid size data");
@@ -794,8 +793,6 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: not totaly parsed");
 
 	sc_log(ctx, "docp.acls_contact.size %i; docp.size.size %i", sdo->docp.acls_contact.size, sdo->docp.size.size);
-
-	*out = sdo;
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -2328,6 +2328,8 @@ sc_pkcs15init_select_intrinsic_id(struct sc_pkcs15_card *p15card, struct sc_prof
 		break;
 	default:
 		sc_log(ctx, "Unsupported ID style: %i", id_style);
+		if (allocated)
+			sc_pkcs15_free_pubkey(pubkey);
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Non supported ID style");
 	}
 
@@ -3406,6 +3408,7 @@ sc_pkcs15init_authenticate(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	int  r = 0;
 
 	LOG_FUNC_CALLED(ctx);
+	assert(file != NULL);
 	sc_log(ctx, "path '%s', op=%u", sc_print_path(&file->path), op);
 
 	if (p15card->card->caps & SC_CARD_CAP_USE_FCI_AC) {


### PR DESCRIPTION
I worked through most of the resource leaks reported by Coverity Scan which were mainly due to (non-existing) cleanup in error cases. This is done in one commit per file.

Please test carefully. Thank you!