### PR TITLE
Makefile.am in test needs openssl

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = Makefile.mak
 SUBDIRS = regression
 noinst_PROGRAMS = base64 lottery p15dump pintest prngtest
 
+AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)/src
 LIBS = \
 	$(top_builddir)/src/libopensc/libopensc.la \


### PR DESCRIPTION
#861 introduced a dependency in the tests directory that requires the OPENSSL_CFLAGS =  -I \<path\>  


added:
AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS)
as sc-ossl-compat.h  may include some openssl header files.

 Changes to be committed:
	modified:   src/tests/Makefile.am