### PR TITLE
Certificate removal fixed (IB#1047758)

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -13,6 +13,7 @@
  * on the card. These should be implemented in pkcs15-<cardname>.c
  *
  * Copyright (C) 2002, Olaf Kirch <okir@suse.de>
+ * Copyright (C) 2015 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -599,6 +600,7 @@ sc_pkcs15init_delete_by_path(struct sc_profile *profile, struct sc_pkcs15_card *
 	LOG_TEST_RET(ctx, rv, "'DELETE' authentication failed");
 
 	/* Reselect file to delete: current path could be changed by 'verify PIN' procedure */
+    path = *file_path;
 	rv = sc_select_file(p15card->card, &path, &file);
 	LOG_TEST_RET(ctx, rv, "cannot select file to delete");
 


### PR DESCRIPTION
Hello,

We've hit a bug in opensc (Debian 8, 0.14.0-2) that blocked certificate update operation on our SC (Athena ASEPCOS):
```
$ pkcs15-init -U personal_cert.crt -a 01 --id 4fa066fd58b2e24da6618173bf1f654c57d96ad6 --format pem
Using reader with a card: Gemalto GemPC Express 00 00
Security officer PIN [Security Officer PIN] required.
Please enter Security officer PIN [Security Officer PIN]:
Failed to update certificate: Security status not satisfied
```
PIN was ok. Certificate deletion generated same error.

After debugging we've found that the following code is executed...
```
        sc_log(ctx, "Try to get the parent's 'DELETE' access");
        /*file_type = file->type;*/
        if (file_path->len >= 2) {
            /* Select the parent DF */
            path.len -= 2;
            rv = sc_select_file(p15card->card, &path, &parent);
            LOG_TEST_RET(ctx, rv, "Cannot select parent");

            rv = sc_pkcs15init_authenticate(profile, p15card, parent, SC_AC_OP_DELETE);
            sc_file_free(parent);
            LOG_TEST_RET(ctx, rv, "parent 'DELETE' authentication failed");
        }
```
...in src/pkcs15init/pkcs15-lib.c > sc_pkcs15init_delete_by_path() and leaves path variable pointing to dir not file in
```
    /* Reselect file to delete: current path could be changed by 'verify PIN' procedure */
    rv = sc_select_file(p15card->card, &path, &file);
    LOG_TEST_RET(ctx, rv, "cannot select file to delete");
```
When path variable is reset...
```
path = *file_path;
```
...before calling final sc_select_file, problem does not occur.

Please verify this PR and consider fixing it.

Regards,
Pawel

IB Development Team
https://dev.ib.pl/
