### PR TITLE
Heap-based buffer overflow fix in mutex_create() with PKCS11_THREAD_LOCKING and HAVE_PTHREAD defined

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -46,7 +46,9 @@ extern CK_FUNCTION_LIST pkcs11_function_list;
 #include <pthread.h>
 CK_RV mutex_create(void **mutex)
 {
-	pthread_mutex_t *m = calloc(1, sizeof(*mutex));
+	pthread_mutex_t *m;
+
+	m = calloc(1, sizeof(*m));
 	if (m == NULL)
 		return CKR_GENERAL_ERROR;;
 	pthread_mutex_init(m, NULL);

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -32,6 +32,12 @@
 #define MODULE_APP_NAME "opensc-pkcs11"
 #endif
 
+#ifndef PKCS11_THREAD_LOCKING
+/* libp11 depends on CKF_OS_LOCKING_OK, which
+ * requires PKCS11_THREAD_LOCKING to work */
+#define PKCS11_THREAD_LOCKING
+#endif
+
 sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -32,12 +32,6 @@
 #define MODULE_APP_NAME "opensc-pkcs11"
 #endif
 
-#ifndef PKCS11_THREAD_LOCKING
-/* libp11 depends on CKF_OS_LOCKING_OK, which
- * requires PKCS11_THREAD_LOCKING to work */
-#define PKCS11_THREAD_LOCKING
-#endif
-
 sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;


### PR DESCRIPTION
mutex_create() allocated sizeof(void *) instead of sizeof(pthread_mutex_t) bytes for the pthread mutex.  Consequently, pthread_mutex_init() and subsequent thread operations caused heap corruption.

Security impact is limited by the following factors:
1. This function is **not** currently compiled by default, because PKCS11_THREAD_LOCKING is not defined by default.
2. The attacker has limited control over the mutex structure.  Depending on the specific implementation, careful heap manipulation may still allow for local/remote code execution.