### PR TITLE
Support the use of a VERIFY command to get the PIN retry count for PI…

### DIFF
--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -796,6 +796,7 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		pin_info.attrs.pin.pad_char      = pins[i].pad_char;
 		sc_format_path(pins[i].path, &pin_info.path);
 		pin_info.tries_left    = -1;
+		pin_info.max_tries = 8; /* The value is up to the agency and can not be read from the card */
 
 		label = pins[i].label;
 		if (i == 0 &&


### PR DESCRIPTION
…V cards

ISO 7816-4 and NIST 800-73-3 support using the VERIFY command as a type 1 APDU
to get the current pin retry count via the stats of sw1=63, sw2=CX where X
is the retry count.

Current Neo tokens return sw1=63, sw2=0X, this is also accepted.

The max_retry count is set when the PIV cards are personilized, and is not
defined in the NIST standards. There is no way to read the max_retry count
from the card.  The pkcs15-piv.c assumes it is 8, which is then used in
C_GetTokenInfo to set some of the CKF_USER_PIN_ flags.

The iso7816.c was not modified for these reasons:
  (1) The Neo does not follow the standard.
  (2) Some non piv cards already have code to handle SC_PIN_CMD_GET_INFO
  (3) Some cards may fail if this code was added to iso7816.c