### PR TITLE
fix #788 pkcs15-tool --read-ssh-key crash

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -1051,8 +1051,8 @@ static int read_ssh_key(void)
 		fclose(outf);
 	if (cert)
 		sc_pkcs15_free_certificate(cert);
-	sc_pkcs15_free_pubkey(pubkey);
-
+	else if (pubkey)
+		sc_pkcs15_free_pubkey(pubkey);
 	return 0;
 fail:
 	printf("can't convert key: buffer too small\n");


### PR DESCRIPTION
Don't try to free again pubkey if the parent cert has already been freed.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>