### PR TITLE
Restore blocking wait-for-slot functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -583,7 +583,10 @@ if test "${enable_pcsc}" = "yes"; then
 	if test "${WIN32}" != "yes"; then
 		PKG_CHECK_EXISTS(
 			[libpcsclite],
-			[PKG_CHECK_MODULES([PCSC], [libpcsclite])]
+			[PKG_CHECK_MODULES([PCSC], [libpcsclite >= 1.6.5],
+				[AC_DEFINE([PCSCLITE_GOOD], [1], [Sufficient version of PCSC-Lite with all the required features])],
+				[:]
+			)]
 		)
 		if test -z "${PCSC_CFLAGS}"; then
 			case "${host}" in

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -641,10 +641,11 @@ CK_RV C_WaitForSlotEvent(CK_FLAGS flags,   /* blocking/nonblocking flag */
 		return  CKR_ARGUMENTS_BAD;
 
 	sc_log(context, "C_WaitForSlotEvent(block=%d)", !(flags & CKF_DONT_BLOCK));
+#ifndef PCSCLITE_GOOD
 	/* Not all pcsc-lite versions implement consistently used functions as they are */
-	/* FIXME: add proper checking into build to check correct pcsc-lite version for SCardStatusChange/SCardCancel */
 	if (!(flags & CKF_DONT_BLOCK))
 		return CKR_FUNCTION_NOT_SUPPORTED;
+#endif /* PCSCLITE_GOOD */
 	rv = sc_pkcs11_lock();
 	if (rv != CKR_OK)
 		return rv;


### PR DESCRIPTION
 * Add configure-time dependency on pcsclite (already from comments in reader-pcsc)
 * The functionality is already supported in pcsc-lite