### PR TITLE
really set the --login option when using --pin

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -551,6 +551,8 @@ int main(int argc, char * argv[])
 			opt_output = optarg;
 			break;
 		case 'p':
+			need_session |= NEED_SESSION_RW;
+			opt_login = 1;
 			util_get_pin(optarg, &opt_pin);
 			break;
 		case 'c':


### PR DESCRIPTION
Until now, if -p was used without -l, we didn't authenticate to the token (see man pkcs11-tool)