### PR TITLE
fixing of myeid padding problem.

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -313,7 +313,7 @@ _sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *p
 	struct sc_pin_cmd_data data;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "PIN(type:%X;method:%X;len:)", auth_info->auth_type, auth_info->auth_method, pinlen);
+	sc_log(ctx, "PIN(type:%X;method:%X;codep:%p;len:%i;maxlen:%i)", auth_info->auth_type, auth_info->auth_method, pincode, pinlen, auth_info->attrs.pin.max_length);
 
 	if (pinlen > SC_MAX_PIN_SIZE)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_PIN_LENGTH, "Invalid PIN size");
@@ -366,8 +366,10 @@ _sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *p
 	}
 
 	if(p15card->card->reader->capabilities & SC_READER_CAP_PIN_PAD) {
-		if (!pincode && !pinlen)
+		if ((!pincode && !pinlen) || pinlen>data.pin1.max_length) {
 			data.flags |= SC_PIN_CMD_USE_PINPAD;
+			data.pin1.len = 0;
+		}
 		if (auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN)
 			data.pin1.prompt = "Please enter SO PIN";
 		else


### PR DESCRIPTION
There is a problem with pinpad readers and the myeid smart card.
I believe there will be similar problems with other cards.

C_Login works fine when done with a NULL_PTR PIN; the pinpad prompts the user for PIN and then a CHV is done when entered.
But then if more than one C_xxx is done requiring the application to be logged on; this second C_xxx will fail with p11 error code CKR_PIN_LEN_RANGE (0xA2).

This pull request fixes the p11 so that the user will be prompted for PIN on the pinpad every time a CHV is needed.
Maybe there is a better way to fix this bogus long PIN code (256 chars) than done in this request.  Someone with good opensc knowledge ought to review it and change it if needed.

Also the myeid card should format the PIN objects so that no extra CHV is needed after C_Logon until C_Logout or application end.