### PR TITLE
Add check_state functions for PKCS#11 C_GetSessionInfo

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -384,6 +384,31 @@ int sc_reset(sc_card_t *card, int do_cold_reset)
 	return r;
 }
 
+int sc_check_state(sc_card_t *card, int * logged_in, int flags)
+{
+	int r = 0;
+
+
+	LOG_FUNC_CALLED(card->ctx);
+	if (logged_in)
+	    sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "logged_in=%p *logged_in=%d flags=%2.2x",logged_in, *logged_in, flags);
+	else
+	    sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "logged_in=NULL flags=%2.2x", flags);
+
+	/* if card does not support check_state, return SC_SUCCESS */
+	if (card->ops->check_state != NULL) {
+		r = card->ops->check_state(card, logged_in, flags);
+		if (logged_in)
+		    sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "r=%d logged_in=%p *logged_in=%d flags=%2.2x", r, logged_in, *logged_in, flags);
+		else
+		    sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "r=%d logged_in=NULL flags=%2.2x", r, flags);
+
+	}
+
+	return r;
+}
+
+
 int sc_lock(sc_card_t *card)
 {
 	int r = 0, r2 = 0;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1220,7 +1220,8 @@ static struct sc_card_operations iso_ops = {
 	iso7816_get_data,
 	NULL,			/* put_data */
 	NULL,			/* delete_record */
-	NULL			/* read_public_key */
+	NULL,			/* read_public_key */
+	NULL			/* check_state */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -65,6 +65,7 @@ sc_build_pin
 sc_cancel
 sc_card_ctl
 sc_change_reference_data
+sc_check_state
 sc_check_sw
 sc_compare_oid
 sc_compare_path
@@ -150,6 +151,7 @@ sc_pkcs15_card_clear
 sc_pkcs15_card_free
 sc_pkcs15_card_new
 sc_pkcs15_change_pin
+sc_pkcs15_check_state
 sc_pkcs15_compare_id
 sc_pkcs15_compute_signature
 sc_pkcs15_decipher

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -618,6 +618,12 @@ struct sc_card_operations {
 	int (*read_public_key)(struct sc_card *, unsigned,
 			struct sc_path *, unsigned, unsigned,
 			unsigned char **, size_t *);
+	/* Check if card has not been accessed by other application
+	 * sc_lock checks for card reset, and if SM is working. 
+	 * Check_state does additional checks AID is the same, SM (if used) is still working,
+	 * if a verify is needed
+	 */
+	int (*check_state)(struct sc_card *, int * loged_in, int flags);
 };
 
 typedef struct sc_card_driver {
@@ -908,6 +914,16 @@ int sc_wait_for_event(sc_context_t *ctx, unsigned int event_mask,
  * @retval SC_SUCCESS on success
  */
 int sc_reset(struct sc_card *card, int do_cold_reset);
+
+/**
+ * Check if the card state is as expected, i.e. connected,
+ * AID is set, SM (if used) is operating, verify has been done
+ * @param card  The card to check
+ * @param logged_in = (in/out)  -1 not logged  in >= 0 logged in
+ * @param flags What tests to perform/what stat is expected if  1 logged_in error if card  is not loged in 
+ * @retval SC_SUCCESS on success
+ */
+int sc_check_state(struct sc_card *card,  int * logged_in, int flags);
 
 /**
  * Cancel all pending PC/SC calls

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1269,6 +1269,24 @@ sc_pkcs15_unbind(struct sc_pkcs15_card *p15card)
 	return 0;
 }
 
+int
+sc_pkcs15_check_state(struct sc_pkcs15_card *p15card, int * logged_in, int flags)
+{
+	sc_context_t *ctx = p15card->card->ctx;
+	int r = 0;
+
+	LOG_FUNC_CALLED(ctx);
+
+	r = sc_lock(p15card->card);
+	LOG_TEST_RET(ctx, r, "sc_lock() failed");
+
+	r = sc_check_state(p15card->card, logged_in, flags);
+
+	sc_unlock(p15card->card);
+	LOG_TEST_RET(ctx, r, "sc_check_state failed");
+
+	LOG_FUNC_RETURN(ctx, r);
+}
 
 static int
 __sc_pkcs15_search_objects(struct sc_pkcs15_card *p15card, unsigned int class_mask, unsigned int type,

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -738,6 +738,7 @@ int sc_pkcs15_find_skey_by_id(struct sc_pkcs15_card *card,
 			       const struct sc_pkcs15_id *id,
 			       struct sc_pkcs15_object **out);
 
+int sc_pkcs15_check_state(struct sc_pkcs15_card *p15card, int * logged_in, int flags);
 int sc_pkcs15_verify_pin(struct sc_pkcs15_card *card,
 			 struct sc_pkcs15_object *pin_obj,
 			 const u8 *pincode, size_t pinlen);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2970,6 +2970,22 @@ pkcs15_get_random(struct sc_pkcs11_slot *slot, CK_BYTE_PTR p, CK_ULONG len)
 	return sc_to_cryptoki_error(rc, "C_GenerateRandom");
 }
 
+static CK_RV
+pkcs15_check_state(struct sc_pkcs11_slot *slot, int *logged_in, int flags)
+{
+	struct sc_pkcs11_card *p11card = slot->p11card;
+	struct pkcs15_fw_data *fw_data = NULL;
+	int rv = 0;
+
+	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[slot->fw_data_idx];
+	if (!fw_data)
+		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "pkcs15_check_state");
+
+	rv = sc_pkcs15_check_state(fw_data->p15_card, logged_in, flags);
+	/* TODO test rv, and if pin is needed for next line */
+
+	return sc_to_cryptoki_error(rv, "pkcs15_check_state");
+}
 
 struct sc_pkcs11_framework_ops framework_pkcs15 = {
 	pkcs15_bind,
@@ -2990,7 +3006,8 @@ struct sc_pkcs11_framework_ops framework_pkcs15 = {
 	NULL,
 	NULL,
 #endif
-	pkcs15_get_random
+	pkcs15_get_random,
+	pkcs15_check_state
 };
 
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -167,6 +167,7 @@ static CK_RV	get_ec_pubkey_params(struct sc_pkcs15_pubkey *, CK_ATTRIBUTE_PTR);
 static int	lock_card(struct pkcs15_fw_data *);
 static int	unlock_card(struct pkcs15_fw_data *);
 static int	reselect_app_df(sc_pkcs15_card_t *p15card);
+static CK_RV	pkcs15_check_state(struct sc_pkcs11_slot *, int *, int);
 
 #ifdef USE_PKCS15_INIT
 static CK_RV	set_gost_params(struct sc_pkcs15init_keyarg_gost_params *,
@@ -484,6 +485,13 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	if (rv != CKR_OK)   {
 		sc_log(context, "C_GetTokenInfo() get token: rv 0x%X", rv);
 		goto out;
+	}
+
+	/* TODO may be in wrong spot */
+	rv = pkcs15_check_state(slot, NULL, 0);
+	if (rv != SC_SUCCESS) {
+		sc_log(context, "C_GetTokenInfo() check_state: rv 0x%X", rv);
+	    goto out;
 	}
 
 	/* User PIN flags are cleared before re-calculation */

--- a/src/pkcs11/framework-pkcs15init.c
+++ b/src/pkcs11/framework-pkcs15init.c
@@ -180,7 +180,8 @@ struct sc_pkcs11_framework_ops framework_pkcs15init = {
 	NULL, /* init_pin */
 	NULL, /* create_object */
 	NULL, /* gen_keypair */
-	NULL  /* get_random */
+	NULL, /* get_random */
+	NULL  /* check_state */
 };
 
 #else /* ifdef USE_PKCS15_INIT */
@@ -197,7 +198,8 @@ struct sc_pkcs11_framework_ops framework_pkcs15init = {
 	NULL,	/* init_pin */
 	NULL,	/* create_object */
 	NULL,	/* gen_keypair */
-	NULL	/* get_random */
+	NULL,	/* get_random */
+	NULL    /* check_state */
 };
 
 #endif

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -181,6 +181,7 @@ struct sc_pkcs11_framework_ops {
 				CK_OBJECT_HANDLE_PTR, CK_OBJECT_HANDLE_PTR);
 	CK_RV (*get_random)(struct sc_pkcs11_slot *,
 				CK_BYTE_PTR, CK_ULONG);
+	CK_RV (*check_state)(struct sc_pkcs11_slot *, int *, int);
 };
 
 /*


### PR DESCRIPTION
Also sees #596 and #618

Firefox and other applications rely on C_GetSessionInfo to return if a login is needed.
They do this before doing other operations. OpenSC would return stale information because
it does not check with PCSC or the card to determine the state of the card.

This commit adds a stack of functions so C_GetSessionInfo gets the current state of the card.
PCSC only returns if the card has been reset or removed. A card driver can provide a
a check_state function that can issue commands to a card to get its true state.

pkcs11-session.c: C_GetSessionInfo
framework-pkcs15.c: pkcs15_check_state
pkcs15.c: sc_pkcs15_check_state
card.c: sc_check_state
card-<driver>.c: <driver>_check_start

sc_pkcs15_check_state could also be used from minidriver or tokend if needed.

The <driver>_check_state function would be different for each card, and is optional.
Only a piv_check_state is included. It sets the AID back to the PIV AID then tests if
the cards logged state agrees with the the expected pkcs11 session state.

Cards without a <driver>_check_state function can benefit from this modification,
as sc_lock is now called from sc_pkcs15_check_state. if the lock is not held,
pcsc will get involved and could return card removed, card reset or other error.
sc_lock will also do some SM checks.

These routines try to match the calls as uses for sign, decrypt and derive.

A call to sc_pkcs15_pincache_revalidate could be added to sc_pkcs15_check_state.

In reader-pcsc.c: pcsc_lock if SCARD_W_RESET was returned, a sleep(1) was added.
Testing showed pcsc might allow access to the reader while the reader is still busy
with the card reset. Further testing may be needed.

This is experimental, and changes may be needed for other cards, or situations.