### PR TITLE
Fixed name inconsistency for PIV driver by making it "piv" in ctx.c

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -111,7 +111,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "setcos",	(void *(*)(void)) sc_get_setcos_driver },
 	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
 	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
-	{ "PIV-II",	(void *(*)(void)) sc_get_piv_driver },
+	{ "piv",	(void *(*)(void)) sc_get_piv_driver },
 	{ "itacns",	(void *(*)(void)) sc_get_itacns_driver },
 	{ "isoApplet",	(void *(*)(void)) sc_get_isoApplet_driver },
 #ifdef ENABLE_ZLIB

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -111,7 +111,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "setcos",	(void *(*)(void)) sc_get_setcos_driver },
 	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
 	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
-	{ "piv",	(void *(*)(void)) sc_get_piv_driver },
+	{ "piv",		(void *(*)(void)) sc_get_piv_driver },
 	{ "itacns",	(void *(*)(void)) sc_get_itacns_driver },
 	{ "isoApplet",	(void *(*)(void)) sc_get_isoApplet_driver },
 #ifdef ENABLE_ZLIB

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -43,7 +43,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "esteid",	sc_pkcs15emu_esteid_init_ex	},
 	{ "itacns",	sc_pkcs15emu_itacns_init_ex	},
 	{ "postecert",	sc_pkcs15emu_postecert_init_ex  },
-	{ "PIV-II",     sc_pkcs15emu_piv_init_ex	},
+	{ "piv",		sc_pkcs15emu_piv_init_ex	},
 	{ "gemsafeGPK",	sc_pkcs15emu_gemsafeGPK_init_ex	},
 	{ "gemsafeV1",	sc_pkcs15emu_gemsafeV1_init_ex	},
 	{ "actalis",	sc_pkcs15emu_actalis_init_ex	},


### PR DESCRIPTION
Making PIV-II driver consistently appear as "piv" in `opensc-tool` and `opensc.conf`