### PR TITLE
ECDSA helper functions: strip zeroes when converting from R,S to sequence

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1854,6 +1854,17 @@ sc_asn1_sig_value_rs_to_sequence(struct sc_context *ctx, unsigned char *in, size
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
+
+	/* R/S are filled up with zeroes, we do not want that in sequence format */
+	while(r_len > 1 && *r == 0x00) {
+		r++;
+		r_len--;
+	}
+	while(s_len > 1 && *s == 0x00) {
+		s++;
+		s_len--;
+	}
+
 	sc_copy_asn1_entry(c_asn1_sig_value, asn1_sig_value);
 	sc_format_asn1_entry(asn1_sig_value + 0, asn1_sig_value_coefficients, NULL, 1);
 


### PR DESCRIPTION
For ECDSA signatures, there are multiple ways to format the signature:
- R|S (R and S filled with zeroes at the most significant bytes)
- ASN1 sequence of R,S integers (e.g. used by OpenSSL).

It is rare that the filling with zeroes is needed.
But if it is, in the second case, the filling zeroes should not be there
or the verification of the signature by OpenSSL will fail.

See issue #557.