### PR TITLE
Enable OS locking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,13 @@ AC_ARG_ENABLE(
 )
 
 AC_ARG_ENABLE(
+	[thread_locking],
+	[AS_HELP_STRING([--disable-thread-locking],[disable OS thread locking @<:@enabled@:>@])],
+	,
+	[enable_thread_locking="yes"]
+)
+
+AC_ARG_ENABLE(
 	[zlib],
 	[AS_HELP_STRING([--enable-zlib],[enable zlib linkage @<:@detect@:>@])],
 	,
@@ -367,6 +374,10 @@ if test "${WIN32}" = "no"; then
 		[AC_MSG_ERROR([POSIX thread support required])]
 	)
 	CC="${PTHREAD_CC}"
+fi
+
+if test "${enable_thread_locking}" = "yes"; then
+	CPPFLAGS="${CPPFLAGS} -DPKCS11_THREAD_LOCKING"
 fi
 
 if test "${enable_minidriver}" = "yes"; then
@@ -638,6 +649,9 @@ if test "${enable_man}" = "yes" -o "${enable_doc}" = "yes"; then
 fi
 
 OPENSC_FEATURES=""
+if test "${enable_thread_locking}" = "yes"; then
+	OPENSC_FEATURES="${OPENSC_FEATURES} locking"
+fi
 if test "${enable_zlib}" = "yes"; then
 	OPENSC_FEATURES="${OPENSC_FEATURES} zlib"
 	OPTIONAL_ZLIB_CFLAGS="${ZLIB_CFLAGS}"
@@ -719,6 +733,7 @@ AC_SUBST([PROFILE_DIR])
 AC_SUBST([PROFILE_DIR_DEFAULT])
 
 AM_CONDITIONAL([ENABLE_MAN], [test "${enable_man}" = "yes"])
+AM_CONDITIONAL([ENABLE_THREAD_LOCKING], [test "${enable_thread_locking}" = "yes"])
 AM_CONDITIONAL([ENABLE_ZLIB], [test "${enable_zlib}" = "yes"])
 AM_CONDITIONAL([ENABLE_READLINE], [test "${enable_readline}" = "yes"])
 AM_CONDITIONAL([ENABLE_OPENSSL], [test "${enable_openssl}" = "yes"])
@@ -805,6 +820,7 @@ XSL stylesheets:         ${xslstylesheetsdir}
 
 man support:             ${enable_man}
 doc support:             ${enable_doc}
+thread locking support:  ${enable_thread_locking}
 zlib support:            ${enable_zlib}
 readline support:        ${enable_readline}
 OpenSSL support:         ${enable_openssl}

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -26,6 +26,14 @@
 #include <sys/time.h>
 #endif
 
+#ifdef PKCS11_THREAD_LOCKING
+#if defined(HAVE_PTHREAD)
+#include <pthread.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+#endif /* PKCS11_THREAD_LOCKING */
+
 #include "sc-pkcs11.h"
 
 #ifndef MODULE_APP_NAME
@@ -42,11 +50,15 @@ pid_t initialized_pid = (pid_t)-1;
 static int in_finalize = 0;
 extern CK_FUNCTION_LIST pkcs11_function_list;
 
-#if defined(HAVE_PTHREAD) && defined(PKCS11_THREAD_LOCKING)
-#include <pthread.h>
+#ifdef PKCS11_THREAD_LOCKING
+
+#if defined(HAVE_PTHREAD)
+
 CK_RV mutex_create(void **mutex)
 {
-	pthread_mutex_t *m = calloc(1, sizeof(*mutex));
+	pthread_mutex_t *m;
+
+	m = calloc(1, sizeof(*m));
 	if (m == NULL)
 		return CKR_GENERAL_ERROR;;
 	pthread_mutex_init(m, NULL);
@@ -79,7 +91,10 @@ CK_RV mutex_destroy(void *p)
 
 static CK_C_INITIALIZE_ARGS _def_locks = {
 	mutex_create, mutex_destroy, mutex_lock, mutex_unlock, 0, NULL };
-#elif defined(_WIN32) && defined (PKCS11_THREAD_LOCKING)
+#define HAVE_OS_LOCKING
+
+#elif defined(_WIN32)
+
 CK_RV mutex_create(void **mutex)
 {
 	CRITICAL_SECTION *m;
@@ -112,14 +127,18 @@ CK_RV mutex_destroy(void *p)
 	free(p);
 	return CKR_OK;
 }
+
 static CK_C_INITIALIZE_ARGS _def_locks = {
 	mutex_create, mutex_destroy, mutex_lock, mutex_unlock, 0, NULL };
+#define HAVE_OS_LOCKING
+
 #endif
 
+#endif /* PKCS11_THREAD_LOCKING */
+
 static CK_C_INITIALIZE_ARGS_PTR	global_locking;
-static void *			global_lock = NULL;
-#if (defined(HAVE_PTHREAD) || defined(_WIN32)) && defined(PKCS11_THREAD_LOCKING)
-#define HAVE_OS_LOCKING
+static void *global_lock = NULL;
+#ifdef HAVE_OS_LOCKING
 static CK_C_INITIALIZE_ARGS_PTR default_mutex_funcs = &_def_locks;
 #else
 static CK_C_INITIALIZE_ARGS_PTR default_mutex_funcs = NULL;


### PR DESCRIPTION
libp11 depends on OS locking implementation in the PKCS#11 library (by requesting CKF_OS_LOCKING_OK and **not** providing application locking callbacks). On the other hand, OpenSC **only** implements OS locking if PKCS11_THREAD_LOCKING is defined.

Some applications (e.g. OpenVPN) implement relatively complex workarounds for this simple issue. At least libp11 (and consequently engine_pkcs11) does not implement application locking, causing concurrent requests to fail with the CKR_OPERATION_ACTIVE error.