### PR TITLE
add '--raw' option to pkcs15-tools '--read-data-object'

### DIFF
--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -156,6 +156,18 @@
 
 				<varlistentry>
 					<term>
+						<option>--raw</option>
+					</term>
+					<listitem><para>Changes how <option>--read-data-object</option> prints the content
+					to standard output. By default, when <option>--raw</option> is not given, it will
+					print the content in hex notation. If <option>--raw</option> is set, it will print
+					the binary data directly. This does not affect the output that is written to the
+					file specified by the <option>--output</option> option. Data written to a file will
+					always be in raw binary.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--read-certificate</option> <replaceable>cert</replaceable>,
 						<option>-r</option> <replaceable>cert</replaceable>
 					</term>
@@ -168,7 +180,12 @@
 						<option>-R</option> <replaceable>data</replaceable>
 					</term>
 					<listitem><para>Reads data object with OID, applicationName or label.
-                                        </para></listitem>
+					The content is printed to standard output in hex notation, unless
+					the <option>--raw</option> option is given.
+					If an output file is given with the <option>--output</option> option,
+					the content is additionally written to the file.
+					Output to the file is always written in raw binary mode, the
+					<option>--raw</option> only affects standard output behavior.</para></listitem>
 				</varlistentry>
 
 				<varlistentry>

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -50,6 +50,7 @@ static char * opt_auth_id = NULL;
 static char * opt_reader = NULL;
 static char * opt_cert = NULL;
 static char * opt_data = NULL;
+static int opt_raw = 0;
 static char * opt_pubkey = NULL;
 static char * opt_outfile = NULL;
 static char * opt_bind_to_aid = NULL;
@@ -82,6 +83,7 @@ enum {
 	OPT_LIST_APPLICATIONS,
 	OPT_LIST_SKEYS,
 	OPT_NO_PROMPT,
+	OPT_RAW,
 };
 
 #define NELEMENTS(x)	(sizeof(x)/sizeof((x)[0]))
@@ -94,6 +96,7 @@ static const struct option options[] = {
 	{ "read-certificate",	required_argument, NULL,	'r' },
 	{ "list-certificates",	no_argument, NULL,		'c' },
 	{ "read-data-object",	required_argument, NULL,	'R' },
+	{ "raw",		no_argument, NULL,		OPT_RAW },
 	{ "list-data-objects",	no_argument, NULL,		'C' },
 	{ "list-pins",		no_argument, NULL,		OPT_LIST_PINS },
 	{ "list-secret-keys",	no_argument, NULL,		OPT_LIST_SKEYS },
@@ -130,6 +133,7 @@ static const char *option_help[] = {
 	"Reads certificate with ID <arg>",
 	"Lists certificates",
 	"Reads data object with OID, applicationName or label <arg>",
+	"Outputs raw 8 bit data to stdout",
 	"Lists data objects",
 	"Lists PIN codes",
 	"Lists secret keys",
@@ -346,18 +350,28 @@ print_data_object(const char *kind, const u8*data, size_t data_len)
 			}
 		for (i=0; i < data_len; i++)
 			fprintf(outf, "%c", data[i]);
-		printf("Dumping (%lu bytes) to file <%s>: <",
-			(unsigned long) data_len, opt_outfile);
-		for (i=0; i < data_len; i++)
-			printf(" %02X", data[i]);
-		printf(" >\n");
+		if (opt_raw) {
+			for (i=0; i < data_len; i++)
+				printf("%c", data[i]);
+		} else {
+			printf("Dumping (%lu bytes) to file <%s>: <",
+				(unsigned long) data_len, opt_outfile);
+			for (i=0; i < data_len; i++)
+				printf(" %02X", data[i]);
+			printf(" >\n");
+		}
 		fclose(outf);
 	} else {
-		printf("%s (%lu bytes): <",
-			kind, (unsigned long) data_len);
-		for (i=0; i < data_len; i++)
-			printf(" %02X", data[i]);
-		printf(" >\n");
+		if (opt_raw) {
+			for (i=0; i < data_len; i++)
+				printf("%c", data[i]);
+		} else {
+			printf("%s (%lu bytes): <",
+				kind, (unsigned long) data_len);
+			for (i=0; i < data_len; i++)
+				printf(" %02X", data[i]);
+			printf(" >\n");
+		}
 	}
 	return 0;
 }
@@ -1930,6 +1944,9 @@ int main(int argc, char * const argv[])
 			opt_data = optarg;
 			do_read_data_object = 1;
 			action_count++;
+			break;
+		case OPT_RAW:
+			opt_raw = 1;
 			break;
 		case 'C':
 			do_list_data_objects = 1;

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -133,7 +133,7 @@ static const char *option_help[] = {
 	"Reads certificate with ID <arg>",
 	"Lists certificates",
 	"Reads data object with OID, applicationName or label <arg>",
-	"Outputs raw 8 bit data to stdout",
+	"Outputs raw 8 bit data to stdout. File output will not be affected by this, it always uses raw mode.",
 	"Lists data objects",
 	"Lists PIN codes",
 	"Lists secret keys",


### PR DESCRIPTION
This adds a '--raw' option to pkcs15-tool that affects how '--read-data-object' outputs its data.
If it is not given, the current behavior is not changed.
If present, pkcs15-tool outputs the data in raw binary mode, i.e. not in hex mode.

This allows an application to read a data object with pkcs15-tool directly from stdout instead of redirecting it to a file first and reading it back in afterwards, which is inconvenient and might be less secure (e.g. when the data is written to unsecure persistent storage).

This implements #535.