### PR TITLE
asn1: parse 'securityCondition'

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -174,7 +174,8 @@ int sc_pkcs15_decode_aodf_entry(struct sc_pkcs15_card *p15card,
 					info.path = p15card->file_app->path;
 			}
 		}
-		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "decoded PIN(ref:%X,path:%s)", info.attrs.pin.reference, sc_print_path(&info.path));
+		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "decoded '%s'(ref:%X,path:%s)",obj->label,
+			info.attrs.pin.reference, sc_print_path(&info.path));
 	}
 	else if (asn1_auth_type_choice[1].flags & SC_ASN1_PRESENT)   {
 		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_NOT_SUPPORTED, "BIO authentication object not yet supported");

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -318,9 +318,9 @@ int sc_pkcs15_decode_prkdf_entry(struct sc_pkcs15_card *p15card,
 					 SC_PKCS15_ACCESS_RULE_MODE_PSO_CDS |
 					 SC_PKCS15_ACCESS_RULE_MODE_PSO_DECRYPT |
 					 SC_PKCS15_ACCESS_RULE_MODE_INT_AUTH)) {
-				if (obj->access_rules[i].auth_id.len != 0) {
+				if (obj->access_rules[i].sc.auth_id.len != 0) {
 					/* Found an auth ID to use for private key access */
-					obj->auth_id = obj->access_rules[i].auth_id;
+					obj->auth_id = obj->access_rules[i].sc.auth_id;
 					sc_log(ctx, "Auth ID found - %s",
 						 sc_pkcs15_print_id(&obj->auth_id));
 					break;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -360,9 +360,27 @@ struct sc_pkcs15_keyinfo_gostparams
 #define SC_PKCS15_ACCESS_RULE_MODE_INT_AUTH     0x200
 #define SC_PKCS15_ACCESS_RULE_MODE_EXT_AUTH     0x400
 
+struct sc_pkcs15_auth_reference {
+	unsigned auth_method;
+	int se_num;
+};
+
+struct sc_pkcs15_auth_id_and_ref {
+	struct sc_pkcs15_id auth_id;
+	struct sc_pkcs15_auth_reference auth_ref;
+};
+
+struct sc_pkcs15_security_condition {
+	struct sc_pkcs15_id auth_id;
+	struct sc_pkcs15_auth_reference auth_ref;
+	struct sc_pkcs15_auth_id_and_ref sc_not;
+	struct sc_pkcs15_auth_id_and_ref sc_and[2];
+	struct sc_pkcs15_auth_id_and_ref sc_or[2];
+};
+
 struct sc_pkcs15_accessrule {
 	unsigned access_mode;
-	struct sc_pkcs15_id auth_id;
+	struct sc_pkcs15_security_condition sc;
 };
 typedef struct sc_pkcs15_accessrule sc_pkcs15_accessrule_t;
 

--- a/src/pkcs15init/pkcs15-authentic.c
+++ b/src/pkcs15init/pkcs15-authentic.c
@@ -381,16 +381,16 @@ authentic_pkcs15_add_access_rule(struct sc_pkcs15_object *object, unsigned acces
 		if (!object->access_rules[ii].access_mode)   {
 			object->access_rules[ii].access_mode = access_mode;
 			if (auth_id)
-				object->access_rules[ii].auth_id = *auth_id;
+				object->access_rules[ii].sc.auth_id = *auth_id;
 			else
-				object->access_rules[ii].auth_id.len = 0;
+				object->access_rules[ii].sc.auth_id.len = 0;
 			break;
 		}
-		else if (!auth_id && !object->access_rules[ii].auth_id.len)   {
+		else if (!auth_id && !object->access_rules[ii].sc.auth_id.len)   {
 			object->access_rules[ii].access_mode |= access_mode;
 			break;
 		}
-		else if (auth_id && sc_pkcs15_compare_id(&object->access_rules[ii].auth_id, auth_id))   {
+		else if (auth_id && sc_pkcs15_compare_id(&object->access_rules[ii].sc.auth_id, auth_id))   {
 			object->access_rules[ii].access_mode |= access_mode;
 			break;
 		}

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -644,16 +644,16 @@ iasecc_pkcs15_add_access_rule(struct sc_pkcs15_object *object, unsigned access_m
 		if (!object->access_rules[ii].access_mode)   {
 			object->access_rules[ii].access_mode = access_mode;
 			if (auth_id)
-				object->access_rules[ii].auth_id = *auth_id;
+				object->access_rules[ii].sc.auth_id = *auth_id;
 			else
-				object->access_rules[ii].auth_id.len = 0;
+				object->access_rules[ii].sc.auth_id.len = 0;
 			break;
 		}
-		else if (!auth_id && !object->access_rules[ii].auth_id.len)   {
+		else if (!auth_id && !object->access_rules[ii].sc.auth_id.len)   {
 			object->access_rules[ii].access_mode |= access_mode;
 			break;
 		}
-		else if (auth_id && sc_pkcs15_compare_id(&object->access_rules[ii].auth_id, auth_id))   {
+		else if (auth_id && sc_pkcs15_compare_id(&object->access_rules[ii].sc.auth_id, auth_id))   {
 			object->access_rules[ii].access_mode |= access_mode;
 			break;
 		}
@@ -1747,19 +1747,19 @@ iasecc_store_data_object(struct sc_pkcs15_card *p15card, struct sc_profile *prof
 		acl = sc_file_get_acl_entry(file, SC_AC_OP_READ);
 		sc_log(ctx, "iasecc_store_data_object() READ method %i", acl->method);
 		if (acl->method == SC_AC_IDA)
-			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[0].auth_id);
+			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[0].sc.auth_id);
 
 		object->access_rules[1].access_mode = SC_PKCS15_ACCESS_RULE_MODE_UPDATE;
 		acl = sc_file_get_acl_entry(file, SC_AC_OP_UPDATE);
 		sc_log(ctx, "iasecc_store_data_object() UPDATE method %i", acl->method);
 		if (acl->method == SC_AC_IDA)
-			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[1].auth_id);
+			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[1].sc.auth_id);
 
 		object->access_rules[2].access_mode = SC_PKCS15_ACCESS_RULE_MODE_DELETE;
 		acl = sc_file_get_acl_entry(file, SC_AC_OP_DELETE);
 		sc_log(ctx, "iasecc_store_data_object() UPDATE method %i", acl->method);
 		if (acl->method == SC_AC_IDA)
-			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[2].auth_id);
+			iasecc_reference_to_pkcs15_id (acl->key_ref, &object->access_rules[2].sc.auth_id);
 
 	} while(0);
 

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -212,7 +212,7 @@ print_access_rules(const struct sc_pkcs15_accessrule *rules, int num)
 			}
 		}
 
-		printf(":%s;", (rules + i)->auth_id.len ? sc_pkcs15_print_id(&(rules + i)->auth_id) : "<always>");
+		printf(":%s;", (rules + i)->sc.auth_id.len ? sc_pkcs15_print_id(&(rules + i)->sc.auth_id) : "<always>");
 	}
 	printf("\n");
 }


### PR DESCRIPTION
Currently the pkcs15-object data type, together with the existing level of parse of PKCS#15 xDF data,
assumes that protected object contains reference (AuthID) to protecting object in
CommonObjectAttributes.

The PKCS#15 standard and xDF data of existing PKCS#15 cards are more complicated then that:
AuthID of protecting object can be referenced per operation (and referenced in
'AuthID' identifier of related securityCondition),
it can also be present in logical operations 'and', 'or', 'not' combining the different
authentication methods (for ex. SM and/or PUK).

Full parse of such data is too complicated and needs considerable changes in pkcs15-object
data types.

Here is partial improvement:
pkcs15-object is protected if the reference to protecting object is found in:
- CommonObjectAttributes as 'AuthID' identifier (currently implemented);
- 'AuthID' identifier in one of SecurityCondtions (the first occurence);
- 'AuthID' from securityCondition operand of 'and' operation.