### PR TITLE
'Disable' and 'ignore-usage' PKCS#15 application configuration options 

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -513,9 +513,13 @@ app default {
 		#   obtained with the common procedures (ex. object creation protected by secure messaging).
 		#   Used by PKCS#11 module configurated to expose restricted number of slots.
 		#   (for ex. configurated to expose only User PIN slot, User and Sign PINs slots, ...)
+		#
+		# - disable: do not expose application in PKCS15 framework
+		#            default 'false'
 		application E828BD080FD25047656E65726963 {
 			type = generic;
 			model = "ECC Generic PKI";
+			# disable = true
 		}
 
 		application E828BD080FD2500000040301 {

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -516,6 +516,9 @@ app default {
 		#
 		# - disable: do not expose application in PKCS15 framework
 		#            default 'false'
+		#
+		# - ignore_usage: do not consider the SDO usage when looking for available key slot
+		#            default 'false'
 		application E828BD080FD25047656E65726963 {
 			type = generic;
 			model = "ECC Generic PKI";
@@ -530,6 +533,7 @@ app default {
 		application E828BD080FD2504543432D654944 {
 			type = protected;
 			model = "ECC eID";
+			# ignore_usage = true
 		}
 
 		application E828BD080FD2500000040201 {

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -3450,7 +3450,7 @@ iasecc_get_free_reference(struct sc_card *card, struct iasecc_ctl_get_free_refer
 			continue;
 		}
 
-		if (sdo->docp.non_repudiation.value)   {
+		if (ctl_data->usage && sdo->docp.non_repudiation.value)   {
 			sc_log(ctx, "non repudiation flag %X", sdo->docp.non_repudiation.value[0]);
 			if ((ctl_data->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION) && !(*sdo->docp.non_repudiation.value))   {
 				sc_log(ctx, "key index %i ignored: need non repudiation", idx);
@@ -3476,23 +3476,25 @@ iasecc_get_free_reference(struct sc_card *card, struct iasecc_ctl_get_free_refer
 			}
 		}
 
-		if ((ctl_data->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION) && (ctl_data->usage & SC_PKCS15_PRKEY_USAGE_SIGN))   {
-			if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_PSO_SIGN] == IASECC_SCB_NEVER)   {
-				sc_log(ctx, "key index %i ignored: PSO SIGN not allowed", idx);
-				continue;
+		if (ctl_data->usage)   {
+			if ((ctl_data->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION) && (ctl_data->usage & SC_PKCS15_PRKEY_USAGE_SIGN))   {
+				if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_PSO_SIGN] == IASECC_SCB_NEVER)   {
+					sc_log(ctx, "key index %i ignored: PSO SIGN not allowed", idx);
+					continue;
+				}
 			}
-		}
-		else if (ctl_data->usage & SC_PKCS15_PRKEY_USAGE_SIGN)   {
-			if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_INTERNAL_AUTH] == IASECC_SCB_NEVER)   {
-				sc_log(ctx, "key index %i ignored: INTERNAL AUTHENTICATE not allowed", idx);
-				continue;
+			else if (ctl_data->usage & SC_PKCS15_PRKEY_USAGE_SIGN)   {
+				if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_INTERNAL_AUTH] == IASECC_SCB_NEVER)   {
+					sc_log(ctx, "key index %i ignored: INTERNAL AUTHENTICATE not allowed", idx);
+					continue;
+				}
 			}
-		}
 
-		if (ctl_data->usage & (SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP))   {
-			if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_PSO_DECIPHER] == IASECC_SCB_NEVER)   {
-				sc_log(ctx, "key index %i ignored: PSO DECIPHER not allowed", idx);
-				continue;
+			if (ctl_data->usage & (SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP))   {
+				if (sdo->docp.scbs[IASECC_ACLS_RSAKEY_PSO_DECIPHER] == IASECC_SCB_NEVER)   {
+					sc_log(ctx, "key index %i ignored: PSO DECIPHER not allowed", idx);
+					continue;
+				}
 			}
 		}
 

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -259,11 +259,11 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 	}
 
 	if (scconf_get_bool (block, "paranoid-memory",
-			   	ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY))
+				ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY))
 		ctx->flags |= SC_CTX_FLAG_PARANOID_MEMORY;
 
 	if (scconf_get_bool (block, "enable_default_driver",
-			   	ctx->flags & SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER))
+				ctx->flags & SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER))
 		ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;
 
 	val = scconf_get_str(block, "force_card_driver", NULL);


### PR DESCRIPTION
Proposed are two configuration options related to the visibility and using of the on-card PKCS#15 applications:
 -- 'disable' -- to not expose application in pkcs15 framework (and so do not create dedicated slot in PKCS#11) ;
 -- 'ignore_usage' -- ignore 'usage' attribute (in IAS/ECC case it's the SDO's key-usage) when looking for a suitable key slot to import/generate key. Thus allowing the applications, that do not bother with key-usage in template for a new key object, to generate/import key in the slot with restricted usage.