### PR TITLE
Restore compability on os x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -540,10 +540,13 @@ if test "${enable_pcsc}" = "yes"; then
 			case "${host}" in
 				*-*-darwin*)
 					# Locate the latest SDK.
-					SDKS_PATH="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs"
-					SDK_PATH="${SDK_PATH:-$SDKS_PATH/$(ls -1 ${SDKS_PATH} | sort -n -t. -k2 -r | head -1)}"
-					# and set the PC/SC include path
-					PCSC_CFLAGS="-I$SDK_PATH/System/Library/Frameworks/PCSC.framework/Versions/Current/Headers"
+					SDKS_PATH="$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs"
+					if test -d $SDKS_PATH; then
+					    SDK_PATH="${SDK_PATH:-$SDKS_PATH/$(ls -1 ${SDKS_PATH} | sort -n -t. -k2 -r | head -1)}"
+					    PCSC_CFLAGS="-I$SDK_PATH/System/Library/Frameworks/PCSC.framework/Versions/Current/Headers"
+					else
+					    PCSC_CFLAGS="-I/System/Library/Frameworks/PCSC.framework/Headers"
+					fi
 				;;
 				*)
 					PCSC_CFLAGS="-I/usr/include/PCSC"


### PR DESCRIPTION
Fallback to
/System/Library/Frameworks/PCSC.framework/Versions/Current/Headers when
there are no OS X SDKs installed. Fixes bugs introduced in #308