### PR TITLE
Don't free file if pointer is null

### DIFF
--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -493,7 +493,7 @@ static int entersafe_select_fid(sc_card_t *card,
 	path.len=2;
 
 	r = iso_ops->select_file(card,&path,&file);
-	if(r) sc_file_free(file);
+	if(r && file) sc_file_free(file);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");
 
 	/* update cache */


### PR DESCRIPTION
Protects against segmentation fault with Feitian PKI card, issue #854.