### PR TITLE
pincache: respect pin_cache_counter

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -367,6 +367,7 @@ int sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card,
 	r = sc_pin_cmd(card, &data, &auth_info->tries_left);
 	sc_log(ctx, "PIN cmd result %i", r);
 	if (r == SC_SUCCESS)
+	if (r == SC_SUCCESS && pin_obj->usage_counter == 0)
 		sc_pkcs15_pincache_add(p15card, pin_obj, pincode, pinlen);
 out:
 	sc_unlock(card);


### PR DESCRIPTION
sc_pkcs15_pincache_add was being called at every verify,
which is safe beside reseting usage_counter to 0. That
was causing the cache to be reused above pin_cache_counter.

~~This doesn't produce any effects by default because
pin_cache_counter is 10 by default and it usually the pin
is not reused 10 times.~~

Actually pkcs11-tool -lt with my card is failing now, it requires a pin_cache_counter of at least 11!

Anyway, I believe this should be addressed independently by pkcs11-tool - if the cache is not enough it should ask the PIN again, not just fail! I'll wait for comments on this patch before looking to do something about pkcs11-tool.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>