### PR TITLE
Get rid of misleading indentation warnings (GCC6 -Wmisleading-indentation)

### DIFF
--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -169,16 +169,16 @@ void _sc_debug_hex(sc_context_t *ctx, int type, const char *file, int line,
 	if (buf == NULL)
 		return;
 
-    sc_hex_dump(ctx, type, data, len, buf, blen);
+	sc_hex_dump(ctx, type, data, len, buf, blen);
 
-    if (label)
-        sc_do_log(ctx, type, file, line, func,
-                "\n%s (%u byte%s):\n%s",
-                label, (unsigned int) len, len==1?"":"s", buf);
-    else
-        sc_do_log(ctx, type, file, line, func,
-                "%u byte%s:\n%s",
-                (unsigned int) len, len==1?"":"s", buf);
+	if (label)
+		sc_do_log(ctx, type, file, line, func,
+			"\n%s (%u byte%s):\n%s",
+			label, (unsigned int) len, len==1?"":"s", buf);
+	else
+		sc_do_log(ctx, type, file, line, func,
+			"%u byte%s:\n%s",
+			(unsigned int) len, len==1?"":"s", buf);
 
 	free(buf);
 }

--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -558,7 +558,9 @@ int main(
 		exit(1);
 	}
 	printf("\nCard detected (driver: %s)\nATR:", card->driver->name);
-	for(i=0;i<card->atr.len;++i) printf("%c%02X", i?':':' ', card->atr.value[i]); printf("\n");
+	for (i = 0; i < card->atr.len; ++i)
+		printf("%c%02X", i?':':' ', card->atr.value[i]);
+	printf("\n");
 
 	if((r = sc_lock(card))<0){
 		fprintf(stderr,"Lock failed: %s\n", sc_strerror(r));


### PR DESCRIPTION
Recent builds with GCC6 were resulting in warnings about misleading indentation, caused by mixing tabs and spaces or just putting everything on a single line:
```
log.c: In function ‘_sc_debug_hex’:
log.c:178:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
     else
     ^~~~
log.c:183:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘else’
  free(buf);
  ^~~~

netkey-tool.c: In function ‘main’:
netkey-tool.c:561:2: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
  for(i=0;i<card->atr.len;++i) printf("%c%02X", i?':':' ', card->atr.value[i]); printf("\n");
  ^~~
netkey-tool.c:561:80: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
  for(i=0;i<card->atr.len;++i) printf("%c%02X", i?':':' ', card->atr.value[i]); printf("\n");
                                                                                ^~~~~~
```
The pull request is making the use of tabs systematic and improves readability of the for loop above.