### PR TITLE
pkcs15-tool --list-info and tree (supersede #885)

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -279,7 +279,7 @@ static int list_certificates(void)
 		return 1;
 	}
 	if (verbose)
-		printf("Card has %d certificate(s).\n\n", r);
+		printf("Card has %d Certificate(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_cert_info(objs[i]);
 		printf("\n");
@@ -491,6 +491,8 @@ static int list_data_objects(void)
 		return 1;
 	}
 	count = r;
+	if (verbose)
+		printf("Card has %d Data object(s).\n\n", count);
 	for (i = 0; i < count; i++) {
 		int idx;
 		struct sc_pkcs15_data_info *cinfo = (struct sc_pkcs15_data_info *) objs[i]->data;
@@ -600,7 +602,7 @@ static int list_private_keys(void)
 		return 1;
 	}
 	if (verbose)
-		printf("Card has %d private key(s).\n\n", r);
+		printf("Card has %d Private key(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_prkey_info(objs[i]);
 		printf("\n");
@@ -679,7 +681,7 @@ static int list_public_keys(void)
 		return 1;
 	}
 	if (verbose)
-		printf("Card has %d public key(s).\n\n", r);
+		printf("Card has %d Public key(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_pubkey_info(objs[i]);
 		printf("\n");
@@ -1367,7 +1369,7 @@ static int list_pins(void)
 		return 1;
 	}
 	if (verbose)
