### PR TITLE
After card reset detected, run SM open under new transaction

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -388,6 +388,7 @@ int sc_reset(sc_card_t *card, int do_cold_reset)
 int sc_lock(sc_card_t *card)
 {
 	int r = 0, r2 = 0;
+	int was_reset = 0;
 
 	if (card == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
@@ -400,14 +401,12 @@ int sc_lock(sc_card_t *card)
 	if (card->lock_count == 0) {
 		if (card->reader->ops->lock != NULL) {
 			r = card->reader->ops->lock(card->reader);
-			if (r == SC_ERROR_CARD_RESET || r == SC_ERROR_READER_REATTACHED) {
+			while (r == SC_ERROR_CARD_RESET || r == SC_ERROR_READER_REATTACHED) {
 				/* invalidate cache */
 				memset(&card->cache, 0, sizeof(card->cache));
 				card->cache.valid = 0;
-#ifdef ENABLE_SM
-				if (card->sm_ctx.ops.open)
-					card->sm_ctx.ops.open(card);
-#endif
+				if (was_reset++ > 4) /* TODO retry a few times */
+					break;
 				r = card->reader->ops->lock(card->reader);
 			}
 		}
@@ -416,13 +415,21 @@ int sc_lock(sc_card_t *card)
 	}
 	if (r == 0)
 		card->lock_count++;
+
+	if (r == 0 && was_reset > 0) {
+#ifdef ENABLE_SM
+		if (card->sm_ctx.ops.open)
+			card->sm_ctx.ops.open(card);
+#endif
+	}
+
 	r2 = sc_mutex_unlock(card->ctx, card->mutex);
 	if (r2 != SC_SUCCESS) {
-		sc_log(card->ctx, "unable to release lock");
+		sc_log(card->ctx, "unable to release card->mutex lock");
 		r = r != SC_SUCCESS ? r : r2;
 	}
 
-	return r;
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 int sc_unlock(sc_card_t *card)


### PR DESCRIPTION
@viktorTarasov
I have questions on the logic used in sc_lock when card->reader->ops->lock(card->reader) returns SC_ERROR_CARD_RESET after a SCardBeginTransaction fails. It appears the calls to sm_ctx.ops.open is in the wrong place and may cause problems if there are many processes trying to use the same card.

sm_ctx.ops.open is called  while the card mutex is held and there is no PCSC transaction place.
The sm_ctx.ops.open can issue APDU, which will do sc_lock and pcsc_lock to do SCardBeginTranasction and when sm_ctx.ops.open retuerns, pcsc_unlock will be called and thus the transaction would have only been done for the sm_ctx.ops.open. Then when sm_ctx.ops.open returns to sc_lock,  sc_lock will will try and obtain a new transaction. But this new transaction could also fail because of SC_ERROR_CARD_RESET but sm_ctx.ops.open.

This PR is an attempt to address the issue. 

What I think should happen, is the original sc_lock should get the new transaction before sm_ctx.ops.open is called  so sm_ctx.ops.open is run on the same transaction as will be used by the original caller of sc_lock.

In other words after a card was reset, the  sm_ctx.ops.open should be run under a newly acquired Transaction and this is the Transaction returned  to the caller.

What appears to happen is sm_ctx.ops.open is run under its own Transaction then a new Transaction is obtained that is returned to the caller. This second Transaction could also return or interfered with by other processes, and it is not handled by the current code.

I do not have any SM cards, so can not test this. But I want to add #836 that would need to be processed just like the SM open. 
