### PR TITLE
Partial fix for #570. Select AID for PIV

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -723,9 +723,6 @@ static int piv_find_aid(sc_card_t * card, sc_file_t *aid_file)
 	 * that we know about.
 	 */
 
-	if (card->type == SC_CARD_TYPE_PIV_II_GENERIC)
-		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, 0);
-
 	r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, rbuf, &resplen);
 	if (r >= 0 && resplen > 2 ) {
 		tag = sc_asn1_find_tag(card->ctx, rbuf, resplen, 0x61, &taglen);


### PR DESCRIPTION
card-piv.c was not selecting the PIV AID correctly from piv_find_aid.
This cause a CAC card that also has the PIV application to fail a VERIFY command
of the pin would use a VERIFY  APDU P2 where P2 for PIV is 80, but for CAC was 00.

A CAC card could work if the caller requested the serial number of the card
which did call piv_select_aid. All the OpenSC tools, minidriver and
PKCS#11 do this, but Tokend does not.

This is a partial fix for https://github.com/OpenSC/OpenSC/issues/570.
Tokend in later MacOS versions still has other issues.

A  more complete solution is needed for cards with multiple applications.

I do not have a CAC card or MAC to do any testing.

Thanks to https://github.com/mouse07410 who has a CAC card, and a Mac,
and has tested this fix.