-		printf("Card has %d Authentication objects.\n", r);
+		printf("Card has %d Authentication object(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_pin_info(objs[i]);
 		printf("\n");

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -98,7 +98,8 @@ enum {
 	OPT_LIST_SKEYS,
 	OPT_NO_PROMPT,
 	OPT_RAW,
-	OPT_PRINT_VERSION
+	OPT_PRINT_VERSION,
+	OPT_LIST_INFO,
 };
 
 #define NELEMENTS(x)	(sizeof(x)/sizeof((x)[0]))
@@ -107,6 +108,7 @@ static int	authenticate(sc_pkcs15_object_t *obj);
 
 static const struct option options[] = {
 	{ "version",		0, NULL,			OPT_PRINT_VERSION },
+	{ "list-info",	no_argument, NULL,		OPT_LIST_INFO },
 	{ "list-applications",	no_argument, NULL,		OPT_LIST_APPLICATIONS },
 	{ "read-certificate",	required_argument, NULL,	'r' },
 	{ "list-certificates",	no_argument, NULL,		'c' },
@@ -145,6 +147,7 @@ static const struct option options[] = {
 
 static const char *option_help[] = {
 	"Print OpenSC package version",
+	"List card information",
 	"List the on-card PKCS#15 applications",
 	"Reads certificate with ID <arg>",
 	"Lists certificates",
@@ -1403,8 +1406,7 @@ static int list_apps(FILE *fout)
 	return 0;
 }
 
-static int dump(void)
-{
+static void list_info(void){
 	const char *flags[] = {
 		"Read-only",
 		"Login required",
@@ -1433,8 +1435,12 @@ static int dump(void)
 			count++;
 		}
 	}
-	printf("\n\n");
+	printf("\n");
+}
 
+static int dump(void)
+{
+	list_info();
 	list_pins();
 	list_private_keys();
 	list_public_keys();
@@ -1872,6 +1878,7 @@ int main(int argc, char * const argv[])
 	int do_test_update = 0;
 	int do_update = 0;
 	int do_print_version = 0;
+	int do_list_info = 0;
 	int action_count = 0;
 	sc_context_param_t ctx_param;
 
@@ -1888,6 +1895,10 @@ int main(int argc, char * const argv[])
 		switch (c) {
 		case OPT_PRINT_VERSION:
 			do_print_version = 1;
+			action_count++;
+			break;
+		case OPT_LIST_INFO:
+			do_list_info = 1;
 			action_count++;
 			break;
 		case 'r':
@@ -2069,6 +2080,12 @@ int main(int argc, char * const argv[])
 		p15card->opts.use_file_cache = 0;
 	if (verbose)
 		fprintf(stderr, "Found %s!\n", p15card->tokeninfo->label);
+
+	if(do_list_info) {
+		if(!do_dump)
+			list_info();
+		action_count--;
+	}
 
 	if (do_verify_pin)
 		if ((err = verify_pin()))

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -70,6 +70,7 @@ static char * opt_bind_to_aid = NULL;
 static const char * opt_newpin = NULL;
 static const char * opt_pin = NULL;
 static const char * opt_puk = NULL;
+static int	tree = 0;
 static int	verbose = 0;
 static int opt_no_prompt = 0;
 #if defined(ENABLE_OPENSSL) && (defined(_WIN32) || defined(HAVE_INTTYPES_H))
@@ -140,6 +141,7 @@ static const struct option options[] = {
 	{ "auth-id",		required_argument, NULL,	'a' },
 	{ "aid",		required_argument, NULL,	OPT_BIND_TO_AID },
 	{ "wait",		no_argument, NULL,		'w' },
+	{ "tree",			no_argument, NULL,		't' },
 	{ "verbose",		no_argument, NULL,		'v' },
 	{ "no-prompt",		no_argument, NULL,		OPT_NO_PROMPT },
 	{ NULL, 0, NULL, 0 }
@@ -179,6 +181,7 @@ static const char *option_help[] = {
 	"The auth ID of the PIN to use",
 	"Specify AID of the on-card PKCS#15 application to bind to (in hexadecimal form)",
 	"Wait for card insertion",
+	"Output lists in tree format",
 	"Verbose operation. Use several times to enable debug output.",
 	"Do not prompt the user; if no PINs supplied, pinpad will be used.",
 	NULL
@@ -205,6 +208,8 @@ struct _access_rule_text {
 	{SC_PKCS15_ACCESS_RULE_MODE_EXT_AUTH, "ext_auth"},
 	{0, NULL},
 };
+
+static const char *key_types[] = { "", "RSA", "DSA", "GOSTR3410", "EC", "", "", "" };
 
 static void
 print_access_rules(const struct sc_pkcs15_accessrule *rules, int num)
@@ -253,6 +258,14 @@ static void print_cert_info(const struct sc_pkcs15_object *obj)
 	struct sc_pkcs15_cert *cert_parsed = NULL;
 	int rv;
 
+	if(tree) {
+		printf("  Path:%s | %s", sc_print_path(&cert_info->path),
+			sc_pkcs15_print_id(&cert_info->id));
+		if(cert_info->authority)
+			printf(" | Authority");
+		return;
+	}
+
 	printf("X.509 Certificate [%.*s]\n", (int) sizeof obj->label, obj->label);
 	print_common_flags(obj);
 	printf("\tAuthority      : %s\n", cert_info->authority ? "yes" : "no");
@@ -270,7 +283,6 @@ static void print_cert_info(const struct sc_pkcs15_object *obj)
 	}
 }
 
-
 static int list_certificates(void)
 {
 	int r, i;
@@ -281,7 +293,9 @@ static int list_certificates(void)
 		fprintf(stderr, "Certificate enumeration failed: %s\n", sc_strerror(r));
 		return 1;
 	}
-	if (verbose)
+	if(tree)
+		printf("Certificate(s) [%d]\n", r);
+	else if (verbose)
 		printf("Card has %d Certificate(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_cert_info(objs[i]);
@@ -494,11 +508,39 @@ static int list_data_objects(void)
 		return 1;
 	}
 	count = r;
-	if (verbose)
+	if(tree)
+		printf("Data object(s) [%d]\n", r);
+	else if (verbose)
 		printf("Card has %d Data object(s).\n\n", count);
 	for (i = 0; i < count; i++) {
 		int idx;
 		struct sc_pkcs15_data_info *cinfo = (struct sc_pkcs15_data_info *) objs[i]->data;
+
+		if(tree) {
+			printf("  Path:%-12s", sc_print_path(&cinfo->path));
+			if (sc_valid_oid(&cinfo->app_oid)) {
+				printf(" | %i", cinfo->app_oid.value[0]);
+				for (idx = 1; idx < SC_MAX_OBJECT_ID_OCTETS && cinfo->app_oid.value[idx] != -1 ; idx++)
+					printf(".%i", cinfo->app_oid.value[idx]);
+			}
+			if (objs[i]->auth_id.len == 0){
+				struct sc_pkcs15_data *data_object;
+				r = sc_pkcs15_read_data_object(p15card, cinfo, &data_object);
+				if (r) {
+					fprintf(stderr, "Data object read failed: %s\n", sc_strerror(r));
+					if (r == SC_ERROR_FILE_NOT_FOUND)
+						continue; /* DEE emulation may say there is a file */
+					return 1;
+				}
+				sc_pkcs15_free_data_object(data_object);
+				printf(" | Size:%6lu", cinfo->data.len);
+			}else {
+					printf(" | Auth ID:%3s", sc_pkcs15_print_id(&objs[i]->auth_id));
+			}
+			printf(" | %-20s", cinfo->app_label);
+			printf("\n");
+			continue;
+		}
 
 		if (objs[i]->label[0] != '\0')
 			printf("Data object '%.*s'\n",(int) sizeof objs[i]->label, objs[i]->label);
@@ -531,38 +573,59 @@ static int list_data_objects(void)
 	return 0;
 }
 
-static void print_prkey_info(const struct sc_pkcs15_object *obj)
+static void print_key_usages(int usage)
 {
-	unsigned int i;
-	struct sc_pkcs15_prkey_info *prkey = (struct sc_pkcs15_prkey_info *) obj->data;
-	const char *types[] = { "", "RSA", "DSA", "GOSTR3410", "EC", "", "", "" };
 	const char *usages[] = {
-		"encrypt", "decrypt", "sign", "signRecover",
-		"wrap", "unwrap", "verify", "verifyRecover",
-		"derive", "nonRepudiation"
+		"encrypt", "decrypt", "sign", "signRecover", "wrap", "unwrap",
+		"verify", "verifyRecover", "derive", "nonRepudiation"
 	};
 	const size_t usage_count = NELEMENTS(usages);
-	const char *access_flags[] = {
-		"sensitive", "extract", "alwaysSensitive",
-		"neverExtract", "local"
+	for (unsigned int i = 0; i < usage_count; i++)
+		if (usage & (1 << i))
+			printf(", %s", usages[i]);
+}
+
+static void print_key_access_flags(int flags)
+{
+	const char *key_access_flags[] = {
+		"sensitive", "extract", "alwaysSensitive","neverExtract", "local"
 	};
-	const unsigned int af_count = NELEMENTS(access_flags);
+	const unsigned int af_count = NELEMENTS(key_access_flags);
+	for (unsigned int i = 0; i < af_count; i++)
+		if (flags & (1 << i))
+			printf(", %s", key_access_flags[i]);
+}
+
+static void print_prkey_info(const struct sc_pkcs15_object *obj)
+{
+	struct sc_pkcs15_prkey_info *prkey = (struct sc_pkcs15_prkey_info *) obj->data;
 	unsigned char guid[40];
 	size_t guid_len;
 
-	printf("Private %s Key [%.*s]\n", types[7 & obj->type], (int) sizeof obj->label, obj->label);
+	if(tree){
+		printf("  %3s", key_types[7 & obj->type]);
+
+		if (prkey->modulus_length)
+			printf("[%lu]", (unsigned long)prkey->modulus_length);
+		else
+			printf("[FieldLength:%lu]", (unsigned long)prkey->field_length);
+		printf(" | %s", sc_pkcs15_print_id(&prkey->id));
+		printf(" | Ref:%d (0x%X)", prkey->key_reference, prkey->key_reference);
+		if (obj->auth_id.len != 0)
+			printf(" | Auth ID:%s", sc_pkcs15_print_id(&obj->auth_id));
+		printf(" | %15.*s [0x%X", (int) sizeof obj->label, obj->label, prkey->usage);
+		print_key_usages(prkey->usage);
+		printf("]");
+		return;
+	}
+
+	printf("Private %s Key [%.*s]\n", key_types[7 & obj->type], (int) sizeof obj->label, obj->label);
 	print_common_flags(obj);
 	printf("\tUsage          : [0x%X]", prkey->usage);
-	for (i = 0; i < usage_count; i++)
-		if (prkey->usage & (1 << i)) {
-			printf(", %s", usages[i]);
-		}
+	print_key_usages(prkey->usage);
 	printf("\n");
-
 	printf("\tAccess Flags   : [0x%X]", prkey->access_flags);
-	for (i = 0; i < af_count; i++)
-		if (prkey->access_flags & (1 << i))
-			printf(", %s", access_flags[i]);
+	print_key_access_flags(prkey->access_flags);
 	printf("\n");
 
 	print_access_rules(obj->access_rules, SC_PKCS15_MAX_ACCESS_RULES);
@@ -604,7 +667,9 @@ static int list_private_keys(void)
 		fprintf(stderr, "Private key enumeration failed: %s\n", sc_strerror(r));
 		return 1;
 	}
-	if (verbose)
+	if(tree)
+		printf("Private key(s) [%d]\n", r);
+	else if (verbose)
 		printf("Card has %d Private key(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_prkey_info(objs[i]);
@@ -615,35 +680,34 @@ static int list_private_keys(void)
 
 static void print_pubkey_info(const struct sc_pkcs15_object *obj)
 {
-	unsigned int i;
 	const struct sc_pkcs15_pubkey_info *pubkey = (const struct sc_pkcs15_pubkey_info *) obj->data;
-	const char *types[] = { "", "RSA", "DSA", "GOSTR3410", "EC", "", "", "" };
-	const char *usages[] = {
-		"encrypt", "decrypt", "sign", "signRecover",
-		"wrap", "unwrap", "verify", "verifyRecover",
-		"derive", "nonRepudiation"
-	};
-	const unsigned int usage_count = NELEMENTS(usages);
-	const char *access_flags[] = {
-		"sensitive", "extract", "alwaysSensitive",
-		"neverExtract", "local"
-	};
-	const unsigned int af_count = NELEMENTS(access_flags);
 	int have_path = (pubkey->path.len != 0) || (pubkey->path.aid.len != 0);
 
-	printf("Public %s Key [%.*s]\n", types[7 & obj->type], (int) sizeof obj->label, obj->label);
+	if(tree){
+		printf("  %3s", key_types[7 & obj->type]);
+
+		if (pubkey->modulus_length)
+			printf("[%lu]", (unsigned long)pubkey->modulus_length);
+		else
+			printf("[FieldLength:%lu]", (unsigned long)pubkey->field_length);
+		printf(" | %s", sc_pkcs15_print_id(&pubkey->id));
+		printf(" | Ref:%d (0x%X)", pubkey->key_reference, pubkey->key_reference);
+		if (obj->auth_id.len != 0)
+			printf(" | Auth ID:%s", sc_pkcs15_print_id(&obj->auth_id));
+		printf(" | %15.*s [0x%X", (int) sizeof obj->label, obj->label, pubkey->usage);
+		print_key_usages(pubkey->usage);
+		printf("]");
+		return;
+	}
+
+	printf("Public %s Key [%.*s]\n", key_types[7 & obj->type], (int) sizeof obj->label, obj->label);
 	print_common_flags(obj);
 	printf("\tUsage          : [0x%X]", pubkey->usage);
-	for (i = 0; i < usage_count; i++)
-		if (pubkey->usage & (1 << i)) {
-			printf(", %s", usages[i]);
-	}
+	print_key_usages(pubkey->usage);
 	printf("\n");
 
 	printf("\tAccess Flags   : [0x%X]", pubkey->access_flags);
-	for (i = 0; i < af_count; i++)
-		if (pubkey->access_flags & (1 << i))
-			printf(", %s", access_flags[i]);
+	print_key_access_flags(pubkey->access_flags);
 	printf("\n");
 
 	print_access_rules(obj->access_rules, SC_PKCS15_MAX_ACCESS_RULES);
@@ -683,7 +747,9 @@ static int list_public_keys(void)
 		fprintf(stderr, "Public key enumeration failed: %s\n", sc_strerror(r));
 		return 1;
 	}
-	if (verbose)
+	if(tree)
+		printf("Public key(s) [%d]\n", r);
+	else if (verbose)
 		printf("Card has %d Public key(s).\n\n", r);
 	for (i = 0; i < r; i++) {
 		print_pubkey_info(objs[i]);
@@ -756,35 +822,19 @@ static int read_public_key(void)
 
 static void print_skey_info(const struct sc_pkcs15_object *obj)
 {
-	unsigned int i;
 	struct sc_pkcs15_skey_info *skey = (struct sc_pkcs15_skey_info *) obj->data;
 	const char *types[] = { "generic", "DES", "2DES", "3DES"};
-	const char *usages[] = {
-		"encrypt", "decrypt", "sign", "signRecover",
-		"wrap", "unwrap", "verify", "verifyRecover",
-		"derive"
-	};
-	const size_t usage_count = NELEMENTS(usages);
-	const char *access_flags[] = {
-		"sensitive", "extract", "alwaysSensitive",
-		"neverExtract", "local"
-	};
-	const unsigned int af_count = NELEMENTS(access_flags);
 	unsigned char guid[40];
 	size_t guid_len;
 
 	printf("Secret %s Key [%.*s]\n", types[3 & obj->type], (int) sizeof obj->label, obj->label);
 	print_common_flags(obj);
 	printf("\tUsage          : [0x%X]", skey->usage);
-	for (i = 0; i < usage_count; i++)
-		if (skey->usage & (1 << i))
-			printf(", %s", usages[i]);
+	print_key_usages(skey->usage);
 	printf("\n");
 
 	printf("\tAccess Flags   : [0x%X]", skey->access_flags);
-	for (i = 0; i < af_count; i++)
-		if (skey->access_flags & (1 << i))
-			printf(", %s", access_flags[i]);
+	print_key_access_flags(skey->access_flags);
 	printf("\n");
 
 	print_access_rules(obj->access_rules, SC_PKCS15_MAX_ACCESS_RULES);
@@ -1320,10 +1370,32 @@ static void print_pin_info(const struct sc_pkcs15_object *obj)
 	const size_t pf_count = NELEMENTS(pin_flags);
 	size_t i;
 
-	if (obj->type == SC_PKCS15_TYPE_AUTH_PIN)
-		printf("PIN [%.*s]\n", (int) sizeof obj->label, obj->label);
-	else if (obj->type == SC_PKCS15_TYPE_AUTH_AUTHKEY)
-		printf("AuthKey [%.*s]\n", (int) sizeof obj->label, obj->label);
+	assert(obj->type == SC_PKCS15_TYPE_AUTH_PIN || obj->type == SC_PKCS15_TYPE_AUTH_AUTHKEY);
+
+	if(tree){
+		printf("  %s | %s", obj->type == SC_PKCS15_TYPE_AUTH_PIN ? "PIN" : "AuthKey",
+			sc_pkcs15_print_id(&auth_info->auth_id));
+		if (auth_info->auth_type == SC_PKCS15_PIN_AUTH_TYPE_PIN) {
+			const struct sc_pkcs15_pin_attributes *pin_attrs = &(auth_info->attrs.pin);
+			printf(" | Ref:%d (0x%02X)", pin_attrs->reference, pin_attrs->reference);
+		}
+		else {
+			const struct sc_pkcs15_authkey_attributes *attrs = &auth_info->attrs.authkey;
+			printf(" | Derived:%i", attrs->derived);
+			printf(" | SecretKeyID:%s", sc_pkcs15_print_id(&attrs->skey_id));
+		}
+		if (obj->auth_id.len)
+			printf(" | Auth ID:%s", sc_pkcs15_print_id(&obj->auth_id));
+		if (auth_info->path.len || auth_info->path.aid.len)
+			printf(" | Path:%s", sc_print_path(&auth_info->path));
+		if (auth_info->tries_left >= 0)
+			printf(" | Tries left:%d", auth_info->tries_left);
+		printf(" | %.*s", (int) sizeof obj->label, obj->label);
+		return;
+	}
+
+	printf("%s [%.*s]\n", obj->type == SC_PKCS15_TYPE_AUTH_PIN ? "PIN" : "AuthKey",
+		(int) sizeof obj->label, obj->label);
 
 	print_common_flags(obj);
 	if (obj->auth_id.len)
@@ -1371,8 +1443,11 @@ static int list_pins(void)
 		fprintf(stderr, "AUTH objects enumeration failed: %s\n", sc_strerror(r));
 		return 1;
 	}
-	if (verbose)
+	if(tree)
+		printf("Authentication object(s) [%d]\n", r);
+	else if (verbose)
 		printf("Card has %d Authentication object(s).\n\n", r);
+
 	for (i = 0; i < r; i++) {
 		print_pin_info(objs[i]);
 		printf("\n");
@@ -1887,7 +1962,7 @@ int main(int argc, char * const argv[])
 	c = OPT_PUK;
 
 	while (1) {
-		c = getopt_long(argc, argv, "r:cuko:va:LR:CwDTU", options, &long_optind);
+		c = getopt_long(argc, argv, "r:cuko:tva:LR:CwDTU", options, &long_optind);
 		if (c == -1)
 			break;
 		if (c == '?')
@@ -1991,6 +2066,9 @@ int main(int argc, char * const argv[])
 			break;
 		case 'o':
 			opt_outfile = optarg;
+			break;
+		case 't':
+			tree++;
 			break;
 		case 'v':
 			verbose++;


### PR DESCRIPTION
Hi,

I've implemented:

```
./pkcs15-tool --list-info
PKCS#15 Card [CARTAO DE CIDADAO]:
	Version        : 1
	Serial number  : 000004093842343
	Manufacturer ID: GEMALTO
	Flags          : Read-only, PRN generation, EID compliant
```

and

```
./pkcs15-tool -D --tree  
PKCS#15 Card [CARTAO DE CIDADAO]:
	Version        : 1
	Serial number  : 000004093842343
	Manufacturer ID: GEMALTO
	Flags          : Read-only, PRN generation, EID compliant
Authentication object(s) [3]
  PIN | 01 | Ref:129 (0x81) | Tries left:3 | Auth PIN
  PIN | 02 | Ref:130 (0x82) | Tries left:3 | Sign PIN
  PIN | 03 | Ref:131 (0x83) | Tries left:3 | Address PIN
Private key(s) [2]
  RSA[1024] | 45 | Ref:2 (0x2) | Auth ID:01 | CITIZEN AUTHENTICATION KEY [0x4, sign]
  RSA[1024] | 46 | Ref:1 (0x1) | Auth ID:02 | CITIZEN SIGNATURE KEY [0x200, nonRepudiation]
Public key(s) [0]
Certificate(s) [5]
  Path:3f005f00ef09 | 45
  Path:3f005f00ef08 | 46
  Path:3f005f00ef0f | 51
  Path:3f005f00ef10 | 52
  Path:3f005f00ef11 | 50
Data object(s) [5]
  Path:3f005f00ef02 | Size: 15500 | Citizen Data        
  Path:3f005f00ef05 | Auth ID: 03 | Citizen Address Data
  Path:3f005f00ef07 | Size:  1000 | Citizen Notepad     
  Path:3f005f00ef06 | Size:  4000 | SOD                 
  Path:3f000003     | Size:     6 | TRACE
```

The tree format is highly dependent on the specific objects present on the card, and I tried to make it as generic as possible, but it must be checked with other cards to make sure the output continues to be reasonable. Please give it a try.

Thanks!