### PR TITLE
piv: fix typos in usage & man page

### DIFF
--- a/doc/tools/piv-tool.1.xml
+++ b/doc/tools/piv-tool.1.xml
@@ -72,7 +72,7 @@
 						<option>-G</option> <replaceable>argument</replaceable>
 					</term>
 					<listitem><para>Generate a key pair on the card and output the public key.
-					The <replaceable>argument</replaceable> of th form
+					The <replaceable>argument</replaceable> of the form
 					<synopsis><replaceable>ref</replaceable>:<replaceable>alg</replaceable></synopsis>
 					is required, where <replaceable>ref</replaceable> is <literal>9A</literal>,
 					<literal>9C</literal>, <literal>9D</literal> or <literal>9E</literal> and
@@ -85,7 +85,7 @@
 						<option>--object</option> <replaceable>ContainerID</replaceable>,
 						<option>-O</option> <replaceable>ContainerID</replaceable>
 					</term>
-					<listitem><para>Load an object on to the card.
+					<listitem><para>Load an object onto the card.
 					The <replaceable>ContainerID</replaceable> is as defined in NIST 800-73-n
 					without leading <literal>0x</literal>. Example: CHUID object is 3000
 					</para></listitem>
@@ -96,7 +96,7 @@
 						<option>--cert</option> <replaceable>ref</replaceable>,
 						<option>-s</option> <replaceable>ref</replaceable>
 					</term>
-					<listitem><para>Load a certificate on to the card.
+					<listitem><para>Load a certificate onto the card.
 					<replaceable>ref</replaceable> is <literal>9A</literal>,
 					<literal>9C</literal>, <literal>9D</literal> or
 					<literal>9E</literal></para></listitem>
@@ -107,7 +107,7 @@
 						<option>--compresscert</option> <replaceable>ref</replaceable>,
 						<option>-Z</option> <replaceable>ref</replaceable>
 					</term>
-					<listitem><para>Load a certificate that has been gziped on to the card.
+					<listitem><para>Load a certificate that has been gzipped onto the card.
 					<replaceable>ref</replaceable> is <literal>9A</literal>,
 					<literal>9C</literal>, <literal>9D</literal> or
 					 <literal>9E</literal></para></listitem>

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -81,15 +81,15 @@ static const struct option options[] = {
 };
 
 static const char *option_help[] = {
-	"Prints the card serial number",
+	"Print the card serial number",
 	"Identify the card and print its name",
-	"authenticate using default 3des key",
+	"Authenticate using default 3DES key",
 	"Generate key <ref>:<alg> 9A:06 on card, and output pubkey",
 	"Load an object <containerID> containerID as defined in 800-73 without leading 0x",
 	"Load a cert <ref> where <ref> is 9A,9C,9D or 9E",
-	"Load a cert that has been gziped <ref>",
+	"Load a cert that has been gzipped <ref>",
 	"Output file for cert or key",
-	"Inout file for cert",
+	"Input file for cert",
 	"Sends an APDU in format AA:BB:CC:DD:EE:FF...",
 	"Uses reader number <arg> [0]",
 	"Forces the use of driver <arg> [auto-detect]",


### PR DESCRIPTION
Please find attached some fixes for PIV docs.
Details can be found in the individual commit messages.