### PR TITLE
Removed error check to support card with PKCS#15 emulation but no mat…

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -727,10 +727,6 @@ sc_pkcs15init_finalize_profile(struct sc_card *card, struct sc_profile *profile,
 	if (aid)   {
 		sc_log(ctx, "finalize profile for AID %s", sc_dump_hex(aid->value, aid->len));
 		app = sc_find_app(card, aid);
-		if (!app)   {
-			sc_log(ctx, "Cannot find oncard application");
-			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
-		}
 	}
 	else if (card->app_count == 1) {
 		app = card->app[0];


### PR DESCRIPTION
This patch enables support for cards that use PKCS15 emulation but do not maintain an EF.DIR (notably the SmartCard-HSM). For those cards, the PKCS15 AID has no matching entry found by sc_find_app().

This patch removes the error exit, so that the default profile AID is used.

The problem can be observed in minidriver, which always passes the aid parameter taken from p15card.