### PR TITLE
opensc-tool: only show the card name if present, to avoid "(null)"

### DIFF
--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -288,7 +288,7 @@ static int list_readers(void)
 				if ((r = sc_connect_card(reader, &card)) != SC_SUCCESS) {
 					fprintf(stderr, "     failed: %s\n", sc_strerror(r));
 				} else {
-					printf("     %s %s %s\n", tmp, card->name, state & SC_READER_CARD_INUSE ? "[IN USE]" : "");
+					printf("     %s %s %s\n", tmp, card->name ? card->name : "", state & SC_READER_CARD_INUSE ? "[IN USE]" : "");
 					sc_disconnect_card(card);
 				}
 			}


### PR DESCRIPTION
Before:
```
$ opensc-tool -lv
Nr.  Card  Features  Name
0    No              FujitsuTechnologySolutions GmbH SmartCase KB SCR eSIG [SmartCase Smartcard Reader] 00 00
1    Yes             ACS ACR 38U-CCID 01 00
     3b:6e:00:00:80:31:80:66:b0:84:0c:01:6e:01:83:00:90:00 (null)
```
After:
```
$ opensc-tool -lv
Nr.  Card  Features  Name
0    No              FujitsuTechnologySolutions GmbH SmartCase KB SCR eSIG [SmartCase Smartcard Reader] 00 00
1    Yes             ACS ACR 38U-CCID 01 00
     3b:6e:00:00:80:31:80:66:b0:84:0c:01:6e:01:83:00:90:00
```
Change-Id: Id2cb858897cd845d93609e28019c94736b04fa93