### PR TITLE
Fix segfault in pkcs11-tool

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -222,7 +222,7 @@ static const char *option_help[] = {
 	"Decrypt some data",
 	"Hash some data",
 	"Derive a secret key using another key and some data",
-	"Derive ECDHpass DER encoded pubkey for compatibility with some PKCS#11 implementations"
+	"Derive ECDHpass DER encoded pubkey for compatibility with some PKCS#11 implementations",
 	"Specify mechanism (use -M for a list of supported mechanisms)",
 
 	"Log into the token first",


### PR DESCRIPTION
Due to a missing comma, pkcs11-tool segfaulted when displaying the help text, because the number of options and descriptions did not match.