### PR TITLE
sc_pkcs11_card improvements

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -498,7 +498,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 		data.pin_type = SC_AC_CHV;
 		data.pin_reference = pin_info->attrs.pin.reference;
 
-		r = sc_pin_cmd(slot->card->card, &data, NULL);
+		r = sc_pin_cmd(slot->p11card->card, &data, NULL);
 		if (r == SC_SUCCESS) {
 			if (data.pin1.max_tries > 0)
 				pin_info->max_tries = data.pin1.max_tries;
@@ -906,7 +906,7 @@ pkcs15_add_object(struct sc_pkcs11_slot *slot, struct pkcs15_any_object *obj,
 	case SC_PKCS15_TYPE_PRKEY_GOSTR3410:
 	case SC_PKCS15_TYPE_PRKEY_EC:
 		pkcs15_add_object(slot, (struct pkcs15_any_object *) obj->related_pubkey, NULL);
-		card_fw_data = (struct pkcs15_fw_data *) slot->card->fws_data[slot->fw_data_idx];
+		card_fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
 		for (i = 0; i < card_fw_data->num_objects; i++) {
 			struct pkcs15_any_object *obj2 = card_fw_data->objects[i];
 			struct pkcs15_cert_object *cert;
@@ -1394,7 +1394,7 @@ static CK_RV
 pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 		CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15_card *p15card = NULL;
 	struct sc_pkcs15_object *auth_object = NULL;
@@ -1568,7 +1568,7 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 static CK_RV
 pkcs15_logout(struct sc_pkcs11_slot *slot)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	CK_RV ret = CKR_OK;
 	int rc;
@@ -1608,7 +1608,7 @@ pkcs15_change_pin(struct sc_pkcs11_slot *slot,
 		CK_CHAR_PTR pOldPin, CK_ULONG ulOldLen,
 		CK_CHAR_PTR pNewPin, CK_ULONG ulNewLen)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct sc_pkcs15_card *p15card = NULL;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15_auth_info *auth_info = NULL;
@@ -1685,7 +1685,7 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 		CK_UTF8CHAR_PTR pPin, CK_ULONG ulPinLen,
 		CK_UTF8CHAR_PTR pLabel)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct sc_cardctl_pkcs11_init_token args;
 	scconf_block *atrblock = NULL;
 	int rc, enable_InitToken = 0;
@@ -1811,7 +1811,7 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 static CK_RV
 pkcs15_init_pin(struct sc_pkcs11_slot *slot, CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_pinargs args;
 	struct sc_profile	*profile = NULL;
@@ -1911,7 +1911,7 @@ pkcs15_create_private_key(struct sc_pkcs11_slot *slot, struct sc_profile *profil
 		CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 		CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_prkeyargs args;
 	struct pkcs15_any_object *key_any_obj = NULL;
@@ -2065,7 +2065,7 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 		CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 		CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_skeyargs args;
 	struct pkcs15_any_object *key_any_obj = NULL;
@@ -2215,7 +2215,7 @@ static CK_RV
 pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile,
 		CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_pubkeyargs args;
 	struct pkcs15_any_object *key_any_obj = NULL;
@@ -2322,7 +2322,7 @@ pkcs15_create_certificate(struct sc_pkcs11_slot *slot,
 		CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 		CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_certargs args;
 	struct pkcs15_any_object *cert_any_obj = NULL;
@@ -2404,7 +2404,7 @@ pkcs15_create_data(struct sc_pkcs11_slot *slot, struct sc_profile *profile,
 		CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 		CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_pkcs15init_dataargs args;
 	struct pkcs15_any_object *data_any_obj = NULL;
@@ -2492,7 +2492,7 @@ static CK_RV
 pkcs15_create_object(struct sc_pkcs11_slot *slot, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 		CK_OBJECT_HANDLE_PTR phObject)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_profile *profile = NULL;
 	CK_OBJECT_CLASS	_class;
@@ -2679,7 +2679,7 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 			CK_OBJECT_HANDLE_PTR phPubKey, CK_OBJECT_HANDLE_PTR phPrivKey)                /* gets priv. key handle */
 {
 	struct sc_profile *profile = NULL;
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct sc_pkcs15_auth_info *pin = NULL;
 	struct sc_aid *aid = NULL;
 	struct pkcs15_fw_data *fw_data = NULL;
@@ -2864,7 +2864,7 @@ pkcs15_skey_destroy(struct sc_pkcs11_session *session, void *object)
 	return CKR_FUNCTION_NOT_SUPPORTED;
 #else
 	struct pkcs15_any_object *any_obj = (struct pkcs15_any_object*) object;
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	int rv;
 
@@ -2900,7 +2900,7 @@ pkcs15_any_destroy(struct sc_pkcs11_session *session, void *object)
 	struct pkcs15_data_object *obj = (struct pkcs15_data_object*) object;
 	struct pkcs15_any_object *any_obj = (struct pkcs15_any_object*) object;
 	struct sc_pkcs11_slot *slot = session->slot;
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
         struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_aid *aid = NULL;
 	struct sc_profile *profile = NULL;
@@ -2981,7 +2981,7 @@ pkcs15_any_destroy(struct sc_pkcs11_session *session, void *object)
 static CK_RV
 pkcs15_get_random(struct sc_pkcs11_slot *slot, CK_BYTE_PTR p, CK_ULONG len)
 {
-	struct sc_pkcs11_card *p11card = slot->card;
+	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	int rc;
 
@@ -3026,7 +3026,7 @@ pkcs15_set_attrib(struct sc_pkcs11_session *session, struct sc_pkcs15_object *p1
 #else
 	struct sc_profile *profile = NULL;
 	struct sc_pkcs11_slot *slot = session->slot;
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_aid *aid = NULL;
 	struct sc_pkcs15_id id;
@@ -3123,7 +3123,7 @@ pkcs15_cert_get_attribute(struct sc_pkcs11_session *session, void *object, CK_AT
 	size_t len;
 
 	sc_log(context, "pkcs15_cert_get_attribute() called");
-	p11card = session->slot->card;
+	p11card = session->slot->p11card;
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[session->slot->fw_data_idx];
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetAttributeValue");
@@ -3215,7 +3215,7 @@ pkcs15_cert_cmp_attribute(struct sc_pkcs11_session *session,
 		void *object, CK_ATTRIBUTE_PTR attr)
 {
 	struct pkcs15_cert_object *cert = (struct pkcs15_cert_object*) object;
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	const unsigned char *data = NULL, *_data = NULL;
 	size_t	len, _len;
@@ -3318,7 +3318,7 @@ pkcs15_prkey_get_attribute(struct sc_pkcs11_session *session,
 	size_t len;
 
 	sc_log(context, "pkcs15_prkey_get_attribute() called");
-	p11card = session->slot->card;
+	p11card = session->slot->p11card;
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[session->slot->fw_data_idx];
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetAttributeValue");
@@ -3508,7 +3508,7 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 			CK_ULONG_PTR pulDataLen)
 {
 	struct pkcs15_prkey_object *prkey = (struct pkcs15_prkey_object *) obj;
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	int rv, flags = 0, prkey_has_path = 0;
 	unsigned sign_flags = SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
@@ -3609,7 +3609,7 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 		CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen,
 		CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct pkcs15_prkey_object *prkey;
 	unsigned char decrypted[256]; /* FIXME: Will not work for keys above 2048 bits */
@@ -3680,7 +3680,7 @@ pkcs15_prkey_derive(struct sc_pkcs11_session *session, void *obj,
 		CK_BYTE_PTR pParameters, CK_ULONG ulParametersLen,
 		CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct pkcs15_prkey_object *prkey = (struct pkcs15_prkey_object *) obj;
 	int	need_unlock = 0, prkey_has_path = 0;
@@ -3752,7 +3752,7 @@ static CK_RV
 pkcs15_prkey_can_do(struct sc_pkcs11_session *session, void *obj,
 		CK_MECHANISM_TYPE mech_type, unsigned int flags)
 {
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct pkcs15_prkey_object *prkey = (struct pkcs15_prkey_object *) obj;
 	struct sc_pkcs15_prkey_info *pkinfo = NULL;
@@ -3846,7 +3846,7 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 
 	sc_log(context, "pkcs15_pubkey_get_attribute() called");
 
-	p11card = session->slot->card;
+	p11card = session->slot->p11card;
 	cert = pubkey->pub_genfrom;
 
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[session->slot->fw_data_idx];
@@ -4054,9 +4054,9 @@ pkcs15_dobj_get_value(struct sc_pkcs11_session *session,
 		struct pkcs15_data_object *dobj,
 		struct sc_pkcs15_data **out_data)
 {
-	struct sc_pkcs11_card *p11card = session->slot->card;
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
-	struct sc_card *card = session->slot->card->card;
+	struct sc_card *card = session->slot->p11card->card;
 	int rv;
 
 	if (!out_data)

--- a/src/pkcs11/framework-pkcs15init.c
+++ b/src/pkcs11/framework-pkcs15init.c
@@ -127,7 +127,7 @@ pkcs15init_initialize(struct sc_pkcs11_slot *pslot, void *ptr,
 		CK_UTF8CHAR_PTR pPin, CK_ULONG ulPinLen,
 		CK_UTF8CHAR_PTR pLabel)
 {
-	struct sc_pkcs11_card *p11card = pslot->card;
+	struct sc_pkcs11_card *p11card = pslot->p11card;
 	struct sc_profile *profile = (struct sc_profile *) p11card->fws_data[0];
 	struct sc_pkcs15init_initargs args;
 	struct sc_pkcs11_slot *slot;
@@ -159,9 +159,9 @@ pkcs15init_initialize(struct sc_pkcs11_slot *pslot, void *ptr,
 	 * the flags.
 	 */
 	for (id = 0; slot_get_slot(id, &slot) == CKR_OK; id++) {
-		if (slot->card == p11card)
+		if (slot->p11card == p11card)
 			slot->token_info.flags |= CKF_TOKEN_INITIALIZED;
-		if (slot->card->card->caps & SC_CARD_CAP_RNG)
+		if (slot->p11card->card->caps & SC_CARD_CAP_RNG)
 			slot->token_info.flags |= CKF_RNG;
 	}
 

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -155,7 +155,7 @@ sc_pkcs11_md_init(struct sc_pkcs11_session *session,
 	int rv;
 
 	LOG_FUNC_CALLED(context);
-	if (!session || !session->slot || !(p11card = session->slot->card))
+	if (!session || !session->slot || !(p11card = session->slot->p11card))
 		LOG_FUNC_RETURN(context, CKR_ARGUMENTS_BAD);
 
 	/* See if we support this mechanism type */
@@ -234,7 +234,7 @@ sc_pkcs11_sign_init(struct sc_pkcs11_session *session, CK_MECHANISM_PTR pMechani
 	int rv;
 
 	LOG_FUNC_CALLED(context);
-	if (!session || !session->slot || !(p11card = session->slot->card))
+	if (!session || !session->slot || !(p11card = session->slot->p11card))
 		LOG_FUNC_RETURN(context, CKR_ARGUMENTS_BAD);
 
 	/* See if we support this mechanism type */
@@ -518,7 +518,7 @@ sc_pkcs11_verif_init(struct sc_pkcs11_session *session, CK_MECHANISM_PTR pMechan
 	int rv;
 
 	if (!session || !session->slot
-	 || !(p11card = session->slot->card))
+	 || !(p11card = session->slot->p11card))
 		return CKR_ARGUMENTS_BAD;
 
 	/* See if we support this mechanism type */
@@ -729,7 +729,7 @@ sc_pkcs11_decr_init(struct sc_pkcs11_session *session,
 	CK_RV rv;
 
 	if (!session || !session->slot
-	 || !(p11card = session->slot->card))
+	 || !(p11card = session->slot->p11card))
 		return CKR_ARGUMENTS_BAD;
 
 	/* See if we support this mechanism type */
@@ -799,7 +799,7 @@ sc_pkcs11_deri(struct sc_pkcs11_session *session,
 
 
 	if (!session || !session->slot
-	 || !(p11card = session->slot->card))
+	 || !(p11card = session->slot->p11card))
 		return CKR_ARGUMENTS_BAD;
 
 	/* See if we support this mechanism type */

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -167,7 +167,7 @@ static void * dup_mem(void *in, size_t in_len)
 }
 
 void
-sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *card)
+sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE)
 	void (*locking_cb)(int, int, const char *, int);
@@ -207,22 +207,22 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *card)
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE) */
 
 	openssl_sha1_mech.mech_data = EVP_sha1();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L
 	openssl_sha256_mech.mech_data = EVP_sha256();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
 	openssl_sha384_mech.mech_data = EVP_sha384();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
 	openssl_sha512_mech.mech_data = EVP_sha512();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
 #endif
 	openssl_md5_mech.mech_data = EVP_md5();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
 	openssl_ripemd160_mech.mech_data = EVP_ripemd160();
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
-	sc_pkcs11_register_mechanism(card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));
 #endif
 }
 

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -533,7 +533,7 @@ CK_RV C_GetMechanismList(CK_SLOT_ID slotID,
 
 	rv = slot_get_token(slotID, &slot);
 	if (rv == CKR_OK)
-		rv = sc_pkcs11_get_mechanism_list(slot->card, pMechanismList, pulCount);
+		rv = sc_pkcs11_get_mechanism_list(slot->p11card, pMechanismList, pulCount);
 
 	sc_pkcs11_unlock();
 	return rv;
@@ -555,7 +555,7 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID,
 
 	rv = slot_get_token(slotID, &slot);
 	if (rv == CKR_OK)
-		rv = sc_pkcs11_get_mechanism_info(slot->card, type, pInfo);
+		rv = sc_pkcs11_get_mechanism_info(slot->p11card, type, pInfo);
 
 	sc_pkcs11_unlock();
 	return rv;
@@ -582,7 +582,7 @@ CK_RV C_InitToken(CK_SLOT_ID slotID,
 		goto out;
 	}
 
-	if (slot->card->framework->init_token == NULL) {
+	if (slot->p11card->framework->init_token == NULL) {
 		sc_log(context, "C_InitToken() not supported by framework");
 		rv = CKR_FUNCTION_NOT_SUPPORTED;
 		goto out;
@@ -597,7 +597,7 @@ CK_RV C_InitToken(CK_SLOT_ID slotID,
 		}
 	}
 
-	rv = slot->card->framework->init_token(slot,slot->fw_data, pPin, ulPinLen, pLabel);
+	rv = slot->p11card->framework->init_token(slot,slot->fw_data, pPin, ulPinLen, pLabel);
 	if (rv == CKR_OK) {
 		/* Now we should re-bind all tokens so they get the
 		 * corresponding function vector and flags */

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -114,7 +114,7 @@ CK_RV sc_create_object_int(CK_SESSION_HANDLE hSession,	/* the session's handle *
 		goto out;
 	}
 
-	card = session->slot->card;
+	card = session->slot->p11card;
 	if (card->framework->create_object == NULL)
 		rv = CKR_FUNCTION_NOT_SUPPORTED;
 	else
@@ -983,10 +983,10 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	}
 
 	slot = session->slot;
-	if (slot->card->framework->gen_keypair == NULL)
+	if (slot->p11card->framework->gen_keypair == NULL)
 		rv = CKR_FUNCTION_NOT_SUPPORTED;
 	else
-		rv = slot->card->framework->gen_keypair(slot, pMechanism,
+		rv = slot->p11card->framework->gen_keypair(slot, pMechanism,
 				pPublicKeyTemplate, ulPublicKeyAttributeCount,
 				pPrivateKeyTemplate, ulPrivateKeyAttributeCount,
 				phPublicKey, phPrivateKey);
@@ -1120,10 +1120,10 @@ CK_RV C_GenerateRandom(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	rv = get_session(hSession, &session);
 	if (rv == CKR_OK) {
 		slot = session->slot;
-		if (slot->card->framework->get_random == NULL)
+		if (slot->p11card->framework->get_random == NULL)
 			rv = CKR_RANDOM_NO_RNG;
 		else
-			rv = slot->card->framework->get_random(slot, RandomData, ulRandomLen);
+			rv = slot->p11card->framework->get_random(slot, RandomData, ulRandomLen);
 	}
 
 	sc_pkcs11_unlock();

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -107,7 +107,7 @@ static CK_RV sc_pkcs11_close_session(CK_SESSION_HANDLE hSession)
 	slot->nsessions--;
 	if (slot->nsessions == 0 && slot->login_user >= 0) {
 		slot->login_user = -1;
-		slot->card->framework->logout(slot);
+		slot->p11card->framework->logout(slot);
 	}
 
 	if (list_delete(&sessions, session) != 0)
@@ -272,7 +272,7 @@ CK_RV C_Login(CK_SESSION_HANDLE hSession,	/* the session's handle */
 			goto out;
 		}
 		else   {
-			rv = slot->card->framework->login(slot, userType, pPin, ulPinLen);
+			rv = slot->p11card->framework->login(slot, userType, pPin, ulPinLen);
 		}
 	}
 	else {
@@ -286,7 +286,7 @@ CK_RV C_Login(CK_SESSION_HANDLE hSession,	/* the session's handle */
 		}
 
 		sc_log(context, "C_Login() userType %li", userType);
-		rv = slot->card->framework->login(slot, userType, pPin, ulPinLen);
+		rv = slot->p11card->framework->login(slot, userType, pPin, ulPinLen);
 		sc_log(context, "fLogin() rv %li", rv);
 		if (rv == CKR_OK)
 			slot->login_user = userType;
@@ -319,7 +319,7 @@ CK_RV C_Logout(CK_SESSION_HANDLE hSession)
 
 	if (slot->login_user >= 0) {
 		slot->login_user = -1;
-		rv = slot->card->framework->logout(slot);
+		rv = slot->p11card->framework->logout(slot);
 	} else
 		rv = CKR_USER_NOT_LOGGED_IN;
 
@@ -355,10 +355,10 @@ CK_RV C_InitPIN(CK_SESSION_HANDLE hSession, CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
 	slot = session->slot;
 	if (slot->login_user != CKU_SO) {
 		rv = CKR_USER_NOT_LOGGED_IN;
-	} else if (slot->card->framework->init_pin == NULL) {
+	} else if (slot->p11card->framework->init_pin == NULL) {
 		rv = CKR_FUNCTION_NOT_SUPPORTED;
 	} else {
-		rv = slot->card->framework->init_pin(slot, pPin, ulPinLen);
+		rv = slot->p11card->framework->init_pin(slot, pPin, ulPinLen);
 		sc_log(context, "C_InitPIN() init-pin result %li", rv);
 	}
 
@@ -395,7 +395,7 @@ CK_RV C_SetPIN(CK_SESSION_HANDLE hSession,
 		goto out;
 	}
 
-	rv = slot->card->framework->change_pin(slot, pOldPin, ulOldLen, pNewPin, ulNewLen);
+	rv = slot->p11card->framework->change_pin(slot, pOldPin, ulOldLen, pNewPin, ulNewLen);
 out:
 	sc_pkcs11_unlock();
 	return rv;

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -208,7 +208,7 @@ struct sc_pkcs11_slot {
 	CK_SLOT_INFO slot_info;		/* Slot specific information (information about reader) */
 	CK_TOKEN_INFO token_info;	/* Token specific information (information about card) */
 	sc_reader_t *reader;		/* same as card->reader if there's a card present */
-	struct sc_pkcs11_card *card;	/* The card associated with this slot */
+	struct sc_pkcs11_card *p11card;	/* The card associated with this slot */
 	unsigned int events;		/* Card events SC_EVENT_CARD_{INSERTED,REMOVED} */
 	void *fw_data;			/* Framework specific data */  /* TODO: get know how it used */
 	list_t objects;			/* Objects in this slot */


### PR DESCRIPTION
    This is name change only fix.

    The variable name card was being used to refer to a struct sc_card or a struct sc_pkcs11_card
    in some of the routines in the pkcs11 directory, while other routines used the variable name
    p11card for struct sc_pkcs11_card. This creates confusing code, such as:
    slot->card->card.

    All definitations of sc_pkcs11_card *card now use p11card as the variable name.