### PR TITLE
Fixes accessing fixed size arrays

### DIFF
--- a/src/libopensc/pkcs15-data.c
+++ b/src/libopensc/pkcs15-data.c
@@ -157,7 +157,7 @@ int sc_pkcs15_encode_dodf_entry(sc_context_t *ctx,
 	size_t label_len;
 
 	info = (struct sc_pkcs15_data_info *) obj->data;
-	label_len = strlen(info->app_label);
+	label_len = strnlen(info->app_label, sizeof info->app_label);
 
 	sc_copy_asn1_entry(c_asn1_com_data_attr, asn1_com_data_attr);
 	sc_copy_asn1_entry(c_asn1_type_data_attr, asn1_type_data_attr);

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -298,10 +298,10 @@ int sc_pkcs15emu_sc_hsm_encode_cvc(sc_pkcs15_card_t * p15card,
 	}
 
 	sc_format_asn1_entry(asn1_cvc_body    , &cvc->cpi, NULL, 1);
-	lencar = strlen(cvc->car);
+	lencar = strnlen(cvc->car, sizeof cvc->car);
 	sc_format_asn1_entry(asn1_cvc_body + 1, &cvc->car, &lencar, 1);
 	sc_format_asn1_entry(asn1_cvc_body + 2, &asn1_cvc_pubkey, NULL, 1);
-	lenchr = strlen(cvc->chr);
+	lenchr = strnlen(cvc->chr, sizeof cvc->chr);
 	sc_format_asn1_entry(asn1_cvc_body + 3, &cvc->chr, &lenchr, 1);
 
 	sc_format_asn1_entry(asn1_cvcert    , &asn1_cvc_body, NULL, 1);
@@ -846,7 +846,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 	if (appinfo->label == NULL)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 
-	len = strlen(devcert.chr);		/* Strip last 5 digit sequence number from CHR */
+	len = strnlen(devcert.chr, sizeof devcert.chr);		/* Strip last 5 digit sequence number from CHR */
 	assert(len >= 8);
 	len -= 5;
 

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1505,8 +1505,8 @@ compare_obj_data_name(struct sc_pkcs15_object *obj, const char *app_label, const
 	if (obj->type != SC_PKCS15_TYPE_DATA_OBJECT)
 		return 0;
 
-	return !strcmp(cinfo->app_label, app_label) &&
-		!strcmp(obj->label, label);
+	return !strncmp(cinfo->app_label, app_label, sizeof cinfo->app_label) &&
+		!strncmp(obj->label, label, sizeof obj->label);
 }
 
 

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -114,7 +114,6 @@ HINSTANCE g_inst;
 #define MAGIC_SESSION_PIN "opensc-minidriver"
 
 struct md_directory {
-	unsigned char parent[9];
 	unsigned char name[9];
 
 	CARD_DIRECTORY_ACCESS_CONDITION acl;
@@ -126,7 +125,6 @@ struct md_directory {
 };
 
 struct md_file {
-	unsigned char parent[9];
 	unsigned char name[9];
 
 	CARD_FILE_ACCESS_CONDITION acl;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -962,7 +962,7 @@ md_pkcs15_update_container_from_do(PCARD_DATA pCardData, struct sc_pkcs15_object
 
 	rv = sc_pkcs15_read_data_object(vs->p15card, (struct sc_pkcs15_data_info *)dobj->data, &ddata);
 	if (rv)   {
-		logprintf(pCardData, 2, "sc_pkcs15_read_data_object('%s') returned %i\n", dobj->label, rv);
+		logprintf(pCardData, 2, "sc_pkcs15_read_data_object('%.*s') returned %i\n", (int) sizeof dobj->label, dobj->label, rv);
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
@@ -989,7 +989,7 @@ md_pkcs15_update_container_from_do(PCARD_DATA pCardData, struct sc_pkcs15_object
 	for (idx=0; idx<MD_MAX_KEY_CONTAINERS && vs->p15_containers[idx].prkey_obj; idx++)   {
 		if (sc_pkcs15_compare_id(&id, &vs->p15_containers[idx].id))   {
 			snprintf(vs->p15_containers[idx].guid, sizeof(vs->p15_containers[idx].guid),
-					"%s", dobj->label);
+					"%.*s", (int) sizeof dobj->label, dobj->label);
 			vs->p15_containers[idx].flags = flags;
 			logprintf(pCardData, 2, "Set container's guid to '%s' and flags to 0x%X\n",
 					vs->p15_containers[idx].guid, flags);
@@ -1018,7 +1018,7 @@ md_pkcs15_default_container_from_do(PCARD_DATA pCardData, struct sc_pkcs15_objec
 
 	rv = sc_pkcs15_read_data_object(vs->p15card, (struct sc_pkcs15_data_info *)dobj->data, &ddata);
 	if (rv)   {
-		logprintf(pCardData, 2, "sc_pkcs15_read_data_object('%s') returned %i\n", dobj->label, rv);
+		logprintf(pCardData, 2, "sc_pkcs15_read_data_object('%.*s') returned %i\n", (int) sizeof dobj->label, dobj->label, rv);
 		return SCARD_F_INTERNAL_ERROR;
 	}
 
@@ -1060,7 +1060,7 @@ md_pkcs15_delete_object(PCARD_DATA pCardData, struct sc_pkcs15_object *obj)
 
 	if (!obj)
 		return SCARD_S_SUCCESS;
-	logprintf(pCardData, 3, "MdDeleteObject('%s',type:0x%X) called\n", obj->label, obj->type);
+	logprintf(pCardData, 3, "MdDeleteObject('%.*s',type:0x%X) called\n", (int) sizeof obj->label, obj->label, obj->type);
 
 	rv = sc_lock(card);
 	if (rv)   {
@@ -1543,10 +1543,10 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 
 		/* Try to find the friend objects: certficate and public key */
 		if (!sc_pkcs15_find_cert_by_id(vs->p15card, &cont->id, &cont->cert_obj))
-			logprintf(pCardData, 2, "found certificate friend '%s'\n", cont->cert_obj->label);
+			logprintf(pCardData, 2, "found certificate friend '%.*s'\n", (int) sizeof cont->cert_obj->label, cont->cert_obj->label);
 
 		if (!sc_pkcs15_find_pubkey_by_id(vs->p15card, &cont->id, &cont->pubkey_obj))
-			logprintf(pCardData, 2, "found public key friend '%s'\n", cont->pubkey_obj->label);
+			logprintf(pCardData, 2, "found public key friend '%.*s'\n", (int) sizeof cont->pubkey_obj->label, cont->pubkey_obj->label);
 	}
 
 	if (conts_num)   {
@@ -1569,8 +1569,8 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 			if (strcmp(dinfo->app_label, MD_DATA_APPLICAITON_NAME))
 				continue;
 
-			logprintf(pCardData, 2, "Found 'DATA' object '%s'\n", dobjs[ii]->label);
-			if (!strcmp(dobjs[ii]->label, MD_DATA_DEFAULT_CONT_LABEL))   {
+			logprintf(pCardData, 2, "Found 'DATA' object '%.*s'\n", (int) sizeof dobjs[ii]->label, dobjs[ii]->label);
+			if (!strncmp(dobjs[ii]->label, MD_DATA_DEFAULT_CONT_LABEL, sizeof dobjs[ii]->label))   {
 				default_cont = dobjs[ii];
 				continue;
 			}
@@ -2606,7 +2606,7 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 	if (!pubkey_der.value && cont->pubkey_obj)   {
 		struct sc_pkcs15_pubkey *pubkey = NULL;
 
-		logprintf(pCardData, 1, "now read public key '%s'\n", cont->pubkey_obj->label);
+		logprintf(pCardData, 1, "now read public key '%.*s'\n", (int) sizeof cont->pubkey_obj->label, cont->pubkey_obj->label);
 		rv = sc_pkcs15_read_pubkey(vs->p15card, cont->pubkey_obj, &pubkey);
 		if (!rv)   {
 			rv = sc_pkcs15_encode_pubkey(vs->ctx, pubkey, &pubkey_der.value, &pubkey_der.len);
@@ -2630,7 +2630,7 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 	if (!pubkey_der.value && cont->cert_obj)   {
 		struct sc_pkcs15_cert *cert = NULL;
 
-		logprintf(pCardData, 1, "now read certificate '%s'\n", cont->cert_obj->label);
+		logprintf(pCardData, 1, "now read certificate '%.*s'\n", (int) sizeof cont->cert_obj->label, cont->cert_obj->label);
 		rv = sc_pkcs15_read_certificate(vs->p15card, (struct sc_pkcs15_cert_info *)(cont->cert_obj->data), &cert);
 		if(!rv)   {
 			rv = sc_pkcs15_encode_pubkey(vs->ctx, cert->key, &pubkey_der.value, &pubkey_der.len);

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -809,7 +809,7 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 			 * For this, create a 'virtual' AUTH object 'SO PIN', accessible by the card specific part,
 			 * but not yet written into the on-card PKCS#15.
 			 */
-			sc_log(ctx, "Add virtual SO_PIN('%s',flags:%X,reference:%i,path:'%s')", pin_obj->label,
+			sc_log(ctx, "Add virtual SO_PIN('%.*s',flags:%X,reference:%i,path:'%s')", (int) sizeof pin_obj->label, pin_obj->label,
 					pin_attrs->flags, pin_attrs->reference, sc_print_path(&pin_ainfo.path));
 			r = sc_pkcs15_add_object(p15card, pin_obj);
 			LOG_TEST_RET(ctx, r, "Failed to add 'SOPIN' AUTH object");
@@ -1005,7 +1005,7 @@ sc_pkcs15init_store_pin(struct sc_pkcs15_card *p15card, struct sc_profile *profi
 	auth_info->auth_id = args->auth_id;
 
 	/* Now store the PINs */
-	sc_log(ctx, "Store PIN(%s,authID:%s)", pin_obj->label, sc_pkcs15_print_id(&auth_info->auth_id));
+	sc_log(ctx, "Store PIN(%.*s,authID:%s)", (int) sizeof pin_obj->label, pin_obj->label, sc_pkcs15_print_id(&auth_info->auth_id));
 	r = sc_pkcs15init_create_pin(p15card, profile, pin_obj, args);
 	if (r < 0)
 		sc_pkcs15_free_object(pin_obj);
@@ -1676,7 +1676,7 @@ sc_pkcs15init_store_certificate(struct sc_pkcs15_card *p15card,
 		cert_info->path = existing_path;
 	}
 
-	sc_log(ctx, "Store cert(%s,ID:%s,der(%p,%i))", object->label,
+	sc_log(ctx, "Store cert(%.*s,ID:%s,der(%p,%i))", (int) sizeof object->label, object->label,
 			sc_pkcs15_print_id(&cert_info->id), args->der_encoded.value, args->der_encoded.len);
 
 	if (!profile->pkcs15.direct_certificates)
@@ -1825,8 +1825,8 @@ sc_pkcs15init_get_pin_reference(struct sc_pkcs15_card *p15card,
 		struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *)auth_objs[ii]->data;
 		struct sc_pkcs15_pin_attributes *pin_attrs = &auth_info->attrs.pin;
 
-		sc_log(ctx, "check PIN(%s,auth_method:%i,type:%i,reference:%i,flags:%X)",
-				auth_objs[ii]->label, auth_info->auth_method, pin_attrs->type,
+		sc_log(ctx, "check PIN(%.*s,auth_method:%i,type:%i,reference:%i,flags:%X)",
+				(int) sizeof auth_objs[ii]->label, auth_objs[ii]->label, auth_info->auth_method, pin_attrs->type,
 				pin_attrs->reference, pin_attrs->flags);
 		/* Find out if there is AUTH pkcs15 object with given 'type' and 'reference' */
 		if (auth_info->auth_method == auth_method && pin_attrs->reference == reference)
@@ -3305,11 +3305,11 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 
 	if (!r && pin_obj)   {
 		memcpy(&auth_info, pin_obj->data, sizeof(auth_info));
-		sc_log(ctx, "found PIN object '%s'", pin_obj->label);
+		sc_log(ctx, "found PIN object '%.*s'", (int) sizeof pin_obj->label, pin_obj->label);
 	}
 
 	if (pin_obj)   {
-		sc_log(ctx, "PIN object '%s'; pin_obj->content.len:%i", pin_obj->label, pin_obj->content.len);
+		sc_log(ctx, "PIN object '%.*s'; pin_obj->content.len:%i", (int) sizeof pin_obj->label, pin_obj->label, pin_obj->content.len);
 		if (pin_obj->content.value && pin_obj->content.len)   {
 			if (pin_obj->content.len > pinsize)
 				LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "PIN buffer is too small");

--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -436,7 +436,7 @@ cosm_create_pin(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 
 	pin_attrs = &auth_info->attrs.pin;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "create '%s'; ref 0x%X; flags %X", pin_obj->label, pin_attrs->reference, pin_attrs->flags);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "create '%.*s'; ref 0x%X; flags %X", (int) sizeof pin_obj->label, pin_obj->label, pin_attrs->reference, pin_attrs->flags);
 	if (sc_profile_get_file(profile, COSM_TITLE "-AppDF", &pin_file) < 0)
 		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INCONSISTENT_PROFILE, "\""COSM_TITLE"-AppDF\" not defined");
 
@@ -794,11 +794,11 @@ cosm_emu_update_any_df(struct sc_profile *profile, struct sc_pkcs15_card *p15car
 	SC_FUNC_CALLED(ctx, 1);
 	switch(op)   {
 	case SC_AC_OP_ERASE:
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Update DF; erase object('%s',type:%X)", object->label, object->type);
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Update DF; erase object('%.*s',type:%X)", (int) sizeof object->label, object->label, object->type);
 		rv = awp_update_df_delete(p15card, profile, object);
 		break;
 	case SC_AC_OP_CREATE:
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Update DF; create object('%s',type:%X)", object->label, object->type);
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Update DF; create object('%.*s',type:%X)", (int) sizeof object->label, object->label, object->type);
 		rv = awp_update_df_create(p15card, profile, object);
 		break;
 	}

--- a/src/pkcs15init/pkcs15-sc-hsm.c
+++ b/src/pkcs15init/pkcs15-sc-hsm.c
@@ -260,8 +260,8 @@ static int sc_hsm_generate_key(struct sc_profile *profile, struct sc_pkcs15_card
 
 	memset(&cvc, 0, sizeof(cvc));
 
-	strcpy(cvc.car, "UTCA00001");
-	strcpy(cvc.chr, "UTTM00001");
+	strlcpy(cvc.car, "UTCA00001", sizeof cvc.car);
+	strlcpy(cvc.chr, "UTTM00001", sizeof cvc.chr);
 
 	switch(object->type) {
 	case SC_PKCS15_TYPE_PRKEY_RSA:

--- a/src/tests/pintest.c
+++ b/src/tests/pintest.c
@@ -60,11 +60,11 @@ static int ask_and_verify_pin(struct sc_pkcs15_object *pin_obj)
 	u8 *pass;
 
 	if (pin_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN) {
-		printf("Skipping unblocking pin [%s]\n", pin_obj->label);
+		printf("Skipping unblocking pin [%.*s]\n", (int) sizeof pin_obj->label, pin_obj->label);
 		return 0;
 	}
 
-	sprintf(prompt, "Please enter PIN code [%s]: ", pin_obj->label);
+	sprintf(prompt, "Please enter PIN code [%.*s]: ", (int) sizeof pin_obj->label, pin_obj->label);
 	pass = (u8 *) getpass(prompt);
 
 	if (SC_SUCCESS != sc_lock(card))

--- a/src/tests/print.c
+++ b/src/tests/print.c
@@ -260,7 +260,7 @@ void sc_test_print_object(const struct sc_pkcs15_object *obj)
 
 	printf("%s", kind);
 	if (obj->label[0])
-		printf(" [%s]\n", obj->label);
+		printf(" [%.*s]\n", (int) sizeof obj->label, obj->label);
 	else
 		printf(" (no label)\n");
 	printf("\tCom. Flags  : ");

--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -140,7 +140,7 @@ static char * get_pin(struct sc_pkcs15_object *obj)
 			return strdup(opt_pincode);
 	}
 
-	sprintf(buf, "Enter PIN [%s]: ", obj->label);
+	sprintf(buf, "Enter PIN [%.*s]: ", (int) sizeof obj->label, obj->label);
 	while (1) {
 		pincode = getpass(buf);
 		if (strlen(pincode) == 0)

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2852,7 +2852,7 @@ static int verify_pin(struct sc_pkcs15_card *p15card, char *auth_id_str)
                 if (opt_no_prompt)
 			return SC_ERROR_OBJECT_NOT_FOUND;
 
-		if (0 < strnlen(pin_obj->label, sizeof pin_obj->label))
+		if (pin_obj->label[0])
 			snprintf(pin_label, sizeof(pin_label), "User PIN [%s]", pin_obj->label);
 		else
 			snprintf(pin_label, sizeof(pin_label), "User PIN");

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1015,7 +1015,7 @@ is_cacert_already_present(struct sc_pkcs15init_certargs *args)
 
 		if (!cinfo->authority)
 			continue;
-		if (strcmp(args->label, objs[i]->label))
+		if (strncmp(args->label, objs[i]->label, sizeof objs[i]->label))
 			continue;
 		/* XXX we should also match the usage field here */
 

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -477,7 +477,7 @@ static int list_data_objects(void)
 		int idx;
 		struct sc_pkcs15_data_info *cinfo = (struct sc_pkcs15_data_info *) objs[i]->data;
 
-		if (0 < strnlen(objs[i]->label, sizeof objs[i]->label))
+		if (objs[i]->label[0] != '\0')
 			printf("Data object '%.*s'\n",(int) sizeof objs[i]->label, objs[i]->label);
 		else
 			printf("Data object <%i>\n", i);
@@ -822,7 +822,7 @@ static void print_ssh_key(FILE *outf, const char * alg, struct sc_pkcs15_object 
 
 		fprintf(outf,"---- BEGIN SSH2 PUBLIC KEY ----\n");
 
-		if (strnlen(obj->label, sizeof obj->label))
+		if (obj->label[0] != '\0')
 			fprintf(outf,"Comment: \"%.*s\"\n", (int) sizeof obj->label, obj->label);
 
 		fprintf(outf,"%s", uu);
@@ -834,7 +834,7 @@ static void print_ssh_key(FILE *outf, const char * alg, struct sc_pkcs15_object 
 		if (r < 0)
 			return;
 
-		if (strnlen(obj->label, sizeof obj->label))
+		if (obj->label[0] != '\0')
 			fprintf(outf,"ssh-%s %s %.*s\n", alg, uu, (int) sizeof obj->label, obj->label);
 		else
 			fprintf(outf,"ssh-%s %s\n", alg, uu);


### PR DESCRIPTION
The pkcs_15_object_t label is a fixed size array, which means that it is possibly not terminated with `\0`. This PR fixes potentially bad access to the memory.