### PR TITLE
Adding sm decode function with complete response.

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -504,12 +504,18 @@ sc_get_response(struct sc_card *card, struct sc_apdu *apdu, size_t olen)
 			/* if the card has returned 0x9000 but we still expect data ask for more
 			 * until we have read enough bytes */
 			le = minlen;
-	} while (rv != 0 || minlen != 0);
+	} while (rv != 0 && minlen != 0);
 
 	/* we've read all data, let's return 0x9000 */
 	apdu->resplen = buf - apdu->resp;
 	apdu->sw1 = 0x90;
 	apdu->sw2 = 0x00;
+
+#ifdef ENABLE_SM
+	if (card->sm_ctx.ops.decode_sm_apdu != NULL)
+		rv = card->sm_ctx.ops.decode_sm_apdu(card, apdu);
+	LOG_TEST_RET(ctx, rv, "Error decoding apdu.");
+#endif
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }

--- a/src/libopensc/sm.h
+++ b/src/libopensc/sm.h
@@ -289,6 +289,7 @@ struct sm_card_operations {
 	int (*open)(struct sc_card *card);
 	int (*get_sm_apdu)(struct sc_card *card, struct sc_apdu *apdu, struct sc_apdu **sm_apdu);
 	int (*free_sm_apdu)(struct sc_card *card, struct sc_apdu *apdu, struct sc_apdu **sm_apdu);
+	int (*decode_sm_apdu)(struct sc_card *card, struct sc_apdu *apdu);
 	int (*close)(struct sc_card *card);
 
 	int (*read_binary)(struct sc_card *card, unsigned int idx,


### PR DESCRIPTION
This is what I think would be required to be able to decode secure messages longer than 255 bytes.
Please see the thread in:
get_response should be called recursively. #632
I believe that the decode method needs to be called when the response data is complete in order to do a correct parsing. At least this seems to be the case with DNIe.
I haven't been able to test this code yet, but I would like to start the discussion in order to know how to do the coding of DNIe card software using the SM module in OpenSC.