### PR TITLE
don't always overwrite max_send_size/max_recv_size

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -581,7 +581,7 @@ int sc_transmit_apdu(sc_card_t *card, sc_apdu_t *apdu)
 		 * bytes using command chaining */
 		size_t    len  = apdu->datalen;
 		const u8  *buf = apdu->data;
-		size_t    max_send_size = card->max_send_size > 0 ? card->max_send_size : 255;
+		size_t    max_send_size = card->max_send_size;
 
 		while (len != 0) {
 			size_t    plen;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -871,7 +871,7 @@ static int dnie_compose_and_send_apdu(sc_card_t *card, const u8 *path, size_t pa
 	apdu.lc = pathlen;
 	apdu.data = path;
 	apdu.datalen = pathlen;
-	apdu.le = card->max_recv_size > 0 ? card->max_recv_size : 256;
+	apdu.le = card->max_recv_size;
 	if (p1 == 3)
 		apdu.cse= SC_APDU_CASE_1;
 

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -249,7 +249,7 @@ static int sc_hsm_read_binary(sc_card_t *card,
 	cmdbuff[2] = (idx >> 8) & 0xFF;
 	cmdbuff[3] = idx & 0xFF;
 
-	assert(count <= (card->max_recv_size > 0 ? card->max_recv_size : 256));
+	assert(count <= card->max_recv_size);
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0xB1, 0x00, 0x00);
 	apdu.data = cmdbuff;
 	apdu.datalen = 4;


### PR DESCRIPTION
If the reader announces extended length support, but the card driver leaves `max_send_size`/`max_recv_size` at `0`, `max_send_size`/`max_recv_size` previously would have been overwritten with the reader's size though the card might not have set `SC_CARD_CAP_APDU_EXT`. This commit fixes this behavior.

Additionally card->max_send_size/max_recv_size is always initialized to a value different from `0` after the card initialization. This removes the need to check for this special value in all subsequent calls.

Yes, this is the most intrusive way of fixing this issue. The alternative would be to simply change ´card.c´ to something like
```
	/*  Override card limitations with reader limitations.
	 *  Note that zero means no limitations at all.
	 */
	if ((card->max_recv_size == 0 && card->caps & SC_CARD_CAP_APDU_EXT && reader->max_recv_size < 0xffff+1)
			|| (card->max_recv_size == 0 && !card->caps & SC_CARD_CAP_APDU_EXT && reader->max_recv_size < 0xff+1)
			|| ((reader->max_recv_size != 0) && (reader->max_recv_size < card->max_recv_size)))
		card->max_recv_size = reader->max_recv_size;

	if ((card->max_send_size== 0 && card->caps & SC_CARD_CAP_APDU_EXT && reader->max_send_size < 0xffff)
			|| (card->max_recv_size == 0 && !card->caps & SC_CARD_CAP_APDU_EXT && reader->max_send_size < 0xff)
			|| ((reader->max_send_size != 0) && (reader->max_send_size < card->max_send_size)))
		card->max_send_size = reader->max_send_size;

```
while leaving everything else as is. However, I consider the first approach better because it reduces the overall complexity.

Feedback welcome!