### PR TITLE
Define PKCS11_THREAD_LOCKING

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -32,6 +32,12 @@
 #define MODULE_APP_NAME "opensc-pkcs11"
 #endif
 
+#ifndef PKCS11_THREAD_LOCKING
+/* libp11 depends on CKF_OS_LOCKING_OK, which
+ * requires PKCS11_THREAD_LOCKING to work */
+#define PKCS11_THREAD_LOCKING
+#endif
+
 sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;


### PR DESCRIPTION
libp11 depends on OS locking implementation in the PKCS#11 library (by requesting CKF_OS_LOCKING_OK and **not** providing application locking callbacks).  On the other hand OpenSC does **not** implement OS locking **unless** PKCS11_THREAD_LOCKING is defined.

Some applications (e.g. OpenVPN) implement relatively complex workarounds for this simple issue.  At least libp11 (and consequently engine_pkcs11) does not implement application locking, and concurrent requests fail with the CKR_OPERATION_ACTIVE error.