### PR TITLE
Fix for #183: export more symbols

### DIFF
--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -12,7 +12,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 OPENSC_PKCS11_INC = sc-pkcs11.h pkcs11.h pkcs11-opensc.h
 OPENSC_PKCS11_SRC = pkcs11-global.c pkcs11-session.c pkcs11-object.c misc.c slot.c \
 	mechanism.c openssl.c framework-pkcs15.c \
-	framework-pkcs15init.c debug.c opensc-pkcs11.exports \
+	framework-pkcs15init.c debug.c pkcs11.exports \
 	pkcs11-display.c pkcs11-display.h
 OPENSC_PKCS11_LIBS = \
 	$(top_builddir)/src/libopensc/libopensc.la \
@@ -23,23 +23,23 @@ OPENSC_PKCS11_LIBS = \
 opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC)
 opensc_pkcs11_la_LIBADD = $(OPENSC_PKCS11_LIBS)
 opensc_pkcs11_la_LDFLAGS = $(AM_LDFLAGS) \
-	-export-symbols "$(srcdir)/opensc-pkcs11.exports" \
+	-export-symbols "$(srcdir)/pkcs11.exports" \
 	-module -shared -avoid-version -no-undefined
 
 onepin_opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC)
 onepin_opensc_pkcs11_la_CFLAGS = -DMODULE_APP_NAME=\"onepin-opensc-pkcs11\"
 onepin_opensc_pkcs11_la_LIBADD = $(OPENSC_PKCS11_LIBS)
 onepin_opensc_pkcs11_la_LDFLAGS = $(AM_LDFLAGS) \
-        -export-symbols "$(srcdir)/opensc-pkcs11.exports" \
+        -export-symbols "$(srcdir)/pkcs11.exports" \
         -module -shared -avoid-version -no-undefined
 
-pkcs11_spy_la_SOURCES = pkcs11-spy.c pkcs11-display.c pkcs11-display.h pkcs11-spy.exports
+pkcs11_spy_la_SOURCES = pkcs11-spy.c pkcs11-display.c pkcs11-display.h pkcs11.exports
 pkcs11_spy_la_LIBADD = \
 	$(top_builddir)/src/common/libpkcs11.la \
 	$(top_builddir)/src/common/libscdl.la \
 	$(OPTIONAL_OPENSSL_LIBS)
 pkcs11_spy_la_LDFLAGS = $(AM_LDFLAGS) \
-	-export-symbols "$(srcdir)/pkcs11-spy.exports" \
+	-export-symbols "$(srcdir)/pkcs11.exports" \
 	-module -shared -avoid-version -no-undefined
 
 if WIN32

--- a/src/pkcs11/Makefile.mak
+++ b/src/pkcs11/Makefile.mak
@@ -16,14 +16,14 @@ all: versioninfo-pkcs11.res $(TARGET1) $(TARGET2) $(TARGET3) versioninfo-pkcs11-
 $(TARGET1): $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
 	echo LIBRARY $* > $*.def
 	echo EXPORTS >> $*.def
-	type opensc-pkcs11.exports >> $*.def
+	type pkcs11.exports >> $*.def
 	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET1) $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib $(OPENSSL_LIB) gdi32.lib
 	if EXIST $(TARGET1).manifest mt -manifest $(TARGET1).manifest -outputresource:$(TARGET1);2
 
 $(TARGET2): $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
 	echo LIBRARY $* > $*.def
 	echo EXPORTS >> $*.def
-	type opensc-pkcs11.exports >> $*.def
+	type pkcs11.exports >> $*.def
 	del pkcs11-global.obj
 	cl $(CODE_OPTIMIZATION) $(COPTS) /DMODULE_APP_NAME=\"onepin-opensc-pkcs11\" /c pkcs11-global.c
 	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET2) $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib $(OPENSSL_LIB) gdi32.lib
@@ -32,6 +32,6 @@ $(TARGET2): $(OBJECTS) ..\libopensc\opensc_a.lib ..\pkcs15init\pkcs15init.lib
 $(TARGET3): $(OBJECTS3) ..\libopensc\opensc.lib
 	echo LIBRARY $* > $*.def
 	echo EXPORTS >> $*.def
-	type $*.exports >> $*.def
+	type pkcs11.exports >> $*.def
 	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$(TARGET3) $(OBJECTS3) ..\libopensc\opensc.lib ..\common\libpkcs11.lib ..\common\libscdl.lib $(OPENSSL_LIB) gdi32.lib advapi32.lib
 	if EXIST $(TARGET3).manifest mt -manifest $(TARGET3).manifest -outputresource:$(TARGET3);2

--- a/src/pkcs11/opensc-pkcs11.exports
+++ b/src/pkcs11/opensc-pkcs11.exports
@@ -1,1 +1,0 @@
-C_GetFunctionList

--- a/src/pkcs11/pkcs11-spy.exports
+++ b/src/pkcs11/pkcs11-spy.exports
@@ -1,1 +1,0 @@
-C_GetFunctionList

--- a/src/pkcs11/pkcs11.exports
+++ b/src/pkcs11/pkcs11.exports
@@ -1,0 +1,3 @@
+C_GetFunctionList
+C_Initialize
+C_Finalize


### PR DESCRIPTION
- also export C_Initialize and C_Finalize to please vmware-view
- have a single pkcs11.exports file for both pkcs11-spy and opensc-pkcs11