### PR TITLE
Card removal fixes

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -466,6 +466,9 @@ iso7816_select_file(struct sc_card *card, const struct sc_path *in_path, struct 
 	pathlen = in_path->len;
 	pathtype = in_path->type;
 
+	if (file_out != NULL) {
+		*file_out = NULL;
+	}
 	if (in_path->aid.len) {
 		if (!pathlen) {
 			memcpy(path, in_path->aid.value, in_path->aid.len);


### PR DESCRIPTION
OpenSC reacts sometimes with crashes or assertion failures when a card is removed during operation when the timing is bad.
This adds some error checks to avoid these crashes.