### PR TITLE
Do not expose access to PIV emulated files from utilities

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2440,15 +2440,16 @@ static int piv_select_file(sc_card_t *card, const sc_path_t *in_path,
 	pathlen = in_path->len;
 
 	/* only support single EF in current application */
+	/* 
+	 * PIV emulates files, and only does so becauses sc_pkcs15_* uses
+	 * select_file and read_binary. The emulation adds path emulated structures
+	 * so piv_select_file will find it.
+	 * there is no dir. Only direct access to emulated files
+	 * thus opensc-tool and opensc-explorer can not read the emulated files
+	 */
 
 	if (memcmp(path, "\x3F\x00", 2) == 0) {
-		if (pathlen == 2)   {
-			r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, NULL, NULL);
-			SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "Cannot select PIV AID");
-
-			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
-		}
-		else if (pathlen > 2) {
+		if (pathlen > 2) {
 			path += 2;
 			pathlen -= 2;
 		}


### PR DESCRIPTION
PIV cards uses get/put data not select file and read_binary.
To allow access via pkcs15 emulation card-piv.c emulates
select_file and read_binary but only when used with the path as
created by the piv emulation.

There are no MF.DIR or EF.DIR files.
opensc-tool and opensc-explorer will not work with this emulation.

Patch removes code that caused problems with opensc-tooland opensc-explorer.