### PR TITLE
Coverity remarks

### DIFF
--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -60,6 +60,7 @@ C_LoadModule(const char *mspec, CK_FUNCTION_LIST_PTR_PTR funcs)
 		fprintf(stderr, "C_GetFunctionList failed %lx", rv);
 failed:
 	C_UnloadModule((void *) mod);
+	free(mod);
 	return NULL;
 }
 

--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -82,6 +82,7 @@ sc_aux_data_set_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_da
 	case SC_AUX_DATA_TYPE_NO_DATA:
 		memset(aux_data, 0, sizeof(*aux_data));
 		aux_data->type = SC_AUX_DATA_TYPE_MD_CMAP_RECORD;
+		/* fallthrough */
 	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
 		rec = &aux_data->data.cmap_record;
 		memcpy(rec->guid, guid, strlen(guid));
@@ -112,6 +113,7 @@ sc_aux_data_set_md_flags(struct sc_context *ctx, struct sc_auxiliary_data *aux_d
 	case SC_AUX_DATA_TYPE_NO_DATA:
 		memset(aux_data, 0, sizeof(*aux_data));
 		aux_data->type = SC_AUX_DATA_TYPE_MD_CMAP_RECORD;
+		/* fallthrough */
 	case SC_AUX_DATA_TYPE_MD_CMAP_RECORD:
 		aux_data->data.cmap_record.flags = flags;
 		sc_log(ctx, "set MD container flags '0x%X'", flags);

--- a/src/libopensc/card-asepcos.c
+++ b/src/libopensc/card-asepcos.c
@@ -870,13 +870,8 @@ static int asepcos_build_pin_apdu(sc_card_t *card, sc_apdu_t *apdu,
 		*p++ = (fileid >> 16) & 0xff;
 		*p++ = (fileid >> 8 ) & 0xff;
 		*p++ = fileid & 0xff;
-		if (is_puk == 0) {
-			memcpy(p, data->pin1.data, data->pin1.len);
-			p += data->pin1.len;
-		} else {
-			memcpy(p, data->pin1.data, data->pin1.len);
-			p += data->pin1.len;
-		}
+		memcpy(p, data->pin1.data, data->pin1.len);
+		p += data->pin1.len;
 		apdu->lc       = p - buf;
 		apdu->datalen  = p - buf;
 		apdu->data     = buf;

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -273,26 +273,27 @@ sc_pkcs15_get_extension(struct sc_context *ctx, struct sc_pkcs15_cert *cert,
 			LOG_FUNC_RETURN(ctx, r);
 
 		/* is it the RN we are looking for */
-		if(sc_compare_oid(&oid, type) != 0) {
+		if (sc_compare_oid(&oid, type) != 0) {
 			if (*ext_val == NULL) {
-				*ext_val= val;
+				*ext_val = val;
 				val = NULL;
 				*ext_val_len = val_len;
+				/* do not free here -- return the allocated value to caller */
 			}
 			else {
 				*ext_val_len = MIN(*ext_val_len, val_len);
 				memcpy(*ext_val, val, *ext_val_len);
+				free(val);
 			}
 
 			if (is_critical)
 				*is_critical = critical;
 
 			r = val_len;
-			free(val);
 			LOG_FUNC_RETURN(ctx, r);
 		}
-		free(val);
 	}
+	free(val);
 
 	LOG_FUNC_RETURN(ctx, SC_ERROR_ASN1_OBJECT_NOT_FOUND);
 }

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -406,7 +406,7 @@ int sc_pkcs15_change_pin(struct sc_pkcs15_card *p15card,
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_pin_cmd_data data;
 	struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
-	struct sc_card *card = p15card->card;
+	struct sc_card *card;
 	int r;
 
 	LOG_FUNC_CALLED(ctx);

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1401,6 +1401,8 @@ sc_pkcs15_pubkey_from_spki_sequence(struct sc_context *ctx, const unsigned char 
 
 	if(outpubkey)
 		*outpubkey = pubkey;
+	else
+		free(pubkey);
 
 	LOG_FUNC_RETURN(ctx, r);
 }

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -178,11 +178,10 @@ CK_RV push_login_state(struct sc_pkcs11_slot *slot,
 	struct sc_pkcs11_login *login = NULL;
 
 	if (!sc_pkcs11_conf.atomic || !slot) {
-		r = CKR_OK;
-		goto err;
+		return CKR_OK;
 	}
 
-	login = (struct sc_pkcs11_login *) malloc(sizeof *login);
+	login = (struct sc_pkcs11_login *) calloc(1, sizeof *login);
 	if (login == NULL) {
 		goto err;
 	}
@@ -199,12 +198,15 @@ CK_RV push_login_state(struct sc_pkcs11_slot *slot,
 		goto err;
 	}
 
+	login = NULL;
 	r = CKR_OK;
 
 err:
-	if (r != CKR_OK && login) {
-		sc_mem_clear(login->pPin, login->ulPinLen);
-		free(login->pPin);
+	if (login) {
+		if (login->pPin) {
+			sc_mem_clear(login->pPin, login->ulPinLen);
+			free(login->pPin);
+		}
 		free(login);
 	}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1384,8 +1384,10 @@ static int change_pin(CK_SLOT_ID slot, CK_SESSION_HANDLE sess)
 			r = util_getpass(&new_pin, &len, stdin);
 			if (r < 0)
 				return 1;
-			if (!new_pin || !*new_pin || strcmp(new_buf, new_pin) != 0)
+			if (!new_pin || !*new_pin || strcmp(new_buf, new_pin) != 0) {
+				free(new_pin);
 				return 1;
+			}
 		}
 		else   {
 			new_pin = (char *) opt_new_pin;
@@ -3536,6 +3538,7 @@ static int read_object(CK_SESSION_HANDLE session)
 	if (opt_output)
 		fclose(out);
 
+	free(value);
 	if (oid_buf)
 		free(oid_buf);
 	return 1;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2460,6 +2460,7 @@ handle_option(const struct option *opt)
 		break;
 	case 'h':
 		util_print_usage_and_die(app_name, options, option_help, NULL);
+		/* exit */
 	case 'i':
 		opt_objectid = optarg;
 		break;
@@ -2803,6 +2804,7 @@ int get_pin(sc_ui_hints_t *hints, char **out)
 
 		if (!(flags & SC_UI_PIN_MISMATCH_RETRY)) {
 			fprintf(stderr, "PINs do not match.\n");
+			free(pin);
 			return SC_ERROR_KEYPAD_PIN_MISMATCH;
 		}
 

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -1119,8 +1119,10 @@ static u8 * get_pin(const char *prompt, sc_pkcs15_object_t *pin_obj)
 		r = util_getpass(&pincode, &len, stdin);
 		if (r < 0)
 			return NULL;
-		if (!pincode || strlen(pincode) == 0)
+		if (!pincode || strlen(pincode) == 0) {
+			free(pincode);
 			return NULL;
+		}
 		if (strlen(pincode) < pinfo->attrs.pin.min_length) {
 			printf("PIN code too short, try again.\n");
 			continue;
@@ -1129,7 +1131,7 @@ static u8 * get_pin(const char *prompt, sc_pkcs15_object_t *pin_obj)
 			printf("PIN code too long, try again.\n");
 			continue;
 		}
-		return (u8 *) strdup(pincode);
+		return (u8 *) pincode;
 	}
 }
 
@@ -1489,6 +1491,7 @@ static int change_pin(void)
 
 	if (pincode && strlen((char *) pincode) == 0) {
 		fprintf(stderr, "No PIN code supplied.\n");
+		free(pincode);
 		return 2;
 	}
 
@@ -1508,6 +1511,7 @@ static int change_pin(void)
 		if (newpin == NULL || strlen((char *) newpin) == 0)   {
 			fprintf(stderr, "No new PIN value supplied.\n");
 			free(newpin);
+			free(pincode);
 			return 2;
 		}
 


### PR DESCRIPTION
If interested, I can provide specific messages from Coverity for each change.

It also found one flaw in the change #852 (already accepted) when `free()`ing data, which was caused by my modifications. It is also covered in this pull request.