### PR TITLE
tools: print package revision

### DIFF
--- a/bootstrap.ci
+++ b/bootstrap.ci
@@ -76,4 +76,5 @@ then
     rm -f version.m4.tmp
 fi
 
-autoreconf --verbose --install --force || true
+./bootstrap
+# autoreconf --verbose --install --force || true

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ define([PACKAGE_VERSION_MAJOR], [0])
 define([PACKAGE_VERSION_MINOR], [15])
 define([PACKAGE_VERSION_FIX], [0])
 define([PACKAGE_SUFFIX], [])
-define([PACKAGE_VERSION_REVISION], [0])
 
 define([VS_FF_LEGAL_COPYRIGHT], [OpenSC Project])
 define([VS_FF_LEGAL_COMPANY_NAME], [OpenSC Project])
@@ -31,7 +30,6 @@ AM_INIT_AUTOMAKE(foreign 1.10)
 OPENSC_VERSION_MAJOR="PACKAGE_VERSION_MAJOR"
 OPENSC_VERSION_MINOR="PACKAGE_VERSION_MINOR"
 OPENSC_VERSION_FIX="PACKAGE_VERSION_FIX"
-OPENSC_VERSION_REVISION="PACKAGE_VERSION_REVISION"
 
 OPENSC_VS_FF_LEGAL_COPYRIGHT="VS_FF_LEGAL_COPYRIGHT"
 OPENSC_VS_FF_COMPANY_NAME="VS_FF_LEGAL_COMPANY_NAME"
@@ -303,11 +301,26 @@ AC_MSG_RESULT([${xslstylesheetsdir}])
 AC_MSG_CHECKING([git checkout])
 GIT_CHECKOUT="no"
 if test -n "${GIT}" -a -d "${srcdir}/.git"; then
-        AC_DEFINE([HAVE_CONFIG_VERSION_H], [1], [extra version available in config-version.h])
-        GIT_CHECKOUT="yes"
+	AC_DEFINE([HAVE_CONFIG_VERSION_H], [1], [extra version available in config-version.h])
+	GIT_CHECKOUT="yes"
 fi
 AC_MSG_RESULT([${GIT_CHECKOUT}])
 
+if test "${GIT_CHECKOUT}" = "yes"; then
+	REVISION_DESCRIPTION="$(${GIT} describe || echo '<version not available>' )"
+	if test "${REVISION_DESCRIPTION}" = "<version not available>"; then
+		REVISION_DESCRIPTION="$(${GIT} describe --tags || echo '<version not available>')"
+	fi
+
+	HASH_COMMIT_DATE="$(${GIT} log -1 --pretty=format:'rev: %h, commit-time: %ci')"
+	GIT_TAG_COMMIT="$(${GIT} rev-list --tags --no-walk --max-count=1)"
+
+	OPENSC_SCM_REVISION="OpenSC-${REVISION_DESCRIPTION}, ${HASH_COMMIT_DATE}"
+	OPENSC_VERSION_REVISION="$(${GIT} rev-list ${GIT_TAG_COMMIT}..HEAD --count || echo 0)"
+else
+	OPENSC_SCM_REVISION="No Git revision info available"
+	OPENSC_VERSION_REVISION="0"
+fi
 
 dnl C Compiler features
 AC_C_INLINE
@@ -683,7 +696,8 @@ fi
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_MAJOR], [${OPENSC_VERSION_MAJOR}], [OpenSC version major component])
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_MINOR], [${OPENSC_VERSION_MINOR}], [OpenSC version minor component])
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_FIX], [${OPENSC_VERSION_FIX}], [OpenSC version fix component])
-AC_DEFINE_UNQUOTED([OPENSC_VERSION_REVISION], [${OPENSC_VERSION_REVISION}], [OpenSC version Git describe revision])
+AC_DEFINE_UNQUOTED([OPENSC_VERSION_REVISION], [${OPENSC_VERSION_REVISION}], [OpenSC file version revision])
+AC_DEFINE_UNQUOTED([OPENSC_SCM_REVISION], ["${OPENSC_SCM_REVISION}"], [OpenSC version Git describe revision])
 AC_DEFINE_UNQUOTED([OPENSC_FEATURES], ["${OPENSC_FEATURES}"], [Enabled OpenSC features])
 
 AC_DEFINE_UNQUOTED([OPENSC_VS_FF_LEGAL_COPYRIGHT], [${OPENSC_VS_FF_LEGAL_COPYRIGHT}], [OpenSC version-info LegalCopyright value])
@@ -702,6 +716,7 @@ AC_SUBST([OPENSC_VERSION_MAJOR])
 AC_SUBST([OPENSC_VERSION_MINOR])
 AC_SUBST([OPENSC_VERSION_FIX])
 AC_SUBST([OPENSC_VERSION_REVISION])
