### PR TITLE
Auxiliary, non-pkcs15, data in pkcs15 data types

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -11,7 +11,7 @@ noinst_HEADERS = cards.h ctbcs.h internal.h esteid.h muscle.h muscle-filesystem.
 	cardctl.h asn1.h log.h \
 	errors.h types.h compression.h itacns.h iso7816.h \
 	authentic.h iasecc.h iasecc-sdo.h sm.h card-sc-hsm.h \
-	pace.h cwa14890.h cwa-dnie.h card-gids.h
+	pace.h cwa14890.h cwa-dnie.h card-gids.h aux-data.h
 
 AM_CPPFLAGS = -DOPENSC_CONF_PATH=\"$(sysconfdir)/opensc.conf\" \
 	-I$(top_srcdir)/src
@@ -50,6 +50,7 @@ libopensc_la_SOURCES = \
 	pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
 	pkcs15-dnie.c pkcs15-gids.c \
 	compression.c p15card-helper.c sm.c \
+	aux-data.c \
 	libopensc.exports
 if WIN32
 libopensc_la_SOURCES += $(top_builddir)/win32/versioninfo.rc

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = Makefile.mak
 
 lib_LTLIBRARIES = libopensc.la
 noinst_HEADERS = cards.h ctbcs.h internal.h esteid.h muscle.h muscle-filesystem.h \
-	internal-winscard.h p15card-helper.h \
+	internal-winscard.h p15card-helper.h pkcs15-syn.h \
 	opensc.h pkcs15.h \
 	cardctl.h asn1.h log.h \
 	errors.h types.h compression.h itacns.h iso7816.h \
@@ -48,7 +48,7 @@ libopensc_la_SOURCES = \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
 	pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c pkcs15-oberthur.c \
 	pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
-	pkcs15-dnie.c pkcs15-gids.c \
+	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c \
 	compression.c p15card-helper.c sm.c \
 	aux-data.c \
 	libopensc.exports

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -31,7 +31,7 @@ OBJECTS			= \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \
 	pkcs15-esinit.obj pkcs15-westcos.obj pkcs15-pteid.obj pkcs15-oberthur.obj \
 	pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
-	pkcs15-dnie.obj pkcs15-gids.obj \
+	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj \
 	compression.obj p15card-helper.obj sm.obj \
 	aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -33,6 +33,7 @@ OBJECTS			= \
 	pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
 	pkcs15-dnie.obj pkcs15-gids.obj \
 	compression.obj p15card-helper.obj sm.obj \
+	aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res
 
 all: $(TOPDIR)\win32\versioninfo.res $(TARGET)

--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -1,0 +1,200 @@
+/*
+ * aux-data.c: Auxiliary data help functions
+ *
+ * Copyright (C) 2016 Viktor Tarasov <viktor.tarasov@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+#include "common/compat_strlcat.h"
+
+#include <libopensc/errors.h>
+#include <libopensc/types.h>
+#include <libopensc/log.h>
+#include <libopensc/aux-data.h>
+
+
+int
+sc_aux_data_allocate(struct sc_context *ctx, struct sc_auxiliary_data **dst, struct sc_auxiliary_data *src)
+{
+	int rv = SC_ERROR_INTERNAL;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!dst)
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Cannot allocate auxiliary data");
+
+	if (*dst == NULL)   {
+		*dst = calloc(1, sizeof(struct sc_auxiliary_data));
+		if (*dst == NULL)
+			LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "Cannot allocate aux. data");
+	}
+
+	if ((src == NULL) || (src->type == SC_AUX_DATA_TYPE_NO_DATA))
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	switch(src->type) {
+	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
+		**dst = *src;
+		rv = SC_SUCCESS;
+		break;
+	default:
+		sc_log(ctx, "Invalid aux-data type %X", src->type);
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Unknown aux-data type");
+	}
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+int
+sc_aux_data_set_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_data, char *guid)
+{
+	struct sc_md_cmap_record *rec;
+	int rv = SC_ERROR_INTERNAL;
+
+	LOG_FUNC_CALLED(ctx);
+	if (!aux_data || !guid || strlen(guid) > SC_MD_MAX_CONTAINER_NAME_LEN)
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Cannot set guid for MD container");
+
+	switch(aux_data->type) {
+	case SC_AUX_DATA_TYPE_NO_DATA:
+		memset(aux_data, 0, sizeof(*aux_data));
+		aux_data->type = SC_AUX_DATA_TYPE_MD_CMAP_RECORD;
+	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
+		rec = &aux_data->data.cmap_record;
+		memcpy(rec->guid, guid, strlen(guid));
+		rec->guid_len = strlen(guid);
+		sc_log(ctx, "set MD container GUID '%s'", aux_data->data.cmap_record.guid);
+		rv = SC_SUCCESS;
+		break;
+	default:
+		sc_log(ctx, "Invalid aux-data type %X", aux_data->type);
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Unknown aux-data type");
+	}
+
+	LOG_FUNC_RETURN(ctx, rv);
+	return rv;
+}
+
+
+int
+sc_aux_data_set_md_flags(struct sc_context *ctx, struct sc_auxiliary_data *aux_data, unsigned char flags)
+{
+	int rv = SC_ERROR_INTERNAL;
+
+	LOG_FUNC_CALLED(ctx);
+	if (!aux_data)
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Cannot set flags of MD container");
+
+	switch(aux_data->type) {
+	case SC_AUX_DATA_TYPE_NO_DATA:
+		memset(aux_data, 0, sizeof(*aux_data));
+		aux_data->type = SC_AUX_DATA_TYPE_MD_CMAP_RECORD;
+	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
+		aux_data->data.cmap_record.flags = flags;
+		sc_log(ctx, "set MD container flags '0x%X'", flags);
+		rv = SC_SUCCESS;
+		break;
+	default:
+		sc_log(ctx, "Invalid aux-data type %X", aux_data->type);
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Unknown aux-data type");
+	}
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+int
+sc_aux_data_get_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_data,
+		unsigned flags, unsigned char *out, size_t *out_size)
+{
+	struct sc_md_cmap_record *cmap_record = NULL;
+	char guid[SC_MD_MAX_CONTAINER_NAME_LEN + 3];
+
+	LOG_FUNC_CALLED(ctx);
+	if(!aux_data || !out || !out_size)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (aux_data->type != SC_AUX_DATA_TYPE_MD_CMAP_RECORD)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
+
+	cmap_record = &aux_data->data.cmap_record;
+
+	*guid = '\0';
+	if (!flags)
+		strcpy(guid, "{");
+	strlcat(guid, (char *)cmap_record->guid, sizeof(guid)-1);
+	if (!flags)
+		strlcat(guid, "}", sizeof(guid));
+
+	if (*out_size < strlen(guid))
+		LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
+
+	memset(out, 0, *out_size);
+	memcpy(out, guid, strlen(guid));
+	*out_size = strlen(guid);
+
+	sc_log(ctx, "aux-data: returns guid '%s'", (char *)out);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+
+int
+sc_aux_data_get_md_flags(struct sc_context *ctx, struct sc_auxiliary_data *aux_data,
+		unsigned char *flags)
+{
+	struct sc_md_cmap_record *cmap_record = NULL;
+
+	LOG_FUNC_CALLED(ctx);
+	if(!aux_data || !flags)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (aux_data->type != SC_AUX_DATA_TYPE_MD_CMAP_RECORD)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
+
+	*flags = aux_data->data.cmap_record.flags;
+
+	sc_log(ctx, "aux-data: returns flags '0x%X'", *flags);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+
+void
+sc_aux_data_free(struct sc_auxiliary_data **data)
+{
+	if (data == NULL || *data == NULL)
+		return;
+
+	switch((*data)->type) {
+	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
+		free(*data);
+		break;
+	default:
+		break;
+	}
+
+	*data = NULL;
+}
+

--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -142,6 +142,10 @@ sc_aux_data_get_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_da
 
 	cmap_record = &aux_data->data.cmap_record;
 
+	/* Ignore silently request of '{}' frame if output buffer is too small */
+	if (!flags && *out_size < strlen((char *)cmap_record->guid) + 2)
+		flags = 1;
+
 	*guid = '\0';
 	if (!flags)
 		strcpy(guid, "{");
@@ -149,8 +153,10 @@ sc_aux_data_get_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_da
 	if (!flags)
 		strlcat(guid, "}", sizeof(guid));
 
-	if (*out_size < strlen(guid))
+	if (*out_size < strlen(guid))   {
+		sc_log(ctx, "aux-data: buffer too small: out_size:%i < guid-length:%i", *out_size, strlen(guid));
 		LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
+	}
 
 	memset(out, 0, *out_size);
 	memcpy(out, guid, strlen(guid));
@@ -165,8 +171,6 @@ int
 sc_aux_data_get_md_flags(struct sc_context *ctx, struct sc_auxiliary_data *aux_data,
 		unsigned char *flags)
 {
-	struct sc_md_cmap_record *cmap_record = NULL;
-
 	LOG_FUNC_CALLED(ctx);
 	if(!aux_data || !flags)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);

