### PR TITLE
Fix public key access and attributes

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3879,8 +3879,9 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 		break;
 	case CKA_TOKEN:
 	case CKA_SENSITIVE:
+		/* By PKCS#11 v2.20 public key cannot have SENSITIVE attr TRUE */
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
-		*(CK_BBOOL*)attr->pValue = TRUE;
+		*(CK_BBOOL*)attr->pValue = FALSE;
 		break;
 	case CKA_LOCAL:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3878,6 +3878,9 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 		*(CK_OBJECT_CLASS*)attr->pValue = CKO_PUBLIC_KEY;
 		break;
 	case CKA_TOKEN:
+		check_attribute_buffer(attr, sizeof(CK_BBOOL));
+		*(CK_BBOOL*)attr->pValue = TRUE;
+		break;
 	case CKA_SENSITIVE:
 		/* By PKCS#11 v2.20 public key cannot have SENSITIVE attr TRUE */
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -688,9 +688,7 @@ static int read_public_key(void)
 	if (r >= 0) {
 		if (verbose)
 			printf("Reading public key with ID '%s'\n", opt_pubkey);
-		r = authenticate(obj);
-		if (r >= 0)
-			r = sc_pkcs15_read_pubkey(p15card, obj, &pubkey);
+		r = sc_pkcs15_read_pubkey(p15card, obj, &pubkey);
 	} else if (r == SC_ERROR_OBJECT_NOT_FOUND) {
 		/* No pubkey - try if there's a certificate */
 		r = sc_pkcs15_find_cert_by_id(p15card, &id, &obj);


### PR DESCRIPTION
1. Make public key accessible without entering the PIN.
2. Stop setting attribute CKA_SENSITIVE (which means "stays in hardware only") for public keys.

Since currently certificates are accessible and retrievable without PIN authentication, and public key can be extracted from certificate, this change does not impact security model negatively. This change also makes the implementation PKCS#11-compliant.