### PR TITLE
Make pkcs15-tool --dump object formatting consistent

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -246,6 +246,7 @@ static void print_cert_info(const struct sc_pkcs15_object *obj)
 	if (rv >= 0 && cert_parsed)   {
 		printf("\tEncoded serial : %02X %02X ", *(cert_parsed->serial), *(cert_parsed->serial + 1));
 		util_hex_dump(stdout, cert_parsed->serial + 2, cert_parsed->serial_len - 2, "");
+		printf("\n");
 		sc_pkcs15_free_certificate(cert_parsed);
 	}
 }


### PR DESCRIPTION
Properly terminate "Encoded serial" lines so that the blank line after
X.509 certificate blocks isn't consumed doing so.

Fixes loss of the blank line after X.509 certificate dump in `pkcs15-tool`, e.g.:

```
X.509 Certificate [key10]
	Object Flags   : [0x2], modifiable
	Authority      : no
	Path           : e82b0601040181c31f0201::ca00
	ID             : 6b65793130
	Encoded serial : 02 09 00FF13C53425CD4355
X.509 Certificate [key11]
	Object Flags   : [0x0]
	Authority      : no
	Path           : ce02
	ID             : 11
	Encoded serial : 02 09 00D1B221EF541433F1
kite:OpenSC iay$ 
```

becomes:

```
X.509 Certificate [key10]
	Object Flags   : [0x2], modifiable
	Authority      : no
	Path           : e82b0601040181c31f0201::ca00
	ID             : 6b65793130
	Encoded serial : 02 09 00FF13C53425CD4355

X.509 Certificate [key11]
	Object Flags   : [0x0]
	Authority      : no
	Path           : ce02
	ID             : 11
	Encoded serial : 02 09 00D1B221EF541433F1

kite:OpenSC iay$ 
```

This is consistent with the other outputs from `pkcs15-tool --dump`.