### PR TITLE
pkcs11-tool: support write of GOST Public Key object

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1823,13 +1823,13 @@ do_read_key(unsigned char *data, size_t data_len, int private, EVP_PKEY **key)
 	BIO_set_mem_buf(mem, &buf_mem, BIO_NOCLOSE);
 
 	if (private) {
-		if (!strstr((char *)data, "-----BEGIN PRIVATE KEY-----") && !strstr((char *)data, "-----BEGIN EC PRIVATE KEY-----"))
+		if (!strstr((char *)data, "-----BEGIN "))
 			*key = d2i_PrivateKey_bio(mem, NULL);
 		else
 			*key = PEM_read_bio_PrivateKey(mem, NULL, NULL, NULL);
 	}
 	else {
-		if (!strstr((char *)data, "-----BEGIN PUBLIC KEY-----") && !strstr((char *)data, "-----BEGIN EC PUBLIC KEY-----"))
+		if (!strstr((char *)data, "-----BEGIN "))
 			*key = d2i_PUBKEY_bio(mem, NULL);
 		else
 			*key = PEM_read_bio_PUBKEY(mem, NULL, NULL, NULL);


### PR DESCRIPTION
Example:
```bash
// Make keys
$ openssl genpkey -engine gost -out key.pem -algorithm gost2001 -pkeyopt paramset:A
$ openssl pkey -engine gost -in key.pem -outform DER > key.der
$ openssl pkey -engine gost -in key.pem -outform PEM -pubout > key.pub.pem
$ openssl pkey -engine gost -in key.pem -outform DER -pubout > key.pub.der

$ pkcs11-tool --module /tmp/librtpkcs11ecp.so --login --pin "12345678" -y privkey -w key.pem 
Using slot 0 with a present token (0x0)
Created private key:
Private Key Object; GOSTR3410 
  PARAMS OID: 06072a850302022301
  label:      
  Usage:      sign
$ pkcs11-tool --module /tmp/librtpkcs11ecp.so --login --pin "12345678" -y privkey -w key.der 
Using slot 0 with a present token (0x0)
Created private key:
Private Key Object; GOSTR3410 
  PARAMS OID: 06072a850302022301
  label:      
  Usage:      sign
$ pkcs11-tool --module /tmp/librtpkcs11ecp.so --login --pin "12345678" -y pubkey -w key.pub.pem 
Using slot 0 with a present token (0x0)
Created public key:
Public Key Object; GOSTR3410 
  PARAMS OID: 06072a850302022301
  VALUE:      5c32a4cdbad50516c3dd3c92efba7578d711ba48de4a84a3669923f49663ee6d
              48b574aa950ca70e27378b88ad35bf94803adf96123d224f7e7f5f57d49ae640
  label:      
  Usage:      verify
$ pkcs11-tool --module /tmp/librtpkcs11ecp.so --login --pin "12345678" -y pubkey -w key.pub.der 
Using slot 0 with a present token (0x0)
Created public key:
Public Key Object; GOSTR3410 
  PARAMS OID: 06072a850302022301
  VALUE:      5c32a4cdbad50516c3dd3c92efba7578d711ba48de4a84a3669923f49663ee6d
              48b574aa950ca70e27378b88ad35bf94803adf96123d224f7e7f5f57d49ae640
  label:      
  Usage:      verify
$ 
```