### PR TITLE
pkcs15: use file cache for path with AID

### DIFF
--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2314,7 +2314,16 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 	r = -1; /* file state: not in cache */
 	if (p15card->opts.use_file_cache) {
 		r = sc_pkcs15_read_cached_file(p15card, in_path, &data, &len);
+
+		if (!r && in_path->aid.len > 0 && in_path->len >= 2)   {
+			struct sc_path parent = *in_path;
+
+			parent.len -= 2;
+			parent.type = SC_PATH_TYPE_PATH;
+			r = sc_select_file(p15card->card, &parent, NULL);
+		}
 	}
+
 	if (r) {
 		r = sc_lock(p15card->card);
 		LOG_TEST_RET(ctx, r, "sc_lock() failed");

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -537,8 +537,8 @@ sc_pkcs15_get_lastupdate(struct sc_pkcs15_card *p15card)
 	struct sc_context *ctx  = p15card->card->ctx;
 	struct sc_file *file = NULL;
 	struct sc_asn1_entry asn1_last_update[C_ASN1_LAST_UPDATE_SIZE];
-        unsigned char *content, last_update[32];
-        size_t lupdate_len = sizeof(last_update) - 1;
+	unsigned char *content, last_update[32];
+	size_t lupdate_len = sizeof(last_update) - 1;
 	int r, content_len;
 	size_t size;
 
@@ -552,11 +552,8 @@ sc_pkcs15_get_lastupdate(struct sc_pkcs15_card *p15card)
 	if (r < 0)
 		return NULL;
 
-	if (file->size) {
-		size = 1024;
-	} else {
-		size = file->size;
-	}
+	size = file->size ? file->size : 1024;
+
 	content = calloc(size, 1);
 	if (!content)
 		return NULL;


### PR DESCRIPTION
When activated by configuration, the cache of the on-card files is applied only to paths of type _PATH_ -- full path starting from MF with or without _3F00_.
Proposed PR make it also possible for the application paths (path with AID) of type _FILE_ID_.

Initial motivation of PR was attempt to resolve the _TOCTOU_ coverity-scan issue.