--- a/src/libopensc/aux-data.h
+++ b/src/libopensc/aux-data.h
@@ -1,0 +1,85 @@
+/*
+ * aux-data.h: Non PKCS#15, non ISO7816 data
+ *             Used to pass auxiliary data from non PKCS#15, non ISO7816 appliations (like minidriver)
+ *             to card specific part through the standard PKCS#15 and ISO7816 frameworks
+ *
+ * Copyright (C) 2016  Viktor Tarasov <viktor.tarasov@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _AUX_DATA_H
+#define _AUX_DATA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "cardctl.h"
+#include "internal.h"
+#include "errors.h"
+#include "asn1.h"
+#include "types.h"
+
+#define SC_AUX_DATA_TYPE_NO_DATA	0x00
+#define SC_AUX_DATA_TYPE_MD_CMAP_RECORD	0x01
+
+/* From Windows Smart Card Minidriver Specification
+ * Version 7.06
+ *
+ * #define MAX_CONTAINER_NAME_LEN       39
+ * #define CONTAINER_MAP_VALID_CONTAINER        1
+ * #define CONTAINER_MAP_DEFAULT_CONTAINER      2
+ * typedef struct _CONTAINER_MAP_RECORD
+ * {
+ *      WCHAR wszGuid [MAX_CONTAINER_NAME_LEN + 1];
+ *      BYTE bFlags;
+ *      BYTE bReserved;
+ *      WORD wSigKeySizeBits;
+ *      WORD wKeyExchangeKeySizeBits;
+ * } CONTAINER_MAP_RECORD, *PCONTAINER_MAP_RECORD;
+ */
+#define SC_MD_MAX_CONTAINER_NAME_LEN	39
+#define SC_MD_CONTAINER_MAP_VALID_CONTAINER	0x01
+#define SC_MD_CONTAINER_MAP_DEFAULT_CONTAINER	0x02
+
+struct sc_md_cmap_record {
+	unsigned char guid[SC_MD_MAX_CONTAINER_NAME_LEN + 1];
+	size_t guid_len;
+	unsigned flags;
+	unsigned keysize_sign;
+	unsigned keysize_keyexchange;
+};
+
+struct sc_auxiliary_data {
+	unsigned type;
+	union {
+		struct sc_md_cmap_record cmap_record;
+	} data;
+};
+
+int sc_aux_data_set_md_flags(struct sc_context *, struct sc_auxiliary_data *, unsigned char);
+int sc_aux_data_allocate(struct sc_context *, struct sc_auxiliary_data **, struct sc_auxiliary_data *);
+int sc_aux_data_set_md_guid(struct sc_context *, struct sc_auxiliary_data *, char *);
+void sc_aux_data_free(struct sc_auxiliary_data **);
+int sc_aux_data_get_md_guid(struct sc_context *, struct sc_auxiliary_data *, unsigned,
+		unsigned char *, size_t *);
+int sc_aux_data_get_md_flags(struct sc_context *, struct sc_auxiliary_data *, unsigned char *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ifndef _AUX_DATA_H */

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -53,6 +53,11 @@ sc_asn1_verify_tag
 sc_asn1_write_element
 sc_asn1_sig_value_sequence_to_rs
 sc_asn1_sig_value_rs_to_sequence
+sc_aux_data_set_md_flags
+sc_aux_data_allocate
+sc_aux_data_set_md_guid
+sc_aux_data_free
+sc_aux_data_get_md_guid
 sc_base64_decode
 sc_base64_encode
 sc_bin_to_hex

--- a/src/libopensc/pkcs15-actalis.c
+++ b/src/libopensc/pkcs15-actalis.c
@@ -37,7 +37,7 @@
 #include "libopensc/pkcs15.h"
 #include "libopensc/log.h"
 
-int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int (*set_security_env) (sc_card_t *, const sc_security_env_t *, int);
 
@@ -306,7 +306,8 @@ static int actalis_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t * p15card,
-				   sc_pkcs15emu_opt_t * opts)
+				 struct sc_aid *aid,
+				 sc_pkcs15emu_opt_t * opts)
 {
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
 		return sc_pkcs15emu_actalis_init(p15card);

--- a/src/libopensc/pkcs15-atrust-acos.c
+++ b/src/libopensc/pkcs15-atrust-acos.c
@@ -34,7 +34,7 @@
 #define MANU_ID		"A-Trust"
 #define CARD_LABEL	"a.sign Premium a"
 
-int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *, struct sc_aid *aid, sc_pkcs15emu_opt_t *);
 
 typedef struct cdata_st {
 	const char *label;
@@ -265,6 +265,7 @@ static int sc_pkcs15emu_atrust_acos_init(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,
+				  struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
 

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -261,6 +261,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 /* public functions for in-built module */
 /****************************************/
 int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t * p15card,
+			      struct sc_aid *aid,
 			      sc_pkcs15emu_opt_t * opts)
 {
 	int r=SC_SUCCESS;

--- a/src/libopensc/pkcs15-esinit.c
+++ b/src/libopensc/pkcs15-esinit.c
@@ -29,7 +29,7 @@
 
 #define MANU_ID		"entersafe"
 
-int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int entersafe_detect_card( sc_pkcs15_card_t *p15card)
 {
@@ -77,6 +77,7 @@ static int sc_pkcs15emu_entersafe_init( sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *p15card,
+				   struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
 	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -39,7 +39,7 @@
 #include "pkcs15.h"
 #include "esteid.h"
 
-int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static void
 set_string (char **strp, const char *value)
@@ -269,6 +269,7 @@ static int esteid_detect_card(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *p15card,
+				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
 

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -35,7 +35,7 @@
 
 #define MANU_ID		"GemSAFE on GPK16000"
 
-int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int (*pin_cmd_save)(struct sc_card *, struct sc_pin_cmd_data *, 
 		int *tries_left);
@@ -506,7 +506,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 	return SC_SUCCESS;
 }
 
-int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card,
+int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
 	sc_card_t   *card = p15card->card;

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -40,7 +40,7 @@
 #define GEMSAFE_READ_QUANTUM    248
 #define GEMSAFE_MAX_OBJLEN      28672
 
-int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *, struct sc_aid *,sc_pkcs15emu_opt_t *);
 
 static int
 sc_pkcs15emu_add_cert(sc_pkcs15_card_t *p15card,
@@ -434,6 +434,7 @@ static int sc_pkcs15emu_gemsafeV1_init( sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_gemsafeV1_init_ex( sc_pkcs15_card_t *p15card,
+			struct sc_aid *aid,
 			sc_pkcs15emu_opt_t *opts)
 {
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -221,6 +221,7 @@ static int sc_pkcs15emu_gids_init (sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
+				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
 	if (opts && (opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
@@ -236,6 +237,7 @@ int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
 #else
 
 int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
+				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
 	return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -1,0 +1,78 @@
+/*
+ * PKCS15 emulation layer for IAS/ECC card.
+ *
+ * Copyright (C) 2016, Viktor Tarasov <viktor.tarasov@gmail.com>
+ * Copyright (C) 2004, Bud P. Bruegger <bud@comune.grosseto.it>
+ * Copyright (C) 2004, Antonino Iacono <ant_iacono@tin.it>
+ * Copyright (C) 2003, Olaf Kirch <okir@suse.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#ifdef ENABLE_OPENSSL
+#include <openssl/x509v3.h>
+#endif
+
+#include "internal.h"
+#include "pkcs15.h"
+
+int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
+
+
+static int
+sc_pkcs15emu_iasecc_init (struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	int rv;
+
+	LOG_FUNC_CALLED(ctx);
+
+	rv = sc_pkcs15_bind_internal(p15card, aid);
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+static int
+iasecc_detect_card(sc_pkcs15_card_t *p15card)
+{
+	if (p15card->card->type < SC_CARD_TYPE_IASECC_BASE)
+		return SC_ERROR_WRONG_CARD;
+
+	if (p15card->card->type > SC_CARD_TYPE_IASECC_BASE + 10)
+		return SC_ERROR_WRONG_CARD;
+
+	return SC_SUCCESS;
+}
+
+
+int
+sc_pkcs15emu_iasecc_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid, struct sc_pkcs15emu_opt *opts)
+{
+	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
+		return sc_pkcs15emu_iasecc_init(p15card, aid);
+
+	if (iasecc_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+
+	return sc_pkcs15emu_iasecc_init(p15card, aid);
+}

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -34,8 +34,156 @@
 
 #include "internal.h"
 #include "pkcs15.h"
+#include "iasecc.h"
+#include "aux-data.h"
 
-int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
+#define IASECC_GEMALTO_MD_APPLICAITON_NAME "CSP"
+#define IASECC_GEMALTO_MD_DEFAULT_CONT_LABEL "Default Key Container"
+
+static int
+_iasecc_md_update_keyinfo(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *dobj, int default_cont)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_prkey_info *prkey_info = NULL;
+	struct sc_pkcs15_object *prkey_object = NULL;
+	struct sc_pkcs15_data *ddata = NULL;
+	struct sc_pkcs15_id id;
+	int rv, offs;
+	unsigned flags;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!dobj)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobj->data, &ddata);
+	LOG_TEST_RET(ctx, rv, "Failed to read container DATA object data");
+
+	offs = 0;
+	rv = SC_ERROR_INVALID_DATA;
+	if (*(ddata->data + offs++) != 0x01)   {
+		sc_pkcs15_free_data_object(ddata);
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+	}
+
+	id.len = *(ddata->data + offs++);
+	memcpy(id.value, ddata->data + offs, id.len);
+	offs += (int) id.len;
+
+	if (*(ddata->data + offs++) != 0x02)  {
+		sc_pkcs15_free_data_object(ddata);
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+	}
+	if (*(ddata->data + offs++) != 0x01)  {
+		sc_pkcs15_free_data_object(ddata);
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+	}
+
+	flags = *(ddata->data + offs);
+	if (default_cont)
+		flags |= SC_MD_CONTAINER_MAP_DEFAULT_CONTAINER;
+
+	sc_pkcs15_free_data_object(ddata);
+
+	rv = sc_pkcs15_find_prkey_by_id(p15card, &id, &prkey_object);
+	LOG_TEST_RET(ctx, rv, "Find related PrKey error");
+
+	prkey_info = (struct sc_pkcs15_prkey_info *)prkey_object->data;
+	if (prkey_info->aux_data == NULL)   {
+		rv = sc_aux_data_allocate(ctx, &prkey_info->aux_data, NULL);
+		LOG_TEST_RET(ctx, rv, "Cannot allocate MD auxiliary data");
+	}
+
+	rv = sc_aux_data_set_md_guid(ctx, prkey_info->aux_data, dobj->label);
+	LOG_TEST_RET(ctx, rv, "Cannot set MD CMAP Guid");
+
+	rv = sc_aux_data_set_md_flags(ctx, prkey_info->aux_data, flags);
+	LOG_TEST_RET(ctx, rv, "Cannot set MD CMAP record flags");
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+static int
+_iasecc_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_object *dobjs[32];
+	struct sc_pkcs15_data *default_guid = NULL;
+	int rv, ii, count;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!df)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (df->enumerated)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	rv = sc_pkcs15_parse_df(p15card, df);
+	LOG_TEST_RET(ctx, rv, "DF parse error");
+
+	if (p15card->card->type != SC_CARD_TYPE_IASECC_GEMALTO)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	if (df->type != SC_PKCS15_PRKDF)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	sc_log(ctx, "parse of SC_PKCS15_PRKDF");
+
+	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_DATA_OBJECT, dobjs, sizeof(dobjs)/sizeof(dobjs[0]));
+	LOG_TEST_RET(ctx, rv, "Cannot get DATA objects list");
+
+	count = rv;
+	for(ii=0; ii<count; ii++)   {
+		struct sc_pkcs15_data_info *dinfo = (struct sc_pkcs15_data_info *)dobjs[ii]->data;
+
+		if (strcmp(dinfo->app_label, IASECC_GEMALTO_MD_APPLICAITON_NAME))
+			continue;
+
+		if (!strcmp(dobjs[ii]->label, IASECC_GEMALTO_MD_DEFAULT_CONT_LABEL))   {
+			rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobjs[ii]->data, &default_guid);
+			LOG_TEST_RET(ctx, rv, "Failed to read 'default container' DATA object data");
+			break;
+		}
+	}
+
+	for(ii=0; ii<count; ii++)   {
+		struct sc_pkcs15_data_info *dinfo = (struct sc_pkcs15_data_info *)dobjs[ii]->data;
+		int default_cont = 0;
+
+		if (strcmp(dinfo->app_label, IASECC_GEMALTO_MD_APPLICAITON_NAME))
+			continue;
+
+		if (!strcmp(dobjs[ii]->label, IASECC_GEMALTO_MD_DEFAULT_CONT_LABEL))
+			continue;
+
+		if (default_guid)
+			if (strlen(dobjs[ii]->label) == default_guid->data_len)
+				if (!memcmp(dobjs[ii]->label, default_guid->data, default_guid->data_len))
+					default_cont = 1;
+
+		rv = _iasecc_md_update_keyinfo(p15card, dobjs[ii], default_cont);
+		LOG_TEST_RET(ctx, rv, "Cannot update key MD info");
+	}
+
+	sc_pkcs15_free_data_object(default_guid);
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+static int
+iasecc_pkcs15emu_detect_card(sc_pkcs15_card_t *p15card)
+{
+	if (p15card->card->type < SC_CARD_TYPE_IASECC_BASE)
+		return SC_ERROR_WRONG_CARD;
+
+	if (p15card->card->type > SC_CARD_TYPE_IASECC_BASE + 10)
+		return SC_ERROR_WRONG_CARD;
+
+	return SC_SUCCESS;
+}
 
 
 static int
@@ -48,20 +196,9 @@ sc_pkcs15emu_iasecc_init (struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 
 	rv = sc_pkcs15_bind_internal(p15card, aid);
 
+	p15card->ops.parse_df = _iasecc_parse_df;
+
 	LOG_FUNC_RETURN(ctx, rv);
-}
-
-
-static int
-iasecc_detect_card(sc_pkcs15_card_t *p15card)
-{
-	if (p15card->card->type < SC_CARD_TYPE_IASECC_BASE)
-		return SC_ERROR_WRONG_CARD;
-
-	if (p15card->card->type > SC_CARD_TYPE_IASECC_BASE + 10)
-		return SC_ERROR_WRONG_CARD;
-
-	return SC_SUCCESS;
 }
 
 
@@ -71,7 +208,7 @@ sc_pkcs15emu_iasecc_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid, 
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
 		return sc_pkcs15emu_iasecc_init(p15card, aid);
 
-	if (iasecc_detect_card(p15card))
+	if (iasecc_pkcs15emu_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;
 
 	return sc_pkcs15emu_iasecc_init(p15card, aid);

--- a/src/libopensc/pkcs15-infocamere.c
+++ b/src/libopensc/pkcs15-infocamere.c
@@ -36,7 +36,7 @@
 #include "pkcs15.h"
 #include "log.h"
 
-int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t *,
+int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t *, struct sc_aid *aid,
 		sc_pkcs15emu_opt_t *);
 
 static int (*set_security_env) (sc_card_t *, const sc_security_env_t *,
@@ -822,6 +822,7 @@ static int infocamere_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t * p15card,
+		struct sc_aid *aid,
 		sc_pkcs15emu_opt_t * opts)
 {
 

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -44,8 +44,7 @@
 #include <openssl/x509v3.h>
 #endif
 
-int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *,
-				    sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static const char path_serial[] = "10001003";
 
@@ -847,8 +846,8 @@ static int itacns_init(sc_pkcs15_card_t *p15card)
 	return r;
 }
 
-int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *p15card,
-				    sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
+		sc_pkcs15emu_opt_t *opts)
 {
 	sc_card_t *card = p15card->card;
 	SC_FUNC_CALLED(card->ctx, 1);

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -25,7 +25,7 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
- 
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -65,7 +65,7 @@
 
 #define PIN_DOMAIN_LABEL	"SCM"
 const unsigned char PinDomainID[3] = {0x53, 0x43, 0x4D};
-	
+
 #define AWP_PIN_DF		"3F005011"
 #define AWP_TOKEN_INFO		"3F0050111000"
 #define AWP_PUK_FILE		"3F0050112000"
@@ -91,7 +91,7 @@ static int sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *, unsigned, u
 static int sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *, unsigned);
 static int sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *, unsigned, unsigned, int);
 
-int sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card *, struct sc_pkcs15emu_opt *);
+int sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card *, struct sc_aid *, struct sc_pkcs15emu_opt *);
 
 static int sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *, unsigned char *, size_t, int);
 static int sc_oberthur_parse_containers (struct sc_pkcs15_card *, unsigned char *, size_t, int);
@@ -162,7 +162,7 @@ sc_oberthur_decode_usage(unsigned flags)
 }
 
 
-static int 
+static int
 sc_oberthur_get_friends (unsigned int id, struct crypto_container *ccont)
 {
 	struct container *cont;
@@ -173,14 +173,14 @@ sc_oberthur_get_friends (unsigned int id, struct crypto_container *ccont)
 				memcpy(ccont, &cont->exchange, sizeof(struct crypto_container));
 			break;
 		}
-		
+
 		if (cont->sign.id_pub == id || cont->sign.id_prv == id || cont->sign.id_cert == id)   {
 			if (ccont)
 				memcpy(ccont, &cont->sign, sizeof(struct crypto_container));
 			break;
 		}
 	}
-	
+
 	return cont ? 0 : SC_ERROR_TEMPLATE_NOT_FOUND;
 }
 
@@ -191,7 +191,7 @@ sc_oberthur_get_certificate_authority(struct sc_pkcs15_der *der, int *out_author
 #ifdef ENABLE_OPENSSL
 	X509	*x;
 	BUF_MEM buf_mem;
-   	BIO *bio = NULL;
+	BIO *bio = NULL;
 	BASIC_CONSTRAINTS *bs = NULL;
 
 	if (!der)
@@ -204,20 +204,20 @@ sc_oberthur_get_certificate_authority(struct sc_pkcs15_der *der, int *out_author
 	memcpy(buf_mem.data, der->value, der->len);
 	buf_mem.max = buf_mem.length = der->len;
 
-   	bio = BIO_new(BIO_s_mem());
+	bio = BIO_new(BIO_s_mem());
 	if(!bio)
 		return SC_ERROR_OUT_OF_MEMORY;
-	
+
 	BIO_set_mem_buf(bio, &buf_mem, BIO_NOCLOSE);
 	x = d2i_X509_bio(bio, 0);
 	BIO_free(bio);
 	if (!x)
 		return SC_ERROR_INVALID_DATA;
-		
+
 	bs = (BASIC_CONSTRAINTS *)X509_get_ext_d2i(x, NID_basic_constraints, NULL, NULL);
 	if (out_authority)
 		*out_authority = (bs && bs->ca);
-		
+
 	X509_free(x);
 
 	return SC_SUCCESS;
@@ -227,8 +227,8 @@ sc_oberthur_get_certificate_authority(struct sc_pkcs15_der *der, int *out_author
 }
 
 
-static int 
-sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path, 
+static int
+sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 		unsigned char **out, size_t *out_len,
 		int verify_pin)
 {
@@ -239,27 +239,27 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 	size_t sz;
 	int rv;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 	if (!in_path || !out || !out_len)
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS, "Cannot read oberthur file");
-		
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "read file '%s'; verify_pin:%i", in_path, verify_pin);
-	
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Cannot read oberthur file");
+
+	sc_log(ctx, "read file '%s'; verify_pin:%i", in_path, verify_pin);
+
 	*out = NULL;
 	*out_len = 0;
-	
+
 	sc_format_path(in_path, &path);
 	rv = sc_select_file(card, &path, &file);
-	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot select oberthur file to read");
+	LOG_TEST_RET(ctx, rv, "Cannot select oberthur file to read");
 
 	if (file->ef_structure == SC_FILE_EF_TRANSPARENT)
 		sz = file->size;
 	else
 		sz = (file->record_length + 2) * file->record_count;
-	
+
 	*out = calloc(sz, 1);
 	if (*out == NULL)
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_OUT_OF_MEMORY, "Cannot read oberthur file");
+		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "Cannot read oberthur file");
 
 	if (file->ef_structure == SC_FILE_EF_TRANSPARENT)   {
 		rv = sc_read_binary(card, 0, *out, sz, 0);
@@ -268,7 +268,7 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 		int rec;
 		int offs = 0;
 		int rec_len = file->record_length;
-		
+
 		for (rec = 1; ; rec++)   {
 			rv = sc_read_record(card, rec, *out + offs + 2, rec_len, SC_RECORD_BY_REC_NR);
 			if (rv == SC_ERROR_RECORD_NOT_FOUND)   {
@@ -279,29 +279,29 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 				break;
 			}
 
-			rec_len = rv; 
-				
+			rec_len = rv;
+
 			*(*out + offs) = 'R';
 			*(*out + offs + 1) = rv;
-			
+
 			offs += rv + 2;
 		}
 
 		sz = offs;
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "read oberthur file result %i", rv);
+	sc_log(ctx, "read oberthur file result %i", rv);
 	if (verify_pin && rv == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED)   {
 		struct sc_pkcs15_object *objs[0x10], *pin_obj = NULL;
 		const struct sc_acl_entry *acl = sc_file_get_acl_entry(file, SC_AC_OP_READ);
 		int ii;
 
 		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH_PIN, objs, 0x10);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot read oberthur file: get AUTH objects error");
+		LOG_TEST_RET(ctx, rv, "Cannot read oberthur file: get AUTH objects error");
 
 		for (ii=0; ii<rv; ii++)   {
 			struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *) objs[ii]->data;
-			sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "compare PIN/ACL refs:%i/%i, method:%i/%i", 
+			sc_log(ctx, "compare PIN/ACL refs:%i/%i, method:%i/%i",
 					auth_info->attrs.pin.reference, acl->key_ref, auth_info->auth_method, acl->method);
 			if (auth_info->attrs.pin.reference == (int)acl->key_ref && auth_info->auth_method == (unsigned)acl->method)   {
 				pin_obj = objs[ii];
@@ -318,7 +318,7 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 				rv = sc_oberthur_read_file(p15card, in_path, out, out_len, 0);
 		}
 	};
-			
+
 	sc_file_free(file);
 
 	if (rv < 0)   {
@@ -329,12 +329,12 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 
 	*out_len = sz;
 
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, rv);
+	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
-static int 
-sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *p15card, 
+static int
+sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *p15card,
 		unsigned char *buff, size_t len, int postpone_allowed)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -342,9 +342,9 @@ sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *p15card,
 	unsigned flags;
 	int ii;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 	if (!buff || len < 0x24)
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS, "Cannot parse token info");
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Cannot parse token info");
 
 	memset(label, 0, sizeof(label));
 
@@ -355,28 +355,28 @@ sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *p15card,
 	*(label + ii + 1) = '\0';
 
 	flags = *(buff + 0x22) * 0x100 + *(buff + 0x23);
-	
+
 	p15card->tokeninfo->label = strdup(label);
 	p15card->tokeninfo->manufacturer_id = strdup("Oberthur/OpenSC");
 
 	if (flags & 0x01)
 		p15card->tokeninfo->flags |= SC_PKCS15_TOKEN_PRN_GENERATION;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "label %s", p15card->tokeninfo->label);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "manufacturer_id %s", p15card->tokeninfo->manufacturer_id);
-	
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	sc_log(ctx, "label %s", p15card->tokeninfo->label);
+	sc_log(ctx, "manufacturer_id %s", p15card->tokeninfo->manufacturer_id);
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 
-static int 
-sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card, 
+static int
+sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card,
 		unsigned char *buff, size_t len, int postpone_allowed)
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	size_t offs;
-	
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+
+	LOG_FUNC_CALLED(ctx);
 
 	while (Containers)   {
 		struct container *next = Containers->next;
@@ -388,27 +388,27 @@ sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card,
 	for (offs=0; offs < len;)  {
 		struct container *cont;
 		unsigned char *ptr =  buff + offs + 2;
-		
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "parse contaniers offs:%i, len:%i", offs, len);
+
+		sc_log(ctx, "parse contaniers offs:%i, len:%i", offs, len);
 		if (*(buff + offs) != 'R')
 			return SC_ERROR_INVALID_DATA;
-		
+
 		cont = (struct container *)calloc(sizeof(struct container), 1);
 		if (!cont)
 			return SC_ERROR_OUT_OF_MEMORY;
-		
+
 		cont->exchange.id_pub = *ptr * 0x100 + *(ptr + 1);  ptr += 2;
 		cont->exchange.id_prv = *ptr * 0x100 + *(ptr + 1);  ptr += 2;
 		cont->exchange.id_cert = *ptr * 0x100 + *(ptr + 1); ptr += 2;
-		
+
 		cont->sign.id_pub = *ptr * 0x100 + *(ptr + 1);  ptr += 2;
 		cont->sign.id_prv = *ptr * 0x100 + *(ptr + 1);  ptr += 2;
 		cont->sign.id_cert = *ptr * 0x100 + *(ptr + 1); ptr += 2;
-		
+
 		memcpy(cont->uuid, ptr + 2, 36);
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "UUID: %s; 0x%X, 0x%X, 0x%X", cont->uuid, 
+		sc_log(ctx, "UUID: %s; 0x%X, 0x%X, 0x%X", cont->uuid,
 				cont->exchange.id_pub, cont->exchange.id_prv, cont->exchange.id_cert);
-		
+
 		if (!Containers)  {
 			Containers = cont;
 		}
@@ -417,59 +417,59 @@ sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card,
 			Containers->prev = (void *)cont;
 			Containers = cont;
 		}
-		
+
 		offs += *(buff + offs + 1) + 2;
 	}
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 
-static int 
-sc_oberthur_parse_publicinfo (struct sc_pkcs15_card *p15card, 
+static int
+sc_oberthur_parse_publicinfo (struct sc_pkcs15_card *p15card,
 		unsigned char *buff, size_t len, int postpone_allowed)
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	size_t ii;
 	int rv;
 
-	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 	for (ii=0; ii<len; ii+=5)   {
 		unsigned int file_id, size;
-		
+
 		if(*(buff+ii) != 0xFF)
 			continue;
-		
+
 		file_id = 0x100 * *(buff+ii + 1) + *(buff+ii + 2);
 		size = 0x100 * *(buff+ii + 3) + *(buff+ii + 4);
-		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "add public object(file-id:%04X,size:%X)", file_id, size);
+		sc_log(ctx, "add public object(file-id:%04X,size:%X)", file_id, size);
 
 		switch (*(buff+ii + 1))   {
 		case BASE_ID_PUB_RSA :
 			rv = sc_pkcs15emu_oberthur_add_pubkey(p15card, file_id, size);
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot parse public key info");
+			LOG_TEST_RET(ctx, rv, "Cannot parse public key info");
 			break;
 		case BASE_ID_CERT :
 			rv = sc_pkcs15emu_oberthur_add_cert(p15card, file_id);
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot parse certificate info");
+			LOG_TEST_RET(ctx, rv, "Cannot parse certificate info");
 			break;
 		case BASE_ID_PUB_DES :
 			break;
 		case BASE_ID_PUB_DATA :
 			rv = sc_pkcs15emu_oberthur_add_data(p15card, file_id, size, 0);
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot parse data info");
+			LOG_TEST_RET(ctx, rv, "Cannot parse data info");
 			break;
 		default:
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Public object parse error");
+			LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Public object parse error");
 		}
 	}
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 
-static int 
-sc_oberthur_parse_privateinfo (struct sc_pkcs15_card *p15card, 
+static int
+sc_oberthur_parse_privateinfo (struct sc_pkcs15_card *p15card,
 		unsigned char *buff, size_t len, int postpone_allowed)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -477,17 +477,17 @@ sc_oberthur_parse_privateinfo (struct sc_pkcs15_card *p15card,
 	int rv;
 	int no_more_private_keys = 0, no_more_private_data = 0;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 
 	for (ii=0; ii<len; ii+=5)   {
 		unsigned int file_id, size;
 
 		if(*(buff+ii) != 0xFF)
 			continue;
-		
+
 		file_id = 0x100 * *(buff+ii + 1) + *(buff+ii + 2);
 		size = 0x100 * *(buff+ii + 3) + *(buff+ii + 4);
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "add private object (file-id:%04X, size:%X)", file_id, size);
+		sc_log(ctx, "add private object (file-id:%04X, size:%X)", file_id, size);
 
 		switch (*(buff+ii + 1))   {
 		case BASE_ID_PRV_RSA :
@@ -498,18 +498,18 @@ sc_oberthur_parse_privateinfo (struct sc_pkcs15_card *p15card,
 			if (rv == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED && postpone_allowed)   {
 				struct sc_path path;
 
-				sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "postpone adding of the private keys");
+				sc_log(ctx, "postpone adding of the private keys");
 				sc_format_path("5011A5A5", &path);
 				rv = sc_pkcs15_add_df(p15card, SC_PKCS15_PRKDF, &path);
-				SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Add PrkDF error");
+				LOG_TEST_RET(ctx, rv, "Add PrkDF error");
 				no_more_private_keys = 1;
 			}
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot parse private key info");
+			LOG_TEST_RET(ctx, rv, "Cannot parse private key info");
 			break;
 		case BASE_ID_PRV_DES :
 			break;
 		case BASE_ID_PRV_DATA :
-			sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "*(buff+ii + 1):%X", *(buff+ii + 1));
+			sc_log(ctx, "*(buff+ii + 1):%X", *(buff+ii + 1));
 			if (no_more_private_data)
 				break;
 
@@ -517,33 +517,33 @@ sc_oberthur_parse_privateinfo (struct sc_pkcs15_card *p15card,
 			if (rv == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED && postpone_allowed)   {
 				struct sc_path path;
 
-				sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "postpone adding of the private data");
+				sc_log(ctx, "postpone adding of the private data");
 				sc_format_path("5011A6A6", &path);
 				rv = sc_pkcs15_add_df(p15card, SC_PKCS15_DODF, &path);
-				SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Add DODF error");
+				LOG_TEST_RET(ctx, rv, "Add DODF error");
 				no_more_private_data = 1;
 			}
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot parse private data info");
+			LOG_TEST_RET(ctx, rv, "Cannot parse private data info");
 			break;
 		default:
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Private object parse error");
+			LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Private object parse error");
 		}
 	}
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 
 /* Public key info:
- * 	flags:2, 
- * 	CN(len:2,value:<variable length>), 
- * 	ID(len:2,value:(SHA1 value)), 
+ * 	flags:2,
+ * 	CN(len:2,value:<variable length>),
+ * 	ID(len:2,value:(SHA1 value)),
  * 	StartDate(Ascii:8)
  * 	EndDate(Ascii:8)
- * 	??(0x00:2) 
+ * 	??(0x00:2)
  */
-static int 
-sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *p15card, 
+static int
+sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *p15card,
 		unsigned int file_id, unsigned int size)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -555,29 +555,29 @@ sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *p15card,
 	unsigned flags;
 	int rv;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "public key(file-id:%04X,size:%X)", file_id, size);
+	LOG_FUNC_CALLED(ctx);
+	sc_log(ctx, "public key(file-id:%04X,size:%X)", file_id, size);
 
 	memset(&key_info, 0, sizeof(key_info));
 	memset(&key_obj, 0, sizeof(key_obj));
-	
+
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PUB, file_id | 0x100);
-	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1); 
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add public key: read oberthur file error");
+	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1);
+	LOG_TEST_RET(ctx, rv, "Failed to add public key: read oberthur file error");
 
 	/* Flags */
 	offs = 2;
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'tag'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'tag'");
 	flags = *(info_blob + 0) * 0x100 + *(info_blob + 1);
 	key_info.usage = sc_oberthur_decode_usage(flags);
 	if (flags & OBERTHUR_ATTR_MODIFIABLE)
 		key_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Public key key-usage:%04X", key_info.usage);
+	sc_log(ctx, "Public key key-usage:%04X", key_info.usage);
 
 	/* Label */
-	if (offs + 2 > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'Label'");
+	if (offs + 2 > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'Label'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (len)   {
 		if (len > sizeof(key_obj.label) - 1)
@@ -585,40 +585,40 @@ sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *p15card,
 		memcpy(key_obj.label, info_blob + offs + 2, len);
 	}
 	offs += 2 + len;
-	
+
 	/* ID */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'ID'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add public key: no 'ID'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (!len || len > sizeof(key_info.id.value))
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_DATA, "Failed to add public key: invalie 'ID' length");
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Failed to add public key: invalie 'ID' length");
 	memcpy(key_info.id.value, info_blob + offs + 2, len);
 	key_info.id.len = len;
-	
+
 	/* Ignore Start/End dates */
 
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PUB, file_id);
 	sc_format_path(ch_tmp, &key_info.path);
-	
+
 	key_info.native = 1;
 	key_info.key_reference = file_id & 0xFF;
 	key_info.modulus_length = size;
 
 	rv = sc_pkcs15emu_add_rsa_pubkey(p15card, &key_obj, &key_info);
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, rv);
+	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
 /* Certificate info:
- * 	flags:2, 
- * 	Label(len:2,value:), 
- * 	ID(len:2,value:(SHA1 value)), 
+ * 	flags:2,
+ * 	Label(len:2,value:),
+ * 	ID(len:2,value:(SHA1 value)),
  * 	Subject in ASN.1(len:2,value:)
  * 	Issuer in ASN.1(len:2,value:)
  * 	Serial encoded in LV or ASN.1	FIXME
  */
-static int 
+static int
 sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *p15card, unsigned int file_id)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -630,24 +630,24 @@ sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *p15card, unsigned int file
 	int rv;
 	char ch_tmp[0x20];
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "add certificate(file-id:%04X)", file_id);
+	LOG_FUNC_CALLED(ctx);
+	sc_log(ctx, "add certificate(file-id:%04X)", file_id);
 
 	memset(&cinfo, 0, sizeof(cinfo));
 	memset(&cobj, 0, sizeof(cobj));
-	
-	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PUB, file_id | 0x100);
-	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1); 
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add certificate: read oberthur file error");
 
