### PR TITLE
Fix issues related to selecting a file

### DIFF
--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -468,7 +468,7 @@ static int entersafe_select_fid(sc_card_t *card,
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");
 
 	/* update cache */
-	if (file->type == SC_FILE_TYPE_DF) {
+	if (file && file->type == SC_FILE_TYPE_DF) {
 		 card->cache.current_path.type = SC_PATH_TYPE_PATH;
 		 card->cache.current_path.value[0] = 0x3f;
 		 card->cache.current_path.value[1] = 0x00;

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2166,10 +2166,9 @@ get_external_key_maxtries(struct sc_card *card, unsigned char *maxtries)
 		SC_PATH_TYPE_PATH,
 		{{0}, 0}
 	};
-	struct sc_file *ef_file;
 	int ret;
 
-	ret = sc_select_file(card, &file_path, &ef_file);
+	ret = sc_select_file(card, &file_path, NULL);
 	LOG_TEST_RET(card->ctx, ret, "select max counter file failed");
 
 	ret = sc_read_binary(card, 0, maxcounter, 2, 0);

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -2237,24 +2237,16 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 	iasecc_sdo_free_fields(card, &sdo);
 
 	if (save_current_df)   {
-		struct sc_file *dummy_file = NULL;
-
 		sc_log(ctx, "iasecc_pin_get_policy() restore current DF");
-		rv = iasecc_select_file(card, &save_current_df->path, &dummy_file);
+		rv = iasecc_select_file(card, &save_current_df->path, NULL);
 		LOG_TEST_RET(ctx, rv, "Cannot return to saved DF");
-
-		sc_file_free(dummy_file);
 		sc_file_free(save_current_df);
 	}
 
 	if (save_current_ef)   {
-		struct sc_file *dummy_file = NULL;
-
 		sc_log(ctx, "iasecc_pin_get_policy() restore current EF");
-		rv = iasecc_select_file(card, &save_current_ef->path, &dummy_file);
+		rv = iasecc_select_file(card, &save_current_ef->path, NULL);
 		LOG_TEST_RET(ctx, rv, "Cannot return to saved EF");
-
-		sc_file_free(dummy_file);
 		sc_file_free(save_current_ef);
 	}
 
@@ -2466,9 +2458,7 @@ iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_
 	}
 
 	if (save_current)   {
-		struct sc_file *dummy_file = NULL;
-
-		rv = iasecc_select_file(card, &save_current->path, &dummy_file);
+		rv = iasecc_select_file(card, &save_current->path, NULL);
 		LOG_TEST_RET(ctx, rv, "Cannot return to saved PATH");
 	}
 

--- a/src/libopensc/card-jcop.c
+++ b/src/libopensc/card-jcop.c
@@ -345,7 +345,6 @@ static int jcop_list_files(sc_card_t *card, u8 *buf, size_t buflen) {
      struct jcop_private_data *drvdata=DRVDATA(card);
      struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
      const struct sc_card_operations *iso_ops = iso_drv->ops;
-     sc_file_t  *tfile;
      int r;
 
      if (drvdata->selected == SELECT_MF) {
@@ -355,11 +354,10 @@ static int jcop_list_files(sc_card_t *card, u8 *buf, size_t buflen) {
 	  if (buflen < 4)
 	       return 2;
 	  /* AppDF only exists if applet is selectable */
-	  r = iso_ops->select_file(card, &drvdata->aid, &tfile);
+	  r = iso_ops->select_file(card, &drvdata->aid, NULL);
 	  if (r < 0) { 
 	       return 2;
 	  } else {
-	       sc_file_free(tfile);
 	       memcpy(buf+2, "\x50\x15", 2);
 	       return 4;
 	  }

--- a/src/libopensc/card-jcop.c
+++ b/src/libopensc/card-jcop.c
@@ -269,7 +269,7 @@ static int jcop_select_file(sc_card_t *card, const sc_path_t *path,
 	  }
 	  if ((r = iso_ops->select_file(card, &drvdata->aid, fileptr)) < 0)
 	       return r;
-	  if ((selecting & SELECTING_TARGET) == SELECT_APPDF) {
+	  if (fileptr && (selecting & SELECTING_TARGET) == SELECT_APPDF) {
 	       (*fileptr)->type = SC_FILE_TYPE_DF;
 	       drvdata->selected=SELECT_APPDF;
 	       goto select_ok;
@@ -316,7 +316,6 @@ static int jcop_read_binary(sc_card_t *card, unsigned int idx,
      struct jcop_private_data *drvdata=DRVDATA(card);
      struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
      const struct sc_card_operations *iso_ops = iso_drv->ops;
-     sc_file_t  *tfile;
      int r;
      
      if (drvdata->selected == SELECT_MF) {
@@ -329,11 +328,10 @@ static int jcop_read_binary(sc_card_t *card, unsigned int idx,
 	  if (idx + count > 128) {
 	       count=128-idx;
 	  }
-	  r = iso_ops->select_file(card, &drvdata->aid, &tfile);
+	  r = iso_ops->select_file(card, &drvdata->aid, NULL);
 	  if (r < 0) { /* no pkcs15 app, so return empty DIR. */
 	       memset(buf, 0, count);
 	  } else {
-	       sc_file_free(tfile);
 	       memcpy(buf, (u8 *)(ef_dir_contents + idx), count);
 	  }
 	  return count;

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -810,6 +810,8 @@ do_select(sc_card_t * card, u8 kind,
 	if (p2 == 0x0C) {
 		if (file) {
 			*file = sc_file_new();
+			if (!*file)
+				SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_OUT_OF_MEMORY);
 			(*file)->type = SC_FILE_TYPE_DF;
 			return SC_SUCCESS;
 		}

--- a/src/libopensc/card-miocos.c
+++ b/src/libopensc/card-miocos.c
@@ -383,7 +383,7 @@ static int miocos_select_file(sc_card_t *card,
 	r = iso_ops->select_file(card, in_path, file);
 	if (r)
 		return r;
-	if (file != NULL) {
+	if (file != NULL && *file != NULL) {
 		parse_sec_attr(*file, (*file)->sec_attr, (*file)->sec_attr_len);
 		miocos_get_acl(card, *file);
 	}

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -263,16 +263,10 @@ static void parse_sec_attr(struct sc_file *file, const u8 *buf, size_t len)
 static int myeid_select_file(struct sc_card *card, const struct sc_path *in_path,
 		struct sc_file **file)
 {
-	struct sc_file *dummy_file = NULL;
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
-	r = iso_ops->select_file(card, in_path, &dummy_file);
-
-	if (file)
-		*file = dummy_file;
-	else  if (dummy_file)
-		sc_file_free(dummy_file);
+	r = iso_ops->select_file(card, in_path, file);
 
 	if (r == 0 && file != NULL && *file != NULL)
 		parse_sec_attr(*file, (*file)->sec_attr, (*file)->sec_attr_len);

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -1156,7 +1156,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 		goto out;
 	}
 	r = sc_select_file(card, &(priv_data->env.file_ref), &keyfile);
-	if (r)
+	if (r || !keyfile)
 		goto out;
 
 	do {

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -1097,7 +1097,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 				 size_t outlen)
 {
 	int r;
-	sc_file_t *keyfile = sc_file_new();
+	sc_file_t *keyfile = NULL;
 #ifdef ENABLE_OPENSSL
 	int idx = 0;
 	u8 buf[180];
@@ -1115,7 +1115,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 #ifndef ENABLE_OPENSSL
 	r = SC_ERROR_NOT_SUPPORTED;
 #else
-	if (keyfile == NULL || mem == NULL || card->drv_data == NULL) {
+	if (mem == NULL || card->drv_data == NULL) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -689,6 +689,12 @@ int sc_select_file(sc_card_t *card, const sc_path_t *in_path,  sc_file_t **file)
 	if (r != SC_SUCCESS)
 		pbuf[0] = '\0';
 
+	/* FIXME We should be a bit less strict and let the upper layers do
+	 * the initialization (including reuse of existing file objects). We
+	 * implemented this here because we are lazy. */
+	if (file != NULL)
+		*file = NULL;
+
 	sc_log(card->ctx, "called; type=%d, path=%s", in_path->type, pbuf);
 	if (in_path->len > SC_MAX_PATH_SIZE)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
@@ -713,9 +719,16 @@ int sc_select_file(sc_card_t *card, const sc_path_t *in_path,  sc_file_t **file)
 	r = card->ops->select_file(card, in_path, file);
 	LOG_TEST_RET(card->ctx, r, "'SELECT' error");
 
-	/* Remember file path */
-	if (file && *file)
-		(*file)->path = *in_path;
+	if (file) {
+		if (*file)
+			/* Remember file path */
+			(*file)->path = *in_path;
+		else
+			/* FIXME We should be a bit less strict and let the upper layers do
+			 * the error checking. We implemented this here because we are
+			 * lazy.  */
+			r = SC_ERROR_INVALID_DATA;
+	}
 
 	LOG_FUNC_RETURN(card->ctx, r);
 }

--- a/src/libopensc/cardctl.h
+++ b/src/libopensc/cardctl.h
@@ -523,9 +523,9 @@ typedef struct sc_cardctl_muscle_key_info {
 	int 	keyType;
 	int 	keyLocation;
 	int 	keySize;
-	int 	modLength;
+	size_t 	modLength;
 	u8* 	modValue;
-	int 	expLength;
+	size_t 	expLength;
 	u8* 	expValue;
 	int 	pLength;
 	u8* 	pValue;

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -225,7 +225,7 @@ int dnie_read_file(sc_card_t * card,
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 	/* select file by mean of iso7816 ops */
 	res = card->ops->select_file(card, path, file);
-	if (res != SC_SUCCESS) {
+	if (res != SC_SUCCESS || !file || !(*file)) {
 		msg = "select_file failed";
 		goto dnie_read_file_err;
 	}

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -457,9 +457,6 @@ iso7816_select_file(struct sc_card *card, const struct sc_path *in_path, struct 
 	pathlen = in_path->len;
 	pathtype = in_path->type;
 
-	if (file_out != NULL) {
-		*file_out = NULL;
-	}
 	if (in_path->aid.len) {
 		if (!pathlen) {
 			memcpy(path, in_path->aid.value, in_path->aid.len);

--- a/src/libopensc/muscle.c
+++ b/src/libopensc/muscle.c
@@ -581,9 +581,9 @@ int msc_extract_key(sc_card_t *card,
 
 int msc_extract_rsa_public_key(sc_card_t *card, 
 			int keyLocation,
-			int* modLength, 
+			size_t* modLength, 
 			u8** modulus,
-			int* expLength,
+			size_t* expLength,
 			u8** exponent)
 {
 	int r;

--- a/src/libopensc/muscle.h
+++ b/src/libopensc/muscle.h
@@ -58,9 +58,9 @@ int msc_get_challenge(sc_card_t *card, unsigned short dataLength, unsigned short
 int msc_generate_keypair(sc_card_t *card, int privateKey, int publicKey, int algorithm, int keySize, int options);
 int msc_extract_rsa_public_key(sc_card_t *card, 
 			int keyLocation,
-			int* modLength, 
+			size_t* modLength, 
 			u8** modulus,
-			int* expLength,
+			size_t* expLength,
 			u8** exponent);
 int msc_extract_key(sc_card_t *card, 
 			int keyLocation);

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -41,12 +41,13 @@ static
 int dump_ef(sc_card_t * card, const char *path, u8 * buf, size_t * buf_len)
 {
 	int rv;
-	sc_file_t *file = sc_file_new();
+	sc_file_t *file = NULL;
 	sc_path_t scpath;
 	sc_format_path(path, &scpath);
 	rv = sc_select_file(card, &scpath, &file);
 	if (rv < 0) {
-		sc_file_free(file);
+		if (file)
+			sc_file_free(file);
 		return rv;
 	}
 	if (file->size > *buf_len) {

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -248,7 +248,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 
 	/* we will use dfpath in all other references */
 	dfpath = file->id;
-	free(file);
+	sc_file_free(file);
 	file = NULL;
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "GemSafe file found, id=%d",dfpath);

--- a/src/libopensc/pkcs15-infocamere.c
+++ b/src/libopensc/pkcs15-infocamere.c
@@ -37,13 +37,13 @@
 #include "log.h"
 
 int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t *,
-				    sc_pkcs15emu_opt_t *);
+		sc_pkcs15emu_opt_t *);
 
 static int (*set_security_env) (sc_card_t *, const sc_security_env_t *,
-				int);
+		int);
 
 static int set_sec_env(sc_card_t * card, const sc_security_env_t * env,
-		       int se_num)
+		int se_num)
 {
 	sc_security_env_t tenv = *env;
 	if (tenv.operation == SC_SEC_OPERATION_SIGN)
@@ -52,7 +52,7 @@ static int set_sec_env(sc_card_t * card, const sc_security_env_t * env,
 }
 
 static int do_sign(sc_card_t * card, const u8 * in, size_t inlen, u8 * out,
-		   size_t outlen)
+		size_t outlen)
 {
 	return card->ops->decipher(card, in, inlen, out, outlen);
 }
@@ -68,73 +68,73 @@ static void set_string(char **strp, const char *value)
 /* XXX: temporary copy of the old pkcs15emu functions,
  *      to be removed */
 static int sc_pkcs15emu_add_pin(sc_pkcs15_card_t *p15card,
-                const sc_pkcs15_id_t *id, const char *label,
-                const sc_path_t *path, int ref, int type,
-                unsigned int min_length,
-                unsigned int max_length,
-                int flags, int tries_left, const char pad_char, int obj_flags)
+		const sc_pkcs15_id_t *id, const char *label,
+		const sc_path_t *path, int ref, int type,
+		unsigned int min_length,
+		unsigned int max_length,
+		int flags, int tries_left, const char pad_char, int obj_flags)
 {
-        sc_pkcs15_auth_info_t info;
+	sc_pkcs15_auth_info_t info;
 	sc_pkcs15_object_t   obj;
 
 	memset(&info, 0, sizeof(info));
 	memset(&obj,  0, sizeof(obj));
 
 	info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
-        info.auth_id           = *id;
-        info.attrs.pin.min_length        = min_length;
-        info.attrs.pin.max_length        = max_length;
-        info.attrs.pin.stored_length     = max_length;
-        info.attrs.pin.type              = type;
-        info.attrs.pin.reference         = ref;
-        info.attrs.pin.flags             = flags;
-        info.attrs.pin.pad_char          = pad_char;
-        info.tries_left        = tries_left;
+	info.auth_id           = *id;
+	info.attrs.pin.min_length        = min_length;
+	info.attrs.pin.max_length        = max_length;
+	info.attrs.pin.stored_length     = max_length;
+	info.attrs.pin.type              = type;
+	info.attrs.pin.reference         = ref;
+	info.attrs.pin.flags             = flags;
+	info.attrs.pin.pad_char          = pad_char;
+	info.tries_left        = tries_left;
 
-        if (path)
-                info.path = *path;
-        if (type == SC_PKCS15_PIN_TYPE_BCD)
-                info.attrs.pin.stored_length /= 2;
+	if (path)
+		info.path = *path;
+	if (type == SC_PKCS15_PIN_TYPE_BCD)
+		info.attrs.pin.stored_length /= 2;
 
 	strlcpy(obj.label, label, sizeof(obj.label));
 	obj.flags = obj_flags;
 
-        return sc_pkcs15emu_add_pin_obj(p15card, &obj, &info);
+	return sc_pkcs15emu_add_pin_obj(p15card, &obj, &info);
 }
 
 static int sc_pkcs15emu_add_prkey(sc_pkcs15_card_t *p15card,
-                const sc_pkcs15_id_t *id,
-                const char *label,
-                int type, unsigned int modulus_length, int usage,
-                const sc_path_t *path, int ref,
-                const sc_pkcs15_id_t *auth_id, int obj_flags)
+		const sc_pkcs15_id_t *id,
+		const char *label,
+		int type, unsigned int modulus_length, int usage,
+		const sc_path_t *path, int ref,
+		const sc_pkcs15_id_t *auth_id, int obj_flags)
 {
-        sc_pkcs15_prkey_info_t info;
+	sc_pkcs15_prkey_info_t info;
 	sc_pkcs15_object_t     obj;
 
 	memset(&info, 0, sizeof(info));
 	memset(&obj,  0, sizeof(obj));
 
-        info.id                = *id;
-        info.modulus_length    = modulus_length;
-        info.usage             = usage;
-        info.native            = 1;
-        info.key_reference     = ref;
+	info.id                = *id;
+	info.modulus_length    = modulus_length;
+	info.usage             = usage;
+	info.native            = 1;
+	info.key_reference     = ref;
 
-        if (path)
-                info.path = *path;
+	if (path)
+		info.path = *path;
 
 	obj.flags = obj_flags;
 	strlcpy(obj.label, label, sizeof(obj.label));
 	if (auth_id != NULL)
 		obj.auth_id = *auth_id;
 
-        return sc_pkcs15emu_add_rsa_prkey(p15card, &obj, &info);
+	return sc_pkcs15emu_add_rsa_prkey(p15card, &obj, &info);
 }
 
 static int sc_pkcs15emu_add_cert(sc_pkcs15_card_t *p15card,
-	int type, int authority, const sc_path_t *path,
-	const sc_pkcs15_id_t *id, const char *label, int obj_flags)
+		int type, int authority, const sc_path_t *path,
+		const sc_pkcs15_id_t *id, const char *label, int obj_flags)
 {
 	/* const char *label = "Certificate"; */
 	sc_pkcs15_cert_info_t info;
@@ -159,9 +159,9 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 {
 	const int prkey_usage = SC_PKCS15_PRKEY_USAGE_NONREPUDIATION;
 	const int authprkey_usage = SC_PKCS15_PRKEY_USAGE_SIGN
-	    | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
-	    | SC_PKCS15_PRKEY_USAGE_ENCRYPT
-	    | SC_PKCS15_PRKEY_USAGE_DECRYPT;
+		| SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
+		| SC_PKCS15_PRKEY_USAGE_ENCRYPT
+		| SC_PKCS15_PRKEY_USAGE_DECRYPT;
 
 	sc_card_t *card = p15card->card;
 	sc_path_t path;
@@ -173,7 +173,7 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 	unsigned char certlen[2];
 	int authority, change_sign = 0;
 	struct sc_pkcs15_cert_info cert_info;
-        struct sc_pkcs15_object    cert_obj;
+	struct sc_pkcs15_object    cert_obj;
 
 	const char *label = "User Non-repudiation Certificate";
 	const char *calabel = "CA Certificate";
@@ -231,15 +231,15 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 	const char *nonrepPRKEY = "Non repudiation Key";
 
 	const int flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE |
-	    SC_PKCS15_PIN_FLAG_INITIALIZED |
-	    SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
+		SC_PKCS15_PIN_FLAG_INITIALIZED |
+		SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
 
 	int r, len_iccsn, len_chn;
 
 	sc_format_path("3F002F02", &path);
 
 	r = sc_select_file(card, &path, &file);
-	
+
 	if (r != SC_SUCCESS || file->size > 255) {
 		/* Not EF.GDO */
 		if (file)
@@ -269,8 +269,8 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 	sc_file_free(file);
 
 	if (!
-	    (ef_gdo[len_iccsn + 2] == 0x5F
-	     && ef_gdo[len_iccsn + 3] == 0x20)) {
+			(ef_gdo[len_iccsn + 2] == 0x5F
+			 && ef_gdo[len_iccsn + 3] == 0x20)) {
 		/* Not CHN */
 		return SC_ERROR_WRONG_CARD;
 	}
@@ -283,9 +283,9 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 	}
 
 	if (!
-	    (ef_gdo[len_iccsn + 5] == 0x12
-	     && (ef_gdo[len_iccsn + 6] == 0x02
-		 || ef_gdo[len_iccsn + 6] == 0x03))) {
+			(ef_gdo[len_iccsn + 5] == 0x12
+			 && (ef_gdo[len_iccsn + 6] == 0x02
+				 || ef_gdo[len_iccsn + 6] == 0x03))) {
 		/* Not Infocamere Card */
 		return SC_ERROR_WRONG_CARD;
 	}
@@ -319,43 +319,43 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 		path.count = (certlen[1] << 8) + certlen[0];
 
 		memset(&cert_info, 0, sizeof(cert_info));
-                memset(&cert_obj,  0, sizeof(cert_obj));
+		memset(&cert_obj,  0, sizeof(cert_obj));
 
 		sc_pkcs15_format_id("1", &cert_info.id);
-        	cert_info.authority = authority;
-        	cert_info.path = path;
+		cert_info.authority = authority;
+		cert_info.path = path;
 		strlcpy(cert_obj.label, authlabel, sizeof(cert_obj.label));
-	        cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
+		cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
 
 		r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
-        	if (r < 0)
-        		return SC_ERROR_INTERNAL;
+		if (r < 0)
+			return SC_ERROR_INTERNAL;
 
 		/* XXX: the IDs for the key/pin in case of the 1203 type 
 		 * are wrong, therefore I disable them for now -- Nils */
 		if (!change_sign) {    
-		/* add authentication PIN */
+			/* add authentication PIN */
 
-                sc_format_path(infocamere_auth_path[ef_gdo[len_iccsn+6]-2], &path);
-                
-		sc_pkcs15_format_id("1", &id);
-		sc_pkcs15emu_add_pin(p15card, &id,
-                                authPIN, &path, infocamere_idpin_auth_obj[ef_gdo[len_iccsn+6]-2],
-                                SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-                                5, 8, flags, 3, 0, 
-				SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE);
+			sc_format_path(infocamere_auth_path[ef_gdo[len_iccsn+6]-2], &path);
 
-		/* add authentication private key */
+			sc_pkcs15_format_id("1", &id);
+			sc_pkcs15emu_add_pin(p15card, &id,
+					authPIN, &path, infocamere_idpin_auth_obj[ef_gdo[len_iccsn+6]-2],
+					SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+					5, 8, flags, 3, 0, 
+					SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE);
 
-		auth_id.value[0] = 1;
-		auth_id.len = 1;
+			/* add authentication private key */
 
-		sc_pkcs15emu_add_prkey(p15card, &id,
-				authPRKEY,
-				SC_PKCS15_TYPE_PRKEY_RSA, 
-				1024, authprkey_usage,
-				&path, infocamere_idprkey_auth_obj[ef_gdo[len_iccsn+6]-2],
-				&auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
+			auth_id.value[0] = 1;
+			auth_id.len = 1;
+
+			sc_pkcs15emu_add_prkey(p15card, &id,
+					authPRKEY,
+					SC_PKCS15_TYPE_PRKEY_RSA, 
+					1024, authprkey_usage,
+					&path, infocamere_idprkey_auth_obj[ef_gdo[len_iccsn+6]-2],
+					&auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
 		}
 
 	}
@@ -364,30 +364,29 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 
 	sc_format_path(infocamere_cert_path[ef_gdo[len_iccsn+6]-2], &path);
 
-	if (sc_select_file(card, &path, NULL) < 0)
-		{
+	if (sc_select_file(card, &path, NULL) < 0) {
 		return SC_ERROR_INTERNAL;
-		}
+	}
 
 	sc_read_binary(card, 0, certlen, 2, 0);
 
 	/* Now set the certificate offset/len */
 	path.index = 2;
 	path.count = (certlen[1] << 8) + certlen[0];
-	
-        memset(&cert_info, 0, sizeof(cert_info));
-        memset(&cert_obj,  0, sizeof(cert_obj));
+
+	memset(&cert_info, 0, sizeof(cert_info));
+	memset(&cert_obj,  0, sizeof(cert_obj));
 
 	sc_pkcs15_format_id("2", &cert_info.id);
 
-        cert_info.authority = authority;
-        cert_info.path = path;
-        strlcpy(cert_obj.label, label, sizeof(cert_obj.label));
-        cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
+	cert_info.authority = authority;
+	cert_info.path = path;
+	strlcpy(cert_obj.label, label, sizeof(cert_obj.label));
+	cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
 
 	r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
-        if (r < 0)
-        	return SC_ERROR_INTERNAL;
+	if (r < 0)
+		return SC_ERROR_INTERNAL;
 
 	/* Get the CA certificate length */
 
@@ -410,29 +409,29 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 			path.count = len;
 
 			memset(&cert_info, 0, sizeof(cert_info));
-	                memset(&cert_obj,  0, sizeof(cert_obj));
+			memset(&cert_obj,  0, sizeof(cert_obj));
 
 			sc_pkcs15_format_id("3", &cert_info.id);
-	        	cert_info.authority = authority;
-	        	cert_info.path = path;
-	        	strlcpy(cert_obj.label, calabel, sizeof(cert_obj.label));
-		        cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
+			cert_info.authority = authority;
+			cert_info.path = path;
+			strlcpy(cert_obj.label, calabel, sizeof(cert_obj.label));
+			cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
 
 			r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
-        		if (r < 0)
-        		return SC_ERROR_INTERNAL;
+			if (r < 0)
+				return SC_ERROR_INTERNAL;
 		}
 	}
 
-        /* add non repudiation PIN */
+	/* add non repudiation PIN */
 
 	sc_format_path(infocamere_nrepud_path[ef_gdo[len_iccsn+6]-2], &path);
 
 	sc_pkcs15_format_id("2", &id);
 	sc_pkcs15emu_add_pin(p15card, &id,
-		nonrepPIN, &path, infocamere_idpin_nrepud_obj[ef_gdo[len_iccsn+6]-2],
-		SC_PKCS15_PIN_TYPE_ASCII_NUMERIC, 5, 8, flags, 3, 0,
-		SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE);
+			nonrepPIN, &path, infocamere_idpin_nrepud_obj[ef_gdo[len_iccsn+6]-2],
+			SC_PKCS15_PIN_TYPE_ASCII_NUMERIC, 5, 8, flags, 3, 0,
+			SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE);
 
 
 	/* add non repudiation private key */
@@ -441,10 +440,10 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 	auth_id.len = 1;
 
 	sc_pkcs15emu_add_prkey(p15card, &id, nonrepPRKEY,
-			       SC_PKCS15_TYPE_PRKEY_RSA, 
-                               1024, prkey_usage,
-                               &path, infocamere_idprkey_nrepud_obj[ef_gdo[len_iccsn+6]-2],
-                               &auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
+			SC_PKCS15_TYPE_PRKEY_RSA, 
+			1024, prkey_usage,
+			&path, infocamere_idprkey_nrepud_obj[ef_gdo[len_iccsn+6]-2],
+			&auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
 
 
 	/* return to MF */
@@ -465,8 +464,8 @@ static int infocamere_1200_init(sc_pkcs15_card_t * p15card)
 }
 
 static int infocamere_1400_set_sec_env(struct sc_card *card,
-				       const struct sc_security_env *env,
-				       int se_num)
+		const struct sc_security_env *env,
+		int se_num)
 {
 	int r;
 
@@ -475,7 +474,7 @@ static int infocamere_1400_set_sec_env(struct sc_card *card,
 		tenv.operation = SC_SEC_OPERATION_DECIPHER;
 
 	if ((r =
-	     card->ops->restore_security_env(card, 0x40)) == SC_SUCCESS)
+				card->ops->restore_security_env(card, 0x40)) == SC_SUCCESS)
 		return set_security_env(card, &tenv, se_num);
 	else
 		return r;
@@ -484,18 +483,18 @@ static int infocamere_1400_set_sec_env(struct sc_card *card,
 #ifdef ENABLE_ZLIB
 
 static const u8 ATR_1400[] =
-    { 0x3b, 0xfc, 0x98, 0x00, 0xff, 0xc1, 0x10, 0x31, 0xfe, 0x55, 0xc8,
+{ 0x3b, 0xfc, 0x98, 0x00, 0xff, 0xc1, 0x10, 0x31, 0xfe, 0x55, 0xc8,
 	0x03, 0x49, 0x6e, 0x66, 0x6f, 0x63, 0x61, 0x6d, 0x65, 0x72, 0x65,
 	0x28
 };
 
 /* Loads certificates.
-* Certificates are stored in a ZLib compressed form with
-* a 4 byte header, so we extract, decompress and cache
-* them.
-*/
+ * Certificates are stored in a ZLib compressed form with
+ * a 4 byte header, so we extract, decompress and cache
+ * them.
+ */
 static int loadCertificate(sc_pkcs15_card_t * p15card, int i,
-			   const char *certPath, const char *certLabel)
+		const char *certPath, const char *certLabel)
 {
 	unsigned char *compCert = NULL, *cert = NULL, size[2];
 	unsigned long int compLen, len;
@@ -565,20 +564,20 @@ static int infocamere_1400_init(sc_pkcs15_card_t * p15card)
 	};
 
 	const char *certPath[] =
-	    { "300060000000", "300060000001", "300060000002" };
+	{ "300060000000", "300060000001", "300060000002" };
 
 	const char *pinLabel[] =
-	    { "Non-repudiation PIN", "Authentication PIN" };
+	{ "Non-repudiation PIN", "Authentication PIN" };
 	int retries[] = { 3, -1 };
 
 	const char *keyPath[] = { "30004000001", "30004000002" };
 	const char *keyLabel[] =
-	    { "Non repudiation Key", "Authentication Key" };
+	{ "Non repudiation Key", "Authentication Key" };
 	static int usage[] = { SC_PKCS15_PRKEY_USAGE_NONREPUDIATION,
 		SC_PKCS15_PRKEY_USAGE_SIGN
-		    | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
-		    | SC_PKCS15_PRKEY_USAGE_ENCRYPT
-		    | SC_PKCS15_PRKEY_USAGE_DECRYPT
+			| SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
+			| SC_PKCS15_PRKEY_USAGE_ENCRYPT
+			| SC_PKCS15_PRKEY_USAGE_DECRYPT
 	};
 
 	auth_id.len = 1;
@@ -595,7 +594,7 @@ static int infocamere_1400_init(sc_pkcs15_card_t * p15card)
 	sc_format_path("30000001", &path);
 
 	r = sc_select_file(card, &path, NULL);
-	
+
 	if (r != SC_SUCCESS)
 		return SC_ERROR_WRONG_CARD;
 
@@ -607,19 +606,19 @@ static int infocamere_1400_init(sc_pkcs15_card_t * p15card)
 	set_string(&p15card->tokeninfo->manufacturer_id, "Infocamere");
 
 	if ((r = loadCertificate(p15card, 0, certPath[0], certLabel[0])) !=
-	    SC_SUCCESS) {
+			SC_SUCCESS) {
 		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "%s", sc_strerror(r));
 		return SC_ERROR_WRONG_CARD;
 	}
 
 	hasAuthCert =
-	    loadCertificate(p15card, 1, certPath[1],
-			    certLabel[1]) == SC_SUCCESS;
+		loadCertificate(p15card, 1, certPath[1],
+				certLabel[1]) == SC_SUCCESS;
 	loadCertificate(p15card, 2, certPath[2], certLabel[2]);
 
 	flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE |
-	    SC_PKCS15_PIN_FLAG_INITIALIZED |
-	    SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
+		SC_PKCS15_PIN_FLAG_INITIALIZED |
+		SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
 
 	/* adding PINs & private keys */
 
@@ -627,20 +626,20 @@ static int infocamere_1400_init(sc_pkcs15_card_t * p15card)
 	id.value[0] = 1;
 
 	sc_pkcs15emu_add_pin(p15card, &id,
-			     pinLabel[0], &path, 1,
-			     SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-			     5, 8, flags, retries[0], 0,
-			     SC_PKCS15_CO_FLAG_MODIFIABLE |
-			     SC_PKCS15_CO_FLAG_PRIVATE);
+			pinLabel[0], &path, 1,
+			SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+			5, 8, flags, retries[0], 0,
+			SC_PKCS15_CO_FLAG_MODIFIABLE |
+			SC_PKCS15_CO_FLAG_PRIVATE);
 
 	sc_format_path(keyPath[0], &path);
 	auth_id.value[0] = 1;
 	sc_pkcs15emu_add_prkey(p15card, &id,
-			       keyLabel[0],
-			       SC_PKCS15_TYPE_PRKEY_RSA,
-			       1024, usage[0],
-			       &path, 1,
-			       &auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
+			keyLabel[0],
+			SC_PKCS15_TYPE_PRKEY_RSA,
+			1024, usage[0],
+			&path, 1,
+			&auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
 
 
 	if (hasAuthCert) {
@@ -648,28 +647,28 @@ static int infocamere_1400_init(sc_pkcs15_card_t * p15card)
 		id.value[0] = 2;
 
 		sc_pkcs15emu_add_pin(p15card, &id,
-				     pinLabel[1], &path, 2,
-				     SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-				     5, 8, flags, retries[1], 0,
-				     SC_PKCS15_CO_FLAG_MODIFIABLE |
-				     SC_PKCS15_CO_FLAG_PRIVATE);
+				pinLabel[1], &path, 2,
+				SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+				5, 8, flags, retries[1], 0,
+				SC_PKCS15_CO_FLAG_MODIFIABLE |
+				SC_PKCS15_CO_FLAG_PRIVATE);
 
 		sc_format_path(keyPath[1], &path);
 		auth_id.value[0] = 2;
 		sc_pkcs15emu_add_prkey(p15card, &id,
-				       keyLabel[1],
-				       SC_PKCS15_TYPE_PRKEY_RSA,
-				       1024, usage[1],
-				       &path, 2,
-				       &auth_id,
-				       SC_PKCS15_CO_FLAG_PRIVATE);
+				keyLabel[1],
+				SC_PKCS15_TYPE_PRKEY_RSA,
+				1024, usage[1],
+				&path, 2,
+				&auth_id,
+				SC_PKCS15_CO_FLAG_PRIVATE);
 	}
 
 	/* return to MF */
 	sc_format_path("3F00", &path);
 	r = sc_select_file(card, &path, NULL);
 	return r;
-	}
+}
 
 #endif
 
@@ -694,17 +693,17 @@ static int infocamere_1600_init(sc_pkcs15_card_t * p15card)
 	const char *certPath[] = { "200020010008", "20002001000E" };
 
 	const char *pinLabel[] =
-	    { "Non-repudiation PIN", "Authentication PIN" };
+	{ "Non-repudiation PIN", "Authentication PIN" };
 	int retries[] = { 3, -1 };
 
 	const char *keyPath[] = { "200020010004", "20002001000A" };
 	const char *keyLabel[] =
-	    { "Non repudiation Key", "Authentication Key" };
+	{ "Non repudiation Key", "Authentication Key" };
 	static int usage[] = { SC_PKCS15_PRKEY_USAGE_NONREPUDIATION,
 		SC_PKCS15_PRKEY_USAGE_SIGN
-		    | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
-		    | SC_PKCS15_PRKEY_USAGE_ENCRYPT
-		    | SC_PKCS15_PRKEY_USAGE_DECRYPT
+			| SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
+			| SC_PKCS15_PRKEY_USAGE_ENCRYPT
+			| SC_PKCS15_PRKEY_USAGE_DECRYPT
 	};
 
 	auth_id.len = 1;
@@ -743,9 +742,9 @@ static int infocamere_1600_init(sc_pkcs15_card_t * p15card)
 	id.value[0] = 1;
 
 	sc_pkcs15emu_add_cert(p15card,
-			      SC_PKCS15_TYPE_CERT_X509, 0,
-			      &path, &id, certLabel[0],
-			      SC_PKCS15_CO_FLAG_MODIFIABLE);
+			SC_PKCS15_TYPE_CERT_X509, 0,
+			&path, &id, certLabel[0],
+			SC_PKCS15_CO_FLAG_MODIFIABLE);
 
 	sc_format_path(certPath[1], &path);
 	if (sc_select_file(card, &path, NULL) == SC_SUCCESS) {
@@ -754,54 +753,54 @@ static int infocamere_1600_init(sc_pkcs15_card_t * p15card)
 		id.value[0] = 2;
 
 		sc_pkcs15emu_add_cert(p15card,
-				      SC_PKCS15_TYPE_CERT_X509, 1,
-				      &path, &id, certLabel[1],
-				      SC_PKCS15_CO_FLAG_MODIFIABLE);
+				SC_PKCS15_TYPE_CERT_X509, 1,
+				&path, &id, certLabel[1],
+				SC_PKCS15_CO_FLAG_MODIFIABLE);
 	}
 
 	flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE |
-	    SC_PKCS15_PIN_FLAG_INITIALIZED |
-	    SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
+		SC_PKCS15_PIN_FLAG_INITIALIZED |
+		SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
 
 	/* adding PINs & private keys */
 	sc_format_path("2000", &path);
 	id.value[0] = 1;
 
 	sc_pkcs15emu_add_pin(p15card, &id,
-			     pinLabel[0], &path, 1,
-			     SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-			     5, 8, flags, retries[0], 0,
-			     SC_PKCS15_CO_FLAG_MODIFIABLE |
-			     SC_PKCS15_CO_FLAG_PRIVATE);
+			pinLabel[0], &path, 1,
+			SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+			5, 8, flags, retries[0], 0,
+			SC_PKCS15_CO_FLAG_MODIFIABLE |
+			SC_PKCS15_CO_FLAG_PRIVATE);
 
 	sc_format_path(keyPath[0], &path);
 	auth_id.value[0] = 1;
 	sc_pkcs15emu_add_prkey(p15card, &id,
-			       keyLabel[0],
-			       SC_PKCS15_TYPE_PRKEY_RSA,
-			       1024, usage[0],
-			       &path, 1,
-			       &auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
+			keyLabel[0],
+			SC_PKCS15_TYPE_PRKEY_RSA,
+			1024, usage[0],
+			&path, 1,
+			&auth_id, SC_PKCS15_CO_FLAG_PRIVATE);
 
 	if (hasAuthCert) {
 		id.value[0] = 2;
 
 		sc_pkcs15emu_add_pin(p15card, &id,
-				     pinLabel[1], &path, 2,
-				     SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-				     5, 8, flags, retries[1], 0,
-				     SC_PKCS15_CO_FLAG_MODIFIABLE |
-				     SC_PKCS15_CO_FLAG_PRIVATE);
+				pinLabel[1], &path, 2,
+				SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+				5, 8, flags, retries[1], 0,
+				SC_PKCS15_CO_FLAG_MODIFIABLE |
+				SC_PKCS15_CO_FLAG_PRIVATE);
 
 		sc_format_path(keyPath[1], &path);
 		auth_id.value[0] = 2;
 		sc_pkcs15emu_add_prkey(p15card, &id,
-				       keyLabel[1],
-				       SC_PKCS15_TYPE_PRKEY_RSA,
-				       1024, usage[1],
-				       &path, 2,
-				       &auth_id,
-				       SC_PKCS15_CO_FLAG_PRIVATE);
+				keyLabel[1],
+				SC_PKCS15_TYPE_PRKEY_RSA,
+				1024, usage[1],
+				&path, 2,
+				&auth_id,
+				SC_PKCS15_CO_FLAG_PRIVATE);
 	}
 
 	/* return to MF */
@@ -817,13 +816,13 @@ static int infocamere_detect_card(sc_pkcs15_card_t * p15card)
 
 	/* check if we have the correct card OS */
 	if (strcmp(card->name, "STARCOS SPK 2.3")
-	    && strcmp(card->name, "CardOS M4"))
+			&& strcmp(card->name, "CardOS M4"))
 		return SC_ERROR_WRONG_CARD;
 	return SC_SUCCESS;
 }
 
 int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t * p15card,
-				    sc_pkcs15emu_opt_t * opts)
+		sc_pkcs15emu_opt_t * opts)
 {
 
 	if (!(opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
@@ -835,7 +834,7 @@ int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t * p15card,
 		return infocamere_1600_init(p15card);
 #ifdef ENABLE_ZLIB
 	else if (memcmp(p15card->card->atr.value, ATR_1400, sizeof(ATR_1400)) ==
-		 0)
+			0)
 		return infocamere_1400_init(p15card);
 #endif
 	else

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -544,7 +544,6 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	sc_pkcs15_object_t cert_obj;
 	struct sc_pkcs15_object prkd;
 	sc_pkcs15_prkey_info_t *key_info;
-	sc_file_t *file = NULL;
 	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
@@ -557,13 +556,12 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 
 	/* Try to select a related EF containing the PKCS#15 description of the key */
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 
 	if (r != SC_SUCCESS) {
 		return SC_SUCCESS;
 	}
 
-	sc_file_free(file);
 	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.PRKD");
 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -596,13 +596,11 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	fid[0] = EE_CERTIFICATE_PREFIX;
 
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 
 	if (r != SC_SUCCESS) {
 		return SC_SUCCESS;
 	}
-
-	sc_file_free(file);
 
 	/* Check if the certificate is a X.509 certificate */
 	r = sc_read_binary(p15card->card, 0, efbin, 1, 0);
@@ -644,7 +642,6 @@ static int sc_pkcs15emu_sc_hsm_add_dcod(sc_pkcs15_card_t * p15card, u8 id) {
 	sc_card_t *card = p15card->card;
 	sc_pkcs15_data_info_t *data_info;
 	sc_pkcs15_object_t data_obj;
-	sc_file_t *file = NULL;
 	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
@@ -657,13 +654,12 @@ static int sc_pkcs15emu_sc_hsm_add_dcod(sc_pkcs15_card_t * p15card, u8 id) {
 
 	/* Try to select a related EF containing the PKCS#15 description of the data */
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 
 	if (r != SC_SUCCESS) {
 		return SC_SUCCESS;
 	}
 
-	sc_file_free(file);
 	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.DCOD");
 
@@ -693,7 +689,6 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 	sc_card_t *card = p15card->card;
 	sc_pkcs15_cert_info_t *cert_info;
 	sc_pkcs15_object_t obj;
-	sc_file_t *file = NULL;
 	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
@@ -706,13 +701,12 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 
 	/* Try to select a related EF containing the PKCS#15 description of the data */
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 
 	if (r != SC_SUCCESS) {
 		return SC_SUCCESS;
 	}
 
-	sc_file_free(file);
 	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.DCOD");
 
@@ -737,7 +731,6 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 static int sc_pkcs15emu_sc_hsm_read_tokeninfo (sc_pkcs15_card_t * p15card)
 {
 	sc_card_t *card = p15card->card;
-	sc_file_t *file = NULL;
 	sc_path_t path;
 	int r;
 	u8 efbin[512];
@@ -746,9 +739,8 @@ static int sc_pkcs15emu_sc_hsm_read_tokeninfo (sc_pkcs15_card_t * p15card)
 
 	/* Read token info */
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, (u8 *) "\x2F\x03", 2, 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	LOG_TEST_RET(card->ctx, r, "Could not select EF.TokenInfo");
-	sc_file_free(file);
 
 	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.TokenInfo");
@@ -807,9 +799,8 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 
 	/* Read device certificate to determine serial number */
 	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, (u8 *) "\x2F\x02", 2, 0, 0);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	LOG_TEST_RET(card->ctx, r, "Could not select EF.C_DevAut");
-	sc_file_free(file);
 
 	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.C_DevAut");

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -41,14 +41,10 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 	sc_card_t *card = p15card->card;
 	sc_serial_number_t serial;
 	sc_path_t path;
-	sc_file_t *file = NULL;
 	sc_format_path("3F00", &path);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	if (r)
 		goto out;
-	if (file)
-		sc_file_free(file);
-	file = NULL;
 	if (p15card->tokeninfo->label != NULL)
 		free(p15card->tokeninfo->label);
 	p15card->tokeninfo->label = strdup("westcos");
@@ -65,7 +61,7 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 		free(p15card->tokeninfo->serial_number);
 	p15card->tokeninfo->serial_number = strdup(buf);
 	sc_format_path("AAAA", &path);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	if (r) 
 	{
 		goto out;
@@ -113,11 +109,8 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 		}
 	}
 	
-	if (file)
-		sc_file_free(file);
-	file = NULL;
 	sc_format_path("0002", &path);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	if (r) 
 	{
 		goto out;
@@ -197,11 +190,8 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 				goto out;
 		}
 	}
-	if (file)
-		sc_file_free(file);
-	file = NULL;
 	sc_format_path("0001", &path);
-	r = sc_select_file(card, &path, &file);
+	r = sc_select_file(card, &path, NULL);
 	if (r) 
 	{
 		goto out;
@@ -233,8 +223,6 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 	}
 	r = 0;
 out:
-	if (file)
-		sc_file_free(file);
 	return r;
 }
 

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -548,7 +548,7 @@ sc_pkcs15_get_lastupdate(struct sc_pkcs15_card *p15card)
 	if (!p15card->tokeninfo->last_update.path.len)
 		return NULL;
 
-        r = sc_select_file(p15card->card, &p15card->tokeninfo->last_update.path, &file);
+	r = sc_select_file(p15card->card, &p15card->tokeninfo->last_update.path, &file);
 	if (r < 0)
 		return NULL;
 

--- a/src/smm/sm-card-iasecc.c
+++ b/src/smm/sm-card-iasecc.c
@@ -195,7 +195,7 @@ sm_iasecc_get_apdu_delete_file(struct sc_context *ctx, struct sm_info *sm_info, 
 	if (!file_id)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-        if (!rdata || !rdata->alloc)
+	if (!rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
  	rv = rdata->alloc(rdata, &rapdu);


### PR DESCRIPTION
The card operation `select_file` may return an output file on request, but `sc_select_file` is now guaranteed to return it with `SC_SUCCESS`. To achieve this, I did the following:

1. remove the file parameter from `sc_select_file` or `select_file` if it was not needed to simplify things
2. if the result was actually used after a `select_file` call then I added a check if a correct file object was returned
3. initialize the file object with `NULL` and check for it in `sc_select_file` so that all high-level functions using `sc_select_file` can rely on the initialized object.

Actually I'd prefer delegating the checking to the piece of code that actually accesses some memory, but this would have been way too much work for me...