### PR TITLE
Issue #451: Newer DNIe not working with OpenSC.

### DIFF
--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -136,6 +136,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 	sc_pkcs15_object_t *p15_obj;
 	size_t len = sizeof(buf);
 	int rv;
+	struct sc_pkcs15_cert_info *p15_info = NULL;
 
 	sc_context_t *ctx = p15card->card->ctx;
 	LOG_FUNC_CALLED(ctx);
@@ -225,6 +226,15 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 		    && (p15_obj->auth_id.len == 0)) {
 			p15_obj->auth_id.value[0] = 0x01;
 			p15_obj->auth_id.len = 1;
+		};
+		/* Set path count to -1 for public certificates, as they
+		   will need to be decompressed and read_binary()'d, so
+		   we make sure we end up reading the file->size and not the
+		   path->count which is the compressed size on newer
+                   DNIe versions  */
+		if ( p15_obj->df && (p15_obj->df->type == SC_PKCS15_CDF) ) {
+                    p15_info = (struct sc_pkcs15_cert_info *) p15_obj ->data;
+		    p15_info ->path.count = -1;
 		}
 		/* Remove found public keys as cannot be read_binary()'d */
 		if ( p15_obj->df && (p15_obj->df->type == SC_PKCS15_PUKDF) ) {


### PR DESCRIPTION
This patch fixes 3 issues which consecutively have shown up when debugging the original problem:

1 - Newer DNIe report a byte count for public certificates which is the compressed size,
while older DNIe report the uncompressed size. This resulted in short-reading the x509 certificates,
and in an error parsing. Therefore, during initialization we proceed to set path->count for
public certificates to -1. This ensures that the lenght of the certificates for reading
will be set to file-> length, which has the correct size.

2 - pkcs11-tool -t was broken for DNIe (old and new)as it tried to strip pcks11 padding
from the data to sign and OpenSC tried signatures with non-padded data
(as the card had SC_ALGORITHM_RSA_RAW).
The new algoflags (SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_PAD_PKCS1) and the
removal of the strip-padding call fix the issue.

3 - The new cards won't allow setting the LE bytes when calculating the TLV, when LE equals
256. This caused an wrong SM object error response (0x69 0x88). Therefore,
we don't send the LE bytes anymore in this case.

The patch has been tested to work on the new problematic card and on another old one.