### PR TITLE
remove visual studio compilation error

### DIFF
--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1396,7 +1396,7 @@ do_delete_objects(struct sc_profile *profile, unsigned int myopt_delete_flags)
 
 	if (myopt_delete_flags & SC_PKCS15INIT_TYPE_DATA) {
 		struct sc_object_id app_oid;
-		sc_pkcs15_object_t *obj;
+		sc_pkcs15_object_t *obj = NULL;
 
 		if (opt_application_id != NULL) {
 			sc_format_oid(&app_oid, opt_application_id);


### PR DESCRIPTION
quote:
avoid error C4703: potentially uninitialized local pointer variable 'obj' used line 1414