### PR TITLE
Make dnie driver dependent of sm (issue #927)

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -99,7 +99,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "westcos",	(void *(*)(void)) sc_get_westcos_driver },
 	{ "myeid",      (void *(*)(void)) sc_get_myeid_driver },
 	{ "sc-hsm",		(void *(*)(void)) sc_get_sc_hsm_driver },
-#ifdef ENABLE_OPENSSL
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 	{ "dnie",       (void *(*)(void)) sc_get_dnie_driver },
 #endif
 	{ "masktech",	(void *(*)(void)) sc_get_masktech_driver },

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -27,7 +27,7 @@
 #include "config.h"
 #endif
 
-#ifdef ENABLE_OPENSSL		/* empty file without openssl */
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)	/* empty file without openssl or sm */
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/libopensc/cwa-dnie.h
+++ b/src/libopensc/cwa-dnie.h
@@ -23,7 +23,7 @@
 #ifndef __CWADNIE_H__
 #define __CWADNIE_H__
 
-#ifdef ENABLE_OPENSSL
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 
 #include "libopensc/opensc.h"
 

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -27,7 +27,7 @@
 #include "config.h"
 #endif
 
-#ifdef ENABLE_OPENSSL		/* empty file without openssl */
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)	/* empty file without openssl or sm */
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/libopensc/cwa14890.h
+++ b/src/libopensc/cwa14890.h
@@ -25,7 +25,7 @@
 #ifndef __CWA14890_H__
 #define __CWA14890_H__
 
-#ifdef ENABLE_OPENSSL
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 
 /* Secure Messaging state indicator */
 #define CWA_SM_NONE       0x00	/** No SM channel defined */

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -31,11 +31,7 @@
 #include "libopensc/cwa-dnie.h"
 
 /* Card driver related */
-#ifdef ENABLE_OPENSSL
-extern int dnie_match_card(struct sc_card *card);
-#else
-#define dnie_match_card(card) 0
-#endif
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 
 /* Helper functions to get the pkcs15 stuff bound. */
 
@@ -158,7 +154,6 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 	if (dnie_match_card(p15card->card) != 1)
 		return SC_ERROR_WRONG_CARD;
 
-#ifdef ENABLE_OPENSSL
 	/* The two keys inside DNIe 3.0 needs login before performing any signature.
 	 * They are CKA_ALWAYS_AUTHENTICATE although they are not tagged like that.
 	 * For the moment caching is forced if 3.0 is detected to make it work properly. */
@@ -171,7 +166,6 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 			p15card->opts.pin_cache_counter,
 			p15card->opts.pin_cache_ignore_user_consent);
         }
-#endif
 
 	/* Set root path of this application */
 	p15card->file_app = sc_file_new();
@@ -273,6 +267,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 	
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
+#endif
 
 /****************************************/
 /* public functions for in-built module */
@@ -285,6 +280,7 @@ int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t * p15card,
 	sc_context_t *ctx = p15card->card->ctx;
 	LOG_FUNC_CALLED(ctx);
 
+#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 	/* if no check flag execute unconditionally */
 	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
 		LOG_FUNC_RETURN(ctx, sc_pkcs15emu_dnie_init(p15card));
@@ -294,4 +290,8 @@ int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t * p15card,
 		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_CARD);
 	/* ok: initialize and return */
 	LOG_FUNC_RETURN(ctx, sc_pkcs15emu_dnie_init(p15card));
+#else
+	r = SC_ERROR_WRONG_CARD;
+	LOG_FUNC_RETURN(ctx, r);
+#endif
 }

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -33,6 +33,8 @@
 /* Card driver related */
 #if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 
+extern int dnie_match_card(struct sc_card *card);
+
 /* Helper functions to get the pkcs15 stuff bound. */
 
 static


### PR DESCRIPTION
This pull just makes the dnie driver dependent of sm exactly as it is now of openssl. If sm is disabled (_--disable-sm_ at configure time) the dnie driver is excluded of opensc (not even listed in _opensc-tool -D_). This also fixes the bug #927.