### PR TITLE
Lost change in the previous pull request and disable sm mode too.

### DIFF
--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -556,9 +556,9 @@ static int dnie_get_privkey(sc_card_t * card, EVP_PKEY ** ifd_privkey,
 		sc_log(card->ctx, "Cannot create data for IFD private key");
 		return SC_ERROR_OUT_OF_MEMORY;
 	}
-	ifd_rsa_n = BN_bin2bn(ifd_modulus, sizeof(ifd_modulus), NULL);
-	ifd_rsa_e = BN_bin2bn(ifd_public_exponent, sizeof(ifd_public_exponent), NULL);
-	ifd_rsa_d = BN_bin2bn(ifd_private_exponent, sizeof(ifd_private_exponent), NULL);
+	ifd_rsa_n = BN_bin2bn(modulus, modulus_len, NULL);
+	ifd_rsa_e = BN_bin2bn(public_exponent, public_exponent_len, NULL);
+	ifd_rsa_d = BN_bin2bn(private_exponent, private_exponent_len, NULL);
 	if (RSA_set0_key(ifd_rsa, ifd_rsa_n, ifd_rsa_e, ifd_rsa_d) != 1) {
 		BN_free(ifd_rsa_n);
 		BN_free(ifd_rsa_e);

--- a/src/libopensc/cwa-dnie.h
+++ b/src/libopensc/cwa-dnie.h
@@ -62,6 +62,7 @@ struct cwa_provider_st;
 #define GET_DNIE_UI_CTX(card) (((dnie_private_data_t *) ((card)->drv_data))->ui_ctx)
 
 #define DNIE_30_VERSION 0x04
+#define DNIE_30_CACHE_COUNTER 30000
 
 cwa_provider_t *dnie_get_cwa_provider(sc_card_t * card);
 

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -1076,6 +1076,7 @@ int cwa_create_secure_channel(sc_card_t * card,
 	switch (flag) {
 	case CWA_SM_OFF:	/* disable SM */
 		provider->status.session.state = CWA_SM_NONE;	/* just mark channel inactive */
+		card->sm_ctx.sm_mode = SM_MODE_NONE;
 		sc_log(ctx, "Setting CWA SM status to none");
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 	case CWA_SM_WARM:	/* only initialize if not already done */
@@ -1088,6 +1089,7 @@ int cwa_create_secure_channel(sc_card_t * card,
 		sc_log(ctx, "CWA SM initialization requested => reset and re-initialize");
 		sc_reset(card, 0);
 		provider->status.session.state = CWA_SM_INPROGRESS;
+		card->sm_ctx.sm_mode = SM_MODE_NONE;
 		break;
 	case CWA_SM_OVER:	/* create another channel over an existing one */
 		if (provider->status.session.state != CWA_SM_ACTIVE) {
@@ -1667,8 +1669,7 @@ int cwa_decode_response(sc_card_t * card,
 		if ((apdu->sw2 == 0x88) || (apdu->sw2 == 0x87)) {
 			/* configure the driver to re-establish the SM */
 			msg = "SM related errors in APDU response";
-			sm_session->state = CWA_SM_NONE;
-			card->sm_ctx.sm_mode = SM_MODE_NONE;
+			cwa_create_secure_channel(card, provider, CWA_SM_OFF);
 			res = SC_ERROR_SECURITY_STATUS_NOT_SATISFIED;
 			goto response_decode_end;
 		}

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -158,6 +158,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 	if (dnie_match_card(p15card->card) != 1)
 		return SC_ERROR_WRONG_CARD;
 
+#ifdef ENABLE_OPENSSL
 	/* The two keys inside DNIe 3.0 needs login before performing any signature.
 	 * They are CKA_ALWAYS_AUTHENTICATE although they are not tagged like that.
 	 * For the moment caching is forced if 3.0 is detected to make it work properly. */
@@ -170,6 +171,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 			p15card->opts.pin_cache_counter,
 			p15card->opts.pin_cache_ignore_user_consent);
         }
+#endif
 
 	/* Set root path of this application */
 	p15card->file_app = sc_file_new();


### PR DESCRIPTION
In the previous commit a conflicting section was not pushed. Besides another little change to fix re-login after a DNIe SM channel error. In DNIe 3.0 is used a lot because both keys are CKA_ALWAYS_AUTHENTICATE although not tagged as that.