### PR TITLE
Removing all memory leaks in DNIe module and use of SM functions.

### DIFF
--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -619,6 +619,13 @@ static int dnie_create_pre_ops(sc_card_t * card, cwa_provider_t * provider)
 	return sc_card_ctl(card, SC_CARDCTL_GET_SERIALNR, &serial);
 }
 
+static int dnie_create_post_ops(sc_card_t * card, cwa_provider_t * provider)
+{
+        card->sm_ctx.sm_mode = SM_MODE_TRANSMIT;
+
+        return SC_SUCCESS;
+}
+
 /**
  * Main entry point for DNIe CWA14890 SM data provider.
  *
@@ -638,7 +645,7 @@ cwa_provider_t *dnie_get_cwa_provider(sc_card_t * card)
 
 	/* pre and post operations */
 	res->cwa_create_pre_ops = dnie_create_pre_ops;
-	res->cwa_create_post_ops = NULL;
+	res->cwa_create_post_ops = dnie_create_post_ops;
 
 	/* Get ICC intermediate CA  path */
 	res->cwa_get_icc_intermediate_ca_cert =
@@ -675,127 +682,82 @@ cwa_provider_t *dnie_get_cwa_provider(sc_card_t * card)
 	/* Get ICC Serial Number */
 	res->cwa_get_sn_icc = dnie_get_sn_icc;
 
-    /************** operations related with APDU encoding ******************/
-
-	/* pre and post operations */
-	res->cwa_encode_pre_ops = NULL;
-	res->cwa_encode_post_ops = NULL;
-
-    /************** operations related APDU response decoding **************/
-
-	/* pre and post operations */
-	res->cwa_decode_pre_ops = NULL;
-	res->cwa_decode_post_ops = NULL;
-
 	return res;
 }
 
