### PR TITLE
Allow ASN.1 decoding if the file seems incomplete

### DIFF
--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1720,12 +1720,17 @@ static int do_asn1(int argc, char **argv)
 		goto err;
 	}
 	if ((size_t)r != len) {
-		printf("expecting %lu, got only %d bytes.\n", (unsigned long) len, r);
-		goto err;
+		printf("WARNING: expecting %lu, got %d bytes.\n", (unsigned long) len, r);
+		/* some cards return a bogus value for file length. As
+		 * long as the actual length is not higher than the expected
+		 * length, continue */
+		if(r > len) {
+			goto err;
+		}
 	}
 
 	/* asn1 dump */
-	sc_asn1_print_tags(buf, len);
+	sc_asn1_print_tags(buf, r);
 
 	err = 0;
 err:


### PR DESCRIPTION
Some cards (e.g., BELPIC) have a hardcoded file length that does not
match the actual file length (e.g., 65535 bytes), and simply return the
data that is actually on the card when asked.

It is useful to still be able to do an ASN.1 decode in that case.

Signed-off-by: Wouter Verhelst <w@uter.be>