### PR TITLE
config: added  disable_popups  for internal UI

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -45,6 +45,11 @@ app default {
 	#
 	# paranoid_memory = false;
 
+	# Dsiable pop-ups of built-in GUI
+	#
+	# Default: false
+	# disable_popups = true;
+
 	# Enable default card driver
 	# Default card driver is explicitely enabled for the 'opensc-explorer' and 'opensc-tool'.
 	#

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -222,9 +222,10 @@ int dnie_ask_user_consent(struct sc_card * card, const char *title, const char *
 	if ((title==NULL) || (message==NULL))
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	if (GET_DNIE_UI_CTX(card).user_consent_enabled == 0) {
+	if (GET_DNIE_UI_CTX(card).user_consent_enabled == 0
+			|| card->ctx & SC_CTX_FLAG_ENABLE_POPUPS) {
 		sc_log(card->ctx,
-		       "User Consent is disabled in configuration file");
+		       "User Consent or popups are disabled in configuration file");
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 	}
 #ifdef _WIN32

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -334,6 +334,10 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 				ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY))
 		ctx->flags |= SC_CTX_FLAG_PARANOID_MEMORY;
 
+	if (scconf_get_bool (block, "disable_popups",
+				ctx->flags & SC_CTX_FLAG_DISABLE_POPUPS))
+		ctx->flags |= SC_CTX_FLAG_DISABLE_POPUPS;
+
 	if (scconf_get_bool (block, "enable_default_driver",
 				ctx->flags & SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER))
 		ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -673,6 +673,7 @@ typedef struct {
 #define SC_CTX_FLAG_PARANOID_MEMORY			0x00000002
 #define SC_CTX_FLAG_DEBUG_MEMORY			0x00000004
 #define SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER	0x00000008
+#define SC_CTX_FLAG_DISABLE_POPUPS			0x00000010
 
 typedef struct sc_context {
 	scconf_context *conf;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4619,7 +4619,8 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 	if (NULL == pbPinData) {
 		if (!(vs->reader->capabilities & SC_READER_CAP_PIN_PAD))
 			return SCARD_E_INVALID_PARAMETER;
-		if (!(dwFlags & CARD_PIN_SILENT_CONTEXT)) {
+		if (!(dwFlags & CARD_PIN_SILENT_CONTEXT)
+				&& !(vs->ctx->flags & SC_CTX_FLAG_DISABLE_POPUPS)) {
 			DisplayPinpadUI = TRUE;
 		}
 	}
@@ -4747,7 +4748,8 @@ DWORD WINAPI CardChangeAuthenticatorEx(__in PCARD_DATA pCardData,
 	}
 	/* using a pin pad */
 	if (NULL == pbAuthenticatingPinData) {
-		if (!(dwFlags & CARD_PIN_SILENT_CONTEXT)) {
+		if (!(dwFlags & CARD_PIN_SILENT_CONTEXT)
+				&& !(vs->ctx->flags & SC_CTX_FLAG_DISABLE_POPUPS)) {
 			DisplayPinpadUI = TRUE;
 		}
 	}


### PR DESCRIPTION
The popup for requesting the PIN entry on a PIN-Pad is blocking the fields for entering the username when [smart card group policies](https://technet.microsoft.com/de-de/library/ff404287%28v=ws.10%29.aspx) are configured with `X509HintsNeeded`. This PR suppresses the popup.