### PR TITLE
travis for OCX: fix missing 'sed'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,4 +77,13 @@ script:
       wine "C:/Program Files (x86)/Inno Setup 5/ISCC.exe" win32/OpenSC.iss;
     fi
 
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then
+        brew update;
+        brew uninstall libtool;
+        brew install libtool;
+        brew install libdvbpsi libhdhomerun;
+    fi
+
 cache: ccache


### PR DESCRIPTION
Due to bugs in Travis CI:
$ ./bootstrap
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: glibtoolize --copy --force
/usr/local/bin/glibtoolize: line 401: /usr/local/Library/ENV/4.3/sed: No such file or directory
/usr/local/bin/glibtoolize: line 401: /usr/local/Library/ENV/4.3/sed: No such file or directory
/usr/local/bin/glibtoolize: line 401: /usr/local/Library/ENV/4.3/sed: No such file or directory

Trying to apply solution from https://github.com/mkrufky/libdvbtee/issues/22 .