### PR TITLE
Fix reselect applet for pin verification

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -85,10 +85,6 @@ static int sc_hsm_select_file(sc_card_t *card,
 	sc_file_t *file = NULL;
 
 	if (file_out == NULL) {				// Versions before 0.16 of the SmartCard-HSM do not support P2='0C'
-		if (!in_path->len && in_path->aid.len) {
-			sc_log(card->ctx, "Preventing reselection of applet which would clear the security state");
-			return SC_SUCCESS;
-		}
 		rv = sc_hsm_select_file(card, in_path, &file);
 		if (file != NULL) {
 			sc_file_free(file);

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -402,7 +402,7 @@ int sc_pkcs15_change_pin(struct sc_pkcs15_card *p15card,
 	r = sc_lock(card);
 	LOG_TEST_RET(ctx, r, "sc_lock() failed");
 	/* the path in the pin object is optional */
-	if (auth_info->path.len > 0) {
+	if ((auth_info->path.len > 0) || ((auth_info->path.aid.len > 0))) {
 		r = sc_select_file(card, &auth_info->path, NULL);
 		if (r)
 			goto out;
@@ -509,7 +509,7 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *p15card,
 	LOG_TEST_RET(ctx, r, "sc_lock() failed");
 
 	/* the path in the pin object is optional */
-	if (auth_info->path.len > 0) {
+	if ((auth_info->path.len > 0) || ((auth_info->path.aid.len > 0))) {
 		r = sc_select_file(card, &auth_info->path, NULL);
 		if (r)
 			goto out;

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -358,7 +358,7 @@ int sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card,
 	LOG_TEST_RET(ctx, r, "sc_lock() failed");
 
 	/* the path in the pin object is optional */
-	if (auth_info->path.len > 0) {
+	if ((auth_info->path.len > 0) || ((auth_info->path.aid.len > 0))) {
 		r = sc_select_file(card, &auth_info->path, NULL);
 		if (r)
 			goto out;

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -866,9 +866,10 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 
 	pin_info.auth_id.len = 1;
 	pin_info.auth_id.value[0] = 1;
+	pin_info.path.aid = sc_hsm_aid;
 	pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 	pin_info.attrs.pin.reference = 0x81;
-	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_LOCAL|SC_PKCS15_PIN_FLAG_INITIALIZED|SC_PKCS15_PIN_FLAG_UNBLOCK_DISABLED|SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA;
+	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_LOCAL|SC_PKCS15_PIN_FLAG_INITIALIZED|SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA;
 	pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC;
 	pin_info.attrs.pin.min_length = 6;
 	pin_info.attrs.pin.stored_length = 0;
@@ -890,16 +891,17 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 
 	pin_info.auth_id.len = 1;
 	pin_info.auth_id.value[0] = 2;
+	pin_info.path.aid = sc_hsm_aid;
 	pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 	pin_info.attrs.pin.reference = 0x88;
-	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_LOCAL|SC_PKCS15_PIN_FLAG_CHANGE_DISABLED|SC_PKCS15_PIN_FLAG_INITIALIZED|SC_PKCS15_PIN_FLAG_UNBLOCK_DISABLED|SC_PKCS15_PIN_FLAG_SO_PIN;
+	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_LOCAL|SC_PKCS15_PIN_FLAG_INITIALIZED|SC_PKCS15_PIN_FLAG_UNBLOCK_DISABLED|SC_PKCS15_PIN_FLAG_SO_PIN;
 	pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_BCD;
 	pin_info.attrs.pin.min_length = 16;
 	pin_info.attrs.pin.stored_length = 0;
 	pin_info.attrs.pin.max_length = 16;
 	pin_info.attrs.pin.pad_char = '\0';
-	pin_info.tries_left = 3;
-	pin_info.max_tries = 3;
+	pin_info.tries_left = 15;
+	pin_info.max_tries = 15;
 
 	strlcpy(pin_obj.label, "SOPIN", sizeof(pin_obj.label));
 	pin_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;

--- a/src/pkcs15init/sc-hsm.profile
+++ b/src/pkcs15init/sc-hsm.profile
@@ -5,65 +5,16 @@ cardinfo {
     label               = "SmartCard-HSM";
     manufacturer        = "CardContact";
 
-    max-pin-length      = 16;
+    max-pin-length      = 15;
     min-pin-length      = 6;
     pin-encoding        = ascii-numeric;
 }
 
-# Default settings.
-# This option block will always be processed.
-option default {
-	macros {
-		protected	= *=$SOPIN, READ=NONE;
-		unprotected	= *=NONE;
-		so-pin-flags	= local, initialized, soPin;
-		so-min-pin-length = 8;
-		so-pin-attempts	= 3;
-		so-auth-id	= 3;
-		odf-size	= 256;
-		aodf-size	= 256;
-		cdf-size	= 512;
-		prkdf-size	= 256;
-		pukdf-size	= 256;
-		dodf-size	= 256;
-	}
-}
-
 filesystem {
-	DF MF {
-		path	= 3F00;
+	# Here comes the application DF
+	DF PKCS15-AppDF {
 		type	= DF;
-
-		# This is the DIR file
-		EF DIR {
-			type	= EF;
-			file-id	= 2F00;
-			acl		= *=NONE;
-		}
-
-		# Here comes the application DF
-		DF PKCS15-AppDF {
-			type	= DF;
-			exclusive-aid = E8:2B:06:01:04:01:81:C3:1F:02:01;
-			acl		= *=NONE;
-
-			EF PKCS15-TokenInfo {
-				ACL		= $unprotected;
-			}
-
-			EF PKCS15-PrKDF {
-				size		= $prkdf-size;
-				acl		= $protected;
-			}
-
-			EF PKCS15-PuKDF {
-				size		= $pukdf-size;
-				acl		= $protected;
-			}
-
-			EF PKCS15-CDF {
-				acl		= $unprotected;
-			}
-		}
+		exclusive-aid = E8:2B:06:01:04:01:81:C3:1F:02:01;
+		acl		= *=NONE;
 	}
 }


### PR DESCRIPTION
This patch is required to ensure that the SmartCard-HSM applet is reselected after a reset and before the PIN is verified. This is required by minidriver.

The patch for pkcs15-pin.c fixes a bug that would skip sc_select_file() if only the AID is defined in auth_info->path.