-	if (info_len < 2) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'tag'");
+	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PUB, file_id | 0x100);
+	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1);
+	LOG_TEST_RET(ctx, rv, "Failed to add certificate: read oberthur file error");
+
+	if (info_len < 2)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'tag'");
 	flags = *(info_blob + 0) * 0x100 + *(info_blob + 1);
 	offs = 2;
 
 	/* Label */
-	if (offs + 2 > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'CN'");
+	if (offs + 2 > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'CN'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (len)   {
 		if (len > sizeof(cobj.label) - 1)
@@ -655,13 +655,13 @@ sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *p15card, unsigned int file
 		memcpy(cobj.label, info_blob + offs + 2, len);
 	}
 	offs += 2 + len;
-	
+
 	/* ID */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'ID'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'ID'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (len > sizeof(cinfo.id.value))
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_DATA, "Failed to add certificate: invalie 'ID' length");
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Failed to add certificate: invalie 'ID' length");
 	memcpy(cinfo.id.value, info_blob + offs + 2, len);
 	cinfo.id.len = len;
 
@@ -669,14 +669,14 @@ sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *p15card, unsigned int file
 
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PUB, file_id);
 	sc_format_path(ch_tmp, &cinfo.path);
-	rv = sc_oberthur_read_file(p15card, ch_tmp, &cert_blob, &cert_len, 1); 
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add certificate: read certificate error");
-	
+	rv = sc_oberthur_read_file(p15card, ch_tmp, &cert_blob, &cert_len, 1);
+	LOG_TEST_RET(ctx, rv, "Failed to add certificate: read certificate error");
+
 	cinfo.value.value = cert_blob;
 	cinfo.value.len = cert_len;
 
 	rv = sc_oberthur_get_certificate_authority(&cinfo.value, &cinfo.authority);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add certificate: get certificate attributes error");
