### PR TITLE
install opensc.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -795,11 +795,11 @@ AC_CONFIG_FILES([
 	src/Makefile
 	src/common/Makefile
 	src/libopensc/Makefile
-	src/libopensc/libopensc.pc
 	src/libsm/Makefile
 	src/pkcs11/Makefile
 	src/pkcs11/versioninfo-pkcs11.rc
 	src/pkcs11/versioninfo-pkcs11-spy.rc
+	src/pkcs11/opensc.pc
 	src/pkcs15init/Makefile
 	src/scconf/Makefile
 	src/tests/Makefile

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -19,6 +19,10 @@ OPENSC_PKCS11_LIBS = \
 	$(top_builddir)/src/common/libcompat.la \
 	$(OPTIONAL_OPENSSL_LIBS) $(PTHREAD_LIBS)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = opensc.pc
+DISTCLEANFILES = $(pkgconfig_DATA)
+
 opensc_pkcs11_la_SOURCES = $(OPENSC_PKCS11_SRC) $(OPENSC_PKCS11_INC)
 opensc_pkcs11_la_LIBADD = $(OPENSC_PKCS11_LIBS)
 opensc_pkcs11_la_LDFLAGS = $(AM_LDFLAGS) \

--- a/src/pkcs11/opensc.pc.in
+++ b/src/pkcs11/opensc.pc.in
@@ -3,9 +3,8 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libopensc
-Description: libopensc
+Name: opensc
+Description: opensc
 Version: @VERSION@
-Libs: -L${libdir} -lopensc -lscconf
+Libs: -L${libdir} -lopensc-pkcs11
 Cflags: -I${includedir}
-


### PR DESCRIPTION
This mainly allows applications to detect the installed opensc version, as well as link against opensc's pkcs11 library if needed. This also deletes the unused since long time libopensc.pc.in.