### PR TITLE
Truncate data for ECDSA signature to the size of the key

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -432,6 +432,16 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 		}
 		inlen = modlen;
 	}
+	/* PKCS#11 MECHANISMS V2.30: 6.3.1 EC Signatures
+	 * If the length of the hash value is larger than the bit length of n, only
+	 * the leftmost bits of the hash up to the length of n will be used. Any
+	 * truncation is done by the token.
+	 */
+	else if (senv.algorithm == SC_ALGORITHM_EC &&
+			(flags & SC_ALGORITHM_ECDSA_HASH_NONE) != 0) {
+		inlen = MIN(inlen, (prkey->field_length+7)/8);
+	}
+
 
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);


### PR DESCRIPTION
Based on the paragraph from PKCS#11 MECHANISMS V2.30: 6.3.1 EC Signatures:

	If the length of the hash value is larger than the bit length of n, only
	the leftmost bits of the hash up to the length of n will be used. Any
	truncation is done by the token.

Reworked pull request #742 based on the comment. Verified Sign&Verify functionality against NIST PIV Test Cards (ECC: Curve P-256) for all surrounding lengths.

I missed to add the **original problem** for this PR:

Signature of more than 32 B of data fails with opensc, if we have a card supporting only CKM_ECDSA without SHA1. It is reproducible simple using `pkcs11-tool`:

    echo 12345678901234567890123456789012|pkcs11-tool --module opensc-pkcs11.so --id 01 --sign --pin 123456