### PR TITLE
Fix regression tests: some parameters got renamed (#496)

### DIFF
--- a/src/tests/regression/crypt0007
+++ b/src/tests/regression/crypt0007
@@ -10,7 +10,7 @@
 
 msg <<EOF
 :::
-::: Testing on-card decryption facilities (1048 bit)
+::: Testing on-card decryption facilities (1024 bit)
 :::
 EOF
 
@@ -23,7 +23,7 @@ p15_init --no-so-pin
 p15_set_pin -a 01
 
 suppress_error_msg="Key length/algorithm not supported by card"
-if p15_gen_key rsa/1048 --id 45 --key-usage decrypt -a 01; then
+if p15_gen_key rsa/1024 --id 45 --key-usage decrypt -a 01; then
 	msg "Extracting public key"
 	run_check_status $p15tool --read-public-key 45 -o $p
 

--- a/src/tests/regression/functions
+++ b/src/tests/regression/functions
@@ -255,7 +255,7 @@ EOF
 function p15_erase {
 
 	msg "Erasing card ($*)"
-	run_display_output $p15init --erase \
+	run_display_output $p15init --erase-card \
 			--secret @FF=999999 \
 			"$@" >&3 >&4
 	success
@@ -356,6 +356,6 @@ function p15_validate {
 	msg "Validating card using pkcs11-tool"
 	run_display_output $p11tool -t --login --pin 0000 \
 		--module $p11module \
-		--slot-label "OpenSC Test Card" $* < /dev/null
+		--token-label "OpenSC Test Card" $* < /dev/null
 	success
 }


### PR DESCRIPTION
This fixes two renamed parameters in the regression tests plus invalid key size in test crypt0007.