### PR TITLE
Prevent leaking memory for PIV cards

### DIFF
--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1200,6 +1200,10 @@ sc_pkcs15_free_pubkey_info(sc_pkcs15_pubkey_info_t *info)
 {
 	if (info->subject.value)
 		free(info->subject.value);
+	if (info->direct.spki.value)
+		free(info->direct.spki.value);
+	if (info->direct.raw.value)
+		free(info->direct.raw.value);
 	sc_pkcs15_free_key_params(&info->params);
 	free(info);
 }


### PR DESCRIPTION
I started running OpenSC under `valgrind` and I noticed significant leaks when using PIV test cards:

```
==1541== 14,406 bytes in 49 blocks are definitely lost in loss record 55 of 55
==1541==    at 0x4C2DADE: malloc (vg_replace_malloc.c:298)
==1541==    by 0x4C2FC91: realloc (vg_replace_malloc.c:785)
==1541==    by 0x7DAA481: asn1_encode (asn1.c:1760)
==1541==    by 0x7DAA584: sc_asn1_encode (asn1.c:1782)
==1541==    by 0x7DD252E: sc_pkcs15_encode_pubkey_as_spki (pkcs15-pubkey.c:868)
==1541==    by 0x7EC6A31: sc_pkcs15emu_piv_init (pkcs15-piv.c:1047)
==1541==    by 0x7EC767C: sc_pkcs15emu_piv_init_ex (pkcs15-piv.c:1181)
==1541==    by 0x7DDA8A9: sc_pkcs15_bind_synthetic (pkcs15-syn.c:115)
==1541==    by 0x7DC1E27: sc_pkcs15_bind (pkcs15.c:1260)
==1541==    by 0x7B61C1A: pkcs15_bind (framework-pkcs15.c:280)
==1541==    by 0x7B5CC7F: card_detect (slot.c:286)
==1541==    by 0x7B5C44C: initialize_reader (slot.c:150)
```

The memory allocated above is never freed so I propose to do so in `sc_pkcs15_free_pubkey_info()` function, which takes care of freeing the parent structures, as it is already done for the other nested structures.