### PR TITLE
Unbreak tests without arguments (automatic selection of the reader)

### DIFF
--- a/src/tests/p15dump.c
+++ b/src/tests/p15dump.c
@@ -69,8 +69,10 @@ static int dump_unusedspace(void)
 	else if (p15card->file_app != NULL) {
 		path = p15card->file_app->path;
 		sc_append_path_id(&path, (const u8 *) "\x50\x33", 2);
-	} else
+	} else {
+		printf("\nCan't find unused space file.\n");
 		return -1;
+	}
 	path.count = -1;
 
 	r = sc_pkcs15_read_file(p15card, &path, &buf, &buf_len);

--- a/src/tests/p15dump.c
+++ b/src/tests/p15dump.c
@@ -66,10 +66,11 @@ static int dump_unusedspace(void)
 
 	if (p15card->file_unusedspace != NULL)
 		path = p15card->file_unusedspace->path;
-	else {
+	else if (p15card->file_app != NULL) {
 		path = p15card->file_app->path;
 		sc_append_path_id(&path, (const u8 *) "\x50\x33", 2);
-	}
+	} else
+		return -1;
 	path.count = -1;
 
 	r = sc_pkcs15_read_file(p15card, &path, &buf, &buf_len);

--- a/src/tests/sc-test.c
+++ b/src/tests/sc-test.c
@@ -84,7 +84,7 @@ int sc_test_init(int *argc, char *argv[])
 				return rc;
 		} else {
 			for (i = rc = 0; rc != 1 && i < (int) sc_ctx_get_reader_count(ctx); i++)
-				rc = sc_detect_card_presence(sc_ctx_get_reader(ctx, opt_reader));
+				rc = sc_detect_card_presence(sc_ctx_get_reader(ctx, i));
 			if (rc == 1)
 				opt_reader = i - 1;
 		}


### PR DESCRIPTION
The logic is obvious, but probably copy-paste error. Using negative `opt_reader` in `sc_ctx_get_reader()` made the test suite segfault.

There is one more segfault in `p15dump`.