### PR TITLE
Fix #648

### DIFF
--- a/src/pkcs15init/pkcs15-rtecp.c
+++ b/src/pkcs15init/pkcs15-rtecp.c
@@ -289,12 +289,12 @@ static int rtecp_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	sc_context_t *ctx;
 	/*                              RSA_PRkey/ for Miller-
 	 *                              RSA_PUBkey  Rabin test    Attempts Reserve */
-	const unsigned char prkey_prop[]  = { 0x23,       0x1F, 0,    0xFF, 0, 0 };
-	const unsigned char pbkey_prop[]  = { 0x33,       0x1F, 0,    0xFF, 0, 0 };
+	const unsigned char prkey_prop[]  = { 0x23,       0x1F, 0,    0xAA, 0, 0 };
+	const unsigned char pbkey_prop[]  = { 0x33,       0x1F, 0,    0xAA, 0, 0 };
 	/*                  GOSTR3410_PRkey/
 	 *                  GOSTR3410_PUBkey  paramset    Attempts Reserve */
-	unsigned char prgkey_prop[] = { 0x03,      '?', 0,    0xFF, 0, 0 };
-	unsigned char pbgkey_prop[] = { 0x13,      '?', 0,    0xFF, 0, 0 };
+	unsigned char prgkey_prop[] = { 0x03,      '?', 0,    0xAA, 0, 0 };
+	unsigned char pbgkey_prop[] = { 0x13,      '?', 0,    0xAA, 0, 0 };
 	/*                        AccessMode  - Update  Use  -  -  - Delete */
 	unsigned char prkey_sec[15] = { 0x46, 0,   '?', '?', 0, 0, 0,   '?' };
 	unsigned char pbkey_sec[15] = { 0x46, 0,   '?',   0, 0, 0, 0,   '?' };

--- a/src/pkcs15init/pkcs15-rtecp.c
+++ b/src/pkcs15init/pkcs15-rtecp.c
@@ -287,10 +287,10 @@ static int rtecp_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		sc_pkcs15_object_t *obj)
 {
 	sc_context_t *ctx;
-	/*                              RSA_PRkey/ for Miller-
-	 *                              RSA_PUBkey  Rabin test    Attempts Reserve */
-	const unsigned char prkey_prop[]  = { 0x23,       0x1F, 0,    0xAA, 0, 0 };
-	const unsigned char pbkey_prop[]  = { 0x33,       0x1F, 0,    0xAA, 0, 0 };
+	/*                              RSA_PRkey/ Adds Miller-
+	 *                              RSA_PUBkey Rabin tests    Attempts Reserve */
+	const unsigned char prkey_prop[]  = { 0x23,          0, 0,    0xAA, 0, 0 };
+	const unsigned char pbkey_prop[]  = { 0x33,          0, 0,    0xAA, 0, 0 };
 	/*                  GOSTR3410_PRkey/
 	 *                  GOSTR3410_PUBkey  paramset    Attempts Reserve */
 	unsigned char prgkey_prop[] = { 0x03,      '?', 0,    0xAA, 0, 0 };


### PR DESCRIPTION
Fix 'Incorrect parameters in APDU' (for Rutoken ECP 2.0):

$ ./.opensc/bin/pkcs15-init -G rsa/1024 --auth-id 02 --label "My Private Key" --public-key-label "My Public Key"
Using reader with a card: Aktiv Rutoken ECP 00 00
User PIN [User PIN] required.
Please enter User PIN [User PIN]: 
Failed to generate key: Incorrect parameters in APDU
