### PR TITLE
iso7816.c: allow file length stored in more than 2 bytes

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -350,6 +350,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 {
 	struct sc_context *ctx = card->ctx;
 	size_t taglen, len = buflen;
+	int i;
 	const unsigned char *tag = NULL, *p = buf;
 
 	sc_log(ctx, "processing FCI bytes");
@@ -359,17 +360,26 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 		sc_log(ctx, "  file identifier: 0x%02X%02X", tag[0], tag[1]);
 	}
 
-	tag = sc_asn1_find_tag(ctx, p, len, 0x80, &taglen);
-	if (tag == NULL) {
-		tag = sc_asn1_find_tag(ctx, p, len, 0x81, &taglen);
-	}
-	if (tag != NULL && taglen > 0 && taglen < 3) {
+	/* determine the file size */
+	/* try the tag 0x80 then the tag 0x81 */
+	file->size = 0;
+	for (i = 0x80; i <= 0x81; i++) {
+		tag = sc_asn1_find_tag(ctx, p, len, i, &taglen);
+		if (tag == NULL) {
+			continue;
+		}
+		if (taglen == 0 || taglen > 4) {
+			continue;
+		}
 		file->size = tag[0];
-		if (taglen == 2)
+		if (taglen >= 2)
 			file->size = (file->size << 8) + tag[1];
+		if (taglen >= 3)
+			file->size = (file->size << 8) + tag[2];
+		if (taglen >= 4)
+			file->size = (file->size << 8) + tag[3];
 		sc_log(ctx, "  bytes in file: %d", file->size);
-	} else {
-		file->size = 0;
+		break;
 	}
 
 	tag = sc_asn1_find_tag(ctx, p, len, 0x82, &taglen);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -364,20 +364,23 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 	/* try the tag 0x80 then the tag 0x81 */
 	file->size = 0;
 	for (i = 0x80; i <= 0x81; i++) {
+		int size = 0;
+		len = buflen;
 		tag = sc_asn1_find_tag(ctx, p, len, i, &taglen);
 		if (tag == NULL) {
 			continue;
 		}
-		if (taglen == 0 || taglen > 4) {
+		if (taglen == 0) {
 			continue;
 		}
-		file->size = tag[0];
-		if (taglen >= 2)
-			file->size = (file->size << 8) + tag[1];
-		if (taglen >= 3)
-			file->size = (file->size << 8) + tag[2];
-		if (taglen >= 4)
-			file->size = (file->size << 8) + tag[3];
+		if (sc_asn1_decode_integer(tag, taglen, &size) < 0) {
+			continue;
+		}
+		if (size <0)
+		{
+			continue;
+		}
+		file->size = size;
 		sc_log(ctx, "  bytes in file: %d", file->size);
 		break;
 	}


### PR DESCRIPTION
As indicated in chapter 7.4.3 of iso 7816-4, file length, encoded in tag 0x80 or 0x81 can be stored in more than 2 bytes.
As is, the code allows only 2 bytes and check only for the first tag. If there is 2 tags with 4 bytes then 2 bytes, the file size computation fails.
https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/iso7816.c#L362-373

![chapter 7 4 3](https://cloud.githubusercontent.com/assets/10632326/7556203/b5673432-f767-11e4-9a7b-7866ab830483.png)

This patch push the limit to 4 bytes and moreover, if one tag has an incorrect value, it tries the next tag.