### PR TITLE
pkcs11: don't shrink the number of slots

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -486,6 +486,9 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 		goto out;
 	}
 
+	if (slot->p11card == NULL)
+		return CKR_TOKEN_NOT_PRESENT;
+
 	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetTokenInfo");

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -405,16 +405,20 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 	prev_reader = NULL;
 	numMatches = 0;
 	for (i=0; i<list_size(&virtual_slots); i++) {
-	        slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
+		slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
 		/* the list of available slots contains:
 		 * - if present, virtual hotplug slot;
 		 * - any slot with token;
 		 * - without token(s), one empty slot per reader;
+		 * - any slot that has already been seen;
 		 */
-	        if ((!tokenPresent && !slot->reader)
+		if ((!tokenPresent && !slot->reader)
 				|| (!tokenPresent && slot->reader != prev_reader)
-				|| (slot->slot_info.flags & CKF_TOKEN_PRESENT))
+				|| (slot->slot_info.flags & CKF_TOKEN_PRESENT)
+				|| (slot->flags & SC_PKCS11_SLOT_FLAG_SEEN)) {
 			found[numMatches++] = slot->id;
+			slot->flags |= SC_PKCS11_SLOT_FLAG_SEEN;
+		}
 		prev_reader = slot->reader;
 	}
 

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -316,7 +316,6 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
 
 	while ((slot = list_fetch(&virtual_slots))) {
 		list_destroy(&slot->objects);
-		pop_all_login_states(slot);
 		list_destroy(&slot->logins);
 		free(slot);
 	}

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -205,6 +205,12 @@ struct sc_pkcs11_card {
 	unsigned int nmechanisms;
 };
 
+/* If the slot did already show with `C_GetSlotList`, then we need to keep this
+ * slot alive. PKCS#11 2.30 allows allows adding but not removing slots until
+ * the application calls `C_GetSlotList` with `NULL`. This flag tracks the
+ * visibility to the application */
+#define SC_PKCS11_SLOT_FLAG_SEEN 1
+
 struct sc_pkcs11_slot {
 	CK_SLOT_ID id;			/* ID of the slot */
 	int login_user;			/* Currently logged in user */
@@ -221,6 +227,7 @@ struct sc_pkcs11_slot {
 	int fw_data_idx;		/* Index of framework data */
 	struct sc_app_info *app_info;	/* Application assosiated to slot */
 	list_t logins;			/* tracks all calls to C_Login if atomic operations are requested */
+	int flags;
 };
 typedef struct sc_pkcs11_slot sc_pkcs11_slot_t;
 

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -449,6 +449,7 @@ CK_RV slot_token_removed(CK_SLOT_ID id)
 	/* Reset relevant slot properties */
 	slot->slot_info.flags &= ~CKF_TOKEN_PRESENT;
 	slot->login_user = -1;
+	pop_all_login_states(slot);
 	slot->p11card = NULL;
 
 	if (token_was_present)


### PR DESCRIPTION
... as required by PKCS#11 2.30. Fixes ghost tokens in Firefox detaching a reader that contained a card.

Fixes https://github.com/OpenSC/OpenSC/issues/629
