### PR TITLE
Coolkey improvements

### DIFF
--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -56,10 +56,12 @@ C_LoadModule(const char *mspec, CK_FUNCTION_LIST_PTR_PTR funcs)
 	rv = c_get_function_list(funcs);
 	if (rv == CKR_OK)
 		return (void *) mod;
-	else
+	else {
 		fprintf(stderr, "C_GetFunctionList failed %lx", rv);
+		C_UnloadModule((void *) mod);
+		return NULL;
+	}
 failed:
-	C_UnloadModule((void *) mod);
 	free(mod);
 	return NULL;
 }

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -41,7 +41,7 @@
 #include "pkcs15.h"
 #include "../pkcs11/pkcs11.h"
 
-int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *, sc_pkcs15emu_opt_t *);
+int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 
 typedef struct pdata_st {
@@ -673,16 +673,17 @@ fail:
 	}
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_COOLKEY_FINAL_GET_OBJECTS, &count);
 
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,
-				  sc_pkcs15emu_opt_t *opts)
+int
+sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,
+		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
 {
 	sc_card_t   *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;
 
-	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+	LOG_FUNC_CALLED(ctx);
 
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
 		return sc_pkcs15emu_coolkey_init(p15card);

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -680,17 +680,20 @@ int
 sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,
 		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
 {
-	sc_card_t   *card = p15card->card;
+	sc_card_t      *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;
+	int rv;
 
 	LOG_FUNC_CALLED(ctx);
 
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_coolkey_init(p15card);
+		rv = sc_pkcs15emu_coolkey_init(p15card);
 	else {
-		int r = coolkey_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_coolkey_init(p15card);
+		rv = coolkey_detect_card(p15card);
+		if (rv)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_CARD);
+		rv = sc_pkcs15emu_coolkey_init(p15card);
 	}
+
+	LOG_FUNC_RETURN(ctx, rv);
 }


### PR DESCRIPTION
* Prevent double-free and segfault if `dlopen` fails (broken by #876 -- sorry for it).

```
sc_dlopen failed: ../pkcs11/.libs/opensc-pkcs11.so: cannot open shared object file: No such file or directory
==31434== Invalid free() / delete / delete[] / realloc()
==31434==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==31434==    by 0x411F52: C_LoadModule (libpkcs11.c:63)
==31434==    by 0x4038C0: main (pkcs11-tool.c:760)
==31434==  Address 0x60693e0 is 0 bytes inside a block of size 16 free'd
==31434==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==31434==    by 0x411EA5: C_UnloadModule (libpkcs11.c:84)
==31434==    by 0x411F4A: C_LoadModule (libpkcs11.c:62)
==31434==    by 0x4038C0: main (pkcs11-tool.c:760)
==31434==  Block was alloc'd at
==31434==    at 0x4C2DA60: calloc (vg_replace_malloc.c:711)
==31434==    by 0x411ED8: C_LoadModule (libpkcs11.c:38)
==31434==    by 0x4038C0: main (pkcs11-tool.c:760)
```

* Update coolkey pkcs15 emulator `init_ex()` to new API.

Partially resolves #904 (might need some more work).