### PR TITLE
Only re-lock for Windows and Apple

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Building the installer is only tested and supported on 10.9+ with Xcode 6.0.1
-# Built package targets 10.9+
+# Built package targets 10.10
 # Building should also work on older versions with older revisions or slight changes, YMMV
 
 # You need to have  the following from homebrew or macports or fink:
@@ -15,7 +15,7 @@ SDKS_PATH="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs"
 SDK_PATH="${SDK_PATH:-$SDKS_PATH/$(ls -1 ${SDKS_PATH} | sort -n -k2 -t. -r | head -1)}"
 
 # Set SDK path
-export CFLAGS="-isysroot $SDK_PATH -arch i386 -arch x86_64 -mmacosx-version-min=10.7"
+export CFLAGS="-isysroot $SDK_PATH -arch i386 -arch x86_64 -mmacosx-version-min=10.10"
 
 # OpenSSL is deprecated on OSX since 10.7 and that generates lots of
 # "false positive" warnings and there is no alternative option.

--- a/configure.ac
+++ b/configure.ac
@@ -576,6 +576,7 @@ if test "${enable_pcsc}" = "yes"; then
 	CFLAGS="${CFLAGS} ${PCSC_CFLAGS}"
 	# We must cope with mingw32 that does not have winscard.h mingw64 has it.
 	AC_CHECK_HEADERS([winscard.h],,[test "${WIN32}" != "yes" && AC_MSG_ERROR([winscard.h is required for pcsc])])
+	AC_CHECK_HEADERS([pcsclite.h])
 	CFLAGS="${saved_CFLAGS}"
 
 	if test "${with_pcsc_provider}" = "detect"; then

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -41,6 +41,12 @@
 
 #include "pace.h"
 
+#ifdef HAVE_PCSCLITE_H
+#if !defined (__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+#define HAVE_PCSCLITE 1
+#endif
+#endif
+
 /* Logging */
 #define PCSC_TRACE(reader, desc, rv) do { sc_log(reader->ctx, "%s:" desc ": 0x%08lx\n", reader->name, rv); } while (0)
 #define PCSC_LOG(ctx, desc, rv) do { sc_log(ctx, desc ": 0x%08lx\n", rv); } while (0)
@@ -431,7 +437,7 @@ static int pcsc_reconnect(sc_reader_t * reader, DWORD action)
 	if (check_forced_protocol(reader->ctx, &reader->atr, &tmp))
 		protocol = tmp;
 
-#ifndef HAVE_PCSCLITE_H
+#ifndef HAVE_PCSCLITE
 	/* reconnect unlocks transaction everywhere but in PCSC-lite */
 	priv->locked = 0;
 #endif
@@ -591,7 +597,7 @@ static int pcsc_release(sc_reader_t *reader)
 static int pcsc_reset(sc_reader_t *reader, int do_cold_reset)
 {
 	int r;
-#ifndef HAVE_PCSCLITE_H
+#ifndef HAVE_PCSCLITE
 	struct pcsc_private_data *priv = GET_PRIV_DATA(reader);
 	int old_locked = priv->locked;
 #endif
@@ -600,7 +606,7 @@ static int pcsc_reset(sc_reader_t *reader, int do_cold_reset)
 	if(r != SC_SUCCESS)
 		return r;
 
-#ifndef HAVE_PCSCLITE_H
+#ifndef HAVE_PCSCLITE
 	/* reconnect unlocks transaction everywhere but in PCSC-lite */
 	if(old_locked)
 		r = pcsc_lock(reader);
@@ -2492,4 +2498,3 @@ struct sc_reader_driver * sc_get_cardmod_driver(void)
 #endif
 
 #endif   /* ENABLE_PCSC */
-


### PR DESCRIPTION
See discussion in #487. Apple (beginning with OS X 10.10) behaves like Windows.

If someone tells me how to check for >= OS X 10.10, I'm happy to refine the commit.