### PR TITLE
ASN1: invalid parse of high-number-tags

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -73,14 +73,17 @@ int sc_asn1_read_tag(const u8 ** buf, size_t buflen, unsigned int *cla_out,
 		*tag_out = SC_ASN1_TAG_EOC;
 		return SC_SUCCESS;
 	}
-	/* parse tag byte(s) */
+	/* parse tag byte(s)
+	 * Resulted tag is presented by integer that has not to be
+	 * confused with the 'tag number' part of ASN.1 tag.
+	 */
 	cla = (*p & SC_ASN1_TAG_CLASS) | (*p & SC_ASN1_TAG_CONSTRUCTED);
 	tag = *p & SC_ASN1_TAG_PRIMITIVE;
 	p++;
 	left--;
 	if (tag == SC_ASN1_TAG_PRIMITIVE) {
 		/* high tag number */
-		size_t n = sizeof(int) - 1;
+		size_t n = SC_ASN1_TAGNUM_SIZE - 1;
 		/* search the last tag octet */
 		while (left-- != 0 && n != 0) {
 			tag <<= 8;
@@ -93,10 +96,8 @@ int sc_asn1_read_tag(const u8 ** buf, size_t buflen, unsigned int *cla_out,
 			/* either an invalid tag or it doesn't fit in
 			 * unsigned int */
 			return SC_ERROR_INVALID_ASN1_OBJECT;
-
 	}
-	if (left == 0)
-		return SC_ERROR_INVALID_ASN1_OBJECT;
+
 	/* parse length byte(s) */
 	len = *p & 0x7f;
 	if (*p++ & 0x80) {

--- a/src/libopensc/asn1.h
+++ b/src/libopensc/asn1.h
@@ -135,6 +135,7 @@ int sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx,
 #define SC_ASN1_CONS			0x01000000
 
 #define SC_ASN1_TAG_MASK		0x00FFFFFF
+#define SC_ASN1_TAGNUM_SIZE		3
 
 #define SC_ASN1_PRESENT			0x00000001
 #define SC_ASN1_OPTIONAL		0x00000002


### PR DESCRIPTION
Trying to understand _coverity-scan_ issue, I found out that _high-value-tag_ is not correctly parsed.
Apparently it has never been used, and will never be used, 
but for the purity of code this PR is proposed.