### PR TITLE
adjust Make.rules.mak to work with AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ matrix:
     - compiler: gcc
       os: linux
       env: ENABLE_DOC=--enable-doc
-    - compiler: gcc
-      os: linux
+    - os: linux
+      env: HOST=x86_64-w64-mingw32
+    - os: linux
       env: HOST=i686-w64-mingw32
 
 before_install:
@@ -31,8 +32,10 @@ install:
   - if [ $TRAVIS_OS_NAME == linux ]; then
       if [ -z "$HOST" ]; then
         sudo apt-get install libpcsclite-dev xsltproc docbook-xsl;
-      else
+      elif [ "${HOST}" == i686-w64-mingw32 ]; then
         sudo apt-get install mingw-w64 binutils-mingw-w64-i686 gcc-mingw-w64-i686;
+      elif [ "${HOST}" == x86_64-w64-mingw32 ]; then
+        sudo apt-get install mingw-w64 binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64;
       fi
     fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,71 +1,69 @@
+version: 0.15.0.{build}
+
 platform:
+  # the prebuilt zlib is 32 bit only
   - x86
-  - x64
+
+configuration:
+  - Release
+  - Debug
 
 environment:
   matrix:
-    - VSVER: 14
-    - VSVER: 12
-    - VSVER: 10
-
-matrix:
-  allow_failures:
-    # not included in AppVeyor right now
-    - platform: x64
-      VSVER: 10
-    # does not currently work
-    - VSVER: 14
     - VSVER: 12
     - VSVER: 10
 
 install:
   - date /T & time /T
   - set PATH=C:\cygwin\bin;%PATH%
-  - ps: >-
-      If(!(Test-Path -Path "C:\cccl-1.0" )) {
-        git clone -q --depth=1 git://github.com/swig/cccl.git "C:\cccl-1.0"
-      }
-  - bash -c "cp C:/cccl-1.0/cccl /usr/bin"
+  - set OPENSSL_VER=1_0_2d
+  - set ZLIB_VER=128
   - ps: >-
       If ($env:Platform -Match "x86") {
-        $env:JAVA_HOME="C:/Program Files (x86)/Java/jdk1.8.0"
         $env:VCVARS_PLATFORM="x86"
         $env:ENV_PLATFORM="x86"
-        $env:OPENSSL="https://slproweb.com/download/Win32OpenSSL-1_0_2d.exe"
-        $env:NMAKE_FLAGS=""
+        $env:OPENSSL_PF="Win32"
+        $env:NMAKE_ARCH=""
+        $env:ARTIFACT="OpenSC-${env:APPVEYOR_BUILD_VERSION}-win32_vs${env:VSVER}-${env:CONFIGURATION}.msi"
       } Else {
-        $env:JAVA_HOME="C:/Program Files/Java/jdk1.8.0"
         $env:VCVARS_PLATFORM="amd64"
         $env:ENV_PLATFORM="x64"
-        $env:OPENSSL="https://slproweb.com/download/Win64OpenSSL-1_0_2d.exe"
-        $env:NMAKE_FLAGS="BUILD_ON=WIN64 BUILD_FOR=WIN64"
+        $env:OPENSSL_PF="Win64"
+        $env:NMAKE_ARCH="BUILD_ON=WIN64 BUILD_FOR=WIN64"
+        $env:ARTIFACT="OpenSC-${env:APPVEYOR_BUILD_VERSION}-win64_vs${env:VSVER}-${env:CONFIGURATION}.msi"
+      }
+  - ps: >-
+      If ($env:Configuration -Match "Debug") {
+        $env:NMAKE_DEBUG="DEBUG_DEF=/DDEBUG"
       }
   - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
   - echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
   - call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
-  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /%ENV_PLATFORM% /Release
-  - appveyor DownloadFile %OPENSSL% -FileName C:\WinOpenSSL.exe
-  - C:\WinOpenSSL.exe /SILENT /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART /DIR="C:\OpenSSL"
-  - appveyor DownloadFile "http://prdownloads.sourceforge.net/libpng/zlib128-dll.zip"
-  - 7z x zlib128-dll.zip -oC:\zlib-1.2.8-dll
-  - bash -c "which cl.exe"
-  - bash -c "cl.exe /? 2>&1 | head -n 2"
-  - bash -c "which csc.exe"
-  - bash -c "csc.exe /? | head -n 2"
-  - bash -c "which cccl"
-  - bash -c "cccl --version"
+  - ps: >-
+      If(!(Test-Path -Path "C:\OpenSSL-${env:OPENSSL_PF}" )) {
+          Start-FileDownload https://slproweb.com/download/${env:OPENSSL_PF}OpenSSL-${env:OPENSSL_VER}.exe -FileName C:\WinOpenSSL.exe
+          C:\WinOpenSSL.exe /SILENT /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART
+        }
+  - ps: >-
+      If(!(Test-Path -Path "C:\zlib-dll" )) {
+          appveyor DownloadFile "https://prdownloads.sourceforge.net/libpng/zlib${env:ZLIB_VER}-dll.zip" -FileName zlib-dll.zip
+          7z x zlib-dll.zip -oC:\zlib-dll
+      }
+  - appveyor DownloadFile "http://download.microsoft.com/download/2/C/9/2C93059C-0532-42DF-8C24-9AEAFF00768E/cngsdk.msi"
+  - cngsdk.msi /quiet
   - uname -a
 
 build_script:
