### PR TITLE
Move include for internal.h from aux-date.h to aux-data.c

### DIFF
--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "internal.h"
 #include "common/compat_strlcat.h"
 
 #include <libopensc/errors.h>

--- a/src/libopensc/aux-data.h
+++ b/src/libopensc/aux-data.h
@@ -28,7 +28,6 @@ extern "C" {
 #endif
 
 #include "cardctl.h"
-#include "internal.h"
 #include "errors.h"
 #include "asn1.h"
 #include "types.h"

--- a/src/tools/cryptoflex-tool.c
+++ b/src/tools/cryptoflex-tool.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 
+#include "libopensc/sc-ossl-compat.h"
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>


### PR DESCRIPTION
"internal.h" is included in some 90 source files and one
header file aux-data.h

with PR 861 internal.h, includes sc-ossl-compat.h  which requires
openssl header files. the tests/Makefile.am did not include the
openssl CFLAGS.

 Changes to be committed:
	modified:   src/libopensc/aux-data.c
	modified:   src/libopensc/aux-data.h
	modified:   src/tools/cryptoflex-tool.c