### PR TITLE
Add check_state functions for PKCS#11 C_GetSessionInfo

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1561,6 +1561,7 @@ authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 	data->pin1.offset = 5;
 	data->pin1.pad_char = 0xFF;
 	data->pin1.pad_length = data->pin1.max_length;
+	data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 
 	data->flags |= SC_PIN_CMD_NEED_PADDING;
 

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2352,6 +2352,7 @@ epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 			LOG_TEST_RET(card->ctx, r, "get max counter failed");
 
 			data->pin1.max_tries = maxtries;
+			data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 		}
 
 		return r;

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -954,6 +954,7 @@ static int gids_get_pin_policy(struct sc_card *card, struct sc_pin_cmd_data *dat
 	data->pin1.stored_length = 0;
 	data->pin1.encoding = SC_PIN_ENCODING_ASCII;
 	data->pin1.offset = 5;
+	data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 	return SC_SUCCESS;
 }
 

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -2230,6 +2230,7 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 
 	data->pin1.encoding = SC_PIN_ENCODING_ASCII;
 	data->pin1.offset = 5;
+	data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 
 	sc_log(ctx, "PIN policy: size max/min %i/%i, tries max/left %i/%i",
 				data->pin1.max_length, data->pin1.min_length,

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1420,6 +1420,7 @@ static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
 			return SC_ERROR_INTERNAL;
 		data->pin1.tries_left = buf[5];
 		data->pin1.max_tries = buf[2];
+		data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 		return SC_SUCCESS;
 	}
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1121,11 +1121,15 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 	r = sc_check_sw(card, apdu->sw1, apdu->sw2);
 
 	if (data->cmd == SC_PIN_CMD_GET_INFO) {
-		if (r == SC_ERROR_PIN_CODE_INCORRECT) {
+		if (r == SC_SUCCESS) {
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_IN;
+		} else if (r == SC_ERROR_PIN_CODE_INCORRECT) {
 			data->pin1.tries_left = apdu->sw2 & 0xF;
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_OUT;
 			r = SC_SUCCESS;
 		} else if (r == SC_ERROR_AUTH_METHOD_BLOCKED) {
 			data->pin1.tries_left = 0;
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_OUT;
 			r = SC_SUCCESS;
 		}
 

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -236,6 +236,7 @@ sc_pkcs15_search_objects
 sc_pkcs15_unbind
 sc_pkcs15_unblock_pin
 sc_pkcs15_verify_pin
+sc_pkcs15_get_pin_info
 sc_pkcs15emu_add_data_object
 sc_pkcs15emu_add_pin_obj
 sc_pkcs15emu_add_rsa_prkey

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -339,6 +339,11 @@ typedef struct sc_reader {
 #define SC_PIN_ENCODING_BCD	1
 #define SC_PIN_ENCODING_GLP	2 /* Global Platform - Card Specification v2.0.1 */
 
+/** Values for sc_pin_cmd_pin.logged_in */
+#define SC_PIN_STATE_UNKNOWN	-1
+#define SC_PIN_STATE_LOGGED_OUT 0
+#define SC_PIN_STATE_LOGGED_IN  1
+
 struct sc_pin_cmd_pin {
 	const char *prompt;	/* Prompt to display */
 
@@ -359,6 +364,7 @@ struct sc_pin_cmd_pin {
 
 	int max_tries;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 	int tries_left;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
+	int logged_in;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 
 	struct sc_acl_entry acls[SC_MAX_SDO_ACLS];
 };

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -129,7 +129,7 @@ struct sc_pkcs15_auth_info {
 	/* authentication method: CHV, SEN, SYMBOLIC, ... */
 	unsigned int  auth_method;
 
-	int tries_left, max_tries;
+	int tries_left, max_tries, logged_in;
 	int max_unlocks;
  };
 typedef struct sc_pkcs15_auth_info sc_pkcs15_auth_info_t;
@@ -749,6 +749,8 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *card,
 			 struct sc_pkcs15_object *pin_obj,
 			 const u8 *puk, size_t puklen,
 			 const u8 *newpin, size_t newpinlen);
+int sc_pkcs15_get_pin_info(struct sc_pkcs15_card *card,
+			 struct sc_pkcs15_object *pin_obj);
 int sc_pkcs15_find_pin_by_auth_id(struct sc_pkcs15_card *card,
 				  const struct sc_pkcs15_id *id,
 				  struct sc_pkcs15_object **out);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -466,10 +466,10 @@ __pkcs15_delete_object(struct pkcs15_fw_data *fw_data, struct pkcs15_any_object 
 CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 {
 	struct sc_pkcs11_slot *slot;
+	struct pkcs15_fw_data *fw_data = NULL;
+	struct sc_pkcs15_card *p15card = NULL;
 	struct sc_pkcs15_object *auth;
 	struct sc_pkcs15_auth_info *pin_info;
-	struct sc_pin_cmd_data data;
-	int r;
 	CK_RV rv;
 
 	sc_log(context, "C_GetTokenInfo(%lx)", slotID);
@@ -486,6 +486,11 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 		goto out;
 	}
 
+	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
+	if (!fw_data)
+		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetTokenInfo");
+	p15card = fw_data->p15_card;
+
 	/* User PIN flags are cleared before re-calculation */
 	slot->token_info.flags &= ~(CKF_USER_PIN_COUNT_LOW|CKF_USER_PIN_FINAL_TRY|CKF_USER_PIN_LOCKED);
 	auth = slot_data_auth(slot->fw_data);
@@ -493,24 +498,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	if (auth) {
 		pin_info = (struct sc_pkcs15_auth_info*) auth->data;
 
-		if (pin_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)   {
-			rv = CKR_FUNCTION_REJECTED;
-			goto out;
-		}
-
-		/* Try to update PIN info from card */
-		memset(&data, 0, sizeof(data));
-		data.cmd = SC_PIN_CMD_GET_INFO;
-		data.pin_type = SC_AC_CHV;
-		data.pin_reference = pin_info->attrs.pin.reference;
-
-		r = sc_pin_cmd(slot->p11card->card, &data, NULL);
-		if (r == SC_SUCCESS) {
-			if (data.pin1.max_tries > 0)
-				pin_info->max_tries = data.pin1.max_tries;
-			/* tries_left must be supported or sc_pin_cmd should not return SC_SUCCESS */
-			pin_info->tries_left = data.pin1.tries_left;
-		}
+		sc_pkcs15_get_pin_info(p15card, auth);
 
 		if (pin_info->tries_left >= 0) {
 			if (pin_info->tries_left == 1 || pin_info->max_tries == 1)

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1084,6 +1084,37 @@ _is_slot_auth_object(struct sc_pkcs15_auth_info *pin_info)
 	return 1;
 }
 
+int slot_get_logged_in_state(struct sc_pkcs11_slot *slot)
+{
+	int logged_in = SC_PIN_STATE_UNKNOWN;
+	struct pkcs15_fw_data *fw_data = NULL;
+	struct sc_pkcs15_card *p15card = NULL;
+	struct sc_pkcs15_object *pin_obj = NULL;
+	struct sc_pkcs15_auth_info *pin_info;
+
+	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
+	if (!fw_data)
+		goto out;
+	p15card = fw_data->p15_card;
+
+	if (slot->login_user == CKU_SO) {
+		sc_pkcs15_find_so_pin(p15card, &pin_obj);
+	} else {
+		pin_obj = slot_data_auth(slot->fw_data);
+	}
+
+	if (!pin_obj)
+		goto out;
+
+	pin_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
+	if (!pin_info)
+		goto out;
+	sc_pkcs15_get_pin_info(p15card, pin_obj);
+	logged_in = pin_info->logged_in;
+out:
+	return logged_in;
+}
+
 
 struct sc_pkcs15_object *
 _get_auth_object_by_name(struct sc_pkcs15_card *p15card, char *name)

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -180,6 +180,7 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	CK_RV rv;
 	struct sc_pkcs11_session *session;
 	struct sc_pkcs11_slot *slot;
+	int logged_out;
 
 	if (pInfo == NULL_PTR)
 		return CKR_ARGUMENTS_BAD;
@@ -202,9 +203,10 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	pInfo->ulDeviceError = 0;
 
 	slot = session->slot;
-	if (slot->login_user == CKU_SO) {
+	logged_out = (slot_get_logged_in_state(slot) == SC_PIN_STATE_LOGGED_OUT);
+	if (slot->login_user == CKU_SO && !logged_out) {
 		pInfo->state = CKS_RW_SO_FUNCTIONS;
-	} else if (slot->login_user == CKU_USER || (!(slot->token_info.flags & CKF_LOGIN_REQUIRED))) {
+	} else if ((slot->login_user == CKU_USER && !logged_out) || (!(slot->token_info.flags & CKF_LOGIN_REQUIRED))) {
 		pInfo->state = (session->flags & CKF_RW_SESSION)
 		    ? CKS_RW_USER_FUNCTIONS : CKS_RO_USER_FUNCTIONS;
 	} else {

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -350,6 +350,7 @@ CK_RV slot_get_token(CK_SLOT_ID id, struct sc_pkcs11_slot **);
 CK_RV slot_token_removed(CK_SLOT_ID id);
 CK_RV slot_allocate(struct sc_pkcs11_slot **, struct sc_pkcs11_card *);
 CK_RV slot_find_changed(CK_SLOT_ID_PTR idp, int mask);
+int slot_get_logged_in_state(struct sc_pkcs11_slot *slot);
 
 /* Login tracking functions */
 CK_RV restore_login_state(struct sc_pkcs11_slot *slot);


### PR DESCRIPTION
OpenSC tracks the user that's logged in in its PKCS#11 layer. However, due to some other process that's interfering, this state might get corrupted unnoticed. With this PR the login state is actively requested from the card (if supported by the card). See https://github.com/OpenSC/OpenSC/pull/624 for a more detailed problem description.

This PR is intended to replace https://github.com/OpenSC/OpenSC/pull/624 with the following thoughts in mind:
- reuse SC_PIN_CMD_GET_INFO at the card driver level to get the login state
- allow reusing `sc_pkcs15_get_pin_info` in OpenSC's tokend

This PR is tested with sc-hsm.