### PR TITLE
add zlib compilation into the appveyor built process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
   - set PATH=C:\cygwin\bin;%PATH%
   - set OPENSSL_VER=1_0_2e
   - set ZLIB_VER=128
+  - set ZLIB_VER_DOT=1.2.8
   - ps: >-
       If ($env:Platform -Match "x86") {
         $env:VCVARS_PLATFORM="x86"
@@ -55,14 +56,9 @@ install:
           C:\WinOpenSSL.exe /SILENT /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART
         }
         $env:NMAKE_EXTRA="OPENSSL_DEF=/DENABLE_OPENSSL ${env:NMAKE_EXTRA}"
-        # the prebuilt zlib is 32 bit only
-        If ($env:Platform -Match "x86") {
-          If (!(Test-Path -Path "C:\zlib-dll" )) {
-            appveyor DownloadFile "https://prdownloads.sourceforge.net/libpng/zlib${env:ZLIB_VER}-dll.zip" -FileName zlib-dll.zip
-            7z x zlib-dll.zip -oC:\zlib-dll
-          }
-          $env:NMAKE_EXTRA="ZLIB_DEF=/DENABLE_ZLIB ${env:NMAKE_EXTRA}"
-        }
+        appveyor DownloadFile "https://prdownloads.sourceforge.net/libpng/zlib${env:ZLIB_VER}.zip" -FileName zlib.zip
+        7z x zlib.zip -oC:\
+        Rename-Item -path "c:\zlib-${env:ZLIB_VER_DOT}" -newName "zlib"
       }
   - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
   - echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
@@ -72,6 +68,18 @@ install:
   - uname -a
 
 build_script:
+  # build zlib.lib as a static library
+  - ps: >-
+      if (!($env:Configuration -Like "*Light*")) {
+          cd C:\zlib
+          If ($env:Platform -Match "x86") {
+             nmake -f win32/Makefile.msc LOC="-DASMV -DASMINF" OBJA="inffas32.obj match686.obj" zlib.lib
+          } Else {
+             nmake -f win32/Makefile.msc AS=ml64 LOC="-DASMV -DASMINF -I." OBJA="inffasx64.obj gvmat64.obj inffas8664.obj" zlib.lib
+          }
+          $env:NMAKE_EXTRA="ZLIBSTATIC_DEF=/DENABLE_ZLIB_STATIC ${env:NMAKE_EXTRA}"
+          cd c:\projects\Opensc
+      }
   - bash -c "exec 0</dev/null && ./bootstrap"
   # disable features to speed up the script
   - bash -c "exec 0</dev/null && ./configure --disable-openssl --disable-readline --disable-zlib || cat config.log"
@@ -81,8 +89,9 @@ build_script:
   - cd win32 && nmake /f Makefile.mak %NMAKE_ARCH% %NMAKE_EXTRA% VSVER=%VSVER% OpenSC.msi
   - move OpenSC.msi %ARTIFACT%
   - appveyor PushArtifact %ARTIFACT%
+  # optionaly put all pdb files for dump analysis, but this consume approx 100 MB per build
+  # - ps: Get-ChildItem -recurse c:\projects\OpenSC -exclude vc*.pdb *.pdb | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 cache:
   - C:\OpenSSL-Win32
   - C:\OpenSSL-Win64
-  - C:\zlib-dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,9 @@ install:
           C:\WinOpenSSL.exe /SILENT /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART
         }
         $env:NMAKE_EXTRA="OPENSSL_DEF=/DENABLE_OPENSSL ${env:NMAKE_EXTRA}"
-        appveyor DownloadFile "https://prdownloads.sourceforge.net/libpng/zlib${env:ZLIB_VER}.zip" -FileName zlib.zip
+        If (!(Test-Path zlib.zip )) {
+           appveyor DownloadFile "https://prdownloads.sourceforge.net/libpng/zlib${env:ZLIB_VER}.zip" -FileName zlib.zip
+        }
         7z x zlib.zip -oC:\
         Rename-Item -path "c:\zlib-${env:ZLIB_VER_DOT}" -newName "zlib"
       }
@@ -93,5 +95,6 @@ build_script:
   # - ps: Get-ChildItem -recurse c:\projects\OpenSC -exclude vc*.pdb *.pdb | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 cache:
-  - C:\OpenSSL-Win32
-  - C:\OpenSSL-Win64
+  - C:\OpenSSL-Win32 -> appveyor.yml
+  - C:\OpenSSL-Win64 -> appveyor.yml
+  - zlib.zip -> appveyor.yml

--- a/win32/Make.rules.mak
+++ b/win32/Make.rules.mak
@@ -54,12 +54,19 @@ CANDLEFLAGS = -dOpenSSL="$(OPENSSL_DIR)" $(CANDLEFLAGS)
 # - set the ZLIB_INCL_DIR below to the zlib include lib proceeded by "/I"
 # - set the ZLIB_LIB  below to your zlib lib file
 #ZLIB_DEF = /DENABLE_ZLIB
-!IF "$(ZLIB_DEF)" == "/DENABLE_ZLIB"
+!IF "$(ZLIBSTATIC_DEF)" == "/DENABLE_ZLIB_STATIC"
+ZLIB_DEF = /DENABLE_ZLIB
+ZLIB_INCL_DIR = /IC:\zlib
+ZLIB_LIB = C:\zlib\zlib.lib
+OPENSC_FEATURES = $(OPENSC_FEATURES) zlib
+!ELSE IF "$(ZLIB_DEF)" == "/DENABLE_ZLIB"
 ZLIB_INCL_DIR = /IC:\zlib-dll\include
 ZLIB_LIB = C:\zlib-dll\lib\zdll.lib
 OPENSC_FEATURES = $(OPENSC_FEATURES) zlib
 CANDLEFLAGS = -dzlib="C:\zlib-dll" $(CANDLEFLAGS)
 !ENDIF
+
+
 
 # Used for MiniDriver
 CNGSDK_INCL_DIR = "/IC:\Program Files (x86)\Microsoft CNG Development Kit\Include"


### PR DESCRIPTION
zlib feature now available for x64
zlib is compiled statically and avoid the need to deploy zlib1.dll into system32