### PR TITLE
Card was reset

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3303,6 +3303,22 @@ static int piv_logout(sc_card_t *card)
 }
 
 
+static int piv_card_was_reset(sc_card_t *card)
+{
+	int r = 0;
+	u8 temp[2000];
+	size_t templen = sizeof(temp);
+	piv_private_data_t * priv = PIV_DATA(card); /* may be null */
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	if (priv)
+		priv->logged_in =  SC_PIN_STATE_UNKNOWN;
+
+	r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, temp, &templen);
+
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
+}
+
 static struct sc_card_driver * sc_get_driver(void)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
@@ -3324,6 +3340,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	piv_ops.check_sw = piv_check_sw;
 	piv_ops.card_ctl = piv_card_ctl;
 	piv_ops.pin_cmd = piv_pin_cmd;
+	piv_ops.card_was_reset = piv_card_was_reset;
 
 	return &piv_drv;
 }

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -408,6 +408,8 @@ int sc_lock(sc_card_t *card)
 					card->sm_ctx.ops.open(card);
 #endif
 				r = card->reader->ops->lock(card->reader);
+				if (r == SC_SUCCESS  && card->ops->card_was_reset)
+				    r = card->ops->card_was_reset(card);
 			}
 		}
 		if (r == 0)

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1224,7 +1224,8 @@ static struct sc_card_operations iso_ops = {
 	iso7816_get_data,
 	NULL,			/* put_data */
 	NULL,			/* delete_record */
-	NULL			/* read_public_key */
+	NULL,			/* read_public_key */
+	NULL			/* card_was_reset */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -626,6 +626,8 @@ struct sc_card_operations {
 	int (*read_public_key)(struct sc_card *, unsigned,
 			struct sc_path *, unsigned, unsigned,
 			unsigned char **, size_t *);
+
+	int (*card_was_reset)(struct sc_card *);
 };
 
 typedef struct sc_card_driver {


### PR DESCRIPTION
Add to sc_card_operations a card_was_reset function. Any card driver that need to know that the card was reset by some other process can gain control from sc_lock to do any commands needed to get the card back into the expected state.  

Two commits are in the branch. 

- The  first is  the code to have sc_lock call the card->ops->card_was_reset function. 

- The second is the card-piv.c  piv_card_was_reset function, It selects the PIV AID. 

@mouse07410,
Can you try this? It is OK to use the opensc.conf  disconnect_action = reset if you want. 