### PR TITLE
Improve file caching

### DIFF
--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -77,18 +77,6 @@
 
 				<varlistentry>
 					<term>
-						<option>--learn-card</option>,
-						<option>-L</option>
-					</term>
-					<listitem><para>Cache PKCS #15 token data to the local filesystem.
-					Subsequent operations are performed on the cached data where possible.
-					If the cache becomes out-of-sync with the token state (eg. new key is
-					generated and stored on the token), the cache should be updated or
-					operations may show stale results.</para></listitem>
-				</varlistentry>
-
-				<varlistentry>
-					<term>
 						<option>--list-applications</option>
 					</term>
 					<listitem><para>List the on-card PKCS#15 applications</para></listitem>

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -209,6 +209,7 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 	card->ctx = ctx;
 
 	memcpy(&card->atr, &reader->atr, sizeof(card->atr));
+	memcpy(&card->uid, &reader->uid, sizeof(card->uid));
 
 	_sc_parse_atr(reader);
 

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -314,6 +314,7 @@ typedef struct sc_reader {
 	size_t max_recv_size; /* Mac Le supported by the reader layer */
 
 	struct sc_atr atr;
+	struct sc_uid uid;
 	struct _atr_info {
 		u8 *hist_bytes;
 		size_t hist_bytes_len;
@@ -462,6 +463,7 @@ typedef struct sc_card {
 	struct sc_reader *reader;
 
 	struct sc_atr atr;
+	struct sc_uid uid;
 
 	int type;			/* Card type, for card driver internal use */
 	unsigned long caps, flags;

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -580,7 +580,6 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	sc_pkcs15_object_t cert_obj;
 	struct sc_pkcs15_object prkd;
 	sc_pkcs15_prkey_info_t *key_info;
-	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
 	u8 *ptr;
@@ -646,7 +645,7 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	memset(&cert_obj, 0, sizeof(cert_obj));
 
 	cert_info.id = key_info->id;
-	cert_info.path = path;
+	sc_path_set(&cert_info.path, SC_PATH_TYPE_FILE_ID, fid, 2, 0, 0);
 	cert_info.path.count = -1;
 
 	strlcpy(cert_obj.label, prkd.label, sizeof(cert_obj.label));

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -180,6 +180,41 @@ static const struct sc_asn1_entry c_asn1_req[C_ASN1_REQ_SIZE] = {
 
 
 
+static int read_file(sc_pkcs15_card_t * p15card, u8 fid[2],
+		u8 *efbin, size_t *len)
+{
+	sc_path_t path;
+	int r;
+
+	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, 2, 0, 0);
+	/* look this up with our AID */
+	path.aid = sc_hsm_aid;
+	/* we don't have a pre-known size of the file */
+	path.count = -1;
+	if (!p15card->opts.use_file_cache
+			|| SC_SUCCESS != sc_pkcs15_read_cached_file(p15card, &path, &efbin, len)) {
+		/* avoid re-selection of SC-HSM */
+		path.aid.len = 0;
+		r = sc_select_file(p15card->card, &path, NULL);
+		LOG_TEST_RET(p15card->card->ctx, r, "Could not select EF");
+
+		r = sc_read_binary(p15card->card, 0, efbin, *len, 0);
+		LOG_TEST_RET(p15card->card->ctx, r, "Could not read EF");
+
+		*len = r;
+
+		if (p15card->opts.use_file_cache) {
+			/* save this with our AID */
+			path.aid = sc_hsm_aid;
+			sc_pkcs15_cache_file(p15card, &path, efbin, *len);
+		}
+	}
+
+	return SC_SUCCESS;
+}
+
+
+
 /*
  * Decode a card verifiable certificate as defined in TR-03110.
  */
@@ -481,28 +516,21 @@ void sc_pkcs15emu_sc_hsm_free_cvc(sc_cvc_t *cvc)
 
 
 
-static int sc_pkcs15emu_sc_hsm_add_pubkey(sc_pkcs15_card_t *p15card, sc_pkcs15_prkey_info_t *key_info, char *label)
+static int sc_pkcs15emu_sc_hsm_add_pubkey(sc_pkcs15_card_t *p15card, u8 *efbin, size_t len, sc_pkcs15_prkey_info_t *key_info, char *label)
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	sc_card_t *card = p15card->card;
 	sc_pkcs15_pubkey_info_t pubkey_info;
 	sc_pkcs15_object_t pubkey_obj;
 	struct sc_pkcs15_pubkey pubkey;
-	u8 efbin[1024];
 	sc_cvc_t cvc;
 	u8 *cvcpo;
-	size_t cvclen;
 	int r;
 
-	/* EF.CERT is selected */
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
-	LOG_TEST_RET(ctx, r, "Could not read CSR from EF");
-
 	cvcpo = efbin;
-	cvclen = r;
 
 	memset(&cvc, 0, sizeof(cvc));
-	r = sc_pkcs15emu_sc_hsm_decode_cvc(p15card, (const u8 **)&cvcpo, &cvclen, &cvc);
+	r = sc_pkcs15emu_sc_hsm_decode_cvc(p15card, (const u8 **)&cvcpo, &len, &cvc);
 	LOG_TEST_RET(ctx, r, "Could decode certificate signing request");
 
 	memset(&pubkey, 0, sizeof(pubkey));
@@ -563,20 +591,13 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	fid[1] = keyid;
 
 	/* Try to select a related EF containing the PKCS#15 description of the key */
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, NULL);
-
-	if (r != SC_SUCCESS) {
-		return SC_SUCCESS;
-	}
-
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
+	len = sizeof efbin;
+	r = read_file(p15card, fid, efbin, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.PRKD");
 
-	memset(&prkd, 0, sizeof(prkd));
 	ptr = efbin;
-	len = r;
 
+	memset(&prkd, 0, sizeof(prkd));
 	r = sc_pkcs15_decode_prkdf_entry(p15card, &prkd, (const u8 **)&ptr, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not decode EF.PRKD");
 
@@ -604,22 +625,16 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 	/* Check if we also have a certificate for the private key */
 	fid[0] = EE_CERTIFICATE_PREFIX;
 
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, NULL);
-
-	if (r != SC_SUCCESS) {
-		return SC_SUCCESS;
-	}
-
-	/* Check if the certificate is a X.509 certificate */
-	r = sc_read_binary(p15card->card, 0, efbin, 1, 0);
+	len = sizeof efbin;
+	r = read_file(p15card, fid, efbin, &len);
+	LOG_TEST_RET(card->ctx, r, "Could not read EF");
 
 	if (r < 0) {
 		return SC_SUCCESS;
 	}
 
 	if (efbin[0] == 0x67) {		/* Decode CSR and create public key object */
-		sc_pkcs15emu_sc_hsm_add_pubkey(p15card, key_info, prkd.label);
+		sc_pkcs15emu_sc_hsm_add_pubkey(p15card, efbin, len, key_info, prkd.label);
 		return SC_SUCCESS;		/* Ignore any errors */
 	}
 
@@ -651,7 +666,6 @@ static int sc_pkcs15emu_sc_hsm_add_dcod(sc_pkcs15_card_t * p15card, u8 id) {
 	sc_card_t *card = p15card->card;
 	sc_pkcs15_data_info_t *data_info;
 	sc_pkcs15_object_t data_obj;
-	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
 	const u8 *ptr;
@@ -662,20 +676,13 @@ static int sc_pkcs15emu_sc_hsm_add_dcod(sc_pkcs15_card_t * p15card, u8 id) {
 	fid[1] = id;
 
 	/* Try to select a related EF containing the PKCS#15 description of the data */
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, NULL);
-
-	if (r != SC_SUCCESS) {
-		return SC_SUCCESS;
-	}
-
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
+	len = sizeof efbin;
+	r = read_file(p15card, fid, efbin, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.DCOD");
 
-	memset(&data_obj, 0, sizeof(data_obj));
 	ptr = efbin;
-	len = r;
 
+	memset(&data_obj, 0, sizeof(data_obj));
 	r = sc_pkcs15_decode_dodf_entry(p15card, &data_obj, &ptr, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not decode EF.DCOD");
 
@@ -698,7 +705,6 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 	sc_card_t *card = p15card->card;
 	sc_pkcs15_cert_info_t *cert_info;
 	sc_pkcs15_object_t obj;
-	sc_path_t path;
 	u8 fid[2];
 	u8 efbin[512];
 	const u8 *ptr;
@@ -709,20 +715,13 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 	fid[1] = id;
 
 	/* Try to select a related EF containing the PKCS#15 description of the data */
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0);
-	r = sc_select_file(card, &path, NULL);
-
-	if (r != SC_SUCCESS) {
-		return SC_SUCCESS;
-	}
-
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
+	len = sizeof efbin;
+	r = read_file(p15card, fid, efbin, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.DCOD");
 
-	memset(&obj, 0, sizeof(obj));
 	ptr = efbin;
-	len = r;
 
+	memset(&obj, 0, sizeof(obj));
 	r = sc_pkcs15_decode_cdf_entry(p15card, &obj, &ptr, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not decode EF.CD");
 
@@ -740,18 +739,15 @@ static int sc_pkcs15emu_sc_hsm_add_cd(sc_pkcs15_card_t * p15card, u8 id) {
 static int sc_pkcs15emu_sc_hsm_read_tokeninfo (sc_pkcs15_card_t * p15card)
 {
 	sc_card_t *card = p15card->card;
-	sc_path_t path;
 	int r;
 	u8 efbin[512];
+	size_t len;
 
 	LOG_FUNC_CALLED(card->ctx);
 
 	/* Read token info */
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, (u8 *) "\x2F\x03", 2, 0, 0);
-	r = sc_select_file(card, &path, NULL);
-	LOG_TEST_RET(card->ctx, r, "Could not select EF.TokenInfo");
-
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
+	len = sizeof efbin;
+	r = read_file(p15card, (u8 *) "\x2F\x03", efbin, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not read EF.TokenInfo");
 
 	r = sc_pkcs15_parse_tokeninfo(card->ctx, p15card->tokeninfo, efbin, r);
@@ -807,15 +803,11 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 	sc_file_free(file);
 
 	/* Read device certificate to determine serial number */
-	sc_path_set(&path, SC_PATH_TYPE_FILE_ID, (u8 *) "\x2F\x02", 2, 0, 0);
-	r = sc_select_file(card, &path, NULL);
+	len = sizeof efbin;
+	r = read_file(p15card, (u8 *) "\x2F\x02", efbin, &len);
 	LOG_TEST_RET(card->ctx, r, "Could not select EF.C_DevAut");
 
-	r = sc_read_binary(p15card->card, 0, efbin, sizeof(efbin), 0);
-	LOG_TEST_RET(card->ctx, r, "Could not read EF.C_DevAut");
-
 	ptr = efbin;
-	len = r;
 
 	memset(&devcert, 0 ,sizeof(devcert));
 	r = sc_pkcs15emu_sc_hsm_decode_cvc(p15card, (const u8 **)&ptr, &len, &devcert);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2399,6 +2399,10 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 		sc_unlock(p15card->card);
 
 		sc_file_free(file);
+
+		if (p15card->opts.use_file_cache) {
+			sc_pkcs15_cache_file(p15card, in_path, data, len);
+		}
 	}
 	*buf = data;
 	*buflen = len;

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -468,6 +468,34 @@ static int pcsc_reconnect(sc_reader_t * reader, DWORD action)
 	return pcsc_to_opensc_error(rv);
 }
 
+static void initialize_uid(sc_reader_t *reader)
+{
+	sc_apdu_t apdu;
+	/* though we only expect 10 bytes max, we want to set the Le to 0x00 to not
+	 * get 0x6282 as SW in case of a UID variant shorter than 10 bytes */
+	u8 rbuf[256];
+
+	memset(&apdu, 0, sizeof(apdu));
+	apdu.cse = SC_APDU_CASE_2_SHORT;
+	apdu.cla = 0xFF;
+	apdu.ins = 0xCA;
+	apdu.p1 = 0x00;
+	apdu.p2 = 0x00;
+	apdu.le = 0x00;
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof rbuf;
+
+	if (SC_SUCCESS == pcsc_transmit(reader, &apdu)
+			&& apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
+		reader->uid.len = apdu.resplen;
+		memcpy(reader->uid.value, apdu.resp, reader->uid.len);
+		sc_debug_hex(reader->ctx, SC_LOG_DEBUG_NORMAL, "UID",
+				reader->uid.value, reader->uid.len);
+	} else {
+		sc_debug(reader->ctx, SC_LOG_DEBUG_NORMAL, "unable to get UID");
+	}
+}
+
 static int pcsc_connect(sc_reader_t *reader)
 {
 	DWORD active_proto, tmp, protocol = SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1;
@@ -519,6 +547,8 @@ static int pcsc_connect(sc_reader_t *reader)
 		}
 		sc_log(reader->ctx, "Final protocol: %s", reader->active_protocol == SC_PROTO_T1 ? "T=1" : "T=0");
 	}
+
+	initialize_uid(reader);
 
 	/* After connect reader is not locked yet */
 	priv->locked = 0;
@@ -2173,6 +2203,8 @@ static int cardmod_connect(sc_reader_t *reader)
 		return r;
 	if (!(reader->flags & SC_READER_CARD_PRESENT))
 		return SC_ERROR_CARD_NOT_PRESENT;
+
+	initialize_uid(reader);
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -35,6 +35,7 @@ typedef unsigned char u8;
 #define SC_MAX_EXT_APDU_BUFFER_SIZE	65538
 #define SC_MAX_PIN_SIZE			256 /* OpenPGP card has 254 max */
 #define SC_MAX_ATR_SIZE			33
+#define SC_MAX_UID_SIZE			10
 #define SC_MAX_AID_SIZE			16
 #define SC_MAX_AID_STRING_SIZE		(SC_MAX_AID_SIZE * 2 + 3)
 #define SC_MAX_IIN_SIZE			10
@@ -73,6 +74,11 @@ struct sc_aid {
 
 struct sc_atr {
 	unsigned char value[SC_MAX_ATR_SIZE];
+	size_t len;
+};
+
+struct sc_uid {
+	unsigned char value[SC_MAX_UID_SIZE];
 	size_t len;
 };
 


### PR DESCRIPTION
- uses the static UID of a contactless card for caching if a serial number in EF.TokenInfo is not (yet) available
- uses caching transparently. i.e. the user only needs to change the configuration file without calling `pkcs15-tool -L` anymore. @martinpaljak are there any historic reasons why this has never been done before?