### PR TITLE
Relax XML parsing regexes for bash_completion

### DIFF
--- a/doc/tools/Makefile.am
+++ b/doc/tools/Makefile.am
@@ -30,13 +30,13 @@ tools.html: $(srcdir)/tools.xml $(wildcard $(srcdir)/*.1.xml) $(wildcard $(srcdi
 	@echo $< $@
 	@cat $(srcdir)/completion-template \
 		| sed "s,ALLOPTS,\
-			$(shell sed -n 's,\s\s\s*<option>\([^<]*\)</option>.*,\1,pg' $< \
+			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' ' ')," \
 		| sed "s,OPTSWITHARGS,\
-			$(shell sed -n 's,\s\s\s*<option>\([^<]*\)</option>.*<replaceable>.*,\1,pg' $< \
+			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,')," \
 		| sed "s,FILEOPTS,\
-			$(shell sed -n 's,\s\s\s*<option>\([^<]*\)</option>.*<replaceable>.*filename.*,\1,pg' $< \
+			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*filename.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' '|')," \
 		| sed "s,FUNCTION_NAME,$(shell echo $@ | sed s,-,_,g)," \
 		| sed "s,PROGRAM_NAME,$@," \


### PR DESCRIPTION
Unnecessarily strict regex was failing for some unknown reason on OS X. Easier to just relax the regex than understand what's wrong (and then relax the regex).
Fixes #782