+	LOG_TEST_RET(ctx, rv, "Failed to add certificate: get certificate attributes error");
 
 	if (flags & OBERTHUR_ATTR_MODIFIABLE)
 		cobj.flags |= SC_PKCS15_CO_FLAG_MODIFIABLE;
@@ -688,17 +688,17 @@ sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *p15card, unsigned int file
 
 
 /* Private key info:
- * 	flags:2, 
- * 	CN(len:2,value:), 
- * 	ID(len:2,value:(SHA1 value)), 
+ * 	flags:2,
+ * 	CN(len:2,value:),
+ * 	ID(len:2,value:(SHA1 value)),
  * 	StartDate(Ascii:8)
  * 	EndDate(Ascii:8)
  * 	Subject in ASN.1(len:2,value:)
  * 	modulus(value:)
  *	exponent(length:1, value:3)
  */
-static int 
-sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card, 
+static int
+sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 		unsigned int file_id, unsigned int size)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -712,82 +712,82 @@ sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 	char ch_tmp[0x100];
 	int rv;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "add private key(file-id:%04X,size:%04X)", file_id, size);
-	
+	LOG_FUNC_CALLED(ctx);
+	sc_log(ctx, "add private key(file-id:%04X,size:%04X)", file_id, size);
+
 	memset(&kinfo, 0, sizeof(kinfo));
 	memset(&kobj, 0, sizeof(kobj));
 	memset(&ccont, 0, sizeof(ccont));
-	
+
 	rv = sc_oberthur_get_friends (file_id, &ccont);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add private key: get friends error");
+	LOG_TEST_RET(ctx, rv, "Failed to add private key: get friends error");
 
 	if (ccont.id_cert)   {
 		struct sc_pkcs15_object *objs[32];
 		int ii;
-		
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "friend certificate %04X", ccont.id_cert);
+
+		sc_log(ctx, "friend certificate %04X", ccont.id_cert);
 		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_CERT_X509, objs, 32);
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add private key: get certificates error");
+		LOG_TEST_RET(ctx, rv, "Failed to add private key: get certificates error");
 
 		for (ii=0; ii<rv; ii++) {
 			struct sc_pkcs15_cert_info *cert = (struct sc_pkcs15_cert_info *)objs[ii]->data;
 			struct sc_path path = cert->path;
 			unsigned int id = path.value[path.len - 2] * 0x100 + path.value[path.len - 1];
-		
+
 			if (id == ccont.id_cert)   {
 				strncpy(kobj.label, objs[ii]->label, sizeof(kobj.label) - 1);
 				break;
 			}
 		}
 
-		if (ii == rv) 
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INCONSISTENT_PROFILE, "Failed to add private key: friend not found");
+		if (ii == rv)
+			LOG_TEST_RET(ctx, SC_ERROR_INCONSISTENT_PROFILE, "Failed to add private key: friend not found");
 	}
 
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PRV, file_id | 0x100);
-	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1); 
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add private key: read oberthur file error");
+	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1);
+	LOG_TEST_RET(ctx, rv, "Failed to add private key: read oberthur file error");
 
 	if (info_len < 2)
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'tag'");
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'tag'");
 	flags = *(info_blob + 0) * 0x100 + *(info_blob + 1);
 	offs = 2;
 
 	/* CN */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'CN'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'CN'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (len && !strlen(kobj.label))   {
-		if (len > sizeof(kobj.label) - 1) 
+		if (len > sizeof(kobj.label) - 1)
 			len = sizeof(kobj.label) - 1;
 		strncpy(kobj.label, (char *)(info_blob + offs + 2), len);
 	}
 	offs += 2 + len;
