### PR TITLE
Changes needed for OpenSSL 1.1

### DIFF
--- a/src/common/simclist.c
+++ b/src/common/simclist.c
@@ -116,6 +116,7 @@
 #include <pthread.h>
 #endif
 
+#define SIMCLIST_C_INTERNAL
 #include "simclist.h"
 
 

--- a/src/common/simclist.c
+++ b/src/common/simclist.c
@@ -116,7 +116,6 @@
 #include <pthread.h>
 #endif
 
-#define SIMCLIST_C_INTERNAL
 #include "simclist.h"
 
 
@@ -144,31 +143,31 @@ struct list_dump_header_s {
 
 
 /* deletes tmp from list, with care wrt its position (head, tail, middle) */
-static int list_drop_elem(list_t *restrict l, struct list_entry_s *tmp, unsigned int pos);
+static int list_drop_elem(list_t *simclist_restrict l, struct list_entry_s *tmp, unsigned int pos);
 
 /* set default values for initialized lists */
-static int list_attributes_setdefaults(list_t *restrict l);
+static int list_attributes_setdefaults(list_t *simclist_restrict l);
 
 #ifndef NDEBUG
 /* check whether the list internal REPresentation is valid -- Costs O(n) */
-static int list_repOk(const list_t *restrict l);
+static int list_repOk(const list_t *simclist_restrict l);
 
 /* check whether the list attribute set is valid -- Costs O(1) */
-static int list_attrOk(const list_t *restrict l);
+static int list_attrOk(const list_t *simclist_restrict l);
 #endif
 
 /* do not inline, this is recursive */
-static void list_sort_quicksort(list_t *restrict l, int versus,
+static void list_sort_quicksort(list_t *simclist_restrict l, int versus,
         unsigned int first, struct list_entry_s *fel,
         unsigned int last, struct list_entry_s *lel);
 
-static inline void list_sort_selectionsort(list_t *restrict l, int versus,
+static simclist_inline void list_sort_selectionsort(list_t *simclist_restrict l, int versus,
         unsigned int first, struct list_entry_s *fel,
         unsigned int last, struct list_entry_s *lel);
 
-static void *list_get_minmax(const list_t *restrict l, int versus);
+static void *list_get_minmax(const list_t *simclist_restrict l, int versus);
 
-static inline struct list_entry_s *list_findpos(const list_t *restrict l, int posstart);
+static simclist_inline struct list_entry_s *list_findpos(const list_t *simclist_restrict l, int posstart);
 
 #ifdef SIMCLIST_DUMPRESTORE
 /* write() decorated with error checking logic */
@@ -211,12 +210,12 @@ static inline struct list_entry_s *list_findpos(const list_t *restrict l, int po
 static unsigned random_seed = 0;
 
 /* use local RNG */
-static inline void seed_random() {
+static simclist_inline void seed_random() {
     if (random_seed == 0)
         random_seed = (unsigned)getpid() ^ (unsigned)time(NULL);
 }
 
-static inline long get_random() {
+static simclist_inline long get_random() {
     random_seed = (1664525 * random_seed + 1013904223);
     return random_seed;
 }
@@ -229,7 +228,7 @@ static inline long get_random() {
 
 
 /* list initialization */
-int list_init(list_t *restrict l) {
+int list_init(list_t *simclist_restrict l) {
     if (l == NULL) return -1;
 
     seed_random();
@@ -265,7 +264,7 @@ int list_init(list_t *restrict l) {
     return 0;
 }
 
-void list_destroy(list_t *restrict l) {
+void list_destroy(list_t *simclist_restrict l) {
     unsigned int i;
 
     list_clear(l);
@@ -277,7 +276,7 @@ void list_destroy(list_t *restrict l) {
     free(l->tail_sentinel);
 }
 
-int list_attributes_setdefaults(list_t *restrict l) {
+int list_attributes_setdefaults(list_t *simclist_restrict l) {
     l->attrs.comparator = NULL;
     l->attrs.seeker = NULL;
 
@@ -297,7 +296,7 @@ int list_attributes_setdefaults(list_t *restrict l) {
 }
 
 /* setting list properties */
-int list_attributes_comparator(list_t *restrict l, element_comparator comparator_fun) {
+int list_attributes_comparator(list_t *simclist_restrict l, element_comparator comparator_fun) {
     if (l == NULL) return -1;
 
     l->attrs.comparator = comparator_fun;
@@ -307,7 +306,7 @@ int list_attributes_comparator(list_t *restrict l, element_comparator comparator
     return 0;
 }
 
-int list_attributes_seeker(list_t *restrict l, element_seeker seeker_fun) {
+int list_attributes_seeker(list_t *simclist_restrict l, element_seeker seeker_fun) {
     if (l == NULL) return -1;
 
     l->attrs.seeker = seeker_fun;
@@ -316,7 +315,7 @@ int list_attributes_seeker(list_t *restrict l, element_seeker seeker_fun) {
     return 0;
 }
 
-int list_attributes_copy(list_t *restrict l, element_meter metric_fun, int copy_data) {
+int list_attributes_copy(list_t *simclist_restrict l, element_meter metric_fun, int copy_data) {
     if (l == NULL || (metric_fun == NULL && copy_data != 0)) return -1;
 
     l->attrs.meter = metric_fun;
@@ -327,7 +326,7 @@ int list_attributes_copy(list_t *restrict l, element_meter metric_fun, int copy_
     return 0;
 }
 
-int list_attributes_hash_computer(list_t *restrict l, element_hash_computer hash_computer_fun) {
+int list_attributes_hash_computer(list_t *simclist_restrict l, element_hash_computer hash_computer_fun) {
     if (l == NULL) return -1;
 
     l->attrs.hasher = hash_computer_fun;
@@ -335,7 +334,7 @@ int list_attributes_hash_computer(list_t *restrict l, element_hash_computer hash
     return 0;
 }
 
-int list_attributes_serializer(list_t *restrict l, element_serializer serializer_fun) {
+int list_attributes_serializer(list_t *simclist_restrict l, element_serializer serializer_fun) {
     if (l == NULL) return -1;
 
     l->attrs.serializer = serializer_fun;
@@ -343,7 +342,7 @@ int list_attributes_serializer(list_t *restrict l, element_serializer serializer
     return 0;
 }
 
-int list_attributes_unserializer(list_t *restrict l, element_unserializer unserializer_fun) {
+int list_attributes_unserializer(list_t *simclist_restrict l, element_unserializer unserializer_fun) {
     if (l == NULL) return -1;
 
     l->attrs.unserializer = unserializer_fun;
@@ -351,19 +350,19 @@ int list_attributes_unserializer(list_t *restrict l, element_unserializer unseri
     return 0;
 }
 
-int list_append(list_t *restrict l, const void *data) {
+int list_append(list_t *simclist_restrict l, const void *data) {
     return list_insert_at(l, data, l->numels);
 }
 
-int list_prepend(list_t *restrict l, const void *data) {
+int list_prepend(list_t *simclist_restrict l, const void *data) {
     return list_insert_at(l, data, 0);
 }
 
-void *list_fetch(list_t *restrict l) {
+void *list_fetch(list_t *simclist_restrict l) {
     return list_extract_at(l, 0);
 }
 
-void *list_get_at(const list_t *restrict l, unsigned int pos) {
+void *list_get_at(const list_t *simclist_restrict l, unsigned int pos) {
     struct list_entry_s *tmp;
 
     tmp = list_findpos(l, pos);
@@ -371,17 +370,17 @@ void *list_get_at(const list_t *restrict l, unsigned int pos) {
     return (tmp != NULL ? tmp->data : NULL);
 }
 
-void *list_get_max(const list_t *restrict l) {
+void *list_get_max(const list_t *simclist_restrict l) {
     return list_get_minmax(l, +1);
 }
 
-void *list_get_min(const list_t *restrict l) {
+void *list_get_min(const list_t *simclist_restrict l) {
     return list_get_minmax(l, -1);
 }
 
 /* REQUIRES {list->numels >= 1}
  * return the min (versus < 0) or max value (v > 0) in l */
-static void *list_get_minmax(const list_t *restrict l, int versus) {
+static void *list_get_minmax(const list_t *simclist_restrict l, int versus) {
     void *curminmax;
     struct list_entry_s *s;
 
@@ -398,7 +397,7 @@ static void *list_get_minmax(const list_t *restrict l, int versus) {
 }
 
 /* set tmp to point to element at index posstart in l */
-static inline struct list_entry_s *list_findpos(const list_t *restrict l, int posstart) {
+static simclist_inline struct list_entry_s *list_findpos(const list_t *simclist_restrict l, int posstart) {
     struct list_entry_s *ptr;
     float x;
     int i;
@@ -424,7 +423,7 @@ static inline struct list_entry_s *list_findpos(const list_t *restrict l, int po
     return ptr;
 }
 
-void *list_extract_at(list_t *restrict l, unsigned int pos) {
+void *list_extract_at(list_t *simclist_restrict l, unsigned int pos) {
     struct list_entry_s *tmp;
     void *data;
 
@@ -442,7 +441,7 @@ void *list_extract_at(list_t *restrict l, unsigned int pos) {
     return data;
 }
 
-int list_insert_at(list_t *restrict l, const void *data, unsigned int pos) {
+int list_insert_at(list_t *simclist_restrict l, const void *data, unsigned int pos) {
     struct list_entry_s *lent, *succ, *prec;
 
     if (l->iter_active || pos > l->numels) return -1;
@@ -491,7 +490,7 @@ int list_insert_at(list_t *restrict l, const void *data, unsigned int pos) {
     return 1;
 }
 
-int list_delete(list_t *restrict l, const void *data) {
+int list_delete(list_t *simclist_restrict l, const void *data) {
 	int pos, r;
 
 	pos = list_locate(l, data);
@@ -507,7 +506,7 @@ int list_delete(list_t *restrict l, const void *data) {
 	return 0;
 }
 
-int list_delete_at(list_t *restrict l, unsigned int pos) {
+int list_delete_at(list_t *simclist_restrict l, unsigned int pos) {
     struct list_entry_s *delendo;
 
 
@@ -525,7 +524,7 @@ int list_delete_at(list_t *restrict l, unsigned int pos) {
     return  0;
 }
 
-int list_delete_range(list_t *restrict l, unsigned int posstart, unsigned int posend) {
+int list_delete_range(list_t *simclist_restrict l, unsigned int posstart, unsigned int posend) {
     struct list_entry_s *lastvalid, *tmp, *tmp2;
     unsigned int i;
     int movedx;
@@ -587,7 +586,7 @@ int list_delete_range(list_t *restrict l, unsigned int posstart, unsigned int po
     return 0;
 }
 
-int list_clear(list_t *restrict l) {
+int list_clear(list_t *simclist_restrict l) {
     struct list_entry_s *s;
 
     if (l->iter_active) return -1;
@@ -629,15 +628,15 @@ int list_clear(list_t *restrict l) {
     return 0;
 }
 
-unsigned int list_size(const list_t *restrict l) {
+unsigned int list_size(const list_t *simclist_restrict l) {
     return l->numels;
 }
 
-int list_empty(const list_t *restrict l) {
+int list_empty(const list_t *simclist_restrict l) {
     return (l->numels == 0);
 }
 
-int list_locate(const list_t *restrict l, const void *data) {
+int list_locate(const list_t *simclist_restrict l, const void *data) {
     struct list_entry_s *el;
     int pos = 0;
 
@@ -657,7 +656,7 @@ int list_locate(const list_t *restrict l, const void *data) {
     return pos;
 }
 
-void *list_seek(list_t *restrict l, const void *indicator) {
+void *list_seek(list_t *simclist_restrict l, const void *indicator) {
     const struct list_entry_s *iter;
 
     if (l->attrs.seeker == NULL) return NULL;
@@ -669,11 +668,11 @@ void *list_seek(list_t *restrict l, const void *indicator) {
     return NULL;
 }
 
-int list_contains(const list_t *restrict l, const void *data) {
+int list_contains(const list_t *simclist_restrict l, const void *data) {
     return (list_locate(l, data) >= 0);
 }
 
-int list_concat(const list_t *l1, const list_t *l2, list_t *restrict dest) {
+int list_concat(const list_t *l1, const list_t *l2, list_t *simclist_restrict dest) {
     struct list_entry_s *el, *srcel;
     unsigned int cnt;
     int err;
@@ -726,7 +725,7 @@ int list_concat(const list_t *l1, const list_t *l2, list_t *restrict dest) {
     return 0;
 }
 
-int list_sort(list_t *restrict l, int versus) {
+int list_sort(list_t *simclist_restrict l, int versus) {
     if (l->iter_active || l->attrs.comparator == NULL) /* cannot modify list in the middle of an iteration */
         return -1;
 
@@ -739,7 +738,7 @@ int list_sort(list_t *restrict l, int versus) {
 
 #ifdef SIMCLIST_WITH_THREADS
 struct list_sort_wrappedparams {
-    list_t *restrict l;
+    list_t *simclist_restrict l;
     int versus;
     unsigned int first, last;
     struct list_entry_s *fel, *lel;
@@ -754,7 +753,7 @@ static void *list_sort_quicksort_threadwrapper(void *wrapped_params) {
 }
 #endif
 
-static inline void list_sort_selectionsort(list_t *restrict l, int versus,
+static simclist_inline void list_sort_selectionsort(list_t *simclist_restrict l, int versus,
         unsigned int first, struct list_entry_s *fel,
         unsigned int last, struct list_entry_s *lel) {
     struct list_entry_s *cursor, *toswap, *firstunsorted;
@@ -775,7 +774,7 @@ static inline void list_sort_selectionsort(list_t *restrict l, int versus,
     }
 }
 
-static void list_sort_quicksort(list_t *restrict l, int versus,
+static void list_sort_quicksort(list_t *simclist_restrict l, int versus,
         unsigned int first, struct list_entry_s *fel,
         unsigned int last, struct list_entry_s *lel) {
     unsigned int pivotid;
@@ -898,7 +897,7 @@ static void list_sort_quicksort(list_t *restrict l, int versus,
 #endif
 }
 
-int list_iterator_start(list_t *restrict l) {
+int list_iterator_start(list_t *simclist_restrict l) {
     if (l->iter_active) return 0;
     l->iter_pos = 0;
     l->iter_active = 1;
@@ -906,7 +905,7 @@ int list_iterator_start(list_t *restrict l) {
     return 1;
 }
 
-void *list_iterator_next(list_t *restrict l) {
+void *list_iterator_next(list_t *simclist_restrict l) {
     void *toret;
 
     if (! l->iter_active) return NULL;
@@ -918,19 +917,19 @@ void *list_iterator_next(list_t *restrict l) {
     return toret;
 }
 
-int list_iterator_hasnext(const list_t *restrict l) {
+int list_iterator_hasnext(const list_t *simclist_restrict l) {
     if (! l->iter_active) return 0;
     return (l->iter_pos < l->numels);
 }
 
-int list_iterator_stop(list_t *restrict l) {
+int list_iterator_stop(list_t *simclist_restrict l) {
     if (! l->iter_active) return 0;
     l->iter_pos = 0;
     l->iter_active = 0;
     return 1;
 }
 
-int list_hash(const list_t *restrict l, list_hash_t *restrict hash) {
+int list_hash(const list_t *simclist_restrict l, list_hash_t *simclist_restrict hash) {
     struct list_entry_s *x;
     list_hash_t tmphash;
 
@@ -977,7 +976,7 @@ int gettimeofday(struct timeval* tp, void* tzp) {
     return 0;
 }
 #endif
-int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *restrict info) {
+int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *simclist_restrict info) {
     int32_t terminator_head, terminator_tail;
     uint32_t elemlen;
     off_t hop;
@@ -1039,7 +1038,7 @@ int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *restrict info) {
     return 0;
 }
 
-int list_dump_getinfo_file(const char *restrict filename, list_dump_info_t *restrict info) {
+int list_dump_getinfo_file(const char *simclist_restrict filename, list_dump_info_t *simclist_restrict info) {
     int fd, ret;
 
     fd = open(filename, O_RDONLY, 0);
@@ -1051,7 +1050,7 @@ int list_dump_getinfo_file(const char *restrict filename, list_dump_info_t *rest
     return ret;
 }
 
-int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict len) {
+int list_dump_filedescriptor(const list_t *simclist_restrict l, int fd, size_t *simclist_restrict len) {
     struct list_entry_s *x;
     void *ser_buf;
     uint32_t bufsize;
@@ -1198,7 +1197,7 @@ int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict 
     return 0;
 }
 
-int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len) {
+int list_restore_filedescriptor(list_t *simclist_restrict l, int fd, size_t *simclist_restrict len) {
     struct list_dump_header_s header;
     unsigned long cnt;
     void *buf = NULL;
@@ -1319,7 +1318,7 @@ int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len
     return 0;
 }
 
-int list_dump_file(const list_t *restrict l, const char *restrict filename, size_t *restrict len) {
+int list_dump_file(const list_t *simclist_restrict l, const char *simclist_restrict filename, size_t *simclist_restrict len) {
     int fd, mode;
     size_t sizetoret;
     mode = O_RDWR | O_CREAT | O_TRUNC;
@@ -1335,7 +1334,7 @@ int list_dump_file(const list_t *restrict l, const char *restrict filename, size
     return sizetoret;
 }
 
-int list_restore_file(list_t *restrict l, const char *restrict filename, size_t *restrict len) {
+int list_restore_file(list_t *simclist_restrict l, const char *simclist_restrict filename, size_t *simclist_restrict len) {
     int fd;
     size_t totdata;
 
@@ -1350,7 +1349,7 @@ int list_restore_file(list_t *restrict l, const char *restrict filename, size_t 
 #endif /* ifdef SIMCLIST_DUMPRESTORE */
 
 
-static int list_drop_elem(list_t *restrict l, struct list_entry_s *tmp, unsigned int pos) {
+static int list_drop_elem(list_t *simclist_restrict l, struct list_entry_s *tmp, unsigned int pos) {
     if (tmp == NULL) return -1;
 
     /* fix mid pointer. This is wrt the PRE situation */
@@ -1447,7 +1446,7 @@ list_hash_t list_hashcomputer_string(const void *el) {
 
 
 #ifndef NDEBUG
-static int list_repOk(const list_t *restrict l) {
+static int list_repOk(const list_t *simclist_restrict l) {
     int ok, i;
     struct list_entry_s *s;
 
@@ -1479,7 +1478,7 @@ static int list_repOk(const list_t *restrict l) {
     return ok;
 }
 
-static int list_attrOk(const list_t *restrict l) {
+static int list_attrOk(const list_t *simclist_restrict l) {
     int ok;
 
     ok = (l->attrs.copy_data == 0 || l->attrs.meter != NULL);

--- a/src/common/simclist.h
+++ b/src/common/simclist.h
@@ -44,11 +44,20 @@ typedef INT64   int64_t;
 #include <errno.h>
 #include <sys/types.h>
 
+/* OpenSSL-1.1 e_os2.h does #if !defined(inline)
+ * the following causes problems. One of them needs to be fixed
+ * other files  may still want inline!
+ *
+ * only do the define inline when in the simclilst.c  code
+ */
+
 /* Be friend of both C90 and C99 compilers */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     /* "inline" and "restrict" are keywords */
 #else
+#ifdef SIMCLIST_C_INTERNAL
 #   define inline           /* inline */
+#endif /* SIMCLIST_C_INTERNAL */
 #   define restrict         /* restrict */
 #endif
 

--- a/src/common/simclist.h
+++ b/src/common/simclist.h
@@ -45,7 +45,7 @@ typedef INT64   int64_t;
 #include <sys/types.h>
 
 /* bases on OpenSSL's version in e_os2.h  */
-#if !defined(inline) && !defined(__cplusplus)
+#if !defined(inline)
 /* Be friend of both C90 and C99 compilers */
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
    /* "inline" and "restrict" are keywords */
@@ -62,7 +62,8 @@ typedef INT64   int64_t;
 #endif
 
 /* bases on OpenSSL's version in e_os2.h  */
-#if !defined(restrict) && !defined(__cplusplus)
+/* On MacOS  C++ is used for tokend */
+#if !defined(restrict)
 /* Be friend of both C90 and C99 compilers */
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
    /* "inline" and "restrict" are keywords */

--- a/src/common/simclist.h
+++ b/src/common/simclist.h
@@ -44,21 +44,38 @@ typedef INT64   int64_t;
 #include <errno.h>
 #include <sys/types.h>
 
-/* OpenSSL-1.1 e_os2.h does #if !defined(inline)
- * the following causes problems. One of them needs to be fixed
- * other files  may still want inline!
- *
- * only do the define inline when in the simclilst.c  code
- */
-
+/* bases on OpenSSL's version in e_os2.h  */
+#if !defined(inline) && !defined(__cplusplus)
 /* Be friend of both C90 and C99 compilers */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    /* "inline" and "restrict" are keywords */
-#else
-#ifdef SIMCLIST_C_INTERNAL
-#   define inline           /* inline */
-#endif /* SIMCLIST_C_INTERNAL */
-#   define restrict         /* restrict */
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+   /* "inline" and "restrict" are keywords */
+#  define simclist_inline  inline
+# elif defined(__GNUC__) && __GNUC__>=2
+#  define simclist_inline  __inline__
+# elif defined(_MSC_VER)
+#  define simclist_inline __inline
+# else
+#  define simclist_inline
+# endif
+#else    /* use what caller wants as inline  may be from config.h */
+#   define simclist_inline  inline           /* inline */
+#endif
+
+/* bases on OpenSSL's version in e_os2.h  */
+#if !defined(restrict) && !defined(__cplusplus)
+/* Be friend of both C90 and C99 compilers */
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+   /* "inline" and "restrict" are keywords */
+#  define simclist_restrict restrict         /* restrict */
+# elif defined(__GNUC__) && __GNUC__>=2
+#  define simclist_restrict __restrict__
+# elif defined(_MSC_VER)
+#  define simclist_restrict __restrict
+# else
+#  define simclist_restrict
+# endif
+#else    /* use what caller wants as restrict may be from config.h */
+#   define simclist_restrict  restrict
 #endif
 
 
@@ -145,7 +162,7 @@ typedef list_hash_t (*element_hash_computer)(const void *el);
  * @param serialize_buffer  reference to fill with the length of the buffer
  * @return                  reference to the buffer with the serialized data
  */
-typedef void *(*element_serializer)(const void *restrict el, uint32_t *restrict serializ_len);
+typedef void *(*element_serializer)(const void *simclist_restrict el, uint32_t *simclist_restrict serializ_len);
 
 /**
  * a function for un-serializing an element.
@@ -162,7 +179,7 @@ typedef void *(*element_serializer)(const void *restrict el, uint32_t *restrict 
  * @param data_len          reference to the location where to store the length of the data in the buffer returned
  * @return                  reference to a buffer with the original, unserialized representation of the element
  */
-typedef void *(*element_unserializer)(const void *restrict data, uint32_t *restrict data_len);
+typedef void *(*element_unserializer)(const void *simclist_restrict data, uint32_t *simclist_restrict data_len);
 
 /* [private-use] list entry -- olds actual user datum */
 struct list_entry_s {
@@ -222,7 +239,7 @@ typedef struct {
  * @param l     must point to a user-provided memory location
  * @return      0 for success. -1 for failure
  */
-int list_init(list_t *restrict l);
+int list_init(list_t *simclist_restrict l);
 
 /**
  * completely remove the list from memory.
@@ -233,7 +250,7 @@ int list_init(list_t *restrict l);
  *
  * @param l     list to destroy
  */
-void list_destroy(list_t *restrict l);
+void list_destroy(list_t *simclist_restrict l);
 
 /**
  * set the comparator function for list elements.
@@ -247,7 +264,7 @@ void list_destroy(list_t *restrict l);
  *
  * @see element_comparator()
  */
-int list_attributes_comparator(list_t *restrict l, element_comparator comparator_fun);
+int list_attributes_comparator(list_t *simclist_restrict l, element_comparator comparator_fun);
 
 /**
  * set a seeker function for list elements.
@@ -261,7 +278,7 @@ int list_attributes_comparator(list_t *restrict l, element_comparator comparator
  *
  * @see element_seeker()
  */
-int list_attributes_seeker(list_t *restrict l, element_seeker seeker_fun);
+int list_attributes_seeker(list_t *simclist_restrict l, element_seeker seeker_fun);
 
 /**
  * require to free element data when list entry is removed (default: don't free).
@@ -293,7 +310,7 @@ int list_attributes_seeker(list_t *restrict l, element_seeker seeker_fun);
  * @see list_meter_double()
  * @see list_meter_string()
  */
-int list_attributes_copy(list_t *restrict l, element_meter metric_fun, int copy_data);
+int list_attributes_copy(list_t *simclist_restrict l, element_meter metric_fun, int copy_data);
 
 /**
  * set the element hash computing function for the list elements.
@@ -313,7 +330,7 @@ int list_attributes_copy(list_t *restrict l, element_meter metric_fun, int copy_
  *
  * @see element_hash_computer()
  */
-int list_attributes_hash_computer(list_t *restrict l, element_hash_computer hash_computer_fun);
+int list_attributes_hash_computer(list_t *simclist_restrict l, element_hash_computer hash_computer_fun);
 
 /**
  * set the element serializer function for the list elements.
@@ -334,7 +351,7 @@ int list_attributes_hash_computer(list_t *restrict l, element_hash_computer hash
  * @see     list_dump_filedescriptor()
  * @see     list_restore_filedescriptor()
  */
-int list_attributes_serializer(list_t *restrict l, element_serializer serializer_fun);
+int list_attributes_serializer(list_t *simclist_restrict l, element_serializer serializer_fun);
 
 /**
  * set the element unserializer function for the list elements.
@@ -356,7 +373,7 @@ int list_attributes_serializer(list_t *restrict l, element_serializer serializer
  * @see     list_dump_filedescriptor()
  * @see     list_restore_filedescriptor()
  */
-int list_attributes_unserializer(list_t *restrict l, element_unserializer unserializer_fun);
+int list_attributes_unserializer(list_t *simclist_restrict l, element_unserializer unserializer_fun);
 
 /**
  * append data at the end of the list.
@@ -368,7 +385,7 @@ int list_attributes_unserializer(list_t *restrict l, element_unserializer unseri
  *
  * @return      1 for success. < 0 for failure
  */
-int list_append(list_t *restrict l, const void *data);
+int list_append(list_t *simclist_restrict l, const void *data);
 
 /**
  * insert data in the head of the list.
@@ -380,7 +397,7 @@ int list_append(list_t *restrict l, const void *data);
  *
  * @return      1 for success. < 0 for failure
  */
-int list_prepend(list_t *restrict l, const void *restrict data);
+int list_prepend(list_t *simclist_restrict l, const void *simclist_restrict data);
 
 /**
  * extract the element in the top of the list.
@@ -390,7 +407,7 @@ int list_prepend(list_t *restrict l, const void *restrict data);
  * @param l     list to operate
  * @return      reference to user datum, or NULL on errors
  */
-void *list_fetch(list_t *restrict l);
+void *list_fetch(list_t *simclist_restrict l);
 
 /**
  * retrieve an element at a given position.
@@ -399,7 +416,7 @@ void *list_fetch(list_t *restrict l);
  * @param pos   [0,size-1] position index of the element wanted
  * @return      reference to user datum, or NULL on errors
  */
-void *list_get_at(const list_t *restrict l, unsigned int pos);
+void *list_get_at(const list_t *simclist_restrict l, unsigned int pos);
 
 /**
  * return the maximum element of the list.
@@ -413,7 +430,7 @@ void *list_get_at(const list_t *restrict l, unsigned int pos);
  * @param l     list to operate
  * @return      the reference to the element, or NULL
  */
-void *list_get_max(const list_t *restrict l);
+void *list_get_max(const list_t *simclist_restrict l);
 
 /**
  * return the minimum element of the list.
@@ -427,7 +444,7 @@ void *list_get_max(const list_t *restrict l);
  * @param l     list to operate
  * @return      the reference to the element, or NULL
  */
-void *list_get_min(const list_t *restrict l);
+void *list_get_min(const list_t *simclist_restrict l);
 
 /**
  * retrieve and remove from list an element at a given position.
@@ -436,7 +453,7 @@ void *list_get_min(const list_t *restrict l);
  * @param pos   [0,size-1] position index of the element wanted
  * @return      reference to user datum, or NULL on errors
  */
-void *list_extract_at(list_t *restrict l, unsigned int pos);
+void *list_extract_at(list_t *simclist_restrict l, unsigned int pos);
 
 /**
  * insert an element at a given position.
@@ -446,7 +463,7 @@ void *list_extract_at(list_t *restrict l, unsigned int pos);
  * @param pos   [0,size-1] position index to insert the element at
  * @return      positive value on success. Negative on failure
  */
-int list_insert_at(list_t *restrict l, const void *data, unsigned int pos);
+int list_insert_at(list_t *simclist_restrict l, const void *data, unsigned int pos);
 
 /**
  * expunge the first found given element from the list.
@@ -463,7 +480,7 @@ int list_insert_at(list_t *restrict l, const void *data, unsigned int pos);
  * @see list_attributes_comparator()
  * @see list_delete_at()
  */
-int list_delete(list_t *restrict l, const void *data);
+int list_delete(list_t *simclist_restrict l, const void *data);
 
 /**
  * expunge an element at a given position from the list.
@@ -472,7 +489,7 @@ int list_delete(list_t *restrict l, const void *data);
  * @param pos   [0,size-1] position index of the element to be deleted
  * @return      0 on success. Negative value on failure
  */
-int list_delete_at(list_t *restrict l, unsigned int pos);
+int list_delete_at(list_t *simclist_restrict l, unsigned int pos);
 
 /**
  * expunge an array of elements from the list, given their position range.
@@ -482,7 +499,7 @@ int list_delete_at(list_t *restrict l, unsigned int pos);
  * @param posend    [posstart,size-1] position of the last element to be deleted
  * @return      the number of elements successfully removed
  */
-int list_delete_range(list_t *restrict l, unsigned int posstart, unsigned int posend);
+int list_delete_range(list_t *simclist_restrict l, unsigned int posstart, unsigned int posend);
 
 /**
  * clear all the elements off of the list.
@@ -495,7 +512,7 @@ int list_delete_range(list_t *restrict l, unsigned int posstart, unsigned int po
  * @param l     list to operate
  * @return      the number of elements in the list before cleaning
  */
-int list_clear(list_t *restrict l);
+int list_clear(list_t *simclist_restrict l);
 
 /**
  * inspect the number of elements in the list.
@@ -503,7 +520,7 @@ int list_clear(list_t *restrict l);
  * @param l     list to operate
  * @return      number of elements currently held by the list
  */
-unsigned int list_size(const list_t *restrict l);
+unsigned int list_size(const list_t *simclist_restrict l);
 
 /**
  * inspect whether the list is empty.
@@ -513,7 +530,7 @@ unsigned int list_size(const list_t *restrict l);
  *
  * @see list_size()
  */
-int list_empty(const list_t *restrict l);
+int list_empty(const list_t *simclist_restrict l);
 
 /**
  * find the position of an element in a list.
@@ -532,7 +549,7 @@ int list_empty(const list_t *restrict l);
  * @see list_attributes_comparator()
  * @see list_get_at()
  */
-int list_locate(const list_t *restrict l, const void *data);
+int list_locate(const list_t *simclist_restrict l, const void *data);
 
 /**
  * returns an element given an indicator.
@@ -547,7 +564,7 @@ int list_locate(const list_t *restrict l, const void *data);
  * @param indicator indicator data to pass to the seeker along with elements
  * @return      reference to the element accepted by the seeker, or NULL if none found
  */
-void *list_seek(list_t *restrict l, const void *indicator);
+void *list_seek(list_t *simclist_restrict l, const void *indicator);
 
 /**
  * inspect whether some data is member of the list.
@@ -568,7 +585,7 @@ void *list_seek(list_t *restrict l, const void *indicator);
  *
  * @see list_attributes_comparator()
  */
-int list_contains(const list_t *restrict l, const void *data);
+int list_contains(const list_t *simclist_restrict l, const void *data);
 
 /**
  * concatenate two lists
@@ -587,7 +604,7 @@ int list_contains(const list_t *restrict l, const void *data);
  * @param dest  reference to the destination list
  * @return      0 for success, -1 for errors
  */
-int list_concat(const list_t *l1, const list_t *l2, list_t *restrict dest);
+int list_concat(const list_t *l1, const list_t *l2, list_t *simclist_restrict dest);
 
 /**
  * sort list elements.
@@ -604,7 +621,7 @@ int list_concat(const list_t *l1, const list_t *l2, list_t *restrict dest);
  *
  * @see list_attributes_comparator()
  */
-int list_sort(list_t *restrict l, int versus);
+int list_sort(list_t *simclist_restrict l, int versus);
 
 /**
  * start an iteration session.
@@ -616,7 +633,7 @@ int list_sort(list_t *restrict l, int versus);
  *
  * @see list_iterator_stop()
  */
-int list_iterator_start(list_t *restrict l);
+int list_iterator_start(list_t *simclist_restrict l);
 
 /**
  * return the next element in the iteration session.
@@ -624,7 +641,7 @@ int list_iterator_start(list_t *restrict l);
  * @param l     list to operate
  * @return		element datum, or NULL on errors
  */
-void *list_iterator_next(list_t *restrict l);
+void *list_iterator_next(list_t *simclist_restrict l);
 
 /**
  * inspect whether more elements are available in the iteration session.
@@ -632,7 +649,7 @@ void *list_iterator_next(list_t *restrict l);
  * @param l     list to operate
  * @return      0 iff no more elements are available.
  */
-int list_iterator_hasnext(const list_t *restrict l);
+int list_iterator_hasnext(const list_t *simclist_restrict l);
 
 /**
  * end an iteration session.
@@ -640,7 +657,7 @@ int list_iterator_hasnext(const list_t *restrict l);
  * @param l     list to operate
  * @return      0 iff the iteration session cannot be stopped
  */
-int list_iterator_stop(list_t *restrict l);
+int list_iterator_stop(list_t *simclist_restrict l);
 
 /**
  * return the hash of the current status of the list.
@@ -650,7 +667,7 @@ int list_iterator_stop(list_t *restrict l);
  *
  * @return      0 for success; <0 for failure
  */
-int list_hash(const list_t *restrict l, list_hash_t *restrict hash);
+int list_hash(const list_t *simclist_restrict l, list_hash_t *simclist_restrict hash);
 
 #ifdef SIMCLIST_DUMPRESTORE
 /**
@@ -668,7 +685,7 @@ int list_hash(const list_t *restrict l, list_hash_t *restrict hash);
  *
  * @see list_dump_filedescriptor()
  */
-int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *restrict info);
+int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *simclist_restrict info);
 
 /**
  * get meta informations on a list dump on file.
@@ -683,7 +700,7 @@ int list_dump_getinfo_filedescriptor(int fd, list_dump_info_t *restrict info);
  *
  * @see list_dump_filedescriptor()
  */
-int list_dump_getinfo_file(const char *restrict filename, list_dump_info_t *restrict info);
+int list_dump_getinfo_file(const char *simclist_restrict filename, list_dump_info_t *simclist_restrict info);
 
 /**
  * dump the list into an open, writable file descriptor.
@@ -719,7 +736,7 @@ int list_dump_getinfo_file(const char *restrict filename, list_dump_info_t *rest
  * @see list_attributes_copy()
  * @see list_attributes_serializer()
  */
-int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict len);
+int list_dump_filedescriptor(const list_t *simclist_restrict l, int fd, size_t *simclist_restrict len);
 
 /**
  * dump the list to a file name.
@@ -742,7 +759,7 @@ int list_dump_filedescriptor(const list_t *restrict l, int fd, size_t *restrict 
  *
  * This function stores a representation of the list
  */
-int list_dump_file(const list_t *restrict l, const char *restrict filename, size_t *restrict len);
+int list_dump_file(const list_t *simclist_restrict l, const char *simclist_restrict filename, size_t *simclist_restrict len);
 
 /**
  * restore the list from an open, readable file descriptor to memory.
@@ -762,7 +779,7 @@ int list_dump_file(const list_t *restrict l, const char *restrict filename, size
  * @param len   location to store the length of the dump read (bytes), or NULL
  * @return      0 if successful; -1 otherwise
  */
-int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len);
+int list_restore_filedescriptor(list_t *simclist_restrict l, int fd, size_t *simclist_restrict len);
 
 /**
  * restore the list from a file name.
@@ -780,7 +797,7 @@ int list_restore_filedescriptor(list_t *restrict l, int fd, size_t *restrict len
  * @param len       location to store the length of the dump read (bytes), or NULL
  * @return          0 if successful; -1 otherwise
  */
-int list_restore_file(list_t *restrict l, const char *restrict filename, size_t *len);
+int list_restore_file(list_t *simclist_restrict l, const char *simclist_restrict filename, size_t *len);
 #endif
 
 /* ready-made comparators, meters and hash computers */

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -687,7 +687,7 @@ static void dnie_clear_cache(dnie_private_data_t * data)
  *
  * @param card pointer to card data
  */
-static inline void init_flags(struct sc_card *card)
+static void init_flags(struct sc_card *card)
 {
 	unsigned long algoflags;
 	/* set up flags according documentation */

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -194,7 +194,7 @@ static int entersafe_cipher_apdu(sc_card_t *card, sc_apdu_t *apdu,
 								 u8 *key, size_t keylen,
 								 u8 *buff, size_t buffsize)
 {
-	 EVP_CIPHER_CTX ctx;
+	 EVP_CIPHER_CTX * ctx = NULL;
 	 u8 iv[8]={0};
 	 int len;
 
@@ -211,27 +211,26 @@ static int entersafe_cipher_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 memcpy(buff+1,apdu->data,apdu->lc);
 	 buff[apdu->lc+1]=0x80;
 
-	 EVP_CIPHER_CTX_init(&ctx);
-	 EVP_CIPHER_CTX_set_padding(&ctx,0);
+	 ctx = EVP_CIPHER_CTX_new();
+	 if (ctx == NULL)
+		 SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_OUT_OF_MEMORY);
+	 EVP_CIPHER_CTX_set_padding(ctx,0);
 
 	 if(keylen == 8)
-		  EVP_EncryptInit_ex(&ctx, EVP_des_ecb(), NULL, key, iv);
+		  EVP_EncryptInit_ex(ctx, EVP_des_ecb(), NULL, key, iv);
 	 else if (keylen == 16) 
-		  EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, key, iv);
+		  EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, key, iv);
 	 else
 		  SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 	 
 	 len = apdu->lc;
-	 if(!EVP_EncryptUpdate(&ctx, buff, &len, buff, buffsize)){
+	 if(!EVP_EncryptUpdate(ctx, buff, &len, buff, buffsize)){
 		  sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "entersafe encryption error.");
 		  SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 	 }
 	 apdu->lc = len;
 
-	 if (!EVP_CIPHER_CTX_cleanup(&ctx)){
-		  sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "entersafe encryption error.");
-		  SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
-	 }
+	 EVP_CIPHER_CTX_free(ctx);
 
 	 if(apdu->lc!=buffsize)
 	 {
@@ -254,7 +253,7 @@ static int entersafe_mac_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 u8 *tmp=0,*tmp_rounded=NULL;
 	 size_t tmpsize=0,tmpsize_rounded=0;
 	 int outl=0;
-	 EVP_CIPHER_CTX ctx;
+	 EVP_CIPHER_CTX * ctx = NULL;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -292,12 +291,16 @@ static int entersafe_mac_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 tmp_rounded[tmpsize]=0x80;
 
 	 /* block_size-1 blocks*/
-	 EVP_CIPHER_CTX_init(&ctx);
-	 EVP_CIPHER_CTX_set_padding(&ctx,0);
-	 EVP_EncryptInit_ex(&ctx, EVP_des_cbc(), NULL, key, iv);
+	 ctx = EVP_CIPHER_CTX_new();
+	 if (ctx == NULL) {
+		r =  SC_ERROR_OUT_OF_MEMORY;
+		goto out;
+	 }
+	 EVP_CIPHER_CTX_set_padding(ctx,0);
+	 EVP_EncryptInit_ex(ctx, EVP_des_cbc(), NULL, key, iv);
 
 	 if(tmpsize_rounded>8){
-		  if(!EVP_EncryptUpdate(&ctx,tmp_rounded,&outl,tmp_rounded,tmpsize_rounded-8)){
+		  if(!EVP_EncryptUpdate(ctx,tmp_rounded,&outl,tmp_rounded,tmpsize_rounded-8)){
 			   r = SC_ERROR_INTERNAL;
 			   goto out;			   
 		  }
@@ -305,23 +308,18 @@ static int entersafe_mac_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 /* last block */
 	 if(keylen==8)
 	 {
-		  if(!EVP_EncryptUpdate(&ctx,tmp_rounded+outl,&outl,tmp_rounded+outl,8)){
+		  if(!EVP_EncryptUpdate(ctx,tmp_rounded+outl,&outl,tmp_rounded+outl,8)){
 			   r = SC_ERROR_INTERNAL;
 			   goto out;			   
 		  }
 	 }
 	 else
 	 {
-		  EVP_EncryptInit_ex(&ctx, EVP_des_ede_cbc(), NULL, key,tmp_rounded+outl-8);
-		  if(!EVP_EncryptUpdate(&ctx,tmp_rounded+outl,&outl,tmp_rounded+outl,8)){
+		  EVP_EncryptInit_ex(ctx, EVP_des_ede_cbc(), NULL, key,tmp_rounded+outl-8);
+		  if(!EVP_EncryptUpdate(ctx,tmp_rounded+outl,&outl,tmp_rounded+outl,8)){
 			   r = SC_ERROR_INTERNAL;
 			   goto out;			   
 		  }
-	 }
-
-	 if (!EVP_CIPHER_CTX_cleanup(&ctx)){
-		  r = SC_ERROR_INTERNAL;
-		  goto out;			   
 	 }
 
 	 memcpy(buff,apdu->data,apdu->lc);
@@ -336,6 +334,8 @@ out:
 		  free(tmp);
 	 if(tmp_rounded)
 		  free(tmp_rounded);
+	 if  (ctx)
+		EVP_CIPHER_CTX_free(ctx);
 
 	 SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
 }

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -112,27 +112,28 @@ openssl_enc(const EVP_CIPHER * cipher, const unsigned char *key, const unsigned 
 		const unsigned char *input, size_t length, unsigned char *output)
 {
 	int r = SC_ERROR_INTERNAL;
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX * ctx = NULL;
 	int outl = 0;
 	int outl_tmp = 0;
 	unsigned char iv_tmp[EVP_MAX_IV_LENGTH] = { 0 };
 
 	memcpy(iv_tmp, iv, EVP_MAX_IV_LENGTH);
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, cipher, NULL, key, iv_tmp);
-	EVP_CIPHER_CTX_set_padding(&ctx, 0);
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL)
+		goto out;
+	EVP_EncryptInit_ex(ctx, cipher, NULL, key, iv_tmp);
+	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
-	if (!EVP_EncryptUpdate(&ctx, output, &outl, input, length))
+	if (!EVP_EncryptUpdate(ctx, output, &outl, input, length))
 		goto out;
 
-	if (!EVP_EncryptFinal_ex(&ctx, output + outl, &outl_tmp))
-		goto out;
-
-	if (!EVP_CIPHER_CTX_cleanup(&ctx))
+	if (!EVP_EncryptFinal_ex(ctx, output + outl, &outl_tmp))
 		goto out;
 
 	r = SC_SUCCESS;
 out:
+	if (ctx)
+	    EVP_CIPHER_CTX_free(ctx);
 	return r;
 }
 
@@ -141,27 +142,28 @@ openssl_dec(const EVP_CIPHER * cipher, const unsigned char *key, const unsigned 
 		const unsigned char *input, size_t length, unsigned char *output)
 {
 	int r = SC_ERROR_INTERNAL;
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX * ctx = NULL;
 	int outl = 0;
 	int outl_tmp = 0;
 	unsigned char iv_tmp[EVP_MAX_IV_LENGTH] = { 0 };
 
 	memcpy(iv_tmp, iv, EVP_MAX_IV_LENGTH);
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_DecryptInit_ex(&ctx, cipher, NULL, key, iv_tmp);
-	EVP_CIPHER_CTX_set_padding(&ctx, 0);
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL)
+		goto out;
+	EVP_DecryptInit_ex(ctx, cipher, NULL, key, iv_tmp);
+	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
-	if (!EVP_DecryptUpdate(&ctx, output, &outl, input, length))
+	if (!EVP_DecryptUpdate(ctx, output, &outl, input, length))
 		goto out;
 
-	if (!EVP_DecryptFinal_ex(&ctx, output + outl, &outl_tmp))
-		goto out;
-
-	if (!EVP_CIPHER_CTX_cleanup(&ctx))
+	if (!EVP_DecryptFinal_ex(ctx, output + outl, &outl_tmp))
 		goto out;
 
 	r = SC_SUCCESS;
 out:
+	if (ctx)
+		EVP_CIPHER_CTX_free(ctx);
 	return r;
 }
 

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -265,21 +265,33 @@ static int
 openssl_dig(const EVP_MD * digest, const unsigned char *input, size_t length,
 		unsigned char *output)
 {
-	EVP_MD_CTX ctx;
+	int r = 0;
+	EVP_MD_CTX *ctx = NULL;
 	unsigned outl = 0;
 
-	EVP_MD_CTX_init(&ctx);
-	EVP_DigestInit_ex(&ctx, digest, NULL);
-	if (!EVP_DigestUpdate(&ctx, input, length))
-		return SC_ERROR_INTERNAL;
+	ctx = EVP_MD_CTX_create();
+	if (ctx == NULL) {
+	    r = SC_ERROR_OUT_OF_MEMORY;
+	    goto err;
+	}
+	    
+	EVP_MD_CTX_init(ctx);
+	EVP_DigestInit_ex(ctx, digest, NULL);
+	if (!EVP_DigestUpdate(ctx, input, length)) {
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
 
-	if (!EVP_DigestFinal_ex(&ctx, output, &outl))
-		return SC_ERROR_INTERNAL;
+	if (!EVP_DigestFinal_ex(ctx, output, &outl)) {
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
+	r = SC_SUCCESS;
+err:
+	if (ctx)
+		EVP_MD_CTX_destroy(ctx);
 
-	if (!EVP_MD_CTX_cleanup(&ctx))
-		return SC_ERROR_INTERNAL;
-
-	return SC_SUCCESS;
+	return r;
 }
 
 

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1859,7 +1859,7 @@ static int gids_authenticate_admin(sc_card_t *card, u8* key) {
 #ifndef ENABLE_OPENSSL
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_NOT_SUPPORTED);
 #else
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX *ctx = NULL;
 	int r;
 	u8 apduSetRandom[20] = {0x7C,0x12,0x81,0x10,0};
 	u8* randomR1 = apduSetRandom + 4;
@@ -1877,8 +1877,6 @@ static int gids_authenticate_admin(sc_card_t *card, u8* key) {
 	const EVP_CIPHER *cipher;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	// init crypto
-	EVP_CIPHER_CTX_init(&ctx);
 	// this is CBC instead of ECB
 	cipher = EVP_des_ede3_cbc();
 	if (!cipher) {
@@ -1919,21 +1917,28 @@ static int gids_authenticate_admin(sc_card_t *card, u8* key) {
 	memcpy(buffer, randomR2, 16);
 	memcpy(buffer+16, randomR1, 16);
 	memcpy(buffer+32, z1, sizeof(z1));
-	if (!EVP_EncryptInit(&ctx, cipher, key, NULL)) {
-		EVP_CIPHER_CTX_cleanup(&ctx);
+	// init crypto
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL) {
+	    SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
+	}
+
+	if (!EVP_EncryptInit(ctx, cipher, key, NULL)) {
+		EVP_CIPHER_CTX_free(ctx);
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 	}
-	EVP_CIPHER_CTX_set_padding(&ctx,0);
-	if (!EVP_EncryptUpdate(&ctx, buffer2, &buffer2size, buffer, sizeof(buffer))) {
-		EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_set_padding(ctx,0);
+	if (!EVP_EncryptUpdate(ctx, buffer2, &buffer2size, buffer, sizeof(buffer))) {
+		EVP_CIPHER_CTX_free(ctx);
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 	}
 
-	if(!EVP_EncryptFinal(&ctx, buffer2+buffer2size, &buffer2size)) {
-		EVP_CIPHER_CTX_cleanup(&ctx);
+	if(!EVP_EncryptFinal(ctx, buffer2+buffer2size, &buffer2size)) {
+		EVP_CIPHER_CTX_free(ctx);
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 	}
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
+	ctx = NULL;
 	// send it to the card
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, INS_GENERAL_AUTHENTICATE, 0x00, 0x00);
 	apdu.lc = sizeof(apduSendReponse);

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -912,7 +912,7 @@ gpk_set_filekey(const u8 *key, const u8 *challenge,
 #endif
 	if (r == SC_SUCCESS) {
 #if OPENSSL_VERSION_NUMBER  <  0x10100000L
-		r =EVP_CIPHER_CTX_init(ctx);
+		EVP_CIPHER_CTX_init(ctx);
 #endif
 		EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, out, NULL);
 		if (!EVP_EncryptUpdate(ctx, kats+8, &outl, r_rn+4, 8))

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -941,7 +941,7 @@ gpk_select_key(sc_card_t *card, int key_sfi, const u8 *buf, size_t buflen)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
 	/* now do the SelFk */
-	RAND_pseudo_bytes(rnd, sizeof(rnd));
+	RAND_bytes(rnd, sizeof(rnd));
 	memset(&apdu, 0, sizeof(apdu));
 	apdu.cla = 0x80;
 	apdu.cse = SC_APDU_CASE_4_SHORT;

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -731,7 +731,12 @@ gpk_compute_crycks(sc_card_t *card, sc_apdu_t *apdu,
 	u8		in[8], out[8], block[64];
 	unsigned int	len = 0, i;
 	int             r = SC_SUCCESS, outl;
-	EVP_CIPHER_CTX  ctx;
+	EVP_CIPHER_CTX  *ctx = NULL;
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL)
+		return SC_ERROR_INTERNAL; 
+
 
 	/* Fill block with 0x00 and then with the data. */
 	memset(block, 0x00, sizeof(block));
@@ -748,16 +753,17 @@ gpk_compute_crycks(sc_card_t *card, sc_apdu_t *apdu,
 	/* Set IV */
 	memset(in, 0x00, 8);
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, EVP_des_ede_cbc(), NULL, priv->key, in);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	EVP_CIPHER_CTX_init(ctx);
+#endif
+	EVP_EncryptInit_ex(ctx, EVP_des_ede_cbc(), NULL, priv->key, in);
 	for (i = 0; i < len; i += 8) {
-		if (!EVP_EncryptUpdate(&ctx, out, &outl, &block[i], 8)) {
+		if (!EVP_EncryptUpdate(ctx, out, &outl, &block[i], 8)) {
 			r = SC_ERROR_INTERNAL;
 			break;
 		}
 	}
-	if (!EVP_CIPHER_CTX_cleanup(&ctx))
-		r = SC_ERROR_INTERNAL;
+	EVP_CIPHER_CTX_free(ctx);
 
 	memcpy((u8 *) (apdu->data + apdu->datalen), out + 5, 3);
 	apdu->datalen += 3;
@@ -883,25 +889,40 @@ gpk_set_filekey(const u8 *key, const u8 *challenge,
 		const u8 *r_rn, u8 *kats)
 {
 	int			r = SC_SUCCESS, outl;
-	EVP_CIPHER_CTX		ctx;
+	EVP_CIPHER_CTX		* ctx = NULL;
 	u8                      out[16];
 
 	memcpy(out, key+8, 8);
 	memcpy(out+8, key, 8);
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, key, NULL);
-	if (!EVP_EncryptUpdate(&ctx, kats, &outl, r_rn+4, 8))
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL)
+		return SC_ERROR_INTERNAL;
+
+	EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, key, NULL);
+	if (!EVP_EncryptUpdate(ctx, kats, &outl, r_rn+4, 8))
 		r = SC_ERROR_INTERNAL;
-	if (!EVP_CIPHER_CTX_cleanup(&ctx))
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	    /* In OpenSSL 1.1 _init and _cleanup are both done by _reset */
+	    EVP_CIPHER_CTX_reset(ctx);
+#else
+	if (!EVP_CIPHER_CTX_cleanup(ctx))
 		r = SC_ERROR_INTERNAL;
+#endif
 	if (r == SC_SUCCESS) {
-		EVP_CIPHER_CTX_init(&ctx);
-		EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, out, NULL);
-		if (!EVP_EncryptUpdate(&ctx, kats+8, &outl, r_rn+4, 8))
+#if OPENSSL_VERSION_NUMBER  <  0x10100000L
+		r =EVP_CIPHER_CTX_init(ctx);
+#endif
+		EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, out, NULL);
+		if (!EVP_EncryptUpdate(ctx, kats+8, &outl, r_rn+4, 8))
 			r = SC_ERROR_INTERNAL;
-		if (!EVP_CIPHER_CTX_cleanup(&ctx))
-			r = SC_ERROR_INTERNAL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	    EVP_CIPHER_CTX_reset(ctx);
+#else
+	if (!EVP_CIPHER_CTX_cleanup(ctx))
+		r = SC_ERROR_INTERNAL;
+#endif
 	}
 	memset(out, 0, sizeof(out));
 
@@ -910,12 +931,13 @@ gpk_set_filekey(const u8 *key, const u8 *challenge,
 	 * here? INVALID_ARGS doesn't seem quite right
 	 */
 	if (r == SC_SUCCESS) {
-		EVP_CIPHER_CTX_init(&ctx);
-		EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, kats, NULL);
-		if (!EVP_EncryptUpdate(&ctx, out, &outl, challenge, 8))
+#if OPENSSL_VERSION_NUMBER  < 0x10100000L
+		EVP_CIPHER_CTX_init(ctx);
+#endif
+		EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, kats, NULL);
+		if (!EVP_EncryptUpdate(ctx, out, &outl, challenge, 8))
 			r = SC_ERROR_INTERNAL;
-		if (!EVP_CIPHER_CTX_cleanup(&ctx))
-			r = SC_ERROR_INTERNAL;
+		EVP_CIPHER_CTX_free(ctx);
 		if (memcmp(r_rn, out+4, 4) != 0)
 			r = SC_ERROR_INVALID_ARGUMENTS;
 	}
@@ -1509,10 +1531,14 @@ gpk_pkfile_load(sc_card_t *card, struct sc_cardctl_gpk_pkload *args)
 	unsigned int	n;
 	u8		temp[256];
 	int		r = SC_SUCCESS, outl;
-	EVP_CIPHER_CTX  ctx;
+	EVP_CIPHER_CTX  * ctx;
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "gpk_pkfile_load(fid=%04x, len=%d, datalen=%d)\n",
 			args->file->id, args->len, args->datalen);
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL)
+		return SC_ERROR_INTERNAL;
 
 	if (0) {
 		char buf[2048];
@@ -1539,16 +1565,14 @@ gpk_pkfile_load(sc_card_t *card, struct sc_cardctl_gpk_pkload *args)
 		return SC_ERROR_SECURITY_STATUS_NOT_SATISFIED;
 	}
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, priv->key, NULL);
+	EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, priv->key, NULL);
 	for (n = 0; n < args->datalen; n += 8) {
-		if (!EVP_EncryptUpdate(&ctx, temp+n, &outl, args->data + n, 8)) {
+		if (!EVP_EncryptUpdate(ctx, temp+n, &outl, args->data + n, 8)) {
 			r = SC_ERROR_INTERNAL;
 			break;
 		}
 	}
-	if (!EVP_CIPHER_CTX_cleanup(&ctx) || r != SC_SUCCESS)
-		return SC_ERROR_INTERNAL;
+	EVP_CIPHER_CTX_free(ctx);
 
 	apdu.data = temp;
 	apdu.datalen = args->datalen;

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -1344,19 +1344,23 @@ auth_update_component(struct sc_card *card, struct auth_update_component_info *a
 		int outl;
 		const unsigned char in[8] = {0,0,0,0,0,0,0,0};
 		unsigned char out[8];
-		EVP_CIPHER_CTX ctx;
+		EVP_CIPHER_CTX  * ctx = NULL;
 
 		if (args->len!=8 && args->len!=24)
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 
+		ctx = EVP_CIPHER_CTX_new();
+		if (ctx == NULL) 
+		    SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL,SC_ERROR_OUT_OF_MEMORY);
+
 		p2 = 0;
-		EVP_CIPHER_CTX_init(&ctx);
 		if (args->len == 24)
-			EVP_EncryptInit_ex(&ctx, EVP_des_ede(), NULL, args->data, NULL);
+			EVP_EncryptInit_ex(ctx, EVP_des_ede(), NULL, args->data, NULL);
 		else
-			EVP_EncryptInit_ex(&ctx, EVP_des_ecb(), NULL, args->data, NULL);
-		rv = EVP_EncryptUpdate(&ctx, out, &outl, in, 8);
-		if (!EVP_CIPHER_CTX_cleanup(&ctx) || rv == 0) {
+			EVP_EncryptInit_ex(ctx, EVP_des_ecb(), NULL, args->data, NULL);
+		rv = EVP_EncryptUpdate(ctx, out, &outl, in, 8);
+		EVP_CIPHER_CTX_free(ctx);
+		if (rv == 0) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "OpenSSL encryption error.");
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 		}

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1556,14 +1556,19 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	size_t challenge_response_len;
 	u8 *decrypted_reponse = NULL;
 	size_t decrypted_reponse_len;
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX * ctx = NULL;
 
 	u8 sbuf[255];
 	const EVP_CIPHER *cipher;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	EVP_CIPHER_CTX_init(&ctx);
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL) {
+		r = SC_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+
 	cipher = get_cipher_for_algo(alg_id);
 	if(!cipher) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Invalid cipher selector, none found for:  %02x\n", alg_id);
@@ -1622,22 +1627,22 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	}
 
 	/* decrypt the data from the card */
-	if (!EVP_DecryptInit(&ctx, cipher, key, NULL)) {
+	if (!EVP_DecryptInit(ctx, cipher, key, NULL)) {
 		/* may fail if des parity of key is wrong. depends on OpenSSL options */
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	EVP_CIPHER_CTX_set_padding(&ctx,0);
+	EVP_CIPHER_CTX_set_padding(ctx,0);
 
 	p = plain_text;
-	if (!EVP_DecryptUpdate(&ctx, p, &N, witness_data, witness_len)) {
+	if (!EVP_DecryptUpdate(ctx, p, &N, witness_data, witness_len)) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
 	plain_text_len = tmplen = N;
 	p += tmplen;
 
-	if(!EVP_DecryptFinal(&ctx, p, &N)) {
+	if(!EVP_DecryptFinal(ctx, p, &N)) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
@@ -1746,24 +1751,28 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 		goto err;
 	}
 
-	EVP_CIPHER_CTX_cleanup(&ctx);
-	EVP_CIPHER_CTX_init(&ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	EVP_CIPHER_CTX_reset(ctx);
+#else
+	EVP_CIPHER_CTX_cleanup(ctx);
+	EVP_CIPHER_CTX_init(ctx);
+#endif
 
-	if (!EVP_DecryptInit(&ctx, cipher, key, NULL)) {
+	if (!EVP_DecryptInit(ctx, cipher, key, NULL)) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	EVP_CIPHER_CTX_set_padding(&ctx,0);
+	EVP_CIPHER_CTX_set_padding(ctx,0);
 
 	tmp = decrypted_reponse;
-	if (!EVP_DecryptUpdate(&ctx, tmp, &N, challenge_response, challenge_response_len)) {
+	if (!EVP_DecryptUpdate(ctx, tmp, &N, challenge_response, challenge_response_len)) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
 	decrypted_reponse_len = tmplen = N;
 	tmp += tmplen;
 
-	if(!EVP_DecryptFinal(&ctx, tmp, &N)) {
+	if(!EVP_DecryptFinal(ctx, tmp, &N)) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
@@ -1779,7 +1788,8 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	r = SC_SUCCESS;
 
 err:
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	if (ctx)
+		EVP_CIPHER_CTX_free(ctx);
 	if (locked)
 		sc_unlock(card);
 	if (rbuf)
@@ -1827,12 +1837,16 @@ static int piv_general_external_authenticate(sc_card_t *card,
 	size_t keylen = 0;
 	size_t cypher_text_len = 0;
 	u8 sbuf[255];
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX * ctx = NULL;
 	const EVP_CIPHER *cipher;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	EVP_CIPHER_CTX_init(&ctx);
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL) {
+	    r = SC_ERROR_OUT_OF_MEMORY;
+	    goto err;
+	}
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Selected cipher for algorithm id: %02x\n", alg_id);
 
@@ -1898,7 +1912,7 @@ static int piv_general_external_authenticate(sc_card_t *card,
 	tmplen = challenge_len;
 
 	/* Encrypt the challenge with the secret */
-	if (!EVP_EncryptInit(&ctx, cipher, key, NULL)) {
+	if (!EVP_EncryptInit(ctx, cipher, key, NULL)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Encrypt fail\n");
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -1911,15 +1925,15 @@ static int piv_general_external_authenticate(sc_card_t *card,
 		goto err;
 	}
 
-	EVP_CIPHER_CTX_set_padding(&ctx,0);
-	if (!EVP_EncryptUpdate(&ctx, cypher_text, &outlen, challenge_data, challenge_len)) {
+	EVP_CIPHER_CTX_set_padding(ctx,0);
+	if (!EVP_EncryptUpdate(ctx, cypher_text, &outlen, challenge_data, challenge_len)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Encrypt update fail\n");
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
 	cypher_text_len += outlen;
 
-	if (!EVP_EncryptFinal(&ctx, cypher_text + cypher_text_len, &outlen)) {
+	if (!EVP_EncryptFinal(ctx, cypher_text + cypher_text_len, &outlen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Final fail\n");
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -1979,7 +1993,8 @@ static int piv_general_external_authenticate(sc_card_t *card,
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Got response  challenge\n");
 
 err:
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	if (ctx)
+		EVP_CIPHER_CTX_free(ctx);
 
 	if (locked)
 		sc_unlock(card);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1751,12 +1751,7 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 		goto err;
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	EVP_CIPHER_CTX_reset(ctx);
-#else
 	EVP_CIPHER_CTX_cleanup(ctx);
-	EVP_CIPHER_CTX_init(ctx);
-#endif
 
 	if (!EVP_DecryptInit(ctx, cipher, key, NULL)) {
 		r = SC_ERROR_INTERNAL;

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -1182,11 +1182,8 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 	}
 
 	/* pkcs11 reset openssl functions */
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
 	rsa->meth = RSA_PKCS1_OpenSSL();
-#else
-	rsa->meth = RSA_PKCS1_SSLeay();
-#endif
+
 	if ((size_t)RSA_size(rsa) > outlen) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Buffer too small\n");
 		r = SC_ERROR_OUT_OF_MEMORY;

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -1182,7 +1182,11 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 	}
 
 	/* pkcs11 reset openssl functions */
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+	rsa->meth = RSA_PKCS1_OpenSSL();
+#else
 	rsa->meth = RSA_PKCS1_SSLeay();
+#endif
 	if ((size_t)RSA_size(rsa) > outlen) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Buffer too small\n");
 		r = SC_ERROR_OUT_OF_MEMORY;

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -39,8 +39,11 @@
 
 #include "cwa-dnie.h"
 
+#include <openssl/ossl_typ.h>
+#include <openssl/bn.h>
 #include <openssl/x509.h>
 #include <openssl/evp.h>
+#include <openssl/rsa.h>
 
 #define MAX_RESP_BUFFER_SIZE 2048
 

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -36,6 +36,8 @@
 #include "opensc.h"
 #include "cardctl.h"
 #include "internal.h"
+#include <openssl/rsa.h>
+#include <openssl/bn.h>
 #include <openssl/x509.h>
 #include <openssl/des.h>
 #include <openssl/rand.h>

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -1321,8 +1321,13 @@ int cwa_create_secure_channel(sc_card_t * card,
 
 	/* verify received signature */
 	sc_log(ctx, "Verify Internal Auth command response");
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	res = cwa_verify_internal_auth(card, EVP_PKEY_get0_RSA(icc_pubkey),	/* evaluated icc public key */
+				       EVP_PKEY_get0_RSA(ifd_privkey),	/* evaluated from DGP's Manual Annex 3 Data */
+# else
 	res = cwa_verify_internal_auth(card, icc_pubkey->pkey.rsa,	/* evaluated icc public key */
 				       ifd_privkey->pkey.rsa,	/* evaluated from DGP's Manual Annex 3 Data */
+#endif
 				       rndbuf,	/* RND.IFD || SN.IFD */
 				       16,	/* rndbuf length; should be 16 */
 				       sm	/* sm data */
@@ -1342,8 +1347,13 @@ int cwa_create_secure_channel(sc_card_t * card,
 
 	/* compose signature data for external auth */
 	res = cwa_prepare_external_auth(card,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+					EVP_PKEY_get1_RSA(icc_pubkey),
+					EVP_PKEY_get1_RSA(ifd_privkey), sn_icc, sm);
+#else
 					icc_pubkey->pkey.rsa,
 					ifd_privkey->pkey.rsa, sn_icc, sm);
+#endif
 	if (res != SC_SUCCESS) {
 		msg = "Prepare external auth failed";
 		goto csc_end;

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -1321,13 +1321,8 @@ int cwa_create_secure_channel(sc_card_t * card,
 
 	/* verify received signature */
 	sc_log(ctx, "Verify Internal Auth command response");
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
 	res = cwa_verify_internal_auth(card, EVP_PKEY_get0_RSA(icc_pubkey),	/* evaluated icc public key */
 				       EVP_PKEY_get0_RSA(ifd_privkey),	/* evaluated from DGP's Manual Annex 3 Data */
-# else
-	res = cwa_verify_internal_auth(card, icc_pubkey->pkey.rsa,	/* evaluated icc public key */
-				       ifd_privkey->pkey.rsa,	/* evaluated from DGP's Manual Annex 3 Data */
-#endif
 				       rndbuf,	/* RND.IFD || SN.IFD */
 				       16,	/* rndbuf length; should be 16 */
 				       sm	/* sm data */
@@ -1347,13 +1342,8 @@ int cwa_create_secure_channel(sc_card_t * card,
 
 	/* compose signature data for external auth */
 	res = cwa_prepare_external_auth(card,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-					EVP_PKEY_get1_RSA(icc_pubkey),
-					EVP_PKEY_get1_RSA(ifd_privkey), sn_icc, sm);
-#else
-					icc_pubkey->pkey.rsa,
-					ifd_privkey->pkey.rsa, sn_icc, sm);
-#endif
+					EVP_PKEY_get0_RSA(icc_pubkey),
+					EVP_PKEY_get0_RSA(ifd_privkey), sn_icc, sm);
 	if (res != SC_SUCCESS) {
 		msg = "Prepare external auth failed";
 		goto csc_end;

--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -40,6 +40,10 @@ extern "C" {
 #include "libopensc/log.h"
 #include "libopensc/cards.h"
 
+#ifdef ENABLE_OPENSSL
+#include "libopensc/sc-ossl-compat.h"
+#endif
+
 #define SC_FILE_MAGIC			0x14426950
 
 #ifndef _WIN32

--- a/src/libopensc/p15card-helper.c
+++ b/src/libopensc/p15card-helper.c
@@ -25,6 +25,7 @@
 #ifdef ENABLE_OPENSSL	/* empty file without openssl */
 #include <string.h>
 #include <stdlib.h>
+#include <openssl/bn.h>
 #include <openssl/bio.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>

--- a/src/libopensc/p15card-helper.c
+++ b/src/libopensc/p15card-helper.c
@@ -171,22 +171,15 @@ CERT_HANDLE_FUNCTION(default_cert_handle) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-	rsa = EVP_PKEY_get1_RSA(pkey);
-#else
-	rsa = pkey->pkey.rsa;
-#endif
+	rsa = EVP_PKEY_get0_RSA(pkey);
 	if( rsa == NULL) {
 		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "Error: no modulus associated with the certificate");
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
 	
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-	modulus_len = BN_num_bits(rsa->n); /* converting to bits */
-#else
-	modulus_len = 8 * BN_num_bytes(pkey->pkey.rsa->n); /* converting to bits */
-#endif
+	modulus_len =  BN_num_bits(rsa->n); /* converting to bits */
+
 	/* printf("Key Size: %d bits\n\n", modulus_len); */
 	/* cached_cert->modulusLength = modulus_len; */
 	

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -41,6 +41,7 @@
 #include "common/compat_strlcat.h"
 
 #ifdef ENABLE_OPENSSL
+#include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #endif
 
@@ -242,11 +243,20 @@ static int itacns_add_cert(sc_pkcs15_card_t *p15card,
 	sc_pkcs15_free_certificate(cert);
 	if (!x509) return SC_SUCCESS;
 	X509_check_purpose(x509, -1, 0);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+	if(X509_get_extension_flags(x509) & EXFLAG_KUSAGE) {
+		*ext_info_ok = 1;
+		*key_usage = X509_get_key_usage(x509);
+		*x_key_usage = X509_get_extended_key_usage(x509);
+	}
+#else
 	if(x509->ex_flags & EXFLAG_KUSAGE) {
 		*ext_info_ok = 1;
 		*key_usage = x509->ex_kusage;
 		*x_key_usage = x509->ex_xkusage;
 	}
+#endif
 	OPENSSL_free(x509);
 
 	return SC_SUCCESS;

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -30,13 +30,20 @@
 #include <config.h>
 #endif
 
-#include "pkcs15.h"
-#include "log.h"
-#include "cards.h"
-#include "itacns.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+
+#ifdef ENABLE_OPENSSL
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#endif
+
+#include "libopensc/internal.h"
+#include "libopensc/pkcs15.h"
+#include "libopensc/log.h"
+#include "libopensc/cards.h"
+#include "libopensc/itacns.h"
 #include "common/compat_strlcpy.h"
 #include "common/compat_strlcat.h"
 
@@ -244,19 +251,11 @@ static int itacns_add_cert(sc_pkcs15_card_t *p15card,
 	if (!x509) return SC_SUCCESS;
 	X509_check_purpose(x509, -1, 0);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
 	if(X509_get_extension_flags(x509) & EXFLAG_KUSAGE) {
 		*ext_info_ok = 1;
 		*key_usage = X509_get_key_usage(x509);
 		*x_key_usage = X509_get_extended_key_usage(x509);
 	}
-#else
-	if(x509->ex_flags & EXFLAG_KUSAGE) {
-		*ext_info_ok = 1;
-		*key_usage = x509->ex_kusage;
-		*x_key_usage = x509->ex_xkusage;
-	}
-#endif
 	OPENSSL_free(x509);
 
 	return SC_SUCCESS;

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -36,6 +36,9 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 	#ifndef OPENSSL_NO_EC
 	#include <openssl/ec.h>

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -27,11 +27,6 @@
 #include <stdio.h>
 #include <assert.h>
 
-#include "internal.h"
-#include "asn1.h"
-#include "pkcs15.h"
-#include "common/compat_strlcpy.h"
-
 #ifdef ENABLE_OPENSSL
 #include <openssl/opensslv.h>
 #include <openssl/bn.h>
@@ -47,6 +42,11 @@
 	#endif
 #endif
 #endif
+
+#include "libopensc/internal.h"
+#include "libopensc/asn1.h"
+#include "libopensc/pkcs15.h"
+#include "common/compat_strlcpy.h"
 
 /*
  * in src/libopensc/types.h SC_MAX_SUPPORTED_ALGORITHMS  defined as 8
@@ -628,11 +628,8 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 #ifdef ENABLE_OPENSSL
 	EVP_PKEY *pk = (EVP_PKEY *)evp_key;
 	int pk_type;
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
 	 pk_type = EVP_PKEY_base_id(pk);
-#else
-	pk_type = pk->type;
-#endif
+
 	switch (pk_type) {
 	case EVP_PKEY_RSA: {
 		struct sc_pkcs15_prkey_rsa *dst = &pkcs15_key->u.rsa;

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -33,6 +33,8 @@
 #include "common/compat_strlcpy.h"
 
 #ifdef ENABLE_OPENSSL
+#include <openssl/opensslv.h>
+#include <openssl/bn.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -627,8 +627,13 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 {
 #ifdef ENABLE_OPENSSL
 	EVP_PKEY *pk = (EVP_PKEY *)evp_key;
-
-	switch (pk->type) {
+	int pk_type;
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	 pk_type = EVP_PKEY_base_id(pk);
+#else
+	pk_type = pk->type;
+#endif
+	switch (pk_type) {
 	case EVP_PKEY_RSA: {
 		struct sc_pkcs15_prkey_rsa *dst = &pkcs15_key->u.rsa;
 		RSA *src = EVP_PKEY_get1_RSA(pk);

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -34,10 +34,6 @@
 #include <unistd.h>
 #endif
 
-#include "internal.h"
-#include "asn1.h"
-#include "pkcs15.h"
-
 #ifdef ENABLE_OPENSSL
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
@@ -50,6 +46,11 @@
 #endif
 #endif
 #endif
+
+#include "libopensc/internal.h"
+#include "libopensc/asn1.h"
+#include "libopensc/pkcs15.h"
+
 
 #define C_ASN1_PKINFO_ATTR_SIZE 3
 static const struct sc_asn1_entry c_asn1_pkinfo[C_ASN1_PKINFO_ATTR_SIZE] = {
@@ -1531,11 +1532,8 @@ sc_pkcs15_convert_pubkey(struct sc_pkcs15_pubkey *pkcs15_key, void *evp_key)
 #ifdef ENABLE_OPENSSL
 	EVP_PKEY *pk = (EVP_PKEY *)evp_key;
 	int pk_type;
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
 	pk_type = EVP_PKEY_base_id(pk);
-#else
-	pk_type = pk->type;
- #endif
+
 	switch (pk_type) {
 	case EVP_PKEY_RSA: {
 		struct sc_pkcs15_pubkey_rsa *dst = &pkcs15_key->u.rsa;

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1530,8 +1530,13 @@ sc_pkcs15_convert_pubkey(struct sc_pkcs15_pubkey *pkcs15_key, void *evp_key)
 {
 #ifdef ENABLE_OPENSSL
 	EVP_PKEY *pk = (EVP_PKEY *)evp_key;
-
-	switch (pk->type) {
+	int pk_type;
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	pk_type = EVP_PKEY_base_id(pk);
+#else
+	pk_type = pk->type;
+ #endif
+	switch (pk_type) {
 	case EVP_PKEY_RSA: {
 		struct sc_pkcs15_pubkey_rsa *dst = &pkcs15_key->u.rsa;
 		RSA *src = EVP_PKEY_get1_RSA(pk);

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -39,6 +39,7 @@
 #include "pkcs15.h"
 
 #ifdef ENABLE_OPENSSL
+#include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 #include <openssl/evp.h>

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -31,25 +31,67 @@ extern "C" {
 
 /*
  * Provide backward compatability to older versions of OpenSSL
- * while using OpenSSL 1.1  API
+ * while using most of OpenSSL 1.1  API
  */
 
-#if OPENSSL_VERSION_NUMBER =< 0x00907000L
+/*
+ * EVP_CIPHER_CTX functions:
+ * EVP_CIPHER_CTX_new	    not in 0.9.7
+ * EVP_CIPHER_CTX_free	    not in 0.9.7
+ * EVP_CIPHER_CTX_init	    in 0.9.7 to 1.0.2. defined in 1.1 as EVP_CIPHER_CTX_reset
+ * EVP_CIPHER_CTX_cleanup   in 0.9.7 to 1.0.2, defined in 1.1 as EVP_CIPHER_CTX_reset
+ * EVP_CIPHER_CTX_reset	    only in 1.1
+ *
+ * EVP_CIPHER_CTX_new	    does a EVP_CIPHER_CTX_init
+ * EVP_CIPHER_CTX_free	    does a EVP_CIPHER_CTX_cleanup
+ * EVP_CIPHER_CTX_cleanup   does equivelent of a EVP_CIPHER_CTX_init
+ * Use EVP_CIPHER_CTX_new, EVP_CIPHER_CTX_free, and  EVP_CIPHER_CTX_cleanup between operations
+ */
+
+#if OPENSSL_VERSION_NUMBER  <= 0x009070dfL
 
 /* in 0.9.7  EVP_CIPHER_CTX was always allocated inline or in other structures */
 
 #define EVP_CIPHER_CTX_new() ({ \
-    EVP_CIPHER_CTX * tmp = NULL; \
-    tmp = OPENSSL_malloc(sizeof(struct evp_cipher_ctx_st); \
-    if (tmp) { \
+	EVP_CIPHER_CTX * tmp = NULL; \
+	tmp = OPENSSL_malloc(sizeof(struct evp_cipher_ctx_st)); \
+	if (tmp) { \
 	EVP_CIPHER_CTX_init(tmp); \
-    } \
-    tmp; \
-    })
+	} \
+	tmp; \
+	})
 
-#define EVP_CIPHER_CTX_free(x) OPENSSL_free(x)
-
+#define EVP_CIPHER_CTX_free(x) ({ \
+	if (x) { \
+		EVP_CIPHER_CTX_cleanup(x); \
+		OPENSSL_free(x); \
+	} \
+	})
 #endif /* OPENSSL_VERSION_NUMBER =< 0x00907000L */
+
+/*
+ * 1.1 renames RSA_PKCS1_SSLeay to RSA_PKCS1_OpenSSL
+ * use RSA_PKCS1_OpenSSL
+ * Previous versions are missing a number of functions to access
+ * some hidden structures. Define them here:
+ */
+
+#if OPENSSL_VERSION_NUMBER < 0x10001000L
+#define EVP_PKEY_base_id(x)		(x->type)
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define RSA_PKCS1_OpenSSL		RSA_PKCS1_SSLeay
+#define OPENSSL_malloc_init		CRYPTO_malloc_init
+
+#define EVP_PKEY_get0_RSA(x)		(x->pkey.rsa)
+#define EVP_PKEY_get0_DSA(x)		(x->pkey.dsa)
+#define X509_get_extension_flags(x)	(x->ex_flags)
+#define X509_get_key_usage(x)		(x->ex_kusage)
+#define X509_get_extended_key_usage(x)	(x->ex_xkusage)
+#define EVP_PKEY_up_ref(user_key)	CRYPTO_add(&user_key->references, 1, CRYPTO_LOCK_EVP_PKEY)
+#define X509_up_ref(cert)		CRYPTO_add(&cert->references, 1, CRYPTO_LOCK_X509)
+#endif 
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -1,0 +1,59 @@
+/*
+ * sc-ossl-compat.h: OpenSC ecompatability for older OpenSSL versions
+ *
+ * Copyright (C) 2016	Douglas E. Engert <deengert@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _SC_OSSL_COMPAT_H
+#define _SC_OSSL_COMPAT_H
+
+#ifdef ENABLE_OPENSSL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <openssl/opensslv.h>
+
+/*
+ * Provide backward compatability to older versions of OpenSSL
+ * while using OpenSSL 1.1  API
+ */
+
+#if OPENSSL_VERSION_NUMBER =< 0x00907000L
+
+/* in 0.9.7  EVP_CIPHER_CTX was always allocated inline or in other structures */
+
+#define EVP_CIPHER_CTX_new() ({ \
+    EVP_CIPHER_CTX * tmp = NULL; \
+    tmp = OPENSSL_malloc(sizeof(struct evp_cipher_ctx_st); \
+    if (tmp) { \
+	EVP_CIPHER_CTX_init(tmp); \
+    } \
+    tmp; \
+    })
+
+#define EVP_CIPHER_CTX_free(x) OPENSSL_free(x)
+
+#endif /* OPENSSL_VERSION_NUMBER =< 0x00907000L */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ENABLE_OPENSSL */
+#endif

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -9,6 +9,7 @@
 
 #ifdef ENABLE_OPENSSL		/* empty file without openssl */
 #include <string.h>
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/rsa.h>

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -171,17 +171,22 @@ void
 sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE)
-	void (*locking_cb)(int, int, const char *, int);
 	ENGINE *e;
+/* crypto locking removed in 1.1 */
+#if OPENSSL_VERSION_NUMBER  < 0x10100000L
+	void (*locking_cb)(int, int, const char *, int);
 
 	locking_cb = CRYPTO_get_locking_callback();
 	if (locking_cb)
 		CRYPTO_set_locking_callback(NULL);
+#endif
 
 	e = ENGINE_by_id("gost");
 	if (!e)
 	{
 #if !defined(OPENSSL_NO_STATIC_ENGINE) && !defined(OPENSSL_NO_GOST)
+
+/* ENGINE_load_gost removed in 1.1 */
 #if OPENSSL_VERSION_NUMBER  < 0x10100000L
 		ENGINE_load_gost();
 #endif
@@ -205,8 +210,10 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 		ENGINE_free(e);
 	}
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	if (locking_cb)
 		CRYPTO_set_locking_callback(locking_cb);
+#endif
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE) */
 
 	openssl_sha1_mech.mech_data = EVP_sha1();

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -182,7 +182,9 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 	if (!e)
 	{
 #if !defined(OPENSSL_NO_STATIC_ENGINE) && !defined(OPENSSL_NO_GOST)
+#if OPENSSL_VERSION_NUMBER  < 0x10100000L
 		ENGINE_load_gost();
+#endif
 		e = ENGINE_by_id("gost");
 #else
 		/* try to load dynamic gost engine */

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -27,12 +27,13 @@
 #include <sys/types.h>
 
 #include "config.h"
+#include "pkcs15-oberthur.h"
+
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/log.h"
 #include "profile.h"
 #include "pkcs15-init.h"
-#include "pkcs15-oberthur.h"
 #include "libopensc/asn1.h"
 
 #ifdef ENABLE_OPENSSL

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -996,6 +996,20 @@ awp_encode_cert_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 	/*
 	 * serial number
 	 */
+#if 1
+	
+	/* TODO the der encoding of a ANS1_INTEGER is a TLV, the original code only as using the 
+	 * i2c_ASN1_INTEGER which is not in OpenSSL 1.1  
+	 * It was adding the tag V_ASN1_INTEGER and the one byte length back in in effect creating
+	 * a DER encoded ASN1_INTEGER
+	 * So we can simplifty the code and make compatable with OpenSSL 1.1. This needs to be tested
+	 */
+	ci->serial.value = NULL;
+	r = ci->serial.len = i2d_ASN1_INTEGER(X509_get_serialNumber(x), &ci->serial.value);
+	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL, "AWP encode cert failed: cannot get serialNumber");
+
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "cert. serial encoded length %i", ci->serial.len - 2);
+#else
 	do   {
 		int encoded_len;
 		unsigned char encoded[0x40], *encoded_ptr;
@@ -1015,6 +1029,7 @@ awp_encode_cert_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 
 		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "cert. serial encoded length %i", encoded_len);
 	} while (0);
+#endif
 
 	ci->x509 = X509_dup(x);
 done:

--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -20,20 +20,20 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+//#include "config.h"
+#include "pkcs15-oberthur.h"
+//#include <errno.h>
+//#include <stdio.h>
+//#include <stdlib.h>
+//#include <string.h>
 #include <sys/types.h>
 #include <ctype.h>
 
-#include "config.h"
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/log.h"
 #include "profile.h"
 #include "pkcs15-init.h"
-#include "pkcs15-oberthur.h"
 
 #define COSM_TITLE "OberthurAWP"
 

--- a/src/pkcs15init/pkcs15-oberthur.h
+++ b/src/pkcs15init/pkcs15-oberthur.h
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #ifdef ENABLE_OPENSSL
+#include <openssl/opensslv.h>
 #include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
@@ -17,6 +18,10 @@
 #include <openssl/rsa.h>
 #include <openssl/pkcs12.h>
 #include <openssl/x509v3.h>
+
+#include "profile.h"
+#include "libopensc/opensc.h"
+
 
 #define COSM_TLV_TAG		0x00
 

--- a/src/pkcs15init/pkcs15-westcos.c
+++ b/src/pkcs15init/pkcs15-westcos.c
@@ -26,6 +26,7 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/opensslv.h>
+#include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
@@ -255,7 +256,11 @@ static int westcos_pkcs15init_generate_key(sc_profile_t *profile,
 		goto out;
 	}
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+	rsa->meth = RSA_PKCS1_OpenSSL();
+#else
 	rsa->meth = RSA_PKCS1_SSLeay();
+#endif
 
 	if(pubkey != NULL)
 	{

--- a/src/pkcs15init/pkcs15-westcos.c
+++ b/src/pkcs15init/pkcs15-westcos.c
@@ -34,6 +34,7 @@
 #include <openssl/bio.h>
 #endif
 
+#include "libopensc/sc-ossl-compat.h"
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "pkcs15-init.h"
@@ -256,11 +257,7 @@ static int westcos_pkcs15init_generate_key(sc_profile_t *profile,
 		goto out;
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
 	rsa->meth = RSA_PKCS1_OpenSSL();
-#else
-	rsa->meth = RSA_PKCS1_SSLeay();
-#endif
 
 	if(pubkey != NULL)
 	{

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -36,6 +36,7 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
+#include "libopensc/sc-ossl-compat.h"
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/card-gids.h"
@@ -520,11 +521,8 @@ int main(int argc, char * const argv[])
 	}
 
 	/* OpenSSL magic */
-#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
 	OPENSSL_malloc_init();
-#else
-	CRYPTO_malloc_init();
-#endif
+
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
 

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -519,7 +519,12 @@ int main(int argc, char * const argv[])
 		}
 	}
 
+	/* OpenSSL magic */
+#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
+	OPENSSL_malloc_init();
+#else
 	CRYPTO_malloc_init();
+#endif
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
 

--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -144,9 +144,9 @@ static void show_certs(sc_card_t *card)
 			printf(", Len=%d\n", (q[2]<<8)|q[3]);
 			if((c=d2i_X509(NULL,&q,f->size))){
 				char buf2[2000];
-				X509_NAME_get_text_by_NID(c->cert_info->subject, NID_commonName, buf2,sizeof(buf2));
+				X509_NAME_get_text_by_NID(X509_get_subject_name(c), NID_commonName, buf2,sizeof(buf2));
 				printf("  Subject-CN: %s\n", buf2);
-				X509_NAME_get_text_by_NID(c->cert_info->issuer, NID_commonName, buf2,sizeof(buf2));
+				X509_NAME_get_text_by_NID(X509_get_issuer_name(c), NID_commonName, buf2,sizeof(buf2));
 				printf("  Issuer-CN:  %s\n", buf2);
 				X509_free(c);
 			} else printf("  Invalid Certificate-Data\n");

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -534,7 +534,11 @@ int main(int argc, char * const argv[])
 	if (action_count == 0)
 		util_print_usage_and_die(app_name, options, option_help, NULL);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+	OPENSSL_malloc_init();
+#else
 	CRYPTO_malloc_init();
+#endif
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
 

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -45,6 +45,7 @@
 #include <openssl/err.h>
 #include <openssl/obj_mac.h>
 
+#include "libopensc/sc-ossl-compat.h"
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/asn1.h"
@@ -534,11 +535,7 @@ int main(int argc, char * const argv[])
 	if (action_count == 0)
 		util_print_usage_and_die(app_name, options, option_help, NULL);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
 	OPENSSL_malloc_init();
-#else
-	CRYPTO_malloc_init();
-#endif
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2239,7 +2239,12 @@ static int write_object(CK_SESSION_HANDLE session)
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_SUBJECT, cert.subject, cert.subject_len);
 			n_pubkey_attr++;
 		}
-		if (evp_key->type == EVP_PKEY_RSA) {
+#if OPENSSL_VERSION_NUMBER >=  0x10100003L
+		pk_type = EVP_PKEY_base_id(evp_key);
+#else
+		pk_type =  evp_key->type;
+#endif
+		if (pk_type == EVP_PKEY_RSA) {
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_KEY_TYPE, &type, sizeof(type));
 			n_pubkey_attr++;
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_MODULUS,
@@ -2250,7 +2255,7 @@ static int write_object(CK_SESSION_HANDLE session)
 			n_pubkey_attr++;
 		}
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
-		else if (evp_key->type == EVP_PKEY_EC)   {
+		else if (pk_type == EVP_PKEY_EC)   {
 			type = CKK_EC;
 
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_KEY_TYPE, &type, sizeof(type));
@@ -2260,7 +2265,7 @@ static int write_object(CK_SESSION_HANDLE session)
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_VALUE, gost.public.value, gost.public.len);
 			n_pubkey_attr++;
 		}
-		else if (evp_key->type == NID_id_GostR3410_2001) {
+		else if (pk_type == NID_id_GostR3410_2001) {
 			type = CKK_GOSTR3410;
 
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_KEY_TYPE, &type, sizeof(type));

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -37,6 +37,7 @@
 #include <openssl/opensslv.h>
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/opensslconf.h>
+//#include <openssl/crypto.h>
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x00907000L
 #include <openssl/conf.h>
@@ -449,10 +450,11 @@ int main(int argc, char * argv[])
 	/* OpenSSL magic */
 #if OPENSSL_VERSION_NUMBER  >= 0x10100002L
 	OpenSSL_add_all_algorithms();
+	OPENSSL_malloc_init();
 #else
 	SSLeay_add_all_algorithms();
-#endif
 	CRYPTO_malloc_init();
+#endif
 #endif
 	while (1) {
 		c = getopt_long(argc, argv, "ILMOTa:bd:e:hi:klm:o:p:scvf:ty:w:z:r",

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -43,6 +43,8 @@
 #endif
 #include <openssl/evp.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/asn1t.h>
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L && !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_ECDSA)
@@ -445,7 +447,11 @@ int main(int argc, char * argv[])
 	OPENSSL_config(NULL);
 #endif
 	/* OpenSSL magic */
+#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
+	OpenSSL_add_all_algorithms();
+#else
 	SSLeay_add_all_algorithms();
+#endif
 	CRYPTO_malloc_init();
 #endif
 	while (1) {
@@ -1778,36 +1784,38 @@ static void	parse_certificate(struct x509cert_info *cert,
 		util_fatal("OpenSSL error during X509 certificate parsing");
 	}
 	/* check length first */
-	n = i2d_X509_NAME(x->cert_info->subject, NULL);
+	n = i2d_X509_NAME(X509_get_subject_name(x), NULL);
 	if (n < 0)
 		util_fatal("OpenSSL error while encoding subject name");
 	if (n > (int)sizeof (cert->subject))
 		util_fatal("subject name too long");
 	/* green light, actually do it */
 	p = cert->subject;
-	n = i2d_X509_NAME(x->cert_info->subject, &p);
+	n = i2d_X509_NAME(X509_get_subject_name(x), &p);
 	cert->subject_len = n;
 
 	/* check length first */
-	n = i2d_X509_NAME(x->cert_info->issuer, NULL);
+	n = i2d_X509_NAME(X509_get_issuer_name(x), NULL);
 	if (n < 0)
 		util_fatal("OpenSSL error while encoding issuer name");
 	if (n > (int)sizeof (cert->issuer))
 		util_fatal("issuer name too long");
 	/* green light, actually do it */
 	p = cert->issuer;
-	n = i2d_X509_NAME(x->cert_info->issuer, &p);
+	n =i2d_X509_NAME(X509_get_issuer_name(x), &p);
 	cert->issuer_len = n;
 
 	/* check length first */
-	n = i2d_ASN1_INTEGER(x->cert_info->serialNumber, NULL);
+	/* TODO fix this */
+	n = 0;
+	n = i2d_ASN1_INTEGER(X509_get_serialNumber(x), NULL);
 	if (n < 0)
 		util_fatal("OpenSSL error while encoding serial number");
 	if (n > (int)sizeof (cert->serialnum))
 		util_fatal("serial number too long");
 	/* green light, actually do it */
 	p = cert->serialnum;
-	n = i2d_ASN1_INTEGER(x->cert_info->serialNumber, &p);
+	n = i2d_ASN1_INTEGER(X509_get_serialNumber(x), &p);
 	cert->serialnum_len = n;
 }
 

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -432,10 +432,11 @@ main(int argc, char **argv)
 	/* OpenSSL magic */
 #if OPENSSL_VERSION_NUMBER  >= 0x10100002L
 	OpenSSL_add_all_algorithms();
+	OPENSSL_malloc_init();
 #else
 	SSLeay_add_all_algorithms();
-#endif
 	CRYPTO_malloc_init();
+#endif
 #ifdef RANDOM_POOL
 	if (!RAND_load_file(RANDOM_POOL, 32))
 		util_fatal("Unable to seed random number pool for key generation");

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -32,6 +32,10 @@
 #include <sys/stat.h>
 
 /* Requires openssl for dkek import */
+#include <openssl/opensslv.h>
+/* TODO many changes neede to use BIGNUM  correctly leave for someone else to fix */
+#if OPENSSL_VERSION_NUMBER < 0x10100002L
+
 #include <openssl/opensslconf.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
@@ -1696,3 +1700,10 @@ end:
 	ERR_print_errors_fp(stderr);
 	return err;
 }
+#else /* OPENSSL_VERSION_NUMBER */
+#warning "TODO Fix BIGNUM usage for OpenSSL 1.1"
+int main (){
+printf("not implemented needs BIGNUM changes\n");
+return 1;
+}
+#endif /* OPENSSL_VERSION_NUMBER */

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -33,8 +33,6 @@
 
 /* Requires openssl for dkek import */
 #include <openssl/opensslv.h>
-/* TODO many changes neede to use BIGNUM  correctly leave for someone else to fix */
-#if OPENSSL_VERSION_NUMBER < 0x10100002L
 
 #include <openssl/opensslconf.h>
 #include <openssl/bio.h>
@@ -43,6 +41,7 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 
+#include "libopensc/sc-ossl-compat.h"
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/asn1.h"
@@ -121,8 +120,8 @@ static const char *option_help[] = {
 };
 
 typedef struct {
-	BIGNUM x;
-	BIGNUM y;
+	BIGNUM * x;
+	BIGNUM * y;
 } secret_share_t;
 
 static sc_context_t *ctx = NULL;
@@ -155,7 +154,11 @@ static int generatePrime(BIGNUM *prime, const BIGNUM *s, const int bits, unsigne
 
 	do {
 		// Generate random prime
+#if OPENSSL_VERSION_NUMBER  >= 0x00908000L /* last parm is BN_GENCB which is null in our case */
+		BN_generate_prime_ex(prime, bits, 1, NULL, NULL, NULL);
+#else
 		BN_generate_prime(prime, bits, 1, NULL, NULL, NULL, NULL );
+#endif
 
 	} while ((BN_ucmp(prime, s) == -1) && (max_rounds-- > 0));	// If prime < s or not reached 1000 tries
 
@@ -177,21 +180,20 @@ static int generatePrime(BIGNUM *prime, const BIGNUM *s, const int bits, unsigne
  * @param prime Prime for finite field arithmetic
  * @param y Pointer for storage of calculated y-value
  */
-static void calculatePolynomialValue(const BIGNUM x, BIGNUM **polynomial, const unsigned char t, const BIGNUM prime, BIGNUM *y)
+static void calculatePolynomialValue(const BIGNUM *x, BIGNUM **polynomial, const unsigned char t, const BIGNUM *prime, BIGNUM *y)
 {
 	BIGNUM **pp;
-	BIGNUM temp;
-	BIGNUM exponent;
+	BIGNUM *temp;
+	BIGNUM *exponent;
 
 	unsigned long exp;
 	BN_CTX *ctx;
 
 	// Create context for temporary variables of OpenSSL engine
 	ctx = BN_CTX_new();
-	BN_CTX_init(ctx);
 
-	BN_init(&temp);
-	BN_init(&exponent);
+	temp = BN_new();
+	exponent = BN_new();
 
 	// Set y to ZERO
 	BN_zero(y);
@@ -204,21 +206,21 @@ static void calculatePolynomialValue(const BIGNUM x, BIGNUM **polynomial, const 
 
 	for (exp = 1; exp < t; exp++) {
 
-		BN_copy(&temp, &x);
+		BN_copy(temp, x);
 
-		BN_set_word(&exponent, exp);
+		BN_set_word(exponent, exp);
 		// temp = x^exponent mod prime
-		BN_mod_exp(&temp, &x, &exponent, &prime, ctx);
+		BN_mod_exp(temp, x, exponent, prime, ctx);
 		// exponent = temp * a = a * x^exponent mod prime
-		BN_mod_mul(&exponent, &temp, *pp, &prime, ctx);
+		BN_mod_mul(exponent, temp, *pp, prime, ctx);
 		// add the temp value from exponent to y
-		BN_copy(&temp, y);
-		BN_mod_add(y, &temp, &exponent, &prime, ctx);
+		BN_copy(temp, y);
+		BN_mod_add(y, temp, exponent, prime, ctx);
 		pp++;
 	}
 
-	BN_clear_free(&temp);
-	BN_clear_free(&exponent);
+	BN_clear_free(temp);
+	BN_clear_free(exponent);
 
 	BN_CTX_free(ctx);
 }
@@ -234,7 +236,7 @@ static void calculatePolynomialValue(const BIGNUM x, BIGNUM **polynomial, const 
  * @param prime Prime for finite field arithmetic
  * @param shares Pointer for storage of calculated shares (must be big enough to hold n shares)
  */
-static int createShares(const BIGNUM *s, const unsigned char t, const unsigned char n,	const BIGNUM prime, secret_share_t *shares)
+static int createShares(const BIGNUM *s, const unsigned char t, const unsigned char n,	const BIGNUM *prime, secret_share_t *shares)
 {
 	// Array representing the polynomial a(x) = s + a_1 * x + ... + a_n-1 * x^n-1 mod p
 	BIGNUM **polynomial = malloc(n * sizeof(BIGNUM *));
@@ -245,26 +247,23 @@ static int createShares(const BIGNUM *s, const unsigned char t, const unsigned c
 	// Set the secret value as the constant part of the polynomial
 	pp = polynomial;
 	*pp = BN_new();
-	BN_init(*pp);
 	BN_copy(*pp, s);
 	pp++;
 
 	// Initialize and generate some random values for coefficients a_x in the remaining polynomial
 	for (i = 1; i < t; i++) {
 		*pp = BN_new();
-		BN_init(*pp);
-		BN_rand_range(*pp, &prime);
+		BN_rand_range(*pp, prime);
 		pp++;
 	}
 
 	sp = shares;
 	// Now calculate n secret shares
 	for (i = 1; i <= n; i++) {
-		BN_init(&(sp->x));
-		BN_init(&(sp->y));
-
-		BN_set_word(&(sp->x), i);
-		calculatePolynomialValue(sp->x, polynomial, t, prime, &(sp->y));
+		sp->x = BN_new();
+		sp->y = BN_new();
+		BN_set_word((sp->x), i);
+		calculatePolynomialValue(sp->x, polynomial, t, prime, (sp->y));
 		sp++;
 	}
 
@@ -290,7 +289,7 @@ static int createShares(const BIGNUM *s, const unsigned char t, const unsigned c
  * @param prime Prime for finite field arithmetic
  * @param s Pointer for storage of calculated secred
  */
-static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGNUM prime, BIGNUM *s)
+static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGNUM *prime, BIGNUM *s)
 {
 	unsigned char i;
 	unsigned char j;
@@ -298,9 +297,9 @@ static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGN
 	// Array representing the polynomial a(x) = s + a_1 * x + ... + a_n-1 * x^n-1 mod p
 	BIGNUM **bValue = malloc(t * sizeof(BIGNUM *));
 	BIGNUM **pbValue;
-	BIGNUM numerator;
-	BIGNUM denominator;
-	BIGNUM temp;
+	BIGNUM * numerator;
+	BIGNUM * denominator;
+	BIGNUM * temp;
 	secret_share_t *sp_i;
 	secret_share_t *sp_j;
 	BN_CTX *ctx;
@@ -309,24 +308,22 @@ static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGN
 	pbValue = bValue;
 	for (i = 0; i < t; i++) {
 		*pbValue = BN_new();
-		BN_init(*pbValue);
 		pbValue++;
 	}
 
-	BN_init(&numerator);
-	BN_init(&denominator);
-	BN_init(&temp);
+	numerator = BN_new();
+	denominator = BN_new();
+	temp = BN_new();
 
 	// Create context for temporary variables of engine
 	ctx = BN_CTX_new();
-	BN_CTX_init(ctx);
 
 	pbValue = bValue;
 	sp_i = shares;
 	for (i = 0; i < t; i++) {
 
-		BN_one(&numerator);
-		BN_one(&denominator);
+		BN_one(numerator);
+		BN_one(denominator);
 
 		sp_j = shares;
 
@@ -337,9 +334,9 @@ static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGN
 				continue;
 			}
 
-			BN_mul(&numerator, &numerator, &(sp_j->x), ctx);
-			BN_sub(&temp, &(sp_j->x), &(sp_i->x));
-			BN_mul(&denominator, &denominator, &temp, ctx);
+			BN_mul(numerator, numerator, (sp_j->x), ctx);
+			BN_sub(temp, (sp_j->x), (sp_i->x));
+			BN_mul(denominator, denominator, temp, ctx);
 
 			sp_j++;
 		}
@@ -348,12 +345,12 @@ static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGN
 		 * Use the modular inverse value of the denominator for the
 		 * multiplication
 		 */
-		if (BN_mod_inverse(&denominator, &denominator, &prime, ctx) == NULL ) {
+		if (BN_mod_inverse(denominator, denominator, prime, ctx) == NULL ) {
 			free(bValue);
 			return -1;
 		}
 
-		BN_mod_mul(*pbValue, &numerator, &denominator, &prime, ctx);
+		BN_mod_mul(*pbValue, numerator, denominator, prime, ctx);
 
 		pbValue++;
 		sp_i++;
@@ -368,19 +365,19 @@ static int reconstructSecret(secret_share_t *shares, unsigned char t, const BIGN
 	BN_zero(s);
 	for (i = 0; i < t; i++) {
 
-		BN_mul(&temp, &(sp_i->y), *pbValue, ctx);
-		BN_add(s, s, &temp);
+		BN_mul(temp, (sp_i->y), *pbValue, ctx);
+		BN_add(s, s, temp);
 		pbValue++;
 		sp_i++;
 	}
 
 	// Perform modulo operation and copy result
-	BN_nnmod(&temp, s, &prime, ctx);
-	BN_copy(s, &temp);
+	BN_nnmod(temp, s, prime, ctx);
+	BN_copy(s, temp);
 
-	BN_clear_free(&numerator);
-	BN_clear_free(&denominator);
-	BN_clear_free(&temp);
+	BN_clear_free(numerator);
+	BN_clear_free(denominator);
+	BN_clear_free(temp);
 
 	BN_CTX_free(ctx);
 
@@ -411,8 +408,8 @@ static int cleanUpShares(secret_share_t *shares, unsigned char n)
 
 	sp = shares;
 	for (i = 0; i < n; i++) {
-		BN_clear_free(&(sp->x));
-		BN_clear_free(&(sp->y));
+		BN_clear_free((sp->x));
+		BN_clear_free((sp->y));
 		sp++;
 	}
 
@@ -638,8 +635,8 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_password_shares)
 {
 	int r, i;
-	BIGNUM prime;
-	BIGNUM secret;
+	BIGNUM *prime;
+	BIGNUM *secret;
 	BIGNUM *p;
 	char inbuf[64];
 	unsigned char bin[64];
@@ -656,8 +653,8 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 	/*
 	 * Initialize prime and secret
 	 */
-	BN_init(&prime);
-	BN_init(&secret);
+	prime = BN_new();
+	secret = BN_new();
 
 	// Allocate data buffer for the shares
 	shares = malloc(num_of_password_shares * sizeof(secret_share_t));
@@ -674,7 +671,7 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 	}
 	binlen = 64;
 	sc_hex_to_bin(inbuf, bin, &binlen);
-	BN_bin2bn(bin, binlen, &prime);
+	BN_bin2bn(bin, binlen, prime);
 
 	sp = shares;
 	for (i = 0; i < num_of_password_shares; i++) {
@@ -685,8 +682,8 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 
 		clearScreen();
 
-		BN_init(&(sp->x));
-		BN_init(&(sp->y));
+		sp->x = BN_new();
+		sp->y = BN_new();
 
 		printf("Share %i of %i\n\n", i + 1, num_of_password_shares);
 
@@ -696,7 +693,7 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 			fprintf(stderr, "Input aborted\n");
 			return -1;
 		}
-		p = &(sp->x);
+		p = (sp->x);
 		BN_hex2bn(&p, inbuf);
 
 		printf("Please enter share value: ");
@@ -707,14 +704,14 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 		}
 		binlen = 64;
 		sc_hex_to_bin(inbuf, bin, &binlen);
-		BN_bin2bn(bin, binlen, &(sp->y));
+		BN_bin2bn(bin, binlen, (sp->y));
 
 		sp++;
 	}
 
 	clearScreen();
 
-	r = reconstructSecret(shares, num_of_password_shares, prime, &secret);
+	r = reconstructSecret(shares, num_of_password_shares, prime, secret);
 
 	if (r < 0) {
 		printf("\nError during reconstruction of secret. Wrong shares?\n");
@@ -726,14 +723,14 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 	 * Encode the secret value
 	 */
 	ip = (unsigned char *) inbuf;
-	*pwdlen = BN_bn2bin(&secret, ip);
+	*pwdlen = BN_bn2bin(secret, ip);
 	*pwd = calloc(1, *pwdlen);
 	memcpy(*pwd, ip, *pwdlen);
 
 	cleanUpShares(shares, num_of_password_shares);
 
-	BN_clear_free(&prime);
-	BN_clear_free(&secret);
+	BN_clear_free(prime);
+	BN_clear_free(secret);
 
 	return 0;
 }
@@ -743,7 +740,7 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 static int import_dkek_share(sc_card_t *card, const char *inf, int iter, const char *password, int num_of_password_shares)
 {
 	sc_cardctl_sc_hsm_dkek_t dkekinfo;
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX *ctx = NULL;
 	FILE *in = NULL;
 	u8 filebuff[64],key[EVP_MAX_KEY_LENGTH], iv[EVP_MAX_IV_LENGTH],outbuff[64];
 	char *pwd = NULL;
@@ -801,14 +798,14 @@ static int import_dkek_share(sc_card_t *card, const char *inf, int iter, const c
 		free(pwd);
 	}
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, key, iv);
-	if (!EVP_DecryptUpdate(&ctx, outbuff, &outlen, filebuff + 16, sizeof(filebuff) - 16)) {
+	ctx = EVP_CIPHER_CTX_new();
+	EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv);
+	if (!EVP_DecryptUpdate(ctx, outbuff, &outlen, filebuff + 16, sizeof(filebuff) - 16)) {
 		fprintf(stderr, "Error decrypting DKEK share. Password correct ?\n");
 		return -1;
 	}
 
-	if (!EVP_DecryptFinal_ex(&ctx, outbuff + outlen, &r)) {
+	if (!EVP_DecryptFinal_ex(ctx, outbuff + outlen, &r)) {
 		fprintf(stderr, "Error decrypting DKEK share. Password correct ?\n");
 		return -1;
 	}
@@ -822,7 +819,7 @@ static int import_dkek_share(sc_card_t *card, const char *inf, int iter, const c
 	r = sc_card_ctl(card, SC_CARDCTL_SC_HSM_IMPORT_DKEK_SHARE, (void *)&dkekinfo);
 
 	OPENSSL_cleanse(&dkekinfo.dkek_share, sizeof(dkekinfo.dkek_share));
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
 
 	if (r == SC_ERROR_INS_NOT_SUPPORTED) {			// Not supported or not initialized for key shares
 		fprintf(stderr, "Not supported by card or card not initialized for key share usage\n");
@@ -880,8 +877,8 @@ static void ask_for_password(char **pwd, int *pwdlen)
 static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int password_shares_threshold, int password_shares_total)
 {
 	int r, i;
-	BIGNUM prime;
-	BIGNUM secret;
+	BIGNUM *prime;
+	BIGNUM *secret;
 	unsigned char buf[64];
 	char hex[64];
 	int l;
@@ -937,13 +934,13 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 	/*
 	 * Initialize prime and secret
 	 */
-	BN_init(&prime);
-	BN_init(&secret);
+	prime = BN_new();
+	secret = BN_new();
 
 	/*
 	 * Encode the secret value
 	 */
-	BN_bin2bn((unsigned char *)*pwd, *pwdlen, &secret);
+	BN_bin2bn((unsigned char *)*pwd, *pwdlen, secret);
 
 	/*
 	 * Generate seed and calculate a prime depending on the size of the secret
@@ -956,7 +953,7 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 		return r;
 	}
 
-	r = generatePrime(&prime, &secret, 64, rngseed, SEED_LENGTH);
+	r = generatePrime(prime, secret, 64, rngseed, SEED_LENGTH);
 	if (r < 0) {
 		printf("Error generating valid prime number. Please try again.");
 		OPENSSL_cleanse(*pwd, *pwdlen);
@@ -967,7 +964,7 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 	// Allocate data buffer for the generated shares
 	shares = malloc(password_shares_total * sizeof(secret_share_t));
 
-	createShares(&secret, password_shares_threshold, password_shares_total, prime, shares);
+	createShares(secret, password_shares_threshold, password_shares_total, prime, shares);
 
 	sp = shares;
 	for (i = 0; i < password_shares_total; i++) {
@@ -980,12 +977,12 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 
 		printf("Share %i of %i\n\n", i + 1, password_shares_total);
 
-		l = BN_bn2bin(&prime, buf);
+		l = BN_bn2bin(prime, buf);
 		sc_bin_to_hex(buf, l, hex, 64, ':');
 		printf("\nPrime       : %s\n", hex);
 
-		printf("Share ID    : %s\n", BN_bn2dec(&(sp->x)));
-		l = BN_bn2bin(&(sp->y), buf);
+		printf("Share ID    : %s\n", BN_bn2dec((sp->x)));
+		l = BN_bn2bin((sp->y), buf);
 		sc_bin_to_hex(buf, l, hex, 64, ':');
 		printf("Share value : %s\n", hex);
 
@@ -999,8 +996,8 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 
 	cleanUpShares(shares, password_shares_total);
 
-	BN_clear_free(&prime);
-	BN_clear_free(&secret);
+	BN_clear_free(prime);
+	BN_clear_free(secret);
 
 	return 0;
 }
@@ -1009,7 +1006,7 @@ static int generate_pwd_shares(sc_card_t *card, char **pwd, int *pwdlen, int pas
 
 static int create_dkek_share(sc_card_t *card, const char *outf, int iter, const char *password, int password_shares_threshold, int password_shares_total)
 {
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX *ctx = NULL;
 	FILE *out = NULL;
 	u8 filebuff[64], key[EVP_MAX_KEY_LENGTH], iv[EVP_MAX_IV_LENGTH];
 	u8 dkek_share[32];
@@ -1060,14 +1057,14 @@ static int create_dkek_share(sc_card_t *card, const char *outf, int iter, const 
 		return -1;
 	}
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, key, iv);
-	if (!EVP_EncryptUpdate(&ctx, filebuff + 16, &outlen, dkek_share, sizeof(dkek_share))) {
+	ctx = EVP_CIPHER_CTX_new();
+	EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv);
+	if (!EVP_EncryptUpdate(ctx, filebuff + 16, &outlen, dkek_share, sizeof(dkek_share))) {
 		fprintf(stderr, "Error encrypting DKEK share\n");
 		return -1;
 	}
 
-	if (!EVP_EncryptFinal_ex(&ctx, filebuff + 16 + outlen, &r)) {
+	if (!EVP_EncryptFinal_ex(ctx, filebuff + 16 + outlen, &r)) {
 		fprintf(stderr, "Error encrypting DKEK share\n");
 		return -1;
 	}
@@ -1088,7 +1085,7 @@ static int create_dkek_share(sc_card_t *card, const char *outf, int iter, const 
 	fclose(out);
 
 	OPENSSL_cleanse(filebuff, sizeof(filebuff));
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_free(ctx);
 
 	printf("DKEK share created and saved to %s\n", outf);
 	return 0;
@@ -1631,9 +1628,16 @@ int main(int argc, char * const argv[])
 		}
 	}
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS
+		| OPENSSL_INIT_ADD_ALL_CIPHERS
+		| OPENSSL_INIT_ADD_ALL_DIGESTS,
+		NULL);
+#else
 	CRYPTO_malloc_init();
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
+#endif
 
 	memset(&ctx_param, 0, sizeof(sc_context_param_t));
 	ctx_param.app_name = app_name;
@@ -1700,10 +1704,3 @@ end:
 	ERR_print_errors_fp(stderr);
 	return err;
 }
-#else /* OPENSSL_VERSION_NUMBER */
-#warning "TODO Fix BIGNUM usage for OpenSSL 1.1"
-int main (){
-printf("not implemented needs BIGNUM changes\n");
-return 1;
-}
-#endif /* OPENSSL_VERSION_NUMBER */

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -617,7 +617,11 @@ int main(int argc, char *argv[])
 			goto out;
 		}
 
+#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
+		RSA_set_method(rsa, RSA_PKCS1_OpenSSL());
+#else
 		rsa->meth = RSA_PKCS1_SSLeay();
+#endif
 
 		if(!i2d_RSAPrivateKey_bio(mem, rsa))
 		{

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -33,6 +33,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/bn.h>
 
+#include "libopensc/sc-ossl-compat.h"
 #include "libopensc/opensc.h"
 #include "libopensc/errors.h"
 #include "libopensc/pkcs15.h"
@@ -617,11 +618,7 @@ int main(int argc, char *argv[])
 			goto out;
 		}
 
-#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
 		RSA_set_method(rsa, RSA_PKCS1_OpenSSL());
-#else
-		rsa->meth = RSA_PKCS1_SSLeay();
-#endif
 
 		if(!i2d_RSAPrivateKey_bio(mem, rsa))
 		{


### PR DESCRIPTION
This change is the first cut at changes to OpenSC so it can be compiled against OpenSSL 1.1 as well as previous versions.

OpenSSL 1.1 will be released later this year.

	https://www.openssl.org/policies/releasestrat.html

	https://www.openssl.org/news/changelog.html#x0

17 OpenSC routines need changes ranging from adding headers for ossl_type.h, rsa.h and bn.h to rewriting code to use changed interfaces. 

5 routines that should be looked at closely are:

	src/libopensc/card-epass2003.c
	src/libopensc/pkcs15-itacns.c
	src/pkcs15init/pkcs15-oberthur-awp.c
	src/tools/pkcs15-init.c
	src/tools/sc-hsm-tool.c

src/tools/sc-hsm-tool.c needs so many changes that I did not attempt to change it. If compiled against OpenSSL 1.1 it will produce a dummy routine, and a warning message.
It uses the BIGNUM structure in line in many places, but BIGNUM is now just a typedef and the actual structure is now hidden.
@CardContact 
The sc-hsm developers need to make the changes.

I have compiles against OpenSSL 1.0.1g, 1.0.2d and 1.1.0-pre2-dev
from github.com Minimal testing has been done.

Next is engine and libp11 so ECDH can be used from engine.