### PR TITLE
Fix tokend install on OSX 10.11

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -70,12 +70,9 @@ fi
 test -L OpenSC.tokend/build/opensc-src || ln -sf ${BUILDPATH}/src OpenSC.tokend/build/opensc-src
 
 # Build and copy OpenSC.tokend
-xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj
+xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj install DSTROOT=${PWD}/target
 
 # Prepare target root
-# Copy Tokend
-mkdir -p target/System/Library/Security/tokend
-mv OpenSC.tokend/build/OpenSC.tokend target/System/Library/Security/tokend
 # The "UnInstaller"
 mkdir -p target/usr/local/bin
 cp MacOSX/opensc-uninstall target/usr/local/bin

--- a/MacOSX/opensc-uninstall
+++ b/MacOSX/opensc-uninstall
@@ -16,6 +16,7 @@ test -L /usr/lib/opensc-pkcs11.so && rm -f /usr/lib/opensc-pkcs11.so
 
 # Remove installed files
 rm -rf /Library/OpenSC
+rm -rf /Library/Security/tokend/OpenSC.tokend
 rm -rf /System/Library/Security/tokend/OpenSC.tokend
 
 # delete receipts on 10.6+


### PR DESCRIPTION
Install to /Library/Security/tokend instead /System/Library/Security/tokend
http://forums.macrumors.com/threads/os-x-10-11-all-the-little-things.1890519/
/System folder is readonly

Depends https://github.com/OpenSC/OpenSC.tokend/pull/16

Signed-off-by: Raul Metsma <raul@metsma.ee>