### PR TITLE
Fixed bug in pkcs11_tool.c:derive_key()

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2659,7 +2659,11 @@ derive_key(CK_SLOT_ID slot, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key)
 		{CKA_ENCRYPT, &true, sizeof(true)},
 		{CKA_DECRYPT, &true, sizeof(true)}
 	};
-
+#if defined(ENABLE_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x00908000L && !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_ECDSA)
+	CK_ECDH1_DERIVE_PARAMS ecdh_parms;
+	unsigned char buf[512];
+#endif /* ENABLE_OPENSSL etc */
+	
 	if (!opt_mechanism_used)
 		if (!find_mechanism(slot, CKF_DERIVE|CKF_HW, NULL, 0, &opt_mechanism))
 			util_fatal("Derive mechanism not supported\n");
@@ -2674,8 +2678,6 @@ derive_key(CK_SLOT_ID slot, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key)
 	case CKM_ECDH1_DERIVE:
 		/*  Use OpenSSL to read the other public key, and get the raw verion */
 		{
-		CK_ECDH1_DERIVE_PARAMS ecdh_parms;
-		unsigned char buf[512];
 		int len;
 		BIO     *bio_in = NULL;
 		const EC_KEY  *eckey = NULL;


### PR DESCRIPTION
Correct execution depended on undefined compiler behavior. Now it doesn't, as the two offending variables are moved to the correct scope.