### PR TITLE
Yubikey NEO pin functions support

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -987,6 +987,7 @@ iso7816_build_pin_apdu(struct sc_card *card, struct sc_apdu *apdu,
 		struct sc_pin_cmd_data *data, u8 *buf, size_t buf_len)
 {
 	int r, len = 0, pad = 0, use_pin_pad = 0, ins, p1 = 0;
+	int cse = SC_APDU_CASE_3_SHORT;
 
 	switch (data->pin_type) {
 	case SC_AC_CHV:
@@ -1052,11 +1053,16 @@ iso7816_build_pin_apdu(struct sc_card *card, struct sc_apdu *apdu,
 			p1 |= 0x01;
 		}
 		break;
+	case SC_PIN_CMD_GET_INFO:
+		ins = 0x20;
+		/* No data to send or to receive */
+		cse = SC_APDU_CASE_1;
+		break;
 	default:
 		return SC_ERROR_NOT_SUPPORTED;
 	}
 
-	sc_format_apdu(card, apdu, SC_APDU_CASE_3_SHORT, ins, p1, data->pin_reference);
+	sc_format_apdu(card, apdu, cse, ins, p1, data->pin_reference);
 	apdu->lc = len;
 	apdu->datalen = len;
 	apdu->data = buf;
@@ -1076,6 +1082,16 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 	if (tries_left)
 		*tries_left = -1;
 
+	/* Many cards do support PIN status queries, but some cards don't and
+	 * mistakenly count the command as a failed PIN attempt, so for now we
+	 * whitelist cards with this flag.  In future this may be reduced to a
+	 * blacklist, subject to testing more cards. */
+	if (data->cmd == SC_PIN_CMD_GET_INFO &&
+	    !(card->caps & SC_CARD_CAP_ISO7816_PIN_INFO)) {
+		sc_log(card->ctx, "Card does not support PIN status queries");
+		return SC_ERROR_NOT_SUPPORTED;
+	}
+
 	/* See if we've been called from another card driver, which is
 	 * passing an APDU to us (this allows to write card drivers
 	 * whose PIN functions behave "mostly like ISO" except in some
@@ -1089,7 +1105,7 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 	}
 	apdu = data->apdu;
 
-	if (!(data->flags & SC_PIN_CMD_USE_PINPAD)) {
+	if (!(data->flags & SC_PIN_CMD_USE_PINPAD) || data->cmd == SC_PIN_CMD_GET_INFO) {
 		/* Transmit the APDU to the card */
 		r = sc_transmit_apdu(card, apdu);
 
@@ -1119,12 +1135,23 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 		data->apdu = NULL;
 
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-	if (apdu->sw1 == 0x63) {
-		if ((apdu->sw2 & 0xF0) == 0xC0 && tries_left != NULL)
-			*tries_left = apdu->sw2 & 0x0F;
-		return SC_ERROR_PIN_CODE_INCORRECT;
+	r = sc_check_sw(card, apdu->sw1, apdu->sw2);
+
+	if (data->cmd == SC_PIN_CMD_GET_INFO) {
+		if (r == SC_ERROR_PIN_CODE_INCORRECT) {
+			data->pin1.tries_left = apdu->sw2 & 0xF;
+			r = SC_SUCCESS;
+		} else if (r == SC_ERROR_AUTH_METHOD_BLOCKED) {
+			data->pin1.tries_left = 0;
+			r = SC_SUCCESS;
+		}
+
+		if (tries_left != NULL) {
+			*tries_left = data->pin1.tries_left;
+		}
 	}
-	return sc_check_sw(card, apdu->sw1, apdu->sw2);
+
+	return r;
 }
 
 

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -439,6 +439,9 @@ struct sc_reader_operations {
 /* Card has on-board random number source. */
 #define SC_CARD_CAP_RNG			0x00000004
 
+/* Card supports ISO7816 PIN status queries using an empty VERIFY */
+#define SC_CARD_CAP_ISO7816_PIN_INFO	0x00000008
+
 /* Use the card's ACs in sc_pkcs15init_authenticate(),
  * instead of relying on the ACL info in the profile files. */
 #define SC_CARD_CAP_USE_FCI_AC		0x00000010


### PR DESCRIPTION
Two changes here, in two commits.

One of them adds support for C_GetTokenInfo to ISO7816 cards. If you do a PIN "VERIFY" command without sending the PIN, the card is supposed to give you back the number of tries remaining without counting it as a failed attempt. This feature of the spec seems to work fine with the Yubikey, and is hopefully safe for other cards (I'm completely new to OpenSC's codebase, so do please check I've implemented this is the right way!)

The other thing is a hack for the Yubikey, which returns status codes for the PIN attempts in a format not described by the spec, but I think it's safe to add support for the Yubikey format. I sent in a technical support request to Yubico to ask if they knew why that behaviour was there, I haven't heard back yet.