### PR TITLE
Notify card driver that Reader lock obtained and if card was reset

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3300,6 +3300,25 @@ static int piv_logout(sc_card_t *card)
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 
+static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = 0;
+	u8 temp[2000];
+	size_t templen = sizeof(temp);
+	piv_private_data_t * priv = PIV_DATA(card); /* may be null */
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	if (was_reset > 0) {
+		if (priv)
+			priv->logged_in =  SC_PIN_STATE_UNKNOWN;
+
+		r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, temp, &templen);
+	}
+
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
+}
+
+
 
 static struct sc_card_driver * sc_get_driver(void)
 {
@@ -3322,6 +3341,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	piv_ops.check_sw = piv_check_sw;
 	piv_ops.card_ctl = piv_card_ctl;
 	piv_ops.pin_cmd = piv_pin_cmd;
+	piv_ops.card_reader_lock_obtained = piv_card_reader_lock_obtained;
 
 	return &piv_drv;
 }

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1224,7 +1224,8 @@ static struct sc_card_operations iso_ops = {
 	iso7816_get_data,
 	NULL,			/* put_data */
 	NULL,			/* delete_record */
-	NULL			/* read_public_key */
+	NULL,			/* read_public_key */
+	NULL			/* card_reader_lock_obtained */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -628,6 +628,8 @@ struct sc_card_operations {
 	int (*read_public_key)(struct sc_card *, unsigned,
 			struct sc_path *, unsigned, unsigned,
 			unsigned char **, size_t *);
+
+	int (*card_reader_lock_obtained)(struct sc_card *, int was_reset);
 };
 
 typedef struct sc_card_driver {


### PR DESCRIPTION
This is a replacement for #836. This new PR builds upon #837 and calls the card driver's card_reader_lock_obtained function whenever PCSC (or other reader driver) obtains the lock on the card. 
This allows the card driver to take action at the start of a SCardBeginTransaction if needed. 

A piv_card_reader_lock_obtained function is also added. If the card was reset, the PIV driver will select the AID again. There are some PIV cards where the PIV AID is not the default. 