-		
+
 	/* ID */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'ID'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: no 'ID'");
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (!len)
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: zero length ID");
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add private key: zero length ID");
 	else if (len > sizeof(kinfo.id.value))
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_DATA, "Failed to add private key: invalid ID length");
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Failed to add private key: invalid ID length");
 	memcpy(kinfo.id.value, info_blob + offs + 2, len);
 	kinfo.id.len = len;
 	offs += 2 + len;
-		
-	/* Ignore Start/End dates */	
+
+	/* Ignore Start/End dates */
 	offs += 16;
-		
+
 	/* Subject encoded in ASN1 */
-	if (offs > info_len) 
+	if (offs > info_len)
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (len)   {
 		kinfo.subject.value = malloc(len);
 		if (!kinfo.subject.value)
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_OUT_OF_MEMORY, "Failed to add private key: memory allocation error");
+			LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "Failed to add private key: memory allocation error");
 		kinfo.subject.len = len;
 		memcpy(kinfo.subject.value, info_blob + offs + 2, len);
 	}
@@ -796,7 +796,7 @@ sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", AWP_OBJECTS_DF_PRV, file_id);
 	sc_format_path(ch_tmp, &kinfo.path);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Private key info path %s", ch_tmp);
+	sc_log(ctx, "Private key info path %s", ch_tmp);
 
 	kinfo.modulus_length	= size;
 	kinfo.native		= 1;
@@ -807,19 +807,19 @@ sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 	if (flags & OBERTHUR_ATTR_MODIFIABLE)
 		kobj.flags |= SC_PKCS15_CO_FLAG_MODIFIABLE;
 
-	kobj.auth_id.len = sizeof(PinDomainID) > sizeof(kobj.auth_id.value) 
+	kobj.auth_id.len = sizeof(PinDomainID) > sizeof(kobj.auth_id.value)
 			? sizeof(kobj.auth_id.value) : sizeof(PinDomainID);
 	memcpy(kobj.auth_id.value, PinDomainID, kobj.auth_id.len);
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Parsed private key(reference:%i,usage:%X,flags:%X)", kinfo.key_reference, kinfo.usage, kobj.flags);
+	sc_log(ctx, "Parsed private key(reference:%i,usage:%X,flags:%X)", kinfo.key_reference, kinfo.usage, kobj.flags);
 
 	rv = sc_pkcs15emu_add_rsa_prkey(p15card, &kobj, &kinfo);
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, rv);
+	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
-static int 
-sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *p15card, 
+static int
+sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *p15card,
 		unsigned int file_id, unsigned int size, int private)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -832,54 +832,54 @@ sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *p15card,
 	int rv;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Add data(file-id:%04X,size:%i,is-private:%i)", file_id, size, private);
+	sc_log(ctx, "Add data(file-id:%04X,size:%i,is-private:%i)", file_id, size, private);
 	memset(&dinfo, 0, sizeof(dinfo));
 	memset(&dobj, 0, sizeof(dobj));
 
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", private ? AWP_OBJECTS_DF_PRV : AWP_OBJECTS_DF_PUB, file_id | 0x100);
-		
-	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Failed to add data: read oberthur file error");
 
-	if (info_len < 2) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'tag'");
+	rv = sc_oberthur_read_file(p15card, ch_tmp, &info_blob, &info_len, 1);
+	LOG_TEST_RET(ctx, rv, "Failed to add data: read oberthur file error");
+
+	if (info_len < 2)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add certificate: no 'tag'");
 	flags = *(info_blob + 0) * 0x100 + *(info_blob + 1);
 	offs = 2;
 
 	/* Label */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'label'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'label'");
 	label = info_blob + offs + 2;
 	label_len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (label_len > sizeof(dobj.label) - 1)
 		label_len = sizeof(dobj.label) - 1;
 	offs += 2 + *(info_blob + offs + 1);
-	
+
 	/* Application */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'application'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'application'");
 	app = info_blob + offs + 2;
 	app_len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (app_len > sizeof(dinfo.app_label) - 1)
 		app_len = sizeof(dinfo.app_label) - 1;
 	offs += 2 + app_len;
-	
+
 	/* OID encode like DER(ASN.1(oid)) */
-	if (offs > info_len) 
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'OID'");
+	if (offs > info_len)
+		LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: no 'OID'");
 	oid_len = *(info_blob + offs + 1) + *(info_blob + offs) * 0x100;
 	if (oid_len)   {
 		oid = info_blob + offs + 2;
 		if (*oid != 0x06 || (*(oid + 1) != oid_len - 2))
-			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: invalid 'OID' format");
+			LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Failed to add data: invalid 'OID' format");
 		oid += 2;
 		oid_len -= 2;
 	}
-	
+
 	snprintf(ch_tmp, sizeof(ch_tmp), "%s%04X", private ? AWP_OBJECTS_DF_PRV : AWP_OBJECTS_DF_PUB, file_id);
 
 	sc_format_path(ch_tmp, &dinfo.path);
-	
+
 	memcpy(dobj.label, label, label_len);
 	memcpy(dinfo.app_label, app, app_len);
 	if (oid_len)
@@ -890,7 +890,7 @@ sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *p15card,
 
 	if (private)   {
 		dobj.auth_id.len = sizeof(PinDomainID) > sizeof(dobj.auth_id.value)
-		                        ? sizeof(dobj.auth_id.value) : sizeof(PinDomainID);
+				? sizeof(dobj.auth_id.value) : sizeof(PinDomainID);
 		memcpy(dobj.auth_id.value, PinDomainID, dobj.auth_id.len);
 
 		dobj.flags |= SC_PKCS15_CO_FLAG_PRIVATE;
@@ -902,7 +902,7 @@ sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *p15card,
 }
 
 
-static int 
+static int
 sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -913,20 +913,20 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 	int rv, ii, tries_left;
 	char serial[0x10];
 	unsigned char sopin_reference = 0x04;
-	
+
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_bin_to_hex(card->serialnr.value, card->serialnr.len, serial, sizeof(serial), 0);
 	p15card->tokeninfo->serial_number = strdup(serial);
 
 	p15card->ops.parse_df = sc_awp_parse_df;
 	p15card->ops.clear = sc_awp_clear;
-	
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Oberthur init: serial %s", p15card->tokeninfo->serial_number);
+
+	sc_log(ctx, "Oberthur init: serial %s", p15card->tokeninfo->serial_number);
 
 	sc_format_path(AWP_PIN_DF, &path);
 	rv = sc_select_file(card, &path, NULL);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: cannot select PIN dir");
-	
+	LOG_TEST_RET(ctx, rv, "Oberthur init failed: cannot select PIN dir");
+
 	tries_left = -1;
 	rv = sc_verify(card, SC_AC_CHV, sopin_reference, (unsigned char *)"", 0, &tries_left);
 	if (rv && rv != SC_ERROR_PIN_CODE_INCORRECT)   {
@@ -934,13 +934,13 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 		rv = sc_verify(card, SC_AC_CHV, sopin_reference, (unsigned char *)"", 0, &tries_left);
 	}
 	if (rv && rv != SC_ERROR_PIN_CODE_INCORRECT)
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Invalid state of SO-PIN");
+		LOG_TEST_RET(ctx, rv, "Invalid state of SO-PIN");
 
 	/* add PIN */
 	memset(&auth_info, 0, sizeof(auth_info));
 	memset(&obj,  0, sizeof(obj));
 
-	auth_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;	
+	auth_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 	auth_info.auth_method	= SC_AC_CHV;
 	auth_info.auth_id.len = 1;
 	auth_info.auth_id.value[0] = 0xFF;
@@ -950,19 +950,19 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 	auth_info.attrs.pin.type		= SC_PKCS15_PIN_TYPE_ASCII_NUMERIC;
 	auth_info.attrs.pin.reference		= sopin_reference;
 	auth_info.attrs.pin.pad_char		= 0xFF;
-	auth_info.attrs.pin.flags		= SC_PKCS15_PIN_FLAG_CASE_SENSITIVE 
-				| SC_PKCS15_PIN_FLAG_INITIALIZED 
+	auth_info.attrs.pin.flags		= SC_PKCS15_PIN_FLAG_CASE_SENSITIVE
+				| SC_PKCS15_PIN_FLAG_INITIALIZED
 				| SC_PKCS15_PIN_FLAG_NEEDS_PADDING
 				| SC_PKCS15_PIN_FLAG_SO_PIN;
 	auth_info.tries_left		= tries_left;
-	
+
 	strncpy(obj.label, "SO PIN", SC_PKCS15_MAX_LABEL_SIZE-1);
 	obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
-	
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Add PIN(%s,auth_id:%s,reference:%i)", obj.label, 
+
+	sc_log(ctx, "Add PIN(%s,auth_id:%s,reference:%i)", obj.label,
 			sc_pkcs15_print_id(&auth_info.auth_id), auth_info.attrs.pin.reference);
 	rv = sc_pkcs15emu_add_pin_obj(p15card, &obj, &auth_info);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: cannot add PIN object");
+	LOG_TEST_RET(ctx, rv, "Oberthur init failed: cannot add PIN object");
 
 	tries_left = -1;
 	rv = sc_verify(card, SC_AC_CHV, 0x81, (unsigned char *)"", 0, &tries_left);
@@ -970,8 +970,8 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 		/* add PIN */
 		memset(&auth_info, 0, sizeof(auth_info));
 		memset(&obj,  0, sizeof(obj));
-	
-		auth_info.auth_id.len = sizeof(PinDomainID) > sizeof(auth_info.auth_id.value) 
+
+		auth_info.auth_id.len = sizeof(PinDomainID) > sizeof(auth_info.auth_id.value)
 				? sizeof(auth_info.auth_id.value) : sizeof(PinDomainID);
 		memcpy(auth_info.auth_id.value, PinDomainID, auth_info.auth_id.len);
 		auth_info.auth_method	= SC_AC_CHV;
@@ -982,45 +982,45 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 		auth_info.attrs.pin.type		= SC_PKCS15_PIN_TYPE_ASCII_NUMERIC;
 		auth_info.attrs.pin.reference		= 0x81;
 		auth_info.attrs.pin.pad_char		= 0xFF;
-		auth_info.attrs.pin.flags		= SC_PKCS15_PIN_FLAG_CASE_SENSITIVE 
-					| SC_PKCS15_PIN_FLAG_INITIALIZED 
+		auth_info.attrs.pin.flags		= SC_PKCS15_PIN_FLAG_CASE_SENSITIVE
+					| SC_PKCS15_PIN_FLAG_INITIALIZED
 					| SC_PKCS15_PIN_FLAG_NEEDS_PADDING
 					| SC_PKCS15_PIN_FLAG_LOCAL;
 		auth_info.tries_left		= tries_left;
-	
+
 		strncpy(obj.label, PIN_DOMAIN_LABEL, SC_PKCS15_MAX_LABEL_SIZE-1);
 		obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
-	
-		sc_format_path(AWP_PIN_DF, &auth_info.path); 
+
+		sc_format_path(AWP_PIN_DF, &auth_info.path);
 		auth_info.path.type = SC_PATH_TYPE_PATH;
