### PR TITLE
After a fork do not release resources shared with parent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,8 +39,8 @@ OPENSC_VS_FF_PRODUCT_NAME="VS_FF_PRODUCT_NAME"
 #   (Code changed:                      REVISION++)
 #   (Oldest interface removed:          OLDEST++)
 #   (Interfaces added:                  CURRENT++, REVISION=0)
-OPENSC_LT_CURRENT="3"
-OPENSC_LT_OLDEST="3"
+OPENSC_LT_CURRENT="4"
+OPENSC_LT_OLDEST="4"
 OPENSC_LT_REVISION="0"
 OPENSC_LT_AGE="0"
 OPENSC_LT_AGE="$((${OPENSC_LT_CURRENT}-${OPENSC_LT_OLDEST}))"

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -218,7 +218,8 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 			if (ops == NULL || ops->match_card == NULL)   {
 				continue;
 			}
-			else if (!ctx->enable_default_driver && !strcmp("default", drv->short_name))   {
+			else if (!(ctx->flags & SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER)
+				   	&& !strcmp("default", drv->short_name))   {
 				sc_log(ctx , "ignore 'default' card driver");
 				continue;
 			}

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -639,6 +639,16 @@ typedef struct {
 	unsigned long (*thread_id)(void);
 } sc_thread_context_t;
 
+/** Stop modifing or using external resources
+ *
+ * Currently this is used to avoid freeing duplicated external resources for a
+ * process that has been forked. For example, a child process may want to leave
+ * the duplicated card handles for the parent process. With this flag the child
+ * process indicates that shall the reader shall ignore those resources when
+ * calling sc_disconnect_card.
+ */
+#define SC_TERMINATE			0x00000001
+
 typedef struct sc_context {
 	scconf_context *conf;
 	scconf_block *conf_blocks[3];

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -647,15 +647,17 @@ typedef struct {
  * process indicates that shall the reader shall ignore those resources when
  * calling sc_disconnect_card.
  */
-#define SC_TERMINATE			0x00000001
+#define SC_CTX_FLAG_TERMINATE				0x00000001
+#define SC_CTX_FLAG_PARANOID_MEMORY			0x00000002
+#define SC_CTX_FLAG_DEBUG_MEMORY			0x00000004
+#define SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER	0x00000008
 
 typedef struct sc_context {
 	scconf_context *conf;
 	scconf_block *conf_blocks[3];
 	char *app_name;
 	int debug;
-	int paranoid_memory;
-	int enable_default_driver;
+	unsigned long flags;
 
 	FILE *debug_file;
 	char *debug_filename;
@@ -729,7 +731,7 @@ typedef struct {
 	 *  dependend configuration data). If NULL the name "default"
 	 *  will be used. */
 	const char    *app_name;
-	/** flags, currently unused */
+	/** context flags */
 	unsigned long flags;
 	/** mutex functions to use (optional) */
 	sc_thread_context_t *thread_ctx;

--- a/src/libopensc/reader-ctapi.c
+++ b/src/libopensc/reader-ctapi.c
@@ -116,6 +116,9 @@ static int refresh_attributes(sc_reader_t *reader)
 	u8 cmd[5], rbuf[256], sad, dad;
 	unsigned short lr;
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	cmd[0] = CTBCS_CLA;
 	cmd[1] = CTBCS_INS_STATUS;
 	cmd[2] = CTBCS_P1_CT_KERNEL;
@@ -158,6 +161,9 @@ static int ctapi_internal_transmit(sc_reader_t *reader,
 	u8 dad, sad;
 	unsigned short lr;
 	char rv;
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 	
 	if (control)
 		dad = 1;
@@ -235,6 +241,9 @@ static int ctapi_connect(sc_reader_t *reader)
 	unsigned short lr;
 	int r;
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	cmd[0] = CTBCS_CLA;
 	cmd[1] = CTBCS_INS_REQUEST;
 	cmd[2] = CTBCS_P1_INTERFACE1;
@@ -280,7 +289,9 @@ static int ctapi_release(sc_reader_t *reader)
 {
 	struct ctapi_private_data *priv = GET_PRIV_DATA(reader);
 
-	priv->funcs.CT_close(priv->ctn);
+
+	if (!(reader->ctx->magic & SC_TERMINATE))
+		priv->funcs.CT_close(priv->ctn);
 
 	free(priv);
 	return 0;

--- a/src/libopensc/reader-ctapi.c
+++ b/src/libopensc/reader-ctapi.c
@@ -116,7 +116,7 @@ static int refresh_attributes(sc_reader_t *reader)
 	u8 cmd[5], rbuf[256], sad, dad;
 	unsigned short lr;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	cmd[0] = CTBCS_CLA;
@@ -162,7 +162,7 @@ static int ctapi_internal_transmit(sc_reader_t *reader,
 	unsigned short lr;
 	char rv;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 	
 	if (control)
@@ -241,7 +241,7 @@ static int ctapi_connect(sc_reader_t *reader)
 	unsigned short lr;
 	int r;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	cmd[0] = CTBCS_CLA;
@@ -290,7 +290,7 @@ static int ctapi_release(sc_reader_t *reader)
 	struct ctapi_private_data *priv = GET_PRIV_DATA(reader);
 
 
-	if (!(reader->ctx->magic & SC_TERMINATE))
+	if (!(reader->ctx->flags & SC_CTX_FLAG_TERMINATE))
 		priv->funcs.CT_close(priv->ctn);
 
 	free(priv);

--- a/src/libopensc/reader-openct.c
+++ b/src/libopensc/reader-openct.c
@@ -154,7 +154,7 @@ static int openct_reader_release(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 	if (data) {
-		if (data->h)
+		if (data->h && !(reader->ctx->magic & SC_TERMINATE))
 			ct_reader_disconnect(data->h);
 		sc_mem_clear(data, sizeof(*data));
 		reader->drv_data = NULL;
@@ -173,6 +173,9 @@ static int openct_reader_detect_card_presence(sc_reader_t *reader)
 	int rc, status;
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	reader->flags = 0;
 	if (!data->h && !(data->h = ct_reader_connect(data->num)))
@@ -196,6 +199,9 @@ openct_reader_connect(sc_reader_t *reader)
 	int rc;
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	if (data->h)
 		ct_reader_disconnect(data->h);
@@ -242,7 +248,7 @@ static int openct_reader_disconnect(sc_reader_t *reader)
 	struct driver_data *data = (struct driver_data *) reader->drv_data;
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
-	if (data->h)
+	if (data->h && !(reader->flags & SC_TERMINATE))
 		ct_reader_disconnect(data->h);
 	data->h = NULL;
 	return SC_SUCCESS;
@@ -255,6 +261,9 @@ openct_reader_internal_transmit(sc_reader_t *reader,
 {
 	struct driver_data *data = (struct driver_data *) reader->drv_data;
 	int rc;
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	/* Hotplug check */
 	if ((rc = openct_reader_reconnect(reader)) < 0)
@@ -324,6 +333,9 @@ static int openct_reader_perform_verify(sc_reader_t *reader, struct sc_pin_cmd_d
 	u8 buf[254];
 	int rc;
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	/* Hotplug check */
 	if ((rc = openct_reader_reconnect(reader)) < 0)
 		return rc;
@@ -382,6 +394,9 @@ static int openct_reader_lock(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	/* Hotplug check */
 	if ((rc = openct_reader_reconnect(reader)) < 0)
 		return rc;
@@ -407,6 +422,9 @@ static int openct_reader_unlock(sc_reader_t *reader)
 	int rc;
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	/* Not connected */
 	if (data->h == NULL)

--- a/src/libopensc/reader-openct.c
+++ b/src/libopensc/reader-openct.c
@@ -154,7 +154,7 @@ static int openct_reader_release(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 	if (data) {
-		if (data->h && !(reader->ctx->magic & SC_TERMINATE))
+		if (data->h && !(reader->ctx->flags & SC_CTX_FLAG_TERMINATE))
 			ct_reader_disconnect(data->h);
 		sc_mem_clear(data, sizeof(*data));
 		reader->drv_data = NULL;
@@ -174,7 +174,7 @@ static int openct_reader_detect_card_presence(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	reader->flags = 0;
@@ -200,7 +200,7 @@ openct_reader_connect(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	if (data->h)
@@ -262,7 +262,7 @@ openct_reader_internal_transmit(sc_reader_t *reader,
 	struct driver_data *data = (struct driver_data *) reader->drv_data;
 	int rc;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	/* Hotplug check */
@@ -333,7 +333,7 @@ static int openct_reader_perform_verify(sc_reader_t *reader, struct sc_pin_cmd_d
 	u8 buf[254];
 	int rc;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	/* Hotplug check */
@@ -394,7 +394,7 @@ static int openct_reader_lock(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	/* Hotplug check */
@@ -423,7 +423,7 @@ static int openct_reader_unlock(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	/* Not connected */

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -184,6 +184,9 @@ static int pcsc_internal_transmit(sc_reader_t *reader,
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 	card = priv->pcsc_card;
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	sSendPci.dwProtocol = opensc_proto_to_pcsc(reader->active_protocol);
 	sSendPci.cbPciLength = sizeof(sSendPci);
 	sRecvPci.dwProtocol = opensc_proto_to_pcsc(reader->active_protocol);
@@ -283,6 +286,9 @@ static int refresh_attributes(sc_reader_t *reader)
 	LONG rv;
 
 	sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "%s check", reader->name);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	if (priv->reader_state.szReader == NULL) {
 		priv->reader_state.szReader = reader->name;
@@ -505,7 +511,8 @@ static int pcsc_disconnect(sc_reader_t * reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
-	priv->gpriv->SCardDisconnect(priv->pcsc_card, priv->gpriv->disconnect_action);
+	if (!(reader->ctx->magic & SC_TERMINATE))
+		priv->gpriv->SCardDisconnect(priv->pcsc_card, priv->gpriv->disconnect_action);
 	reader->flags = 0;
 	return SC_SUCCESS;
 }
@@ -517,6 +524,9 @@ static int pcsc_lock(sc_reader_t *reader)
 	struct pcsc_private_data *priv = GET_PRIV_DATA(reader);
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	rv = priv->gpriv->SCardBeginTransaction(priv->pcsc_card);
 
@@ -554,6 +564,9 @@ static int pcsc_unlock(sc_reader_t *reader)
 	struct pcsc_private_data *priv = GET_PRIV_DATA(reader);
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
+
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
 
 	rv = priv->gpriv->SCardEndTransaction(priv->pcsc_card, priv->gpriv->transaction_end_action);
 
@@ -597,12 +610,18 @@ static int pcsc_cancel(sc_context_t *ctx)
 	struct pcsc_global_private_data *gpriv = (struct pcsc_global_private_data *)ctx->reader_drv_data;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
+
+	if (ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 #ifndef _WIN32
 	if (gpriv->pcsc_wait_ctx != -1) {
 		rv = gpriv->SCardCancel(gpriv->pcsc_wait_ctx);
-		if (rv == SCARD_S_SUCCESS)
+		if (rv == SCARD_S_SUCCESS) {
 			 /* Also close and clear the waiting context */
 			 rv = gpriv->SCardReleaseContext(gpriv->pcsc_wait_ctx);
+			 gpriv->pcsc_wait_ctx = -1;
+		}
 	}
 #else
 	rv = gpriv->SCardCancel(gpriv->pcsc_ctx);
@@ -747,7 +766,7 @@ static int pcsc_finish(sc_context_t *ctx)
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
 
 	if (gpriv) {
-		if (gpriv->pcsc_ctx != -1)
+		if (gpriv->pcsc_ctx != -1 && !(ctx->magic & SC_TERMINATE))
 			gpriv->SCardReleaseContext(gpriv->pcsc_ctx);
 		if (gpriv->dlhandle != NULL)
 			sc_dlclose(gpriv->dlhandle);
@@ -1643,6 +1662,9 @@ pcsc_pin_cmd(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
+	if (reader->ctx->magic & SC_TERMINATE)
+		return SC_ERROR_NOT_ALLOWED;
+
 	if (priv->gpriv->SCardControl == NULL)
 		return SC_ERROR_NOT_SUPPORTED;
 
@@ -1932,8 +1954,8 @@ static int transform_pace_output(u8 *rbuf, size_t rbuflen,
 static int
 pcsc_perform_pace(struct sc_reader *reader, void *input_pace, void *output_pace)
 {
-        struct establish_pace_channel_input *pace_input = (struct establish_pace_channel_input *) input_pace;
-        struct establish_pace_channel_output *pace_output = (struct establish_pace_channel_output *) output_pace;
+	struct establish_pace_channel_input *pace_input = (struct establish_pace_channel_input *) input_pace;
+	struct establish_pace_channel_output *pace_output = (struct establish_pace_channel_output *) output_pace;
 	struct pcsc_private_data *priv;
 	u8 rbuf[SC_MAX_EXT_APDU_BUFFER_SIZE], sbuf[SC_MAX_EXT_APDU_BUFFER_SIZE];
 	size_t rcount = sizeof rbuf, scount = sizeof sbuf;

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -184,7 +184,7 @@ static int pcsc_internal_transmit(sc_reader_t *reader,
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 	card = priv->pcsc_card;
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	sSendPci.dwProtocol = opensc_proto_to_pcsc(reader->active_protocol);
@@ -287,7 +287,7 @@ static int refresh_attributes(sc_reader_t *reader)
 
 	sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "%s check", reader->name);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	if (priv->reader_state.szReader == NULL) {
@@ -511,7 +511,7 @@ static int pcsc_disconnect(sc_reader_t * reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (!(reader->ctx->magic & SC_TERMINATE))
+	if (!(reader->ctx->flags & SC_CTX_FLAG_TERMINATE))
 		priv->gpriv->SCardDisconnect(priv->pcsc_card, priv->gpriv->disconnect_action);
 	reader->flags = 0;
 	return SC_SUCCESS;
@@ -525,7 +525,7 @@ static int pcsc_lock(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	rv = priv->gpriv->SCardBeginTransaction(priv->pcsc_card);
@@ -565,7 +565,7 @@ static int pcsc_unlock(sc_reader_t *reader)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	rv = priv->gpriv->SCardEndTransaction(priv->pcsc_card, priv->gpriv->transaction_end_action);
@@ -611,7 +611,7 @@ static int pcsc_cancel(sc_context_t *ctx)
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (ctx->magic & SC_TERMINATE)
+	if (ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 #ifndef _WIN32
@@ -766,7 +766,7 @@ static int pcsc_finish(sc_context_t *ctx)
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
 
 	if (gpriv) {
-		if (gpriv->pcsc_ctx != -1 && !(ctx->magic & SC_TERMINATE))
+		if (gpriv->pcsc_ctx != -1 && !(ctx->flags & SC_CTX_FLAG_TERMINATE))
 			gpriv->SCardReleaseContext(gpriv->pcsc_ctx);
 		if (gpriv->dlhandle != NULL)
 			sc_dlclose(gpriv->dlhandle);
@@ -1662,7 +1662,7 @@ pcsc_pin_cmd(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 
 	SC_FUNC_CALLED(reader->ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (reader->ctx->magic & SC_TERMINATE)
+	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
 	if (priv->gpriv->SCardControl == NULL)

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -806,7 +806,7 @@ void *sc_mem_alloc_secure(sc_context_t *ctx, size_t len)
         locked = 1;
 #endif
     if (!locked) {
-        if (ctx->paranoid_memory) {
+        if (ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY) {
             sc_do_log (ctx, 0, NULL, 0, NULL, "cannot lock memory, failing allocation because paranoid set");
             free (pointer);
             pointer = NULL;

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -206,7 +206,7 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs)
 	/* Handle fork() exception */
 	if (current_pid != initialized_pid) {
 		if (context)
-			context->magic |= SC_TERMINATE;
+			context->flags |= SC_CTX_FLAG_TERMINATE;
 		C_Finalize(NULL_PTR);
 	}
 	initialized_pid = current_pid;

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -202,9 +202,11 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs)
 	unsigned int i;
 	sc_context_param_t ctx_opts;
 
-	/* Handle fork() exception */
 #if !defined(_WIN32)
+	/* Handle fork() exception */
 	if (current_pid != initialized_pid) {
+		if (context)
+			context->magic |= SC_TERMINATE;
 		C_Finalize(NULL_PTR);
 	}
 	initialized_pid = current_pid;

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1836,7 +1836,7 @@ int main(int argc, char * const argv[])
 		return 1;
 	}
 
-	ctx->enable_default_driver = 1;
+	ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;
 
 	if (verbose > 1) {
 		ctx->debug = verbose;

--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -758,7 +758,7 @@ int main(int argc, char * const argv[])
 		return 1;
 	}
 
-	ctx->enable_default_driver = 1;
+	ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;
 
 	if (verbose > 1) {
 		ctx->debug = verbose;


### PR DESCRIPTION
This PR implements the second option proposed in https://github.com/OpenSC/OpenSC/pull/493#issuecomment-121917436 . I hope my approach is a bit cleaner and more complete than what is proposed in #493. Everything works as expected with a CardOS card and `pkcs11-tool --test-fork --login --test`