### PR TITLE
Change CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       description: "Build submitted via Travis CI"
     notification_email: viktor.tarasov@gmail.com
     build_command:   "make -j 4"
-    branch_pattern: master
+    branch_pattern: coverity_scan
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,5 @@
 version: 0.16.0.{build}
 
-#init:
-#  # Exclude combinations allowed to fail
-#  - if "%Environment%" == "VSVER=14" (if "%Configuration%" == "Release" (exit /b 1))
-#  - if "%Environment%" == "VSVER=14" (if "%Configuration%" == "Debug" (exit /b 1))
-#  - if "%Environment%" == "VSVER=10" (if "%Platform%" == "x64" (exit /b 1))
-
 platform:
   - x86
   - x64
@@ -18,20 +12,23 @@ configuration:
 
 environment:
   matrix:
-    # - VSVER: 14
+    - VSVER: 14
     - VSVER: 12
-    # - VSVER: 10
+    - VSVER: 10
 
 matrix:
-  fast_finish: true     # set this flag to immediately finish build once one of the jobs fails.
   allow_failures:
     # not included in AppVeyor right now
     - platform: x64
       VSVER: 10
-    # does currently not build zlib out of the box
+    # FIXME does currently not build zlib out of the box
+    # FIXME The OpenSSL binaries we fetch only allow static linking with VS12
+    # and earlier
     - configuration: Release
       VSVER: 14
-    # does currently not build zlib out of the box
+    # FIXME does currently not build zlib out of the box
+    # FIXME The OpenSSL binaries we fetch only allow static linking with VS12
+    # and earlier
     - configuration: Debug
       VSVER: 14
 


### PR DESCRIPTION
- AppVeyor: Build on as many platforms as we can
- use a dedicated branch for Coverity Scan

The reasoning behind these changes are given in the commit messages