### PR TITLE
Move PIN type label front of description

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -972,7 +972,7 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 		}
 		else   {
 			if (auth->label[0])
-				snprintf(label, sizeof(label), "%s (%.*s)", p15card->tokeninfo->label, (int) sizeof auth->label, auth->label);
+				snprintf(label, sizeof(label), "%.*s: %s", (int) sizeof auth->label, auth->label, p15card->tokeninfo->label);
 			else
 				snprintf(label, sizeof(label), "%s", p15card->tokeninfo->label);
 			slot->token_info.flags |= CKF_LOGIN_REQUIRED;


### PR DESCRIPTION
With very long labels it is unable identify which PIN Firefox is asking.
PKCS11 label is 32 char's and it gets truncated.

Current format "LABEL (PIN1)"
New format "PIN1: LABEL"