-static int dnie_transmit_apdu_internal(sc_card_t * card, sc_apdu_t * apdu)
+static int dnie_sm_free_wrapped_apdu(struct sc_card *card,
+		struct sc_apdu *plain, struct sc_apdu **sm_apdu)
 {
-	u8 buf[MAX_RESP_BUFFER_SIZE];		/* use for store partial le responses */
-	int res = SC_SUCCESS;
+	struct sc_context *ctx = card->ctx;
+	int rv = SC_SUCCESS;
+
+	LOG_FUNC_CALLED(ctx);
+	if (!sm_apdu)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+	if (!(*sm_apdu))
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+		/* parse response and handle SM related errors */
+	rv=card->ops->check_sw(card,(*sm_apdu)->sw1,(*sm_apdu)->sw2);
+	if (rv == SC_SUCCESS) {
+		plain->resp = (*sm_apdu)->resp;
+		plain->resplen = (*sm_apdu)->resplen;
+	}
+
+	if (((*sm_apdu)->data) != plain->data)
+		free((unsigned char *) (*sm_apdu)->data);
+	free(*sm_apdu);
+	*sm_apdu = NULL;
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+static int dnie_sm_get_wrapped_apdu(struct sc_card *card,
+		struct sc_apdu *plain, struct sc_apdu **sm_apdu)
+{
+	struct sc_context *ctx = card->ctx;
+	struct sc_apdu *apdu = NULL;
 	cwa_provider_t *provider = NULL;
-	if ((card == NULL) || (card->ctx == NULL) || (apdu == NULL))
-		return SC_ERROR_INVALID_ARGUMENTS;
-	LOG_FUNC_CALLED(card->ctx);
+	int rv;
+
+	LOG_FUNC_CALLED(ctx);
+	if (!plain || !sm_apdu)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
 	provider = GET_DNIE_PRIV_DATA(card)->cwa_provider;
-	memset(buf, 0, sizeof(buf));
+	*sm_apdu = NULL;
+	//construct new SM apdu from original apdu
+	apdu = calloc(1, sizeof(struct sc_apdu));
+	if (!apdu)
+		return SC_ERROR_OUT_OF_MEMORY;
 
-	/* check if envelope is needed */
-	if (apdu->lc <= card->max_send_size) {
-		int tmp;
-		/* no envelope needed */
-		sc_log(card->ctx, "envelope tx is not required");
+	memcpy(apdu, plain, sizeof(sc_apdu_t));
+	/* SM is active, encode apdu */
+	apdu->resp = NULL;
+	apdu->resplen = 0;	/* let get_response() assign space */
+	rv = cwa_encode_apdu(card, provider, plain, apdu);
 
-		tmp = apdu->cse;	/* save original apdu type */
-		/* if SM is on, assure rx buffer exists and force get_response */
-		if (provider->status.session.state == CWA_SM_ACTIVE) {
-			if (tmp == SC_APDU_CASE_3_SHORT)
-				apdu->cse = SC_APDU_CASE_4_SHORT;
-			if (apdu->resplen == 0) {	/* no response buffer: create */
-				apdu->resp = calloc(1, MAX_RESP_BUFFER_SIZE);
-				if (apdu->resp == NULL)
-					LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
-				apdu->resplen = MAX_RESP_BUFFER_SIZE;
-				apdu->le = card->max_recv_size;
-			}
-		}
-		/* call std sc_transmit_apdu */
-		res = sc_transmit_apdu(card, apdu);
-		/* and restore original apdu type */
-		apdu->cse = tmp;
-	} else {
+	if (rv)   {
+		dnie_sm_free_wrapped_apdu(card, NULL, &apdu);
+		goto err;
+	}
 
-		size_t e_txlen = 0;
-		size_t index = 0;
-		sc_apdu_t e_apdu;
-		u8 * e_tx = NULL;
-
-		/* envelope needed */
-		sc_log(card->ctx, "envelope tx required: lc:%d", apdu->lc);
-
-		e_tx = calloc(7 + apdu->datalen, sizeof(u8));	/* enveloped data */
-
-		if (!e_tx)
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
-
-		/* copy apdu info into enveloped data */
-		*(e_tx + 0) = apdu->cla;	/* apdu header */
-		*(e_tx + 1) = apdu->ins;
-		*(e_tx + 2) = apdu->p1;
-		*(e_tx + 3) = apdu->p2;
-		*(e_tx + 4) = 0x00;	/* length in extended format */
-		*(e_tx + 5) = 0xff & (apdu->lc >> 8);
-		*(e_tx + 6) = 0xff & apdu->lc;
-		memcpy(e_tx + 7, apdu->data, apdu->lc);
-		e_txlen = 7 + apdu->lc;
-		/* sc_log(card->ctx, "Data to be enveloped & sent: (%d bytes)\n%s\n===============================================================",e_txlen,sc_dump_hex(e_tx,e_txlen)); */
-		/* split apdu in n chunks of max_send_size len */
-		for (index = 0; index < e_txlen; index += card->max_send_size) {
-			size_t len = MIN(card->max_send_size, e_txlen - index);
-			sc_log(card->ctx, "envelope tx offset:%04X size:%02X",
-			       index, len);
-
-			/* compose envelope apdu command */
-			dnie_format_apdu(card, &e_apdu, apdu->cse, 0xC2, 0x00, 0x00, apdu->le, len,
-							apdu->resp, apdu->resplen, e_tx + index, len);
-			e_apdu.cla = 0x90;	/* propietary CLA */
-			/* if SM is ON, ensure resp exists, and force getResponse() */
-			if (provider->status.session.state == CWA_SM_ACTIVE) {
-				/* set up proper apdu type */
-				if (e_apdu.cse == SC_APDU_CASE_3_SHORT)
-					e_apdu.cse = SC_APDU_CASE_4_SHORT;
-				/* if no response buffer: create */
-				if (apdu->resplen == 0) {
-					e_apdu.resp = buf;
-					e_apdu.resplen = 2048;
-					e_apdu.le = card->max_recv_size;
-				}
-			}
-			/* send data chunk bypassing apdu wrapping */
-			res = sc_transmit_apdu(card, &e_apdu);
-			if (res != SC_SUCCESS) {
-				if (e_tx) {
-					free(e_tx);
-					e_tx = NULL;
-				}
-				sc_log(card->ctx, "Error in envelope() send apdu");
-				LOG_FUNC_RETURN(card->ctx, res);
-			}
-		}		/* for */
-		if (e_tx) {
-			free(e_tx);
-			e_tx = NULL;
-		}
-		/* last apdu sent contains response to enveloped cmd */
+	/* if SM is on, assure rx buffer exists and force get_response */
+	if (apdu->cse == SC_APDU_CASE_3_SHORT)
+		apdu->cse = SC_APDU_CASE_4_SHORT;
+	if (apdu->resplen == 0) {	/* no response buffer: create */
 		apdu->resp = calloc(1, MAX_RESP_BUFFER_SIZE);
 		if (apdu->resp == NULL)
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
-		memcpy(apdu->resp, e_apdu.resp, e_apdu.resplen);
-		apdu->resplen = e_apdu.resplen;
-		res = SC_SUCCESS;
+			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+		apdu->resplen = MAX_RESP_BUFFER_SIZE;
+		apdu->le = card->max_recv_size;
 	}
-	LOG_FUNC_RETURN(card->ctx, res);
+
+	*sm_apdu = apdu;
+	apdu = NULL;
+err:
+	free(apdu);
+	LOG_FUNC_RETURN(ctx, rv);
 }
 
 /**
@@ -824,79 +786,26 @@ static int dnie_transmit_apdu_internal(sc_card_t * card, sc_apdu_t * apdu)
 static int dnie_wrap_apdu(sc_card_t * card, sc_apdu_t * apdu)
 {
 	int res = SC_SUCCESS;
-	sc_apdu_t wrapped;
+	sc_apdu_t * wrapped;
 	sc_context_t *ctx;
-	cwa_provider_t *provider = NULL;
-	int retries = 3;
 	char * msg = NULL;
 
 	if ((card == NULL) || (card->ctx == NULL) || (apdu == NULL))
 		return SC_ERROR_INVALID_ARGUMENTS;
 	ctx=card->ctx;
 	LOG_FUNC_CALLED(ctx);
-	provider = GET_DNIE_PRIV_DATA(card)->cwa_provider;
-	for (retries=3; retries>0; retries--) {
-		/* preserve original apdu to take care of retransmission */
-		memcpy(&wrapped, apdu, sizeof(sc_apdu_t));
-		/* SM is active, encode apdu */
-		if (provider->status.session.state == CWA_SM_ACTIVE) {
-			wrapped.resp = NULL;
-			wrapped.resplen = 0;	/* let get_response() assign space */
-			res = cwa_encode_apdu(card, provider, apdu, &wrapped);
-			if (res != SC_SUCCESS) {
-				msg = "Error in cwa_encode_apdu process";
-				goto cleanup_and_return;
-			}
-		}
-		/* send apdu via envelope() cmd if needed */
-		res = dnie_transmit_apdu_internal(card, &wrapped);
-		/* check for tx errors */
-		if (res != SC_SUCCESS) {
-			msg = "Error in dnie_transmit_apdu process";
-			goto cleanup_and_return;
-		}
 
-		/* parse response and handle SM related errors */
-		res=card->ops->check_sw(card,wrapped.sw1,wrapped.sw2);
-		if ( res == SC_ERROR_SM ) {
-			sc_log(ctx,"Detected SM error/collision. Try %d",retries);
-			switch(provider->status.session.state) {
-				/* No SM or creating: collision with other process
-				   just retry as SM error reset ICC SM state */
-				case CWA_SM_NONE: 
-				case CWA_SM_INPROGRESS: 
-					continue;
-				/* SM was active: force restart SM and retry */
-				case CWA_SM_ACTIVE:
-					res=cwa_create_secure_channel(card, provider, CWA_SM_COLD);
-					if (res != SC_SUCCESS) {
-						msg = "Cannot re-enable SM";
-						goto cleanup_and_return;
-					}
-					continue;
-			}
-		}
+	dnie_sm_get_wrapped_apdu(card, apdu, &wrapped);
 
-		/* if SM is active; decode apdu */
-		if (provider->status.session.state == CWA_SM_ACTIVE) {
-			apdu->resp = NULL;
-			apdu->resplen = 0;	/* let cwa_decode_response() eval & create size */
-			res = cwa_decode_response(card, provider, &wrapped, apdu);
-			if (res != SC_SUCCESS)
-				msg = "Error in cwa_decode_response process";
-			goto cleanup_and_return;
-		} else {
-			if (apdu->resp != wrapped.resp) free(apdu->resp);
-			/* memcopy result to original apdu */
-			memcpy(apdu, &wrapped, sizeof(sc_apdu_t));
-			LOG_FUNC_RETURN(ctx, res);
-		}
+	/* call std sc_transmit_apdu */
+	res = sc_transmit_apdu(card, wrapped);
+	/* check for tx errors */
+	if (res != SC_SUCCESS) {
+		msg = "Error in dnie_transmit_apdu process";
 	}
-	msg = "Too many retransmissions. Abort and return";
-	res = SC_ERROR_INTERNAL;
 
-cleanup_and_return:
-	if (apdu->resp != wrapped.resp) free(wrapped.resp);
+	dnie_sm_free_wrapped_apdu(card, apdu, &wrapped);
+
 	if (msg)
 		sc_log(ctx, msg);
 	LOG_FUNC_RETURN(ctx, res);
@@ -905,9 +814,20 @@ cleanup_and_return:
 int dnie_transmit_apdu(sc_card_t * card, sc_apdu_t * apdu)
 {
 	int res = SC_SUCCESS;
-	res = dnie_wrap_apdu(card, apdu);
-	if (res <= 0) return res;
-	return sc_transmit_apdu(card, apdu);
+	sc_context_t *ctx;
+	cwa_provider_t *provider = NULL;
+	ctx=card->ctx;
+	provider = GET_DNIE_PRIV_DATA(card)->cwa_provider;
+	if ((provider->status.session.state == CWA_SM_ACTIVE) &&
+		(card->sm_ctx.sm_mode == SM_MODE_TRANSMIT)) {
+		res = dnie_wrap_apdu(card, apdu);
+		LOG_TEST_RET(ctx, res, "Error in dnie_wrap_apdu process");
+		res = cwa_decode_response(card, provider, apdu);
+		LOG_TEST_RET(ctx, res, "Error in cwa_decode_response process");
+	}
+	else 
+		res = sc_transmit_apdu(card, apdu);
+	return res;
 }
 
 void dnie_format_apdu(sc_card_t *card, sc_apdu_t *apdu,

--- a/src/libopensc/cwa14890.h
+++ b/src/libopensc/cwa14890.h
@@ -274,61 +274,7 @@ typedef struct cwa_provider_st {
 	*/
 	int (*cwa_get_sn_icc) (sc_card_t * card, u8 ** buf);
 
-    /************** operations related with APDU encoding ******************/
-
-	/**
- 	* Operation to be done before any APDU encode procedure.
- 	*
- 	* @param card Pointer to card driver data structure
- 	* @param provider pointer to cwa1890 SM provider
- 	* @param from APDU to be encoded
- 	* @param to resulting APDU to be sent to encode procedure
- 	* @return SC_SUCCESS if OK, else error code
- 	*/
-	int (*cwa_encode_pre_ops) (sc_card_t * card,
-				   struct cwa_provider_st * provider,
-				   sc_apdu_t * from, sc_apdu_t * to);
-
-	/**
- 	* Operation to be done after APDU encode process finished ok.
- 	*
- 	* @param card Pointer to card driver data structure
- 	* @param provider pointer to cwa1890 SM provider
- 	* @param from encoded APDU
- 	* @param to resulting encoded APDU to be returned to libopensc
- 	* @return SC_SUCCESS if OK, else error code
- 	*/
-	int (*cwa_encode_post_ops) (sc_card_t * card,
-				    struct cwa_provider_st * provider,
-				    sc_apdu_t * from, sc_apdu_t * to);
-
-    /************** operations related APDU response decoding **************/
-
-	/**
- 	* Operation to be done before any APDU Response decode procedure.
- 	*
- 	* @param card Pointer to card driver data structure
- 	* @param provider pointer to cwa1890 SM provider
- 	* @param from APDU Response to be decoded
- 	* @param to resulting APDU response to be sent to decode procedure
- 	* @return SC_SUCCESS if OK, else error code
- 	*/
-	int (*cwa_decode_pre_ops) (sc_card_t * card,
-				   struct cwa_provider_st * provider,
-				   sc_apdu_t * from, sc_apdu_t * to);
-
-	/**
- 	* Operation to be done after APDU Response decode process finished ok.
- 	*
- 	* @param card Pointer to card driver data structure
- 	* @param provider pointer to cwa1890 SM provider
- 	* @param from decoded APDU Response
- 	* @param to resulting APDU Response to be returned to libopensc
- 	* @return SC_SUCCESS if OK, else error code
- 	*/
-	int (*cwa_decode_post_ops) (sc_card_t * card,
-				    struct cwa_provider_st * provider,
-				    sc_apdu_t * from, sc_apdu_t * to);
+ 
 } cwa_provider_t;
 
 /************************** external function prototypes ******************/
@@ -359,13 +305,12 @@ extern int cwa_create_secure_channel(sc_card_t * card,
  *
  * @param card card info structure
  * @param provider cwa provider data to handle SM channel
- * @param from apdu to be decoded
- * @param to   where to store decoded apdu
+ * @param apdu apdu to be decoded
  * @return SC_SUCCESS if ok; else error code
  */
 extern int cwa_decode_response(sc_card_t * card,
 			       cwa_provider_t * provider,
-			       sc_apdu_t * from, sc_apdu_t * to);
+			       sc_apdu_t * apdu);
 
 /**
  * Encode an APDU.


### PR DESCRIPTION
This is related to
`dnie_transmit_apdu` should not modify the original APDU #610
And to
Fixing some memory leaks in DNIe. #606

As far as I can see, there are no more memory leaks in the DNIe module.
The wrapping and unwrapping functions of OpenSC SM module are used now, however I haven't been able to move the "tricks" in dnie_transmit_apdu to these functions ... yet.
I have done a lot of cleanup, note that the change involves around 380 deleted lines and less than 200 added (if I remember correctly) and these added lines include the OpenSC SM get and free which are not that useful at the moment.
I have tested this code with the Afirma application, the FNMT web and valgrind pkcs11-tool. It might be my imagination, but it even seems faster than the previous version to me.
I would like to have this changes in, and then move to work on support of DNIe 3.0, which seems the most important thing to do now. 
Please consider reviewing and merging these changes.