### PR TITLE
Avoid re-opening the log file for every debug message on Windows (fixes #824, superseedes #910)

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -727,9 +727,9 @@ app onepin-opensc-pkcs11 {
 # Used by OpenSC.tokend on Mac OS X only.
 app tokend {
 	# The file to which debug log will be written
-	# Default: /tmp/opensc-tokend.log
+	# Default: stderr
 	#
-	# debug_file = /Library/Logs/OpenSC.tokend.log
+	# debug_file = /tmp/opensc-tokend.log
 
 	framework tokend {
 		# Score for OpenSC.tokend

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -21,15 +21,6 @@ app default {
 	#
 	# debug_file = @DEBUG_FILE@
 
-	# Re-open debug file  (used in WIN32)
-	#
-	# In Windows, file handles can not be shared between DLL-s,
-	#  each DLL has a separate file handle table.
-	# For that reason reopen debug file before every debug message.
-	#
-	# Default: true
-	# reopen_debug_file = false;
-
 	# PKCS#15 initialization / personalization
 	# profiles directory for pkcs15-init.
 	# Default: @PROFILE_DIR_DEFAULT@

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -253,18 +253,6 @@ static void add_internal_drvs(struct _sc_ctx_options *opts)
 	}
 }
 
-static void set_defaults(sc_context_t *ctx, struct _sc_ctx_options *opts)
-{
-	ctx->debug = 0;
-	if (ctx->debug_file && (ctx->debug_file != stderr && ctx->debug_file != stdout))
-		fclose(ctx->debug_file);
-	ctx->debug_file = stderr;
-	ctx->flags = 0;
-
-	ctx->forced_driver = NULL;
-	add_internal_drvs(opts);
-}
-
 /* In Windows, file handles can not be shared between DLL-s,
  * each DLL has a separate file handle table. Thus tools and utilities
  * can not set the file handle themselves when -v is specified on command line.
@@ -744,7 +732,7 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 	}
 
 	ctx->flags = parm->flags;
-	set_defaults(ctx, &opts);
+	add_internal_drvs(&opts);
 
 	list_init(&ctx->readers);
 	list_attributes_seeker(&ctx->readers, reader_list_seeker);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -286,13 +286,10 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 	const scconf_list *list;
 	const char *val, *s_internal = "internal";
 	int debug;
-	int reopen;
 #ifdef _WIN32
 	char expanded_val[PATH_MAX];
 	DWORD expanded_len;
 #endif
-
-	reopen = scconf_get_bool(block, "reopen_debug_file", 1);
 
 	debug = scconf_get_int(block, "debug", ctx->debug);
 	if (debug > ctx->debug)

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -316,19 +316,15 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 	if (debug > ctx->debug)
 		ctx->debug = debug;
 
-	val = scconf_get_str(block, "debug_file", NULL);
-	if (val)   {
+	val = scconf_get_str(block, "debug_file", "stderr");
 #ifdef _WIN32
-		expanded_len = PATH_MAX;
-		expanded_len = ExpandEnvironmentStringsA(val, expanded_val, expanded_len);
-		if (expanded_len > 0)
-			val = expanded_val;
+	expanded_len = PATH_MAX;
+	expanded_len = ExpandEnvironmentStringsA(val, expanded_val, expanded_len);
+	if (expanded_len > 0)
+		val = expanded_val;
 #endif
-		if (reopen)
-			ctx->debug_filename = strdup(val);
-
-		sc_ctx_log_to_file(ctx, val);
-	}
+	ctx->debug_filename = strdup(val);
+	sc_ctx_log_to_file(ctx, val);
 
 	if (scconf_get_bool (block, "paranoid-memory",
 				ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY))

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -261,12 +261,6 @@ static void set_defaults(sc_context_t *ctx, struct _sc_ctx_options *opts)
 	ctx->debug_file = stderr;
 	ctx->flags = 0;
 
-#ifdef __APPLE__
-	/* Override the default debug log for OpenSC.tokend to be different from PKCS#11.
-	 * TODO: Could be moved to OpenSC.tokend */
-	if (!strcmp(ctx->app_name, "tokend"))
-		ctx->debug_file = fopen("/tmp/opensc-tokend.log", "a");
-#endif
 	ctx->forced_driver = NULL;
 	add_internal_drvs(opts);
 }

--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -112,14 +112,6 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 	if (r < 0)
 		return;
 
-#ifdef _WIN32
-	if (ctx->debug_filename)   {
-		r = sc_ctx_log_to_file(ctx, ctx->debug_filename);
-		if (r < 0)
-			return;
-	}
-#endif
-
 	outf = ctx->debug_file;
 	if (outf == NULL)
 		return;
@@ -129,27 +121,15 @@ static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int lin
 	if (n == 0 || buf[n-1] != '\n')
 		fprintf(outf, "\n");
 	fflush(outf);
-
-#ifdef _WIN32
-	if (ctx->debug_filename)   {
-		if (ctx->debug_file && (ctx->debug_file != stderr && ctx->debug_file != stdout))   {
-			fclose(ctx->debug_file);
-			ctx->debug_file = NULL;
-		}
-	}
-#endif
-
-
-	return;
 }
 
 void _sc_debug(struct sc_context *ctx, int level, const char *format, ...)
 {
 	va_list ap;
 
-        va_start(ap, format);
-        sc_do_log_va(ctx, level, NULL, 0, NULL, format, ap);
-        va_end(ap);
+	va_start(ap, format);
+	sc_do_log_va(ctx, level, NULL, 0, NULL, format, ap);
+	va_end(ap);
 }
 
 void _sc_log(struct sc_context *ctx, const char *format, ...)
@@ -162,7 +142,7 @@ void _sc_log(struct sc_context *ctx, const char *format, ...)
 }
 
 void _sc_debug_hex(sc_context_t *ctx, int type, const char *file, int line,
-        const char *func, const char *label, const u8 *data, size_t len)
+		const char *func, const char *label, const u8 *data, size_t len)
 {
 	size_t blen = len * 5 + 128;
 	char *buf = malloc(blen);

--- a/src/smm/smm-local.c
+++ b/src/smm/smm-local.c
@@ -243,6 +243,10 @@ initialize(struct sc_context *ctx, struct sm_info *sm_info, struct sc_remote_dat
 	if (!sm_info)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
+#ifdef _WIN32
+	sc_ctx_log_to_file(ctx, ctx->debug_filename);
+#endif
+
 	sc_log(ctx, "Current AID: %s", sc_dump_hex(sm_info->current_aid.value, sm_info->current_aid.len));
 	switch (sm_info->sm_type)   {
 	case SM_TYPE_GP_SCP01:


### PR DESCRIPTION
#910 fixes #824 by extending the logic for reopening the debug file for every log message. This approach, however, is very problematic in regard to performance.

Instead of building on sandy ground, this PR tries to solve #824 by reopening the debug file once, when needed. This improves overall performance for logging on Windows, simplifies the user configuration options and, of course, fixes the segmentation fault in question.

This PR is compile tested only and needs to be verified on Windows with a IASECC card.