### PR TITLE
sc-hsm: Add status info support for SmartCard-HSM V2.0

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -867,7 +867,7 @@ static int sc_hsm_init_token(sc_card_t *card, sc_cardctl_pkcs11_init_token_t *pa
 	memset(&ip, 0, sizeof(ip));
 	ip.dkek_shares = -1;
 	ip.options[0] = 0x00;
-	ip.options[0] = 0x01;
+	ip.options[1] = 0x01;
 
 	r = sc_hsm_encode_sopin(params->so_pin, ip.init_code);
 	LOG_TEST_RET(ctx, r, "SO PIN wrong format");

--- a/src/libopensc/card-sc-hsm.h
+++ b/src/libopensc/card-sc-hsm.h
@@ -50,6 +50,9 @@
 #define ID_USER_PIN				0x81		/* User PIN identifier */
 #define ID_SO_PIN				0x88		/* Security officer PIN identifier */
 
+#define INIT_RRC_ENABLED		0x01		/* Bit 1 of initialization options */
+#define INIT_TRANSPORT_PIN		0x02		/* Bit 2 of initialization options */
+
 /* Information the driver maintains between calls */
 typedef struct sc_hsm_private_data {
 	const sc_security_env_t *env;


### PR DESCRIPTION
This patch ensures that status information returned by the new 2.0 version are properly displayed