### PR TITLE
hex_to_bin: don't strip leading null-bytes

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5346,7 +5346,6 @@ static int hex_to_bin(const char *in, unsigned char *out, size_t *outlen)
 
 	left = *outlen;
 
-	while (*in == '0' && *(++in) != '\0') ; // strip leading zeros in input
 	if (strlen(in) % 2)
 		nybbles = 1; // any leading zero in output should be in most-significant byte, not last one!
 	while (*in != '\0') {


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/838

... and hopefully doesn't have any side effects

tested with `pkcs11-tool --test` and cardos 4.3
