### PR TITLE
Empty user-interface.c if there is no SSL support. Related with issue #362

### DIFF
--- a/src/libopensc/user-interface.c
+++ b/src/libopensc/user-interface.c
@@ -29,6 +29,8 @@
 #include "config.h"
 #endif
 
+#ifdef ENABLE_OPENSSL           /* empty file without openssl */
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
@@ -318,4 +320,6 @@ do_error:
 	LOG_FUNC_RETURN(card->ctx, res);
 }
 
-#endif
+#endif				/* ENABLE_DNIE_UI */
+
+#endif                          /* ENABLE_OPENSSL */


### PR DESCRIPTION
The module with a default user interface for DNIe should not be compiled if there is no SSL support (just as other modules of DNIe).