### PR TITLE
Allow tools to choose if lock is required

### DIFF
--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -1646,7 +1646,7 @@ int main(int argc, char * const argv[])
 		sc_ctx_log_to_file(ctx, "stderr");
 	}
 
-	r = util_connect_card(ctx, &card, opt_reader, opt_wait, verbose);
+	r = util_connect_card_ex(ctx, &card, opt_reader, opt_wait, 0, verbose);
 	if (r != SC_SUCCESS) {
 		if (r < 0) {
 			fprintf(stderr, "Failed to connect to card: %s\n", sc_strerror(err));
@@ -1687,7 +1687,6 @@ fail:
 	err = 1;
 end:
 	if (card) {
-		sc_unlock(card);
 		sc_disconnect_card(card);
 	}
 	if (ctx)

--- a/src/tools/util.c
+++ b/src/tools/util.c
@@ -47,8 +47,8 @@ is_string_valid_atr(const char *atr_str)
 }
 
 int
-util_connect_card(sc_context_t *ctx, sc_card_t **cardp,
-		 const char *reader_id, int do_wait, int verbose)
+util_connect_card_ex(sc_context_t *ctx, sc_card_t **cardp,
+		 const char *reader_id, int do_wait, int do_lock, int verbose)
 {
 	struct sc_reader *reader = NULL, *found = NULL;
 	struct sc_card *card = NULL;
@@ -156,15 +156,24 @@ autofound:
 	if (verbose)
 		printf("Using card driver %s.\n", card->driver->name);
 
-	r = sc_lock(card);
-	if (r < 0) {
-		fprintf(stderr, "Failed to lock card: %s\n", sc_strerror(r));
-		sc_disconnect_card(card);
-		return 1;
+	if (do_lock) {
+		r = sc_lock(card);
+		if (r < 0) {
+			fprintf(stderr, "Failed to lock card: %s\n", sc_strerror(r));
+			sc_disconnect_card(card);
+			return 1;
+		}
 	}
 
 	*cardp = card;
 	return 0;
+}
+
+int
+util_connect_card(sc_context_t *ctx, sc_card_t **cardp,
+		 const char *reader_id, int do_wait, int verbose)
+{
+	return util_connect_card_ex(ctx, cardp, reader_id, do_wait, 1, verbose);
 }
 
 void util_print_binary(FILE *f, const u8 *buf, int count)

--- a/src/tools/util.h
+++ b/src/tools/util.h
@@ -33,7 +33,8 @@ void util_warn(const char *fmt, ...);
 void util_error(const char *fmt, ...);
 void util_fatal(const char *fmt, ...);
 /* All singing all dancing card connect routine */
-int util_connect_card(struct sc_context *, struct sc_card **, const char *reader_id, int wait, int verbose);
+int util_connect_card_ex(struct sc_context *, struct sc_card **, const char *reader_id, int do_wait, int do_lock, int verbose);
+int util_connect_card(struct sc_context *, struct sc_card **, const char *reader_id, int do_wait, int verbose);
 
 int util_getpass (char **lineptr, size_t *n, FILE *stream);
 


### PR DESCRIPTION
This pull request aims at fixing #750. It's an alternative to #868.

The API remains backwards compatible and tools can now choose in util_connect_card_ex() if they want to lock cards immediately or not.