### PR TITLE
Fix smartcard certificate removal and update

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -599,6 +599,7 @@ sc_pkcs15init_delete_by_path(struct sc_profile *profile, struct sc_pkcs15_card *
 	LOG_TEST_RET(ctx, rv, "'DELETE' authentication failed");
 
 	/* Reselect file to delete: current path could be changed by 'verify PIN' procedure */
+	path = *file_path;
 	rv = sc_select_file(p15card->card, &path, &file);
 	LOG_TEST_RET(ctx, rv, "cannot select file to delete");
 


### PR DESCRIPTION
This patch fixes bug found in opensc 0.14.0-2 (Debian 8) that blocks
certificate update and removal on Athena ASEPCOS smartcard with error

    Failed to update certificate: Security status not satisfied

OpenSC tries to get the parent's 'DELETE' access before cert removal
and leaves path variable pointing to dir not file to be removed.

Author-Change-Id: IB#1047758