### PR TITLE
Define PKCS11_THREAD_LOCKING

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -46,7 +46,9 @@ extern CK_FUNCTION_LIST pkcs11_function_list;
 #include <pthread.h>
 CK_RV mutex_create(void **mutex)
 {
-	pthread_mutex_t *m = calloc(1, sizeof(*mutex));
+	pthread_mutex_t *m;
+
+	m = calloc(1, sizeof(*m));
 	if (m == NULL)
 		return CKR_GENERAL_ERROR;;
 	pthread_mutex_init(m, NULL);

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -32,6 +32,12 @@
 #define MODULE_APP_NAME "opensc-pkcs11"
 #endif
 
+#ifndef PKCS11_THREAD_LOCKING
+/* libp11 depends on CKF_OS_LOCKING_OK, which
+ * requires PKCS11_THREAD_LOCKING to work */
+#define PKCS11_THREAD_LOCKING
+#endif
+
 sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -55,9 +55,7 @@ extern CK_FUNCTION_LIST pkcs11_function_list;
 #include <pthread.h>
 CK_RV mutex_create(void **mutex)
 {
-	pthread_mutex_t *m;
-
-	m = calloc(1, sizeof(*m));
+	pthread_mutex_t *m = calloc(1, sizeof(*mutex));
 	if (m == NULL)
 		return CKR_GENERAL_ERROR;;
 	pthread_mutex_init(m, NULL);

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -25,6 +25,9 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+#ifdef _WIN32
+#include <winbase.h>
+#endif
 
 #include "sc-pkcs11.h"
 

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -32,12 +32,6 @@
 #define MODULE_APP_NAME "opensc-pkcs11"
 #endif
 
-#ifndef PKCS11_THREAD_LOCKING
-/* libp11 depends on CKF_OS_LOCKING_OK, which
- * requires PKCS11_THREAD_LOCKING to work */
-#define PKCS11_THREAD_LOCKING
-#endif
-
 sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;


### PR DESCRIPTION
libp11 depends on OS locking implementation in the PKCS#11 library (by requesting CKF_OS_LOCKING_OK and **not** providing application locking callbacks). On the other hand OpenSC does **not** implement OS locking **unless** PKCS11_THREAD_LOCKING is defined.

Some applications (e.g. OpenVPN) implement relatively complex workarounds for this simple issue. At least libp11 (and consequently engine_pkcs11) does not implement application locking, and concurrent requests fail with the CKR_OPERATION_ACTIVE error.