### PR TITLE
libopensc: allow setting driver via OPENSC_DRIVER environment variable

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -792,6 +792,13 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 
 	load_card_drivers(ctx, &opts);
 	load_card_atrs(ctx);
+
+	if (!opts.forced_card_driver) {
+		char *driver = getenv("OPENSC_DRIVER");
+		if(driver) {
+			opts.forced_card_driver = strdup(driver);
+		}
+	}
 	if (opts.forced_card_driver) {
 		/* FIXME: check return value? */
 		sc_set_card_driver(ctx, opts.forced_card_driver);


### PR DESCRIPTION
When you have cards with multiple supported applets (such as the YubiKey with OpenPGP+PIV and any other GlobalPlatform card) it is very convenient to be able to temporarily override the selected card driver and use a different applet than it would be selected by default without having to create and maintain a completely separate config file.

I'm proposing that the driver name could be specified via an environment variable, so in case the driver is not forced by the client the variable would override the auto-selection mechanism. I have been trying this for a while and it proved to be very useful, especially when using the PKCS#11 module: I can easily use the OpenPGP keys in one program and the PIV certificates in another. The change is so small and localized that I feel it is worth to incorporate that into the codebase. 

This PR is for mostly to start this conversation and for feedback. The proposed variable name is just a suggestion.