+AC_SUBST([OPENSC_SCM_REVISION])
 AC_SUBST([OPENSC_VS_FF_LEGAL_COPYRIGHT])
 AC_SUBST([OPENSC_VS_FF_COMPANY_NAME])
 AC_SUBST([OPENSC_VS_FF_COMMENTS])
@@ -805,6 +820,7 @@ OpenSC has been configured with the following options:
 Version:                 ${PACKAGE_VERSION}
 Version fix:             ${OPENSC_VERSION_FIX}
 Version revision:        ${OPENSC_VERSION_REVISION}
+Git revision:            ${OPENSC_SCM_REVISION}
 
 Copyright:               ${OPENSC_VS_FF_LEGAL_COPYRIGHT}
 Company:                 ${OPENSC_VS_FF_COMPANY_NAME}

--- a/doc/tools/opensc-tool.1.xml
+++ b/doc/tools/opensc-tool.1.xml
@@ -35,6 +35,12 @@
 			<variablelist>
 				<varlistentry>
 					<term>
+						<option>--version</option>,
+					</term>
+					<listitem><para>Print the OpenSC package release version.</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>--atr</option>,
 						<option>-a</option>
 					</term>

--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -50,17 +50,19 @@ static int	verbose = 0;
 
 enum {
 	OPT_SERIAL = 0x100,
-	OPT_LIST_ALG
+	OPT_LIST_ALG,
+	OPT_VERSION
 };
 
 static const struct option options[] = {
+	{ "version",		0, NULL,	OPT_VERSION },
 	{ "info",		0, NULL,		'i' },
 	{ "atr",		0, NULL,		'a' },
 	{ "serial",		0, NULL,	OPT_SERIAL  },
 	{ "name",		0, NULL,		'n' },
 	{ "get-conf-entry",	1, NULL,		'G' },
 	{ "set-conf-entry",	1, NULL,		'S' },
-	{ "list-readers",	0, NULL, 		'l' },
+	{ "list-readers",	0, NULL,		'l' },
 	{ "list-drivers",	0, NULL,		'D' },
 	{ "list-files",		0, NULL,		'f' },
 	{ "send-apdu",		1, NULL,		's' },
@@ -73,6 +75,7 @@ static const struct option options[] = {
 };
 
 static const char *option_help[] = {
+	"Prints OpenSC package revision",
 	"Prints information about OpenSC",
 	"Prints the ATR bytes of the card",
 	"Prints the card serial number",
@@ -650,6 +653,7 @@ int main(int argc, char * const argv[])
 	int do_list_files = 0;
 	int do_send_apdu = 0;
 	int do_print_atr = 0;
+	int do_print_version = 0;
 	int do_print_serial = 0;
 	int do_print_name = 0;
 	int do_list_algorithms = 0;
@@ -724,6 +728,10 @@ int main(int argc, char * const argv[])
 		case 'v':
 			verbose++;
 			break;
+		case OPT_VERSION:
+			do_print_version = 1;
+			action_count++;
+			break;
 		case 'c':
 			opt_driver = optarg;
 			break;
@@ -742,6 +750,11 @@ int main(int argc, char * const argv[])
 	}
 	if (action_count == 0)
 		util_print_usage_and_die(app_name, options, option_help, NULL);
+
+	if (do_print_version)   {
+		printf("%s\n", OPENSC_SCM_REVISION);
+		action_count--;
+	}
 
 	if (do_info) {
 		opensc_info();

--- a/version.m4
+++ b/version.m4
@@ -3,7 +3,6 @@ define([PRODUCT_NAME], [OpenSC])
 define([PRODUCT_TARNAME], [opensc])
 define([PRODUCT_BUGREPORT], [opensc-devel@lists.sourceforge.net])
 define([PACKAGE_SUFFIX], [])
-define([PACKAGE_VERSION_REVISION], [0])
 
 define([VS_FF_LEGAL_COPYRIGHT], [OpenSC Project])
 define([VS_FF_LEGAL_COMPANY_NAME], [OpenSC Project])

--- a/win32/winconfig.h.in
+++ b/win32/winconfig.h.in
@@ -100,4 +100,8 @@
 #define DEFAULT_PKCS11_PROVIDER "opensc-pkcs11.dll"
 #endif
 
+#ifndef OPENSC_SCM_REVISION
+#define OPENSC_SCM_REVISION "@OPENSC_SCM_REVISION@"
+#endif
+
 #endif


### PR DESCRIPTION
Follows issue #691

- Initialize the _PACKAGE_VERSION_REVISION_ with commits number from _'git describe'_.
- Introduces the OpenSC package revision printed by tools when tools are used with _--version_ cmd argument. For a while only for _opensc-tools_, but will also be applied to other main opensc-xx and pkcs15x-xx tools.