### PR TITLE
change  parse_x509_cert()  to handle extensions correctly.

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1263,7 +1263,7 @@ int sc_format_oid(struct sc_object_id *oid, const char *in);
  * Compares two sc_object_id objects
  * @param  oid1  the first sc_object_id object
  * @param  oid2  the second sc_object_id object
- * @return 1 if the oids are equal and a non-zero value otherwise
+ * @return 1 if the oids are equal and a zero value otherwise
  */
 int sc_compare_oid(const struct sc_object_id *oid1, const struct sc_object_id *oid2);
 /**

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -136,12 +136,12 @@ parse_x509_cert(sc_context_t *ctx, struct sc_pkcs15_der *der, struct sc_pkcs15_c
 /* get a component of a Distinguished Name (e.i. subject or issuer) from an oid tag. dn can be either
  * cert->subject or cert->issuer. dn_len would be cert->subject_len or cert->issuer_len.
  * common types:
- *   CN: type[] = {0x55, 0x04, 0x03} type_len = 3;
- *   Country: type[] = {0x55, 0x04, 0x06} type_len = 3;
- *   L: type[] = {0x55, 0x04, 0x07} type_len = 3;
- *   S: type[] = {0x55, 0x04, 0x08} type_len = 3;
- *   O: type[] = {0x55, 0x04, 0x0a} type_len = 3;
- *   OU: type[] = {0x55, 0x04, 0x0b} type_len = 3;
+ *   CN:      struct sc_object_id type = {{85, 4, 3, -1}};
+ *   Country: struct sc_object_id type = {{85, 4, 6, -1}};
+ *   L:       struct sc_object_id type = {{85, 4, 7, -1}};
+ *   S:       struct sc_object_id type = {{85, 4, 8, -1}};
+ *   O:       struct sc_object_id type = {{85, 4, 10, -1}};
+ *   OU:      struct sc_object_id type = {{85, 4, 11, -1}};
  * if *name is NULL, sc_pkcs15_get_name_from_dn will allocate space for name.
  */
 int
