### PR TITLE
#824: tools: fix segfault with verbose log into 'stderr'

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -21,14 +21,14 @@ app default {
 	#
 	# debug_file = @DEBUG_FILE@
 
-	# Re-open debug file  (used in WIN32)
+	# Reopen debug file at the every debug message.
 	#
-	# In Windows, file handles can not be shared between DLL-s,
-	#  each DLL has a separate file handle table.
-	# For that reason reopen debug file before every debug message.
+	# For Windows it's forced to 'true'. The reason is that
+	#   in Windows file handles can not be shared between DLL-s,
+	#   each DLL has a separate file handle table.
 	#
-	# Default: true
-	# reopen_debug_file = false;
+	# Default: false
+	# reopen_debug_file = true;
 
 	# PKCS#15 initialization / personalization
 	# profiles directory for pkcs15-init.

--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -112,13 +112,11 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 	if (r < 0)
 		return;
 
-#ifdef _WIN32
-	if (ctx->debug_filename)   {
+	if (ctx->reopen_log_file)   {
 		r = sc_ctx_log_to_file(ctx, ctx->debug_filename);
 		if (r < 0)
 			return;
 	}
-#endif
 
 	outf = ctx->debug_file;
 	if (outf == NULL)
@@ -130,15 +128,11 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 		fprintf(outf, "\n");
 	fflush(outf);
 
-#ifdef _WIN32
-	if (ctx->debug_filename)   {
-		if (ctx->debug_file && (ctx->debug_file != stderr && ctx->debug_file != stdout))   {
+	if (ctx->reopen_log_file)   {
+		if (ctx->debug_file && (ctx->debug_file != stderr && ctx->debug_file != stdout))
 			fclose(ctx->debug_file);
-			ctx->debug_file = NULL;
-		}
+		ctx->debug_file = NULL;
 	}
-#endif
-
 
 	return;
 }
@@ -147,9 +141,9 @@ void _sc_debug(struct sc_context *ctx, int level, const char *format, ...)
 {
 	va_list ap;
 
-        va_start(ap, format);
-        sc_do_log_va(ctx, level, NULL, 0, NULL, format, ap);
-        va_end(ap);
+	va_start(ap, format);
+	sc_do_log_va(ctx, level, NULL, 0, NULL, format, ap);
+	va_end(ap);
 }
 
 void _sc_log(struct sc_context *ctx, const char *format, ...)
@@ -162,7 +156,7 @@ void _sc_log(struct sc_context *ctx, const char *format, ...)
 }
 
 void _sc_debug_hex(sc_context_t *ctx, int type, const char *file, int line,
-        const char *func, const char *label, const u8 *data, size_t len)
+		const char *func, const char *label, const u8 *data, size_t len)
 {
 	size_t blen = len * 5 + 128;
 	char *buf = malloc(blen);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -679,6 +679,7 @@ typedef struct sc_context {
 	scconf_block *conf_blocks[3];
 	char *app_name;
 	int debug;
+	int reopen_log_file;
 	unsigned long flags;
 
 	FILE *debug_file;


### PR DESCRIPTION
Issue #824

In Windows, file handles (including 'stderr', 'stdout') can not be shared
between DLL-s, and so, the log handle (File *), defined in one module, cannot
be reused in another.

That is the situation when, for example, the SM is processed
in external, dynamically loadable module as it currently implemented for
IAS/ECC card.

That's for the configuration option 're-open log file on every log message' was
introduced.

This 're-open' logic has not been tested in the particular case of opensc-*
tools used with verbose log into 'stderr' -- in dynamically loaded module the
'stderr' handle, defined in the 'main' module, was not recognized as 'stderr'
and there was an attempt to close it.