-  - set CCCL_OPTIONS=--cccl-muffle /W3 /D_CRT_SECURE_NO_DEPRECATE /Dsnprintf=_snprintf
-  - set CC=cccl
-  - set CXX=cccl
-  - set LD=cccl
-  - bash -c "exec 0</dev/null && find C:/zlib-1.2.8-dll"
-  - bash -c "exec 0</dev/null && find C:/OpenSSL"
   - bash -c "exec 0</dev/null && ./bootstrap"
-  - bash -c "exec 0</dev/null && ./configure OPENSSL_LIBS='-LC:/OpenSSL/lib -llibeay32' OPENSSL_CFLAGS='-IC:/OpenSSL/include' ZLIB_CFLAGS='-IC:/zlib-1.2.8-dll/include' ZLIB_LIBS='-LC:/zlib-1.2.8-dll/lib -lzdll' LDFLAGS='-LC:/OpenSSL/bin -LC:/zlib-1.2.5-dll' --with-cygwin-native"
-  - bash -c "exec 0</dev/null && cp win32/winconfig.h config.h && make"
-  # nmake doesn't work out of the box, all Makefile.mak have way too many hard coded paths
-  #- bash -c "exec 0</dev/null && ./bootstrap >> /tmp/oscout 2>&1 && ./configure >> /tmp/oscout 2>&1"
-  #- nmake /f Makefile.mak %NMAKE_FLAGS%
+  # disable features to speed up the script
+  - bash -c "exec 0</dev/null && ./configure --disable-openssl --disable-readline --disable-zlib || cat config.log"
+  - cp win32/winconfig.h config.h
+  - nmake /f Makefile.mak %NMAKE_ARCH% %NMAKE_DEBUG%
+  - cd win32 && nmake /f Makefile.mak %NMAKE_ARCH% %NMAKE_DEBUG% VSVER=%VSVER% OpenSC.msi
+  - move OpenSC.msi %ARTIFACT%
+  - appveyor PushArtifact %ARTIFACT%
+
+cache:
+  - C:\OpenSSL-Win32
+  - C:\OpenSSL-Win64
+  - C:\zlib-dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ environment:
     - VSVER: 10
 
 install:
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
   - date /T & time /T
   - set PATH=C:\cygwin\bin;%PATH%
   - set OPENSSL_VER=1_0_2d

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -1127,10 +1127,10 @@ static int flex_generate_key(sc_card_t *card, struct sc_cardctl_cryptoflex_genke
 	apdu.lc = 4;
 
 	/* Little endian representation of exponent */
-	sbuf[0] = data->exponent;
-	sbuf[1] = data->exponent >> 8;
-	sbuf[2] = data->exponent >> 16;
-	sbuf[3] = data->exponent >> 24;
+	sbuf[0] = data->exponent & 0xFF;
+	sbuf[1] = (data->exponent >> 8) & 0xFF;
+	sbuf[2] = (data->exponent >> 16) & 0xFF;
+	sbuf[3] = (data->exponent >> 24) & 0xFF;
 
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -500,8 +500,8 @@ static int get_se_num_from_keyd(sc_card_t * card, unsigned short fid,
 	char dbgbuf[2048];
 	u8 fidbuf[2];
 
-	fidbuf[0] = fid >> 8;
-	fidbuf[1] = fid;
+	fidbuf[0] = (fid >> 8) & 0xFF;
+	fidbuf[1] = fid & 0xFF;
 
 	dfi = get_df_info(card);
 	if (!dfi || !dfi->keyd_file) {
@@ -1271,7 +1271,7 @@ static int mcrd_set_security_env(sc_card_t * card,
 
 	if (card->type == SC_CARD_TYPE_MCRD_DTRUST
 	    || card->type == SC_CARD_TYPE_MCRD_GENERIC) {
-		unsigned short fid;
+		unsigned char fid;
 
 		fid = env->key_ref[0];
 		*p = fid;

--- a/win32/Make.rules.mak
+++ b/win32/Make.rules.mak
@@ -3,28 +3,14 @@ OPENSC_FEATURES = pcsc
 #Include support for minidriver
 MINIDRIVER_DEF = /DENABLE_MINIDRIVER
 
-#Build MSI with the Windows Installer XML (WIX) toolkit, requires WIX >= 3.6
-!IF "$(BUILD_ON)" == "WIN64"
-WIX_PATH = "C:\Program Files (x86)\Windows Installer XML v3.6"
-WIX_INCL_DIR = "/IC:\Program Files (x86)\Windows Installer XML v3.6\SDK\inc"
+#Build MSI with the Windows Installer XML (WIX) toolkit, requires WIX >= 3.9
+WIX_PATH = C:\Program Files (x86)\WiX Toolset v3.10
+WIX_INCL_DIR = "/I$(WIX_PATH)\SDK\VS20$(VSVER)\inc"
 !IF "$(BUILD_FOR)" == "WIN64"
-WIX_LIBS = "C:\Program Files (x86)\Windows Installer XML v3.6\SDK\lib\dutil_2010_x64.lib" "C:\Program Files (x86)\Windows Installer XML v3.6\SDK\lib\wcautil_2010_x64.lib"
+WIX_LIBS = "$(WIX_PATH)\SDK\VS20$(VSVER)\lib\x64\dutil.lib" "$(WIX_PATH)\SDK\VS20$(VSVER)\lib\x64\wcautil.lib"
 !ELSE
-WIX_LIBS = "C:\Program Files (x86)\Windows Installer XML v3.6\SDK\lib\dutil_2010.lib" "C:\Program Files (x86)\Windows Installer XML v3.6\SDK\lib\wcautil_2010.lib"
+WIX_LIBS = "$(WIX_PATH)\SDK\VS20$(VSVER)\lib\x86\dutil.lib" "$(WIX_PATH)\SDK\VS20$(VSVER)\lib\x86\wcautil.lib"
 !ENDIF
-
-!ELSE
-WIX_PATH = "C:\Program Files\Windows Installer XML v3.6"
-WIX_INCL_DIR = "/IC:\Program Files\Windows Installer XML v3.6\SDK\inc"
-!IF "$(BUILD_FOR)" == "WIN64"
-WIX_LIBS = "C:\Program Files\Windows Installer XML v3.6\SDK\lib\dutil_2010_x64.lib" "C:\Program Files\Windows Installer XML v3.6\SDK\lib\wcautil_2010_x64.lib"
-!ELSE
-WIX_LIBS = "C:\Program Files\Windows Installer XML v3.6\SDK\lib\dutil_2010.lib" "C:\Program Files\Windows Installer XML v3.6\SDK\lib\wcautil_2010.lib"
-!ENDIF
-
-!ENDIF
-
-
 
 #Include support for Secure Messaging
 SM_DEF = /DENABLE_SM
@@ -46,10 +32,17 @@ OPENSSL_DIR = C:\OpenSSL-Win32
 !ENDIF
 OPENSSL_INCL_DIR = /I$(OPENSSL_DIR)\include
 
-!IF "$(DEBUG_DEF)" == "/DDEBUG"
-OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\static\libeay32MTd.lib $(OPENSSL_DIR)\lib\VC\static\ssleay32MTd.lib user32.lib advapi32.lib crypt32.lib
+#define OPENSSL_STATIC if you have visual studio compatible with OpenSSL's static binaries
+!IF "$(OPENSSL_STATIC)" == "yes, I know what I do"
+OPENSSL_STATIC_DIR = static
 !ELSE
-OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\static\libeay32MT.lib $(OPENSSL_DIR)\lib\VC\static\ssleay32MT.lib user32.lib advapi32.lib crypt32.lib
+OPENSSL_EXTRA_CFLAGS = /DOPENSSL_NO_STATIC_ENGINE
+!ENDIF
+
+!IF "$(DEBUG_DEF)" == "/DDEBUG"
+OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\$(OPENSSL_STATIC_DIR)\libeay32MTd.lib user32.lib advapi32.lib crypt32.lib
+!ELSE
+OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\$(OPENSSL_STATIC_DIR)\libeay32MT.lib user32.lib advapi32.lib crypt32.lib
 !ENDIF
 
 PROGRAMS_OPENSSL = pkcs15-init.exe cryptoflex-tool.exe netkey-tool.exe piv-tool.exe westcos-tool.exe
@@ -58,23 +51,19 @@ OPENSC_FEATURES = $(OPENSC_FEATURES) openssl
 
 
 # If you want support for zlib (Used for PIV, infocamere and actalis):
-# - Download zlib and build with "nmake /f win32\Makefile.msc zlib.lib"
+# - Download zlib-dll and
 # - uncomment the line starting with ZLIB_DEF 
 # - set the ZLIB_INCL_DIR below to the zlib include lib proceeded by "/I"
 # - set the ZLIB_LIB  below to your zlib lib file
 ZLIB_DEF = /DENABLE_ZLIB
 !IF "$(ZLIB_DEF)" == "/DENABLE_ZLIB"
-ZLIB_INCL_DIR = /IC:\zlib-1.2.5
-ZLIB_LIB = C:\zlib-1.2.5\zlib.lib
+ZLIB_INCL_DIR = /IC:\zlib-dll\include
+ZLIB_LIB = C:\zlib-dll\lib\zdll.lib
 OPENSC_FEATURES = $(OPENSC_FEATURES) zlib
 !ENDIF
 
 # Used for MiniDriver
-!IF "$(BUILD_ON)" == "WIN64"
 CNGSDK_INCL_DIR = "/IC:\Program Files (x86)\Microsoft CNG Development Kit\Include"
-!ELSE
-CNGSDK_INCL_DIR = "/IC:\Program Files\Microsoft CNG Development Kit\Include"
-!ENDIF
 # Mandatory path to 'ISO C9x compliant stdint.h and inttypes.h for Microsoft Visual Studio'
 # http://msinttypes.googlecode.com/files/msinttypes-r26.zip
 # INTTYPES_INCL_DIR =  /IC:\opensc\dependencies\msys\local
@@ -83,7 +72,7 @@ CNGSDK_INCL_DIR = "/IC:\Program Files\Microsoft CNG Development Kit\Include"
 #  O1 - minimal code size
 CODE_OPTIMIZATION = /O1
 
-ALL_INCLUDES = /I$(TOPDIR)\win32 /I$(TOPDIR)\src $(OPENSSL_INCL_DIR) $(ZLIB_INCL_DIR) $(LIBLTDL_INCL) $(INTTYPES_INCL_DIR) $(CNGSDK_INCL_DIR) $(WIX_INCL_DIR)
+ALL_INCLUDES = /I$(TOPDIR)\win32 /I$(TOPDIR)\src $(OPENSSL_INCL_DIR) $(OPENSSL_EXTRA_CFLAGS) $(ZLIB_INCL_DIR) $(LIBLTDL_INCL) $(INTTYPES_INCL_DIR) $(CNGSDK_INCL_DIR) $(WIX_INCL_DIR)
 
 !IF "$(DEBUG_DEF)" == "/DDEBUG"
 LINKDEBUGFLAGS = /NODEFAULTLIB:LIBCMT /DEBUG

--- a/win32/Makefile.mak
+++ b/win32/Makefile.mak
@@ -14,10 +14,10 @@ customactions.dll: versioninfo-customactions.res customactions.obj
         link /dll $(LINKFLAGS) /def:$*.def /out:customactions.dll versioninfo-customactions.res customactions.obj msi.lib $(WIX_LIBS) Advapi32.lib User32.lib Version.lib Shell32.lib
 
 OpenSC.msi: OpenSC.wixobj
-        $(WIX_PATH)\bin\light.exe -sh -ext WixUIExtension -ext WiXUtilExtension $?
+        "$(WIX_PATH)\bin\light.exe" -sh -ext WixUIExtension -ext WiXUtilExtension $?
 
 OpenSC.wixobj: OpenSC.wxs customactions.dll
-        $(WIX_PATH)\bin\candle.exe -ext WiXUtilExtension -dSOURCE_DIR=$(TOPDIR) $(CANDLEFLAGS) OpenSC.wxs
+        "$(WIX_PATH)\bin\candle.exe" -ext WiXUtilExtension -dSOURCE_DIR=$(TOPDIR) $(CANDLEFLAGS) OpenSC.wxs
 
 clean::
 	del /Q config.h *.msi *.wixobj *.wixpdb


### PR DESCRIPTION
# Work in progress, do not yet merge

The old configuration doesn't work (anymore):

- The current builds of OpenSSL from https://slproweb.com/products/Win32OpenSSL.html include security measures https://blogs.microsoft.com/cybertrust/2012/01/26/enhancements-to-gs-in-visual-studio-11/ that previously yielded an error (`error LNK2001: unresolved external symbol ___report_rangecheckfailure`)
- I guess that the configuration for zlib 1.2.5 never ever has worked anyway, because the library names were totally wrong...