@@ -218,14 +218,14 @@ sc_pkcs15_get_name_from_dn(struct sc_context *ctx, const u8 *dn, size_t dn_len,
  * pass of the asn1 decoder. If is_critical is supplied, then it is set to 1 if the extention is critical and 0
  * if it is not. The data in the extension is extension specific. The following are
  * common extension values:
- *   Subject Key ID: type[] = {0x55, 0x1d, 0x0e} type_len = 3;
- *   Key Usage: type[] = {0x55, 0x1d, 0x0f} type_len = 3;
- *   Subject Alt Name: type[] = {0x55, 0x1d, 0x11} type_len = 3;
- *   Basic Constraints: type[] = {0x55, 0x1d, 0x13} type_len = 3;
- *   CRL Distribution Points: type[] = {0x55, 0x1d, 0x1f} type_len = 3;
- *   Certificate Policies: type[] = {0x55, 0x1d, 0x20} type_len = 3;
- *   Extended Key Usage: type[] = {0x55, 0x1d, 0x25} type_len = 3;
- * if *name is NULL, sc_pkcs15_get_extension will allocate space for name.
+ *   Subject Key ID:          struct sc_object_id type = {{85, 29, 14, -1}};
+ *   Key Usage:               struct sc_object_id type = {{85, 29, 15, -1}};
+ *   Subject Alt Name:        struct sc_object_id type = {{85, 29, 17, -1}};
+ *   Basic Constraints:       struct sc_object_id type = {{85, 29, 19, -1}};
+ *   CRL Distribution Points: struct sc_object_id type = {{85, 29, 31, -1}};
+ *   Certificate Policies:    struct sc_object_id type = {{85, 29, 32, -1}};
+ *   Extended Key Usage:      struct sc_object_id type = {{85, 29, 37, -1}};
+ * if *ext_val is NULL, sc_pkcs15_get_extension will allocate space for ext_val.
  */
 int
 sc_pkcs15_get_extension(struct sc_context *ctx, struct sc_pkcs15_cert *cert,

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -194,7 +194,7 @@ sc_pkcs15_get_name_from_dn(struct sc_context *ctx, const u8 *dn, size_t dn_len,
 			LOG_TEST_RET(ctx, SC_ERROR_INVALID_ASN1_OBJECT, "ASN.1 decoding of AVA OID");
 		}
 
-		if (sc_compare_oid(&oid, type) != 0) {
+		if (sc_compare_oid(&oid, type) == 0) {
 			continue;
 		}
 		/* Yes, then return the name */
@@ -269,9 +269,8 @@ sc_pkcs15_get_extension(struct sc_context *ctx, struct sc_pkcs15_cert *cert,
 			LOG_FUNC_RETURN(ctx, r);
 		}
 
-
 		/* is it the RN we are looking for */
-		if(sc_compare_oid(&oid, type) == 0) {
+		if(sc_compare_oid(&oid, type) != 0) {
 			if (*ext_val == NULL) {
 				*ext_val= val;
 				val = NULL;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -276,8 +276,8 @@ struct sc_pkcs15_cert {
 	size_t issuer_len;
 	u8 *subject;
 	size_t subject_len;
-	u8 *crl;
-	size_t crl_len;
+	u8 *extensions;
+	size_t extensions_len;
 
 	struct sc_pkcs15_pubkey * key;
 
@@ -713,6 +713,20 @@ void sc_pkcs15_free_certificate(struct sc_pkcs15_cert *cert);
 int sc_pkcs15_find_cert_by_id(struct sc_pkcs15_card *card,
 			      const struct sc_pkcs15_id *id,
 			      struct sc_pkcs15_object **out);
+int sc_pkcs15_get_name_from_dn(struct sc_context *ctx,
+                              const u8 *dn, size_t dn_len,
+                              const u8 *type, size_t type_len,
+                              u8 **name, size_t *name_len);
+int sc_pkcs15_get_extension(struct sc_context *ctx,
+                            struct sc_pkcs15_cert *cert,
+                            const u8 *type, size_t type_len,
+                            u8 **ext_val, size_t *ext_val_len,
+                            int *is_critical);
+int sc_pkcs15_get_bitstring_extension(struct sc_context *ctx,
+                                      struct sc_pkcs15_cert *cert,
+                                      const u8 *type, size_t type_len,
+                                      unsigned long long *value,
+                                      int *is_critical);
 /* sc_pkcs15_create_cdf:  Creates a new certificate DF on a card pointed
  * by <card>.  Information about the file, such as the file ID, is read
  * from <file>.  <certs> has to be NULL-terminated. */

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -719,12 +719,12 @@ int sc_pkcs15_get_name_from_dn(struct sc_context *ctx,
                               u8 **name, size_t *name_len);
 int sc_pkcs15_get_extension(struct sc_context *ctx,
                             struct sc_pkcs15_cert *cert,
-                            const u8 *type, size_t type_len,
+                            const struct sc_object_id *type,
                             u8 **ext_val, size_t *ext_val_len,
                             int *is_critical);
 int sc_pkcs15_get_bitstring_extension(struct sc_context *ctx,
                                       struct sc_pkcs15_cert *cert,
-                                      const u8 *type, size_t type_len,
+                                      const struct sc_object_id *type,
                                       unsigned long long *value,
                                       int *is_critical);
 /* sc_pkcs15_create_cdf:  Creates a new certificate DF on a card pointed

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -715,7 +715,7 @@ int sc_pkcs15_find_cert_by_id(struct sc_pkcs15_card *card,
 			      struct sc_pkcs15_object **out);
 int sc_pkcs15_get_name_from_dn(struct sc_context *ctx,
                               const u8 *dn, size_t dn_len,
-                              const u8 *type, size_t type_len,
+                              const struct sc_object_id *type,
                               u8 **name, size_t *name_len);
 int sc_pkcs15_get_extension(struct sc_context *ctx,
                             struct sc_pkcs15_cert *cert,


### PR DESCRIPTION
The code attempted to handle extensions assuming extensions were ordered. The
only extension it handled was crl's, but the handling was wrong and I didn't
find any actual use of the crl code. I've changed it to cache all the extensions
and then provided accessors functions to read a specific extension. I needed this
to read the key Usage, but the extension fetching code can work with any extension
(though the caller will need to parse the result. I also added code that parses DN
and returns a specifically requested DN component. I needed this to get the Common
Name for the certificate Subject. This gives the token a 'unique' name rather than
some generic name (like CAC-I or CAC-II). Both of these can be used to enhance the
piv support as well.

(Chunk of #841 providing this functionality to other card)