### PR TITLE
Fix inability to find non-Apple-installed OpenSSL libraries

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -24,7 +24,7 @@ CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 
 export SED=/usr/bin/sed
 PREFIX=/Library/OpenSC
-export PKG_CONFIG_PATH=/usr/lib/pkgconfig
+#export PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
 ./configure --prefix=$PREFIX \
 --sysconfdir=$PREFIX/etc \


### PR DESCRIPTION
The way `MacOSX/build-package.in` currently works, it can locate **only** Apple-installed OpenSSL, which (as everybody knows) is 0.9.8 (aka rather outdated).

If a newer version of OpenSSL was installed on a Mac OS X system via package manager such as Macports, Fink, etc. - the `PKGCONFIG` should point at the location where **that** package manager installs packages, which assuredly would **not** be `/usr/lib/` (because of SIP, among other reasons).

More so, `pkg-config` has the default path to its pkg repository hard-coded, so it is unnecessary to tell it where to look. OpenSC would not be in position to know what to set this env variable anyway.

In summary: setting `PKGCONFIG` here is bad. It prevents the build from finding Macports-installed OpenSSL. Removing (or commenting out) this line fixes the problem.

P.S. I could completely delete that line, but chose to leave it in to show what to set in the unlikely case that somebody (for reasons I cannot fathom) decides to explicitly set it to something suitable for his specific installation. I could also change it to `/opt/local/lib/pkgconfig`, but that would be correct only for unmodified Macports installation - and there are other package managers on Mac, and some people configure it to use other locations... So better to let `pkg-config` itself figure where to look.