### PR TITLE
Initial CardOS 5.3 support

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -58,6 +58,8 @@ static struct sc_atr_table cardos_atrs[] = {
 	{ "3b:d2:18:02:c1:0a:31:fe:58:c8:0d:51", NULL, NULL, SC_CARD_TYPE_CARDOS_M4_4, 0, NULL},
 	/* CardOS v5.0 */
 	{ "3b:d2:18:00:81:31:fe:58:c9:01:14", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
+	/* CardOS v5.3 */
+	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -452,6 +452,9 @@ iso7816_select_file(struct sc_card *card, const struct sc_path *in_path, struct 
 	int r, pathlen, pathtype;
 	int select_mf = 0;
 	struct sc_file *file = NULL;
+	const u8 *buffer;
+	size_t buffer_len;
+	unsigned int cla, tag;
 
 	assert(card != NULL && in_path != NULL);
 	ctx = card->ctx;
@@ -577,8 +580,10 @@ iso7816_select_file(struct sc_card *card, const struct sc_path *in_path, struct 
 			sc_file_free(file);
 			LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 		}
-		if ((size_t)apdu.resp[1] + 2 <= apdu.resplen)
-			card->ops->process_fci(card, file, apdu.resp+2, apdu.resp[1]);
+		buffer = apdu.resp;
+		r = sc_asn1_read_tag(&buffer, apdu.resplen, &cla, &tag, &buffer_len);
+		if (r == SC_SUCCESS)
+			card->ops->process_fci(card, file, buffer, buffer_len);
 		*file_out = file;
 		break;
 	case 0x00: /* proprietary coding */


### PR DESCRIPTION
CardOS 5.3 cards have different ATR so they are not picked up by OpenSC at this moment. Unless there will be more differences in the future, using some ATR mask would probably make sense.

These cards also present ODF with non-strict encoded ASN1:
```
6F 81 25 83 02 50 31 82 01 01 80 02 00 3C 88 00 o.%..P1......<..
85 01 00 8A 01 05 AB 10 80 01 01 90 00 80 01 06 ................
A4 06 83 01 11 95 01 80 90 00                   ..........
```
Note the length part `81 25` combining into the length of 37, which is not handled by current code (expecting the length of the "length" to be only single byte).

Further changes to incorporate the support of the CardOS 5.3 might be needed, but so far submitting what we have so far.