-	
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Add PIN(%s,auth_id:%s,reference:%i)", obj.label, 
+
+		sc_log(ctx, "Add PIN(%s,auth_id:%s,reference:%i)", obj.label,
 				sc_pkcs15_print_id(&auth_info.auth_id), auth_info.attrs.pin.reference);
 		rv = sc_pkcs15emu_add_pin_obj(p15card, &obj, &auth_info);
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: cannot add PIN object");
+		LOG_TEST_RET(ctx, rv, "Oberthur init failed: cannot add PIN object");
 	}
 	else if (rv != SC_ERROR_DATA_OBJECT_NOT_FOUND)    {
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: cannot verify PIN");
+		LOG_TEST_RET(ctx, rv, "Oberthur init failed: cannot verify PIN");
 	}
 
 	for (ii=0; oberthur_infos[ii].name; ii++)   {
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Oberthur init: read %s file", oberthur_infos[ii].name);
+		sc_log(ctx, "Oberthur init: read %s file", oberthur_infos[ii].name);
 		rv = sc_oberthur_read_file(p15card, oberthur_infos[ii].path,
 				&oberthur_infos[ii].content, &oberthur_infos[ii].len, 1);
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: read oberthur file error");
-		
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Oberthur init: parse %s file, content length %i", 
+		LOG_TEST_RET(ctx, rv, "Oberthur init failed: read oberthur file error");
+
+		sc_log(ctx, "Oberthur init: parse %s file, content length %i",
 				oberthur_infos[ii].name, oberthur_infos[ii].len);
-		rv = oberthur_infos[ii].parser(p15card, oberthur_infos[ii].content, oberthur_infos[ii].len, 
+		rv = oberthur_infos[ii].parser(p15card, oberthur_infos[ii].content, oberthur_infos[ii].len,
 				oberthur_infos[ii].postpone_allowed);
-		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Oberthur init failed: parse error");
+		LOG_TEST_RET(ctx, rv, "Oberthur init failed: parse error");
 	}
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 
-static int 
+static int
 oberthur_detect_card(struct sc_pkcs15_card * p15card)
 {
 	struct sc_card *card = p15card->card;
@@ -1032,13 +1032,13 @@ oberthur_detect_card(struct sc_pkcs15_card * p15card)
 }
 
 
-int 
-sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card,
+int
+sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card, struct sc_aid *aid,
 				   struct sc_pkcs15emu_opt * opts)
 {
-	int rv; 
-	
-	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
+	int rv;
+
+	LOG_FUNC_CALLED(p15card->card->ctx);
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)   {
 		rv = sc_pkcs15emu_oberthur_init(p15card);
 	}
@@ -1047,12 +1047,12 @@ sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card,
 		if (!rv)
 			rv = sc_pkcs15emu_oberthur_init(p15card);
 	}
-	
-	SC_FUNC_RETURN(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, rv);
+
+	LOG_FUNC_RETURN(p15card->card->ctx, rv);
 }
 
 
-static int 
+static int
 sc_awp_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -1060,15 +1060,15 @@ sc_awp_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 	size_t buf_len;
 	int rv;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 	if (df->type != SC_PKCS15_PRKDF && df->type != SC_PKCS15_DODF)
-		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_NOT_SUPPORTED);
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 
 	if (df->enumerated)
-		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
 	rv = sc_oberthur_read_file(p15card, AWP_OBJECTS_LIST_PRV, &buf, &buf_len, 1);
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Parse DF: read pribate objects info failed");
+	LOG_TEST_RET(ctx, rv, "Parse DF: read pribate objects info failed");
 
 	rv = sc_oberthur_parse_privateinfo(p15card, buf, buf_len, 0);
 
@@ -1076,17 +1076,17 @@ sc_awp_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 		free(buf);
 
 	if (rv == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED)
-		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
-	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "Parse DF: private info parse error");
+	LOG_TEST_RET(ctx, rv, "Parse DF: private info parse error");
 	df->enumerated = 1;
 
-	SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, rv);
+	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
 static void
 sc_awp_clear(struct sc_pkcs15_card *p15card)
 {
-	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(p15card->card->ctx);
 }

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -33,7 +33,7 @@
 #include "pkcs15.h"
 #include "log.h"
 
-int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 static int sc_pkcs15emu_openpgp_add_data(sc_pkcs15_card_t *);
 
 
@@ -429,7 +429,7 @@ static int openpgp_detect_card(sc_pkcs15_card_t *p15card)
 		return SC_ERROR_WRONG_CARD;
 }
 
-int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *p15card,
+int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
 				 sc_pkcs15emu_opt_t *opts)
 {
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -40,7 +40,7 @@
 
 #define MANU_ID		"piv_II "
 
-int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *, struct sc_aid *aid, sc_pkcs15emu_opt_t *);
 
 typedef struct objdata_st {
 	const char *id;
@@ -999,7 +999,7 @@ sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 				prkey_info.modulus_length= ckis[i].pubkey_len;
 				r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
 				break;
-		 	case SC_ALGORITHM_EC: 
+			case SC_ALGORITHM_EC:
 				prkey_info.usage         |= prkeys[i].usage_ec;
 				prkey_info.field_length = ckis[i].pubkey_len;
 				sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE added key_alg %2.2x prkey_obj.flags %8.8x",
@@ -1020,7 +1020,7 @@ sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 }
 
 int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,
