### PR TITLE
fix 4rd test: the other signature keys (may have differing modLenByte…

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3589,7 +3589,7 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 	struct sc_pkcs11_card *p11card = session->slot->p11card;
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct pkcs15_prkey_object *prkey;
-	unsigned char decrypted[256]; /* FIXME: Will not work for keys above 2048 bits */
+	unsigned char decrypted[512]; /* FIXME: Will not work for keys above 4096 bits */
 	int	buff_too_small, rv, flags = 0, prkey_has_path = 0;
 
 	sc_log(context, "Initiating decryption.");

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4097,6 +4097,8 @@ static int test_signature(CK_SESSION_HANDLE sess)
 			break;
 	ck_mech.mechanism = mechTypes[i];
 	j = 1;  /* j-th signature key */
+	data[0] = 0x00; // maybe line commented out, if data[0] has already 0x00 value
+//	data[1] = 0x01;
 	while (find_object(sess, CKO_PRIVATE_KEY, &privKeyObject, NULL, 0, j++) != 0) {
 		CK_ULONG	modLenBits;
 
@@ -4104,10 +4106,8 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		modLenBits = get_private_key_length(sess, privKeyObject);
 		modLenBytes = (modLenBits + 7) / 8;
 
-		/* Fill in data[0] and dataLens[0] */
+		/* Fill in datas[0] and dataLens[0] */
 		dataLen = modLenBytes;
-		data[0] = 0x00;
-		data[1] = 0x01;
 		memset(data + 2, 0xFF, dataLen - 3 - dataLens[1]);
 		data[dataLen - 36] = 0x00;
 		memcpy(data + (dataLen - dataLens[1]), datas[1], dataLens[1]);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4097,8 +4097,6 @@ static int test_signature(CK_SESSION_HANDLE sess)
 			break;
 	ck_mech.mechanism = mechTypes[i];
 	j = 1;  /* j-th signature key */
-	data[0] = 0x00; // maybe line commented out, if data[0] has already 0x00 value
-//	data[1] = 0x01;
 	while (find_object(sess, CKO_PRIVATE_KEY, &privKeyObject, NULL, 0, j++) != 0) {
 		CK_ULONG	modLenBits;
 
@@ -4106,8 +4104,10 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		modLenBits = get_private_key_length(sess, privKeyObject);
 		modLenBytes = (modLenBits + 7) / 8;
 
-		/* Fill in datas[0] and dataLens[0] */
+		/* Fill in data[0] and dataLens[0] */
 		dataLen = modLenBytes;
+		data[0] = 0x00;
+		data[1] = 0x01;
 		memset(data + 2, 0xFF, dataLen - 3 - dataLens[1]);
 		data[dataLen - 36] = 0x00;
 		memcpy(data + (dataLen - dataLens[1]), datas[1], dataLens[1]);


### PR DESCRIPTION
…s); prepare for 4096 bit keys.

After applying the proposed changes to my v0.16.0 repo, I'm able to run "pkcs11-tool -t -l" successfully as far as possible with RSA keys 1792/4096 bits and my upcoming driver.
- mechTypes[i] instead of i is required, if I understood the logic of this test well, assuming the test wants to run with firstMechType and pass it's 'i' to sign_verify_openssl() for sync. with evp_mds[].
- /* Fill in data[0] and dataLens[0] */ is nearly a copy of code in 3rd test, which cares for the differing key lengths.

Some tests like "1st test" may send no digestInfo within their data to be signed, which is a violation of PKCS#1 AFAIK. Thus there seems to be more demand for fixing (and my remaining errors from 1st test might vanish as well).