### PR TITLE
reactivate handling of `0` for max_recv/send_size

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -581,7 +581,7 @@ int sc_transmit_apdu(sc_card_t *card, sc_apdu_t *apdu)
 		 * bytes using command chaining */
 		size_t    len  = apdu->datalen;
 		const u8  *buf = apdu->data;
-		size_t    max_send_size = card->max_send_size;
+		size_t    max_send_size = sc_get_max_send_size(card);
 
 		while (len != 0) {
 			size_t    plen;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -871,7 +871,7 @@ static int dnie_compose_and_send_apdu(sc_card_t *card, const u8 *path, size_t pa
 	apdu.lc = pathlen;
 	apdu.data = path;
 	apdu.datalen = pathlen;
-	apdu.le = card->max_recv_size;
+	apdu.le = sc_get_max_recv_size(card);
 	if (p1 == 3)
 		apdu.cse= SC_APDU_CASE_1;
 

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -249,7 +249,7 @@ static int sc_hsm_read_binary(sc_card_t *card,
 	cmdbuff[2] = (idx >> 8) & 0xFF;
 	cmdbuff[3] = idx & 0xFF;
 
-	assert(count <= card->max_recv_size);
+	assert(count <= sc_get_max_recv_size(card));
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0xB1, 0x00, 0x00);
 	apdu.data = cmdbuff;
 	apdu.datalen = 4;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -35,15 +35,15 @@ static void fixup_transceive_length(const struct sc_card *card,
 {
 	assert(card != NULL && apdu != NULL);
 
-	if (apdu->lc > card->max_send_size) {
+	if (apdu->lc > sc_get_max_send_size(card)) {
 		/* The lower layers will automatically do chaining */
 		apdu->flags |= SC_APDU_FLAGS_CHAINING;
 	}
 
-	if (apdu->le > card->max_recv_size) {
+	if (apdu->le > sc_get_max_recv_size(card)) {
 		/* The lower layers will automatically do a GET RESPONSE, if possible.
 		 * All other workarounds must be carried out by the upper layers. */
-		apdu->le = card->max_recv_size;
+		apdu->le = sc_get_max_recv_size(card);
 	}
 }
 
@@ -526,7 +526,7 @@ iso7816_select_file(struct sc_card *card, const struct sc_path *in_path, struct 
 		apdu.p2 = 0;		/* first record, return FCI */
 		apdu.resp = buf;
 		apdu.resplen = sizeof(buf);
-		apdu.le = card->max_recv_size < 256 ? card->max_recv_size : 256;
+		apdu.le = sc_get_max_recv_size(card) < 256 ? sc_get_max_recv_size(card) : 256;
 	}
 	else {
 		apdu.p2 = 0x0C;		/* first record, return nothing */
@@ -719,8 +719,8 @@ iso7816_get_response(struct sc_card *card, size_t *count, u8 *buf)
 	size_t rlen;
 
 	/* request at most max_recv_size bytes */
-	if (*count > card->max_recv_size)
-		rlen = card->max_recv_size;
+	if (*count > sc_get_max_recv_size(card))
+		rlen = sc_get_max_recv_size(card);
 	else
 		rlen = *count;
 

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -910,6 +910,9 @@ int sc_lock(struct sc_card *card);
  */
 int sc_unlock(struct sc_card *card);
 
+size_t sc_get_max_recv_size(const sc_card_t *card);
+size_t sc_get_max_send_size(const sc_card_t *card);
+
 
 /********************************************************************/
 /*                ISO 7816-4 related functions                      */

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -910,7 +910,28 @@ int sc_lock(struct sc_card *card);
  */
 int sc_unlock(struct sc_card *card);
 
+/**
+ * @brief Calculate the maximum size of R-APDU payload (Ne).
+ *
+ * Takes card limitations into account such as extended length support as well
+ * as the reader's limitation for data transfer.
+ *
+ * @param card Initialized card object with its reader
+ *
+ * @return maximum Ne
+ */
 size_t sc_get_max_recv_size(const sc_card_t *card);
+
+/**
+ * @brief Calculate the maximum size of C-APDU payload (Nc).
+ *
+ * Takes card limitations into account such as extended length support as well
+ * as the reader's limitation for data transfer.
+ *
+ * @param card
+ *
+ * @return maximum Nc
+ */
 size_t sc_get_max_send_size(const sc_card_t *card);
 
 


### PR DESCRIPTION
The special value still needs to be handled for commands that are issued
during card initialization. This especially concerns T=0 cards that need
to use iso_get_response.

fixes #533
regression of 85b79a33320b615c923a6a03b6d295d7543b3f55