### PR TITLE
pkcs11/framework: no 'for-applications' mode of slot creation

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -674,22 +674,19 @@ app opensc-pkcs11 {
 		# Card can contain more then one PINs or more then one on-card application with
 		#   its own PINs. Normally, to access all of them with the PKCS#11 API a slot has to be
 		#   created for all of them. Many slots could be ennoying for some of widely used application,
-		#   like FireFox. This configuration parameter allows to select the PINs or on-card application
+		#   like FireFox. This configuration parameter allows to select the PIN(s)
 		#   for which PKCS#11 slot will be created.
 		# Actually recognised following symbolic names:
-		#  'user', 'sign', 'application', all
+		#  'user', 'sign', 'all'
 		# Only PINs initialised, non-SoPIN, non-unblocking are associated with symbolic name.
 		# 'user' is identified as first global or first local PIN.
 		# 'sign' is identified as second PIN: first local, second global or second local.
-		# 'application' slot created for each on-card application,
-		#   even if they use a common global PIN.
 		# 'all' slot created for all non-sopin, non-unblocking PINs,
 		#   optionally for PUK (see option 'create_puk_slot')
 		#
 		# Default: all
 		# create_slots_for_pins = "user,sign";
-		# create_slots_for_pins = application;
-		# create_slots_for_pins = "application,sign";
+		# create_slots_for_pins = "sign";
 		#
 		# For the module to simulate the opensc-onepin module behavior the following option
 		# must be set:

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1208,7 +1208,7 @@ _add_pin_related_objects(struct sc_pkcs11_slot *slot, struct sc_pkcs15_object *p
 
 
 static void
-_add_public_objects(struct sc_pkcs11_slot *slot, struct pkcs15_fw_data *fw_data, struct pkcs15_fw_data *move_to_fw)
+_add_public_objects(struct sc_pkcs11_slot *slot, struct pkcs15_fw_data *fw_data)
 {
 	unsigned i;
 
@@ -1238,32 +1238,21 @@ _add_public_objects(struct sc_pkcs11_slot *slot, struct pkcs15_fw_data *fw_data,
 
 		sc_log(context, "Add public object(%p,%.*s,%x)", obj, (int) sizeof obj->p15_object->label, obj->p15_object->label, obj->p15_object->type);
 		pkcs15_add_object(slot, obj, NULL);
-
-		if (move_to_fw && move_to_fw != fw_data && move_to_fw->num_objects < MAX_OBJECTS)   {
-			int tail = fw_data->num_objects - i - 1;
-
-			sc_log(context, "Move public object(%p) from %p to %p", obj, fw_data, move_to_fw);
-			move_to_fw->objects[move_to_fw->num_objects++] = obj;
-			if (tail)
-				memcpy(&fw_data->objects[i], &fw_data->objects[i + 1], sizeof(fw_data->objects[0]) * tail);
-			i--;
-			fw_data->num_objects--;
-		}
 	}
 }
 
 
 static CK_RV
-pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_info,
-		struct sc_pkcs11_slot **first_slot)
+pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_info)
 {
-	struct pkcs15_fw_data *fw_data = NULL, *ffda = NULL;
-	struct sc_pkcs15_object *auth_user_pin = NULL, *auth_sign_pin = NULL, *fauo = NULL;
-	struct sc_pkcs11_slot *slot = NULL;
+	struct pkcs15_fw_data *fw_data = NULL;
+	struct sc_pkcs15_object *auth_user_pin = NULL, *auth_sign_pin = NULL;
+	struct sc_pkcs11_slot *slot = NULL, *sign_slot = NULL;
+	unsigned int cs_flags = sc_pkcs11_conf.create_slots_flags;
 	int i, rv, idx;
 
 	sc_log(context, "create PKCS#15 tokens; fws:%p,%p,%p", p11card->fws_data[0], p11card->fws_data[1], p11card->fws_data[2]);
-	sc_log(context, "create slots flags 0x%X", sc_pkcs11_conf.create_slots_flags);
+	sc_log(context, "create slots flags 0x%X", cs_flags);
 
 	/* Find out framework data corresponding to the given application */
 	fw_data = get_fw_data(p11card, app_info, &idx);
@@ -1276,9 +1265,9 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 
 	/* Try to identify UserPIN and SignPIN by their symbolic name */
 	auth_user_pin = _get_auth_object_by_name(fw_data->p15_card, "UserPIN");
-	if (sc_pkcs11_conf.create_slots_flags & SC_PKCS11_SLOT_FOR_PIN_SIGN)
+	if (cs_flags & SC_PKCS11_SLOT_FOR_PIN_SIGN)
 		auth_sign_pin = _get_auth_object_by_name(fw_data->p15_card, "SignPIN");
-	sc_log(context, "Flags:0x%X; Auth User/Sign PINs %p/%p", sc_pkcs11_conf.create_slots_flags, auth_user_pin, auth_sign_pin);
+	sc_log(context, "Flags:0x%X; Auth User/Sign PINs %p/%p", cs_flags, auth_user_pin, auth_sign_pin);
 
 	/* Add PKCS#15 objects of the known types to the framework data */
 	rv = _pkcs15_create_typed_objects(fw_data);
@@ -1290,7 +1279,7 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 	 *  - 'UserPIN' cannot be identified (VT: for some cards with incomplete PIN flags);
 	 *  - configuration impose to create slot for all PINs.
 	 */
-	if (!auth_user_pin || sc_pkcs11_conf.create_slots_flags & SC_PKCS11_SLOT_CREATE_ALL)   {
+	if (!auth_user_pin || cs_flags & SC_PKCS11_SLOT_CREATE_ALL)   {
 		struct sc_pkcs15_object *auths[MAX_OBJECTS];
 		int auth_count;
 
@@ -1325,26 +1314,8 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 		}
 	}
 	else   {
-		/* If there is no need to create slot for each PIN or for each application,
-		 * the objets from the non-first application and protected by the same (global) PIN
-		 * are added to the framework data of the first slot .*/
-		if (!(sc_pkcs11_conf.create_slots_flags & SC_PKCS11_SLOT_FOR_APPLICATION))   {
-			if (first_slot && *first_slot)   {
-				/* Initialize variables related to the first created slot */
-				fauo = slot_data_auth((*first_slot)->fw_data);
-				ffda = (struct pkcs15_fw_data *) p11card->fws_data[(*first_slot)->fw_data_idx];
-				sc_log(context, "%i objects in first slot", ffda->num_objects);
-			}
-		}
-
 		sc_log(context, "User/Sign PINs %p/%p", auth_user_pin, auth_sign_pin);
-		if (fauo && auth_user_pin && !memcmp(fauo->data, auth_user_pin->data, sizeof(struct sc_pkcs15_auth_info)))   {
-			/* Add objects from the non-first application to the FW data of the first slot */
-			sc_log(context, "Add objects to existing slot created for PIN '%.*s'", (int) sizeof fauo->label, fauo->label);
-			_add_pin_related_objects(*first_slot, fauo, fw_data, ffda);
-			slot = *first_slot;
-		}
-		else  if (auth_user_pin) {
+		if (auth_user_pin && (cs_flags & SC_PKCS11_SLOT_FOR_PIN_USER)) {
 			/* For the UserPIN of the first slot create slot */
 			sc_log(context, "Create slot for User PIN '%.*s'", (int) sizeof auth_user_pin->label, auth_user_pin->label);
 			rv = pkcs15_create_slot(p11card, fw_data, auth_user_pin, app_info, &slot);
@@ -1354,10 +1325,8 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 			_add_pin_related_objects(slot, auth_user_pin, fw_data, NULL);
 		}
 
-		/*  Create slot for SignPIN and populate it's FW data with the objects protected by SignPIN*/
-		if (auth_sign_pin && auth_user_pin)   {
-			struct sc_pkcs11_slot *sign_slot = NULL;
-
+		if (auth_sign_pin && (cs_flags & SC_PKCS11_SLOT_FOR_PIN_SIGN))   {
+			/* Only Sign PIN slot needs to be exposed */
 			sc_log(context, "Create slot for Sign PIN '%.*s'", (int) sizeof auth_sign_pin->label, auth_sign_pin->label);
 			rv = pkcs15_create_slot(p11card, fw_data, auth_sign_pin, app_info, &sign_slot);
 			if (rv != CKR_OK)
@@ -1365,26 +1334,23 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 			sign_slot->fw_data_idx = idx;
 			_add_pin_related_objects(sign_slot, auth_sign_pin, fw_data, NULL);
 		}
+
+		sc_log(context, "slot %p, sign-slot %p\n", slot, sign_slot);
+		if (!slot && sign_slot)
+			slot = sign_slot;
 	}
 
-	if (!slot)   {
+	if (!slot && (cs_flags == SC_PKCS11_SLOT_CREATE_ALL))   {
 		sc_log(context, "Now create slot without AUTH object");
 		pkcs15_create_slot(p11card, fw_data, NULL, app_info, &slot);
 		sc_log(context, "Created slot without AUTH object: %p", slot);
 	}
 
-	if (first_slot && *first_slot==NULL)   {
-		sc_log(context, "Set first slot: %p", slot);
-		*first_slot = slot;
-	}
-
 	if (slot)   {
 		sc_log(context, "Add public objects to slot %p", slot);
-		_add_public_objects(slot, fw_data, ffda);
+		_add_public_objects(slot, fw_data);
 	}
 
-	if (ffda)
-		sc_log(context, "Finaly there are %i objects in first slot", ffda->num_objects);
 	sc_log(context, "All tokens created");
 	return CKR_OK;
 }

--- a/src/pkcs11/framework-pkcs15init.c
+++ b/src/pkcs11/framework-pkcs15init.c
@@ -53,8 +53,7 @@ static CK_RV pkcs15init_unbind(struct sc_pkcs11_card *p11card)
 
 
 static CK_RV
-pkcs15init_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_info,
-		struct sc_pkcs11_slot **first_slot)
+pkcs15init_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_info)
 {
 	struct sc_profile	*profile;
 	struct sc_pkcs11_slot	*slot;

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -481,8 +481,6 @@ void load_pkcs11_parameters(struct sc_pkcs11_config *conf, sc_context_t * ctx)
 			conf->create_slots_flags |= SC_PKCS11_SLOT_FOR_PIN_USER;
 		else if (!strcmp(op, "sign"))
 			conf->create_slots_flags |= SC_PKCS11_SLOT_FOR_PIN_SIGN;
-		else if (!strcmp(op, "application"))
-			conf->create_slots_flags |= SC_PKCS11_SLOT_FOR_APPLICATION;
 		else if (!strcmp(op, "all"))
 			conf->create_slots_flags |= SC_PKCS11_SLOT_CREATE_ALL;
 		op = strtok(NULL, " ,");

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -49,8 +49,9 @@ extern "C" {
 
 #define SC_PKCS11_SLOT_FOR_PIN_USER	1
 #define SC_PKCS11_SLOT_FOR_PIN_SIGN	2
-#define SC_PKCS11_SLOT_FOR_APPLICATION	4
 #define SC_PKCS11_SLOT_CREATE_ALL	8
+
+#define SC_PKCS11_SLOT_FOR_PINS		(SC_PKCS11_SLOT_FOR_PIN_USER | SC_PKCS11_SLOT_FOR_PIN_SIGN)
 
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
@@ -152,7 +153,7 @@ struct sc_pkcs11_framework_ops {
 
 	/* Create tokens to virtual slots and
 	 * objects in tokens; called after bind */
-	CK_RV (*create_tokens)(struct sc_pkcs11_card *, struct sc_app_info *, struct sc_pkcs11_slot **);
+	CK_RV (*create_tokens)(struct sc_pkcs11_card *, struct sc_app_info *);
 	CK_RV (*release_token)(struct sc_pkcs11_card *, void *);
 
 	/* Login and logout */

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -255,7 +255,6 @@ again:
 	/* Detect the framework */
 	if (p11card->framework == NULL) {
 		struct sc_app_info *app_generic = sc_pkcs15_get_application_by_type(p11card->card, "generic");
-		struct sc_pkcs11_slot *first_slot = NULL;
 
 		sc_log(context, "%s: Detecting Framework. %i on-card applications", reader->name, p11card->card->app_count);
 		sc_log(context, "%s: generic application %s", reader->name, app_generic ? app_generic->label : "<none>");
@@ -292,7 +291,7 @@ again:
 			}
 
 			sc_log(context, "%s: Creating 'generic' token.", reader->name);
-			rv = frameworks[i]->create_tokens(p11card, app_generic, &first_slot);
+			rv = frameworks[i]->create_tokens(p11card, app_generic);
 			if (rv != CKR_OK)   {
 				sc_log(context, "%s: create 'generic' token error 0x%X", reader->name, rv);
 				return rv;
@@ -315,7 +314,7 @@ again:
 			}
 
 			sc_log(context, "%s: Creating %s token.", reader->name, app_name);
-			rv = frameworks[i]->create_tokens(p11card, app_info, &first_slot);
+			rv = frameworks[i]->create_tokens(p11card, app_info);
 			if (rv != CKR_OK)   {
 				sc_log(context, "%s: create %s token error 0x%X", reader->name, app_name, rv);
 				return rv;


### PR DESCRIPTION
Simplify create tokens rules, no need to manipulate applications in
'pkcs11' configuration part,
applications can be enabled/disabled on the 'pkcs15' one.

Fix the possibility to expose only 'sign' PIN