### PR TITLE
Fix bad code. Maybe this is what was intended ?

### DIFF
--- a/src/libopensc/card-masktech.c
+++ b/src/libopensc/card-masktech.c
@@ -178,7 +178,9 @@ static int masktech_decipher(sc_card_t *card,
 	assert(card != NULL && crgram != NULL && out != NULL);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "masktech_decipher()\n");
 
-	if (crgram_len > SC_MAX_EXT_APDU_BUFFER_SIZE) SC_ERROR_INVALID_ARGUMENTS;
+	if (crgram_len > SC_MAX_EXT_APDU_BUFFER_SIZE) {
+		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
+	}
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_EXT, 0x2A, 0x80, 0x86);
 	apdu.resp = rbuf;


### PR DESCRIPTION
../../src/libopensc/errors.h:73:37: warning: statement with no effect [-Wunused-value]
 #define SC_ERROR_INVALID_ARGUMENTS  -1300
                                     ^
card-masktech.c:181:48: note: in expansion of macro 'SC_ERROR_INVALID_ARGUMENTS'
  if (crgram_len > SC_MAX_EXT_APDU_BUFFER_SIZE) SC_ERROR_INVALID_ARGUMENTS;