-				  sc_pkcs15emu_opt_t *opts)
+		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
 {
 	sc_card_t   *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;

--- a/src/libopensc/pkcs15-postecert.c
+++ b/src/libopensc/pkcs15-postecert.c
@@ -33,7 +33,7 @@
 #include "pkcs15.h"
 #include "log.h"
 
-int sc_pkcs15emu_postecert_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_postecert_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int (*set_security_env) (sc_card_t *, const sc_security_env_t *, int);
 
@@ -354,6 +354,7 @@ static int postecert_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_postecert_init_ex(sc_pkcs15_card_t * p15card,
+				   struct sc_aid *aid,
 				   sc_pkcs15emu_opt_t * opts)
 {
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -31,6 +31,7 @@
 #include "asn1.h"
 #include "pkcs15.h"
 #include "common/compat_strlcpy.h"
+#include "aux-data.h"
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/x509.h>
@@ -596,6 +597,8 @@ void sc_pkcs15_free_prkey_info(sc_pkcs15_prkey_info_t *key)
 		free(key->subject.value);
 
 	sc_pkcs15_free_key_params(&key->params);
+
+	sc_aux_data_free(&key->aux_data);
 
 	free(key);
 }

--- a/src/libopensc/pkcs15-pteid.c
+++ b/src/libopensc/pkcs15-pteid.c
@@ -50,7 +50,7 @@
 #define IAS_CARD 0
 #define GEMSAFE_CARD 1
 
-int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int sc_pkcs15emu_pteid_init(sc_pkcs15_card_t * p15card)
 {
@@ -275,7 +275,7 @@ static int pteid_detect_card(sc_pkcs15_card_t *p15card)
 	return SC_ERROR_WRONG_CARD;
 }
 
-int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *p15card, sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
 {
 	if (opts != NULL && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
 		return sc_pkcs15emu_pteid_init(p15card);

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -933,6 +933,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 
 
 int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *p15card,
+				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
 	if (opts && (opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {

--- a/src/libopensc/pkcs15-starcert.c
+++ b/src/libopensc/pkcs15-starcert.c
@@ -33,7 +33,7 @@
 #define MANU_ID		"Giesecke & Devrient GmbH"
 #define STARCERT	"StarCertV2201"
 
-int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *, struct sc_aid *,sc_pkcs15emu_opt_t *);
 
 typedef struct cdata_st {
 	const char *label;
@@ -270,6 +270,7 @@ static int sc_pkcs15emu_starcert_init(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *p15card,
+				  struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
 

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -1,8 +1,8 @@
 /*
  * pkcs15-syn.c: PKCS #15 emulation of non-pkcs15 cards
  *
- * Copyright (C) 2003  Olaf Kirch <okir@suse.de>
- *               2004  Nils Larsch <nlarsch@betrusted.com>
+ * Copyright (C) 2003 Olaf Kirch <okir@suse.de>
+ *		 2004 Nils Larsch <nlarsch@betrusted.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -85,6 +85,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DNIE_ADMIN:
 		case SC_CARD_TYPE_DNIE_USER:
 		case SC_CARD_TYPE_DNIE_TERMINATED:
+		case SC_CARD_TYPE_IASECC_GEMALTO:
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -1,0 +1,63 @@
+/*
+ * pkcs15-syn.c: PKCS #15 emulation of non-pkcs15 cards
+ *
+ * Copyright (C) 2003  Olaf Kirch <okir@suse.de>
+ *               2004  Nils Larsch <nlarsch@betrusted.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef PKCS15_SYN_H
+#define PKCS15_SYN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libopensc/types.h>
+#include <libopensc/pkcs15.h>
+
+int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_infocamere_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_tcos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_postecert_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_oberthur_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
+
+struct sc_pkcs15_emulator_handler {
+	const char *name;
+	int (*handler)(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libopensc/pkcs15-tccardos.c
+++ b/src/libopensc/pkcs15-tccardos.c
@@ -42,6 +42,7 @@
 #define TC_CARDOS_PIN_MASK	0x3000
 
 int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *p15card,
+				  struct sc_aid *,
 				  sc_pkcs15emu_opt_t *opts);
 
 static int read_file(struct sc_card *card, const char *file, u8 *buf,
@@ -348,6 +349,7 @@ static int sc_pkcs15_tccardos_init_func(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *p15card,
+				  struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
 	return sc_pkcs15_tccardos_init_func(p15card);

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -35,6 +35,7 @@
 
 int sc_pkcs15emu_tcos_init_ex(
 	sc_pkcs15_card_t   *p15card,
+	struct sc_aid *,
 	sc_pkcs15emu_opt_t *opts);
 
 static int insert_cert(
@@ -488,6 +489,7 @@ static int detect_unicard(
 
 int sc_pkcs15emu_tcos_init_ex(
 	sc_pkcs15_card_t   *p15card,
+	struct sc_aid *aid,
 	sc_pkcs15emu_opt_t *opts
 ){
 	sc_card_t         *card = p15card->card;

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -31,7 +31,7 @@
 #include "cardctl.h"
 #include "common/compat_strlcpy.h"
 
-int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 {
@@ -239,6 +239,7 @@ static int westcos_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t * p15card,
+				 struct sc_aid *aid,
 				 sc_pkcs15emu_opt_t * opts)
 {
 	int r;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -88,7 +88,7 @@ static const struct sc_asn1_entry c_asn1_profile_indication[C_ASN1_PROFILE_INDIC
 
 #define C_ASN1_TOKI_ATTRS_SIZE 15
 static const struct sc_asn1_entry c_asn1_toki_attrs[C_ASN1_TOKI_ATTRS_SIZE] = {
-	{ "version",        SC_ASN1_INTEGER,		SC_ASN1_TAG_INTEGER, 0, NULL, NULL },
+	{ "version",	    SC_ASN1_INTEGER,		SC_ASN1_TAG_INTEGER, 0, NULL, NULL },
 	{ "serialNumber",   SC_ASN1_OCTET_STRING,	SC_ASN1_TAG_OCTET_STRING, SC_ASN1_OPTIONAL, NULL, NULL },
 	{ "manufacturerID", SC_ASN1_UTF8STRING,		SC_ASN1_TAG_UTF8STRING, SC_ASN1_OPTIONAL, NULL, NULL },
 	{ "label",	    SC_ASN1_UTF8STRING,		SC_ASN1_CTX | 0, SC_ASN1_OPTIONAL, NULL, NULL },
@@ -111,9 +111,11 @@ static const struct sc_asn1_entry c_asn1_tokeninfo[] = {
 	{ NULL, 0, 0, 0, NULL, NULL }
 };
 
-static void sc_pkcs15_free_unusedspace(struct sc_pkcs15_card *p15card);
-static void sc_pkcs15_remove_dfs(struct sc_pkcs15_card *p15card);
-static void sc_pkcs15_remove_objects(struct sc_pkcs15_card *p15card);
+static void sc_pkcs15_free_unusedspace(struct sc_pkcs15_card *);
+static void sc_pkcs15_remove_dfs(struct sc_pkcs15_card *);
+static void sc_pkcs15_remove_objects(struct sc_pkcs15_card *);
+static int sc_pkcs15_aux_get_md_guid(struct sc_pkcs15_card *, const struct sc_pkcs15_object *,
+		unsigned, unsigned char *, size_t *);
 
 int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 	sc_pkcs15_tokeninfo_t *ti, const u8 *buf, size_t blen)
@@ -132,7 +134,7 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 	u8 preferred_language[3];
 	size_t lang_length = sizeof(preferred_language);
 	struct sc_asn1_entry asn1_supported_algorithms[SC_MAX_SUPPORTED_ALGORITHMS + 1],
-			     asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7];
+			asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7];
 	size_t reference_len = sizeof(ti->supported_algos[0].reference);
 	size_t mechanism_len = sizeof(ti->supported_algos[0].mechanism);
 	size_t operations_len = sizeof(ti->supported_algos[0].operations);
@@ -267,7 +269,7 @@ sc_pkcs15_encode_tokeninfo(sc_context_t *ctx, sc_pkcs15_tokeninfo_t *ti,
 	struct sc_asn1_entry asn1_toki_attrs[C_ASN1_TOKI_ATTRS_SIZE];
 	struct sc_asn1_entry asn1_tokeninfo[2];
 	struct sc_asn1_entry asn1_supported_algorithms[SC_MAX_SUPPORTED_ALGORITHMS + 1],
-			     asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7];
+			asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7];
 	size_t reference_len = sizeof(ti->supported_algos[0].reference);
 	size_t mechanism_len = sizeof(ti->supported_algos[0].mechanism);
 	size_t operations_len = sizeof(ti->supported_algos[0].operations);
@@ -407,7 +409,7 @@ fix_authentic_ddo(struct sc_pkcs15_card *p15card)
 			sc_file_free(p15card->file_odf);
 			p15card->file_odf = NULL;
 		}
-	        if (p15card->file_tokeninfo != NULL) {
+		if (p15card->file_tokeninfo != NULL) {
 			sc_file_free(p15card->file_tokeninfo);
 			p15card->file_tokeninfo = NULL;
 		}
@@ -1205,8 +1207,8 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 				p15card->opts.pin_cache_ignore_user_consent);
 	}
 	sc_log(ctx, "PKCS#15 options: use_file_cache=%d use_pin_cache=%d pin_cache_counter=%d pin_cache_ignore_user_consent=%d",
-	         p15card->opts.use_file_cache, p15card->opts.use_pin_cache,
-		 p15card->opts.pin_cache_counter, p15card->opts.pin_cache_ignore_user_consent);
+			p15card->opts.use_file_cache, p15card->opts.use_pin_cache,p15card->opts.pin_cache_counter,
+			p15card->opts.pin_cache_ignore_user_consent);
 
 	r = sc_lock(card);
 	if (r) {
@@ -1563,9 +1565,8 @@ sc_pkcs15_search_objects(struct sc_pkcs15_card *p15card, struct sc_pkcs15_search
 
 int
 sc_pkcs15_get_objects_cond(struct sc_pkcs15_card *p15card, unsigned int type,
-			       int (* func)(struct sc_pkcs15_object *, void *),
-			       void *func_arg,
-			       struct sc_pkcs15_object **ret, size_t ret_size)
+		int (* func)(struct sc_pkcs15_object *, void *),
+		void *func_arg, struct sc_pkcs15_object **ret, size_t ret_size)
 {
 	return __sc_pkcs15_search_objects(p15card, 0, type,
 			func, func_arg, ret, ret_size);
@@ -1788,8 +1789,7 @@ sc_pkcs15_find_data_object_by_name(struct sc_pkcs15_card *p15card, const char *a
 
 int
 sc_pkcs15_find_prkey_by_id_usage(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_id *id,
-			       unsigned int usage,
-			       struct sc_pkcs15_object **out)
+		unsigned int usage, struct sc_pkcs15_object **out)
 {
 	struct sc_pkcs15_search_key sk;
 
@@ -2703,7 +2703,7 @@ sc_pkcs15_serialize_guid(unsigned char *in, size_t in_size, unsigned flags,
 
 int
 sc_pkcs15_get_object_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_object *obj,
-		                unsigned flags, unsigned char *out, size_t *out_size)
+		unsigned flags, unsigned char *out, size_t *out_size)
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_serial_number serialnr;
@@ -2719,6 +2719,12 @@ sc_pkcs15_get_object_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15
 		rv = p15card->ops.get_guid(p15card, obj, out, out_size);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
+
+	rv = sc_pkcs15_aux_get_md_guid(p15card, obj, flags, out, out_size);
+	if (rv == SC_SUCCESS)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+	else if (rv != SC_ERROR_NOT_SUPPORTED)
+		LOG_TEST_RET(ctx, rv, "Failed to get alternative object GUID");
 
 	memset(out, 0, *out_size);
 
@@ -2750,9 +2756,9 @@ sc_pkcs15_get_object_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15
 	memcpy(guid_bin + id.len, serialnr.value, serialnr.len);
 	guid_bin_size = id.len + serialnr.len;
 
-        /*
+	/*
 	 * If OpenSSL is available (SHA1), then rather use the hash of the data
-         * - this also protects against data being too short
+	 * - this also protects against data being too short
 	 */
 #ifdef ENABLE_OPENSSL
 	SHA1(guid_bin, guid_bin_size, guid_bin);
@@ -2770,6 +2776,31 @@ sc_pkcs15_get_object_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15
 	LOG_TEST_RET(ctx, rv, "Serialize GUID error");
 
 	*out_size = strlen((char *)out);
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+static int
+sc_pkcs15_aux_get_md_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_object *obj,
+		unsigned flags,
+		unsigned char *out, size_t *out_size)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_prkey_info *prkey_info = NULL;
+	int rv;
+
+	LOG_FUNC_CALLED(ctx);
+	if(!out || !out_size)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if ((obj->type & SC_PKCS15_TYPE_CLASS_MASK) != SC_PKCS15_TYPE_PRKEY)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
+
+	prkey_info = (struct sc_pkcs15_prkey_info *)obj->data;
+	if (!prkey_info->aux_data || prkey_info->aux_data->type != SC_AUX_DATA_TYPE_MD_CMAP_RECORD)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
+
+	rv = sc_aux_data_get_md_guid(ctx, prkey_info->aux_data, flags, out, out_size);
 	LOG_FUNC_RETURN(ctx, rv);
 }
 

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1222,7 +1222,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 		sc_log(ctx, "PKCS#15 emulation enabled");
 		emu_first = scconf_get_bool(conf_block, "try_emulation_first", 0);
 		if (emu_first || sc_pkcs15_is_emulation_only(card)) {
-			r = sc_pkcs15_bind_synthetic(p15card);
+			r = sc_pkcs15_bind_synthetic(p15card, aid);
 			if (r == SC_SUCCESS)
 				goto done;
 			r = sc_pkcs15_bind_internal(p15card, aid);
@@ -1232,7 +1232,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 			r = sc_pkcs15_bind_internal(p15card, aid);
 			if (r == SC_SUCCESS)
 				goto done;
-			r = sc_pkcs15_bind_synthetic(p15card);
+			r = sc_pkcs15_bind_synthetic(p15card, aid);
 			if (r < 0)
 				goto error;
 		}
@@ -1278,6 +1278,7 @@ __sc_pkcs15_search_objects(struct sc_pkcs15_card *p15card, unsigned int class_ma
 	struct sc_pkcs15_df	*df = NULL;
 	unsigned int	df_mask = 0;
 	size_t		match_count = 0;
+	int r;
 
 	if (type)
 		class_mask |= SC_PKCS15_TYPE_TO_CLASS(type);
@@ -1314,9 +1315,12 @@ __sc_pkcs15_search_objects(struct sc_pkcs15_card *p15card, unsigned int class_ma
 		}
 		if (df->enumerated)
 			continue;
-		/* Enumerate the DF's, so p15card->obj_list is
-		 * populated. */
-		if (SC_SUCCESS != sc_pkcs15_parse_df(p15card, df))
+		/* Enumerate the DF's, so p15card->obj_list is populated. */
+		if (p15card->ops.parse_df)
+			r = p15card->ops.parse_df(p15card, df);
+		else
+			r = sc_pkcs15_parse_df(p15card, df);
+		if (r != SC_SUCCESS)
 			continue;
 	}
 
@@ -2020,11 +2024,6 @@ sc_pkcs15_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 		     const u8 **nbuf, size_t *nbufsize) = NULL;
 
 	sc_log(ctx, "called; path=%s, type=%d, enum=%d", sc_print_path(&df->path), df->type, df->enumerated);
-
-	if (p15card->ops.parse_df)   {
-		r = p15card->ops.parse_df(p15card, df);
-		LOG_FUNC_RETURN(ctx, r);
-	}
 
 	if (df->enumerated)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -945,7 +945,7 @@ typedef struct sc_pkcs15emu_opt {
 
 #define SC_PKCS15EMU_FLAGS_NO_CHECK	0x00000001
 
-extern int sc_pkcs15_bind_synthetic(struct sc_pkcs15_card *);
+extern int sc_pkcs15_bind_synthetic(struct sc_pkcs15_card *, struct sc_aid *);
 extern int sc_pkcs15_is_emulation_only(sc_card_t *);
 
 int sc_pkcs15emu_object_add(struct sc_pkcs15_card *, unsigned int,

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #include "libopensc/opensc.h"
+#include "libopensc/aux-data.h"
 
 #define SC_PKCS15_CACHE_DIR		".eid"
 
@@ -388,8 +389,8 @@ struct sc_pkcs15_prkey_info {
 
 	struct sc_path path;
 
-	/* Used by minidriver and its on-card support */
-	/*struct sc_md_cmap_record cmap_record;*/
+	/* Non-pkcs15 data, like MD CMAP record */
+	struct sc_auxiliary_data *aux_data;
 };
 typedef struct sc_pkcs15_prkey_info sc_pkcs15_prkey_info_t;
 

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -566,7 +566,7 @@ md_contguid_get_guid_from_card(PCARD_DATA pCardData, struct sc_pkcs15_object *pr
 	size_t guid_len = MAX_CONTAINER_NAME_LEN+1;
 
 	vs = (VENDOR_SPECIFIC*) pCardData->pvVendorSpecific;
-	rv = sc_pkcs15_get_object_guid(vs->p15card, prkey, 0, (unsigned char*) szGuid, &guid_len);
+	rv = sc_pkcs15_get_object_guid(vs->p15card, prkey, 1, (unsigned char*) szGuid, &guid_len);
 	if (rv)   {
 		logprintf(pCardData, 2, "md_contguid_get_guid_from_card(): error %d\n", rv);
 		return SCARD_F_INTERNAL_ERROR;

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2002  Juha Yrjölä <juha.yrjola@iki.fi>
  * Copyright (C) 2010  Viktor Tarasov <vtarasov@opentrust.com>
- *                      OpenTrust <www.opentrust.com>
+ *		      OpenTrust <www.opentrust.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -671,7 +671,7 @@ iasecc_pkcs15_get_auth_id_from_se(struct sc_pkcs15_card *p15card, unsigned char 
 		struct sc_pkcs15_id *auth_id)
 {
 	struct sc_context *ctx = p15card->card->ctx;
-        struct sc_pkcs15_object *pin_objs[32];
+	struct sc_pkcs15_object *pin_objs[32];
 	int rv, ii, nn_pins, se_ref, pin_ref;
 
 	LOG_FUNC_CALLED(ctx);
@@ -683,7 +683,7 @@ iasecc_pkcs15_get_auth_id_from_se(struct sc_pkcs15_card *p15card, unsigned char 
 	if (!(scb & IASECC_SCB_METHOD_USER_AUTH))
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
-        rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH_PIN, pin_objs, 32);
+	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH_PIN, pin_objs, 32);
 	LOG_TEST_RET(ctx, rv, "Error while getting AUTH objects");
 	nn_pins = rv;
 
@@ -1441,12 +1441,12 @@ iasecc_md_gemalto_set_default(struct sc_pkcs15_card *p15card, struct sc_profile 
 		struct sc_file *file = NULL;
 
 		sc_log(ctx, "update data object content in '%s'\n", sc_print_path(&dinfo->path));
-                rv = sc_select_file(p15card->card, &dinfo->path, &file);
-                LOG_TEST_RET(ctx, rv, "Cannot select data object file");
+		rv = sc_select_file(p15card->card, &dinfo->path, &file);
+		LOG_TEST_RET(ctx, rv, "Cannot select data object file");
 
-                rv = sc_pkcs15init_update_file(profile, p15card, file, guid, guid_len);
-                sc_file_free(file);
-                LOG_TEST_RET(ctx, rv, "Failed to update 'CSP'/'Default Key Container' data object");
+		rv = sc_pkcs15init_update_file(profile, p15card, file, guid, guid_len);
+		sc_file_free(file);
+		LOG_TEST_RET(ctx, rv, "Failed to update 'CSP'/'Default Key Container' data object");
 	}
 
 	LOG_FUNC_RETURN(ctx, rv);
@@ -1460,7 +1460,7 @@ iasecc_md_gemalto_unset_default(struct sc_pkcs15_card *p15card, struct sc_profil
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_pkcs15_object *data_obj = NULL;
 	struct sc_pkcs15_data *dod = NULL;
-        struct sc_pkcs15_object *key_objs[32];
+	struct sc_pkcs15_object *key_objs[32];
 	struct sc_pkcs15_prkey_info *key_info = (struct sc_pkcs15_prkey_info *)key_obj->data;
 	unsigned char guid[40];
 	size_t guid_len;
@@ -1545,7 +1545,7 @@ iasecc_md_gemalto_new_prvkey(struct sc_pkcs15_card *p15card, struct sc_profile *
 	sc_init_oid(&data_args.app_oid);
 	data_args.label = (char *)guid;
 	data_args.app_label = "CSP";
-        data_args.der_encoded.value = data;
+	data_args.der_encoded.value = data;
 	data_args.der_encoded.len = offs;
 
 	rv = sc_pkcs15init_store_data_object(p15card, profile, &data_args, NULL);
@@ -1581,7 +1581,7 @@ iasecc_md_gemalto_delete_prvkey(struct sc_pkcs15_card *p15card, struct sc_profil
 	LOG_TEST_RET(ctx, rv, "Cannot get private key GUID");
 
 	rv = sc_pkcs15_find_data_object_by_name(p15card, "CSP", (char *)guid, &data_obj);
-        if (rv == SC_ERROR_OBJECT_NOT_FOUND)
+	if (rv == SC_ERROR_OBJECT_NOT_FOUND)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 	LOG_TEST_RET(ctx, rv, "Find 'CSP'/<key> data object error");
 
@@ -1643,22 +1643,22 @@ iasecc_store_pubkey(struct sc_pkcs15_card *p15card, struct sc_profile *profile, 
 
 	prkey_info = (struct sc_pkcs15_prkey_info *)prkey_object->data;
 
-        pubkey_info->key_reference = prkey_info->key_reference;
+	pubkey_info->key_reference = prkey_info->key_reference;
 
-        pubkey_info->access_flags = prkey_info->access_flags & SC_PKCS15_PRKEY_ACCESS_LOCAL;
-        pubkey_info->access_flags |= SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE;
+	pubkey_info->access_flags = prkey_info->access_flags & SC_PKCS15_PRKEY_ACCESS_LOCAL;
+	pubkey_info->access_flags |= SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE;
 
-        pubkey_info->native = 0;
+	pubkey_info->native = 0;
 
-        pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_SIGN ? SC_PKCS15_PRKEY_USAGE_VERIFY : 0;
-        pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_SIGNRECOVER ? SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER : 0;
-        pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION ? SC_PKCS15_PRKEY_USAGE_VERIFY : 0;
-        pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_DECRYPT ? SC_PKCS15_PRKEY_USAGE_ENCRYPT : 0;
-        pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_UNWRAP ? SC_PKCS15_PRKEY_USAGE_WRAP : 0;
+	pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_SIGN ? SC_PKCS15_PRKEY_USAGE_VERIFY : 0;
+	pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_SIGNRECOVER ? SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER : 0;
+	pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION ? SC_PKCS15_PRKEY_USAGE_VERIFY : 0;
+	pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_DECRYPT ? SC_PKCS15_PRKEY_USAGE_ENCRYPT : 0;
+	pubkey_info->usage |= prkey_info->usage & SC_PKCS15_PRKEY_USAGE_UNWRAP ? SC_PKCS15_PRKEY_USAGE_WRAP : 0;
 
-        iasecc_pkcs15_add_access_rule(object, SC_PKCS15_ACCESS_RULE_MODE_READ, NULL);
+	iasecc_pkcs15_add_access_rule(object, SC_PKCS15_ACCESS_RULE_MODE_READ, NULL);
 
-        memcpy(&pubkey_info->algo_refs[0], &prkey_info->algo_refs[0], sizeof(pubkey_info->algo_refs));
+	memcpy(&pubkey_info->algo_refs[0], &prkey_info->algo_refs[0], sizeof(pubkey_info->algo_refs));
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -1672,6 +1672,7 @@ iasecc_store_cert(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_card *card = p15card->card;
 	struct sc_file *pfile = NULL;
+	struct sc_path parent_path;
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
@@ -1679,6 +1680,14 @@ iasecc_store_cert(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 
 	rv = iasecc_pkcs15_new_file(profile, card, SC_PKCS15_TYPE_CERT, 0, &pfile);
 	LOG_TEST_RET(ctx, rv, "IasEcc new CERT file error");
+
+	parent_path = pfile->path;
+	if (parent_path.len >= 2)
+		parent_path.len -= 2;
+	if (!parent_path.len && !parent_path.aid.len)
+		sc_format_path("3F00", &parent_path);
+	rv = sc_select_file(card, &parent_path, NULL);
+	LOG_TEST_RET(ctx, rv, "cannot select parent of certificate to store");
 
 	rv = iasecc_pkcs15_fix_file_access(p15card, pfile, object);
 	LOG_TEST_RET(ctx, rv, "encode file access rules failed");

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -291,6 +291,7 @@ enum {
 	ACTION_SANITY_CHECK,
 	ACTION_UPDATE_LAST_UPDATE,
 	ACTION_ERASE_APPLICATION,
+	ACTION_PRINT_VERSION,
 
 	ACTION_MAX
 };
@@ -311,7 +312,8 @@ static const char *action_names[] = {
 	"change attribute(s)",
 	"check card's sanity",
 	"update 'last-update'",
-	"erase application"
+	"erase application",
+	"print OpenSC package version"
 };
 
 #define MAX_CERTS		4

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -139,6 +139,8 @@ enum {
 	OPT_ERASE_APPLICATION,
 	OPT_IGNORE_CA_CERTIFICATES,
 	OPT_UPDATE_EXISTING,
+	OPT_MD_CONTAINER_GUID,
+	OPT_VERSION,
 
 	OPT_PIN1     = 0x10000,	/* don't touch these values */
 	OPT_PUK1     = 0x10001,
@@ -201,6 +203,7 @@ const struct option	options[] = {
 	{ "profile",		required_argument, NULL,	'p' },
 	{ "card-profile",	required_argument, NULL,	'c' },
 	{ "options-file",	required_argument, NULL,	OPT_OPTIONS },
+	{ "md-container-guid",	required_argument, NULL,	OPT_MD_CONTAINER_GUID},
 	{ "wait",		no_argument, NULL,		'w' },
 	{ "help",		no_argument, NULL,		'h' },
 	{ "verbose",		no_argument, NULL,		'v' },
@@ -261,6 +264,7 @@ static const char *		option_help[] = {
 	"Specify the general profile to use",
 	"Specify the card profile to use",
 	"Read additional command line options from file",
+	"For a new key specify GUID for a MD container",
 	"Wait for card insertion",
 	"Display this message",
 	"Verbose operation. Use several times to enable debug output.",
@@ -360,6 +364,7 @@ static char *			opt_application_id = NULL;
 static char *			opt_application_name = NULL;
 static char *			opt_bind_to_aid = NULL;
 static char *			opt_puk_authid = NULL;
+static char *			opt_md_container_guid = NULL;
 static unsigned int		opt_x509_usage = 0;
 static unsigned int		opt_delete_flags = 0;
 static unsigned int		opt_type = 0;
@@ -1500,7 +1505,7 @@ do_generate_key(struct sc_profile *profile, const char *spec)
 
 	if ((r = init_keyargs(&keygen_args.prkey_args)) < 0)
 		return r;
-        keygen_args.prkey_args.access_flags |=
+	keygen_args.prkey_args.access_flags |=
 		  SC_PKCS15_PRKEY_ACCESS_SENSITIVE
 		| SC_PKCS15_PRKEY_ACCESS_ALWAYSSENSITIVE
 		| SC_PKCS15_PRKEY_ACCESS_NEVEREXTRACTABLE
@@ -1558,7 +1563,7 @@ static int init_keyargs(struct sc_pkcs15init_prkeyargs *args)
 		sc_pkcs15_format_id(opt_authid, &args->auth_id);
 	} else if (!opt_insecure) {
 		util_error("no PIN given for key - either use --insecure or \n"
-		      "specify a PIN using --auth-id");
+				"specify a PIN using --auth-id");
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	if (opt_extractable) {
@@ -1566,6 +1571,12 @@ static int init_keyargs(struct sc_pkcs15init_prkeyargs *args)
 	}
 	args->label = opt_label;
 	args->x509_usage = opt_x509_usage;
+
+	if (opt_md_container_guid)   {
+		args->guid = (unsigned char *)opt_md_container_guid;
+		args->guid_len = strlen(opt_md_container_guid);
+	}
+
 	return 0;
 }
 
@@ -2551,6 +2562,12 @@ handle_option(const struct option *opt)
 		break;
 	case OPT_UPDATE_EXISTING:
 		opt_update_existing = 1;
+		break;
+	case OPT_MD_CONTAINER_GUID:
+		opt_md_container_guid = optarg;
+		break;
+	case OPT_VERSION:
+		this_action = ACTION_PRINT_VERSION;
 		break;
 	default:
 		util_print_usage_and_die(app_name, options, option_help, NULL);

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -557,7 +557,7 @@ static void print_prkey_info(const struct sc_pkcs15_object *obj)
 	printf("\tID             : %s\n", sc_pkcs15_print_id(&prkey->id));
 
 	guid_len = sizeof(guid);
-	if (!sc_pkcs15_get_object_guid(p15card, obj, 0, guid, &guid_len))   {
+	if (!sc_pkcs15_get_object_guid(p15card, obj, 1, guid, &guid_len))   {
 		printf("\tMD:guid        : ");
 		if (strlen((char *)guid) == guid_len)   {
 			printf("%s\n", (char *)guid);
@@ -775,7 +775,7 @@ static void print_skey_info(const struct sc_pkcs15_object *obj)
 		printf("\tPath           : %s\n", sc_print_path(&skey->path));
 
 	guid_len = sizeof(guid);
-	if (!sc_pkcs15_get_object_guid(p15card, obj, 0, guid, &guid_len))   {
+	if (!sc_pkcs15_get_object_guid(p15card, obj, 1, guid, &guid_len))   {
 		printf("\tGUID           : %s\n", (char *)guid);
 	}
 


### PR DESCRIPTION
Sorry for the long list of commits, but they forms relatively dependent chain and it's too laborious to split them onto multiple PRs.

At the origin there was RC of OpenSC-0.16.0 that failed with test of X509 Enrollment with minidriver for IAS/ECC card -- part of the non-pkcs15 data was removed from pkcs15 data types during the recent source history.

OpenSC driver for IAS/ECC is supposed to create and maintain the on-card file system completely compatible with the native MW (Gemalto, Oberthur, ...), including file-system part to support MD.
From here there is a more general need: possibility to transfer some information from the non-pkcs15 applications (minidriver) until the card specific level through the common framework.

So that, following the commit list:
- introduced 'auxiliary-data.[c,h]' to hold the non-pkcs15 data types (like minidriver), keep its types and related procedures, and finally expose general auxiliary type that contain the union of the non-pkcs15 data to be inlcuded into pkcs15 data types as a _auxiliary data pointer_. For a while it's going about _sc_pkcs15_prkey_info_;
- parameter _aid_ is added to _pkcs15-synthetic-bind_ procedures, in the same manner as it was done for the _internal-bind_: this will allows to PKCS#15 emulation to manage more then one on-card application, like _internal-bind_ do; 
- iasecc card is binded by pkcs#15 emulator -- it uses all procedures of internal pkcs15 bind, the only supplement is when parsing PrKEY DF it tries to get MD related info and to initialize the _auxiliary-data_ (MD) for the private key.
- IAS/ECC specific code is removed from MD and pkcs15init sources and replaces by _general_ procedures to  manage auxiliary data.
- pkcs15init manages auxiliary data (for private keys)
- do not use '{}' frame for GUID -- GUID generated on WIndows can be on the limit of size reserved in MD CMAP record.