### PR TITLE
Align end of the loop with comment in previous line (exit when 90 00 …

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -504,7 +504,7 @@ sc_get_response(struct sc_card *card, struct sc_apdu *apdu, size_t olen)
 			/* if the card has returned 0x9000 but we still expect data ask for more
 			 * until we have read enough bytes */
 			le = minlen;
-	} while (rv != 0 || minlen != 0);
+	} while (rv != 0 && minlen != 0);
 
 	/* we've read all data, let's return 0x9000 */
 	apdu->resplen = buf - apdu->resp;


### PR DESCRIPTION
…or length completed).
Please see thread get_response should be called recursively. #632.
I understand that this seems to affect the code of get_response heavily and I am probably wrong with this PR, but it did improve the behavior for me.