### PR TITLE
sc-hsm: Fix public key usage for keys extracted from CVC

### DIFF
--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -524,10 +524,12 @@ static int sc_pkcs15emu_sc_hsm_add_pubkey(sc_pkcs15_card_t *p15card, sc_pkcs15_p
 
 	if (pubkey.algorithm == SC_ALGORITHM_RSA) {
 		pubkey_info.modulus_length = pubkey.u.rsa.modulus.len << 3;
+		pubkey_info.usage = SC_PKCS15_PRKEY_USAGE_ENCRYPT|SC_PKCS15_PRKEY_USAGE_VERIFY|SC_PKCS15_PRKEY_USAGE_WRAP;
 		r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
 	} else {
 		/* TODO fix if support of non multiple of 8 curves are added */
 		pubkey_info.field_length = cvc.primeOrModuluslen << 3;
+		pubkey_info.usage = SC_PKCS15_PRKEY_USAGE_VERIFY;
 		r = sc_pkcs15emu_add_ec_pubkey(p15card, &pubkey_obj, &pubkey_info);
 	}
 	LOG_TEST_RET(ctx, r, "Could not add public key");


### PR DESCRIPTION
The SmartCard-HSM PKCS#15 emulation does not set the public key usage flags for public key extracted from Card-Verifiable-Certificates.