### PR TITLE
Improve pinpad support and PIN length validation

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -295,6 +295,10 @@ sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *pi
 
 	LOG_FUNC_CALLED(ctx);
 
+	r = _validate_pin(p15card, (struct sc_pkcs15_auth_info *)pin_obj->data, pinlen);
+	if (r)
+		LOG_FUNC_RETURN(ctx, r);
+
 	r = _sc_pkcs15_verify_pin(p15card, pin_obj, pincode, pinlen);
 	if (r == SC_SUCCESS)
 		sc_pkcs15_pincache_add(p15card, pin_obj, pincode, pinlen);

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -268,7 +268,7 @@ _validate_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_auth_info *auth_i
 		return SC_ERROR_BUFFER_TOO_SMALL;
 
 	/* if we use pinpad, no more checks are needed */
-	if (p15card->card->reader->capabilities & SC_READER_CAP_PIN_PAD)
+	if (p15card->card->reader->capabilities & SC_READER_CAP_PIN_PAD && !pinlen)
 		return SC_SUCCESS;
 
 	/* If pin is given, make sure it is within limits */
@@ -371,9 +371,8 @@ _sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *p
 		data.pin_reference = skey_info->key_reference;
 	}
 
-	if(p15card->card->reader->capabilities & SC_READER_CAP_PIN_PAD) {
-		if (!pincode && !pinlen)
-			data.flags |= SC_PIN_CMD_USE_PINPAD;
+	if(p15card->card->reader->capabilities & SC_READER_CAP_PIN_PAD && !pinlen) {
+		data.flags |= SC_PIN_CMD_USE_PINPAD;
 
 		if (auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN)
 			data.pin1.prompt = "Please enter SO PIN";

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1486,10 +1486,6 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 		if (ulPinLen == 0)
 			pPin = NULL;
 	}
-	else if (ulPinLen > pin_info->attrs.pin.max_length)   {
-		return CKR_ARGUMENTS_BAD;
-	}
-
 
 	/* By default, we make the reader resource manager keep other
 	 * processes from accessing the card while we're logged in.

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1094,7 +1094,7 @@ static int do_verify(int argc, char **argv)
 			printf("Please enter PIN: ");
 			r = util_getpass(&pin, &len, stdin);
 			if (r < 0) {
-				printf("No PIN entered - aborting VERIFY.\n");
+				printf("util_getpass error.\n");
 				return -1;
 			}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4127,8 +4127,8 @@ static int test_signature(CK_SESSION_HANDLE sess)
 	rv = p11->C_GetSessionInfo(sess, &sessionInfo);
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
-	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		printf("Signatures: not logged in, skipping signature tests\n");
+	if (!(sessionInfo.state & CKS_RW_USER_FUNCTIONS)) {
+		printf("Signature: not a R/W session, skipping signature tests\n");
 		return errors;
 	}
 
@@ -4440,8 +4440,8 @@ static int test_verify(CK_SESSION_HANDLE sess)
 	rv = p11->C_GetSessionInfo(sess, &sessionInfo);
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
-	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		printf("Verify: not logged in, skipping verify tests\n");
+	if (!(sessionInfo.state & CKS_RW_USER_FUNCTIONS)) {
+		printf("Verify: not a R/W session, skipping verify tests\n");
 		return errors;
 	}
 
@@ -4771,8 +4771,8 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 	rv = p11->C_GetSessionInfo(sess, &sessionInfo);
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
-	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		printf("Decryption: not logged in, skipping decryption tests\n");
+	if (!(sessionInfo.state & CKS_RW_USER_FUNCTIONS)) {
+		printf("Decryption: not a R/W session, skipping decryption tests\n");
 		return errors;
 	}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -365,6 +365,7 @@ static void		show_token(CK_SLOT_ID);
 static void		list_mechs(CK_SLOT_ID);
 static void		list_objects(CK_SESSION_HANDLE, CK_OBJECT_CLASS);
 static int		login(CK_SESSION_HANDLE, int);
+static void		authenticate_if_required(CK_SESSION_HANDLE, CK_OBJECT_HANDLE);
 static void		init_token(CK_SLOT_ID);
 static void		init_pin(CK_SLOT_ID, CK_SESSION_HANDLE);
 static int		change_pin(CK_SLOT_ID, CK_SESSION_HANDLE);
@@ -2882,6 +2883,32 @@ VARATTR_METHOD(GOSTR3410_PARAMS, unsigned char);
 VARATTR_METHOD(EC_POINT, unsigned char);
 VARATTR_METHOD(EC_PARAMS, unsigned char);
 
+static void  authenticate_if_required(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE privKeyObject){
+	CK_SESSION_INFO sessionInfo;
+	CK_TOKEN_INFO	info;
+	CK_RV rv;
+
+	rv = p11->C_GetSessionInfo(session, &sessionInfo);
+	if (rv != CKR_OK)
+		p11_fatal("C_OpenSession", rv);
+
+	switch(sessionInfo.state){
+		case CKS_RW_USER_FUNCTIONS: //logged in, not need to continue.
+			util_warn("authentication was requested, but was already logged in");
+			return;
+		case CKS_RW_PUBLIC_SESSION:
+			break;
+		default:
+			util_fatal("unexpected state");
+	}
+
+	get_token_info(opt_slot, &info);
+	if (!(info.flags & CKF_PROTECTED_AUTHENTICATION_PATH) && !getALWAYS_AUTHENTICATE(session, privKeyObject))
+		return;
+
+	login(session,CKU_CONTEXT_SPECIFIC);
+}
+
 static void list_objects(CK_SESSION_HANDLE sess, CK_OBJECT_CLASS  object_class)
 {
 	CK_OBJECT_HANDLE object;
@@ -4022,8 +4049,7 @@ static int sign_verify_openssl(CK_SESSION_HANDLE session,
 	if (rv != CKR_OK)
 		p11_fatal("C_SignInit", rv);
 
-	if (getALWAYS_AUTHENTICATE(session, privKeyObject))
-		login(session,CKU_CONTEXT_SPECIFIC);
+	authenticate_if_required(session, privKeyObject);
 	printf("    %s: ", p11_mechanism_to_name(ck_mech->mechanism));
 
 	sigLen1 = sizeof(sig1);
@@ -4219,8 +4245,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		rv = p11->C_SignInit(sess, &ck_mech, privKeyObject);
 		if (rv != CKR_OK)
 			p11_fatal("C_SignInit", rv);
-		if (getALWAYS_AUTHENTICATE(sess, privKeyObject))
-			login(sess,CKU_CONTEXT_SPECIFIC);
+		authenticate_if_required(sess, privKeyObject);
 
 		sigLen2 = sizeof(sig2);
 		rv = p11->C_Sign(sess, data, dataLen, sig2, &sigLen2);
@@ -4258,8 +4283,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 	   printf("  ERR: C_Sign() didn't return CKR_OK for a NULL output buf, but %s (0x%0x)\n",
 	   CKR2Str(rv), (int) rv);
 	}
-	if (getALWAYS_AUTHENTICATE(sess, privKeyObject))
-		login(sess,CKU_CONTEXT_SPECIFIC);
+	authenticate_if_required(sess, privKeyObject);
 
 	rv = p11->C_Sign(sess, data, dataLen, sig2, &sigLen2);
 	if (rv == CKR_OPERATION_NOT_INITIALIZED) {
@@ -4395,8 +4419,7 @@ static int sign_verify(CK_SESSION_HANDLE session,
 		}
 
 		printf("    %s: ", p11_mechanism_to_name(*mech_type));
-		if (getALWAYS_AUTHENTICATE(session, priv_key))
-			login(session,CKU_CONTEXT_SPECIFIC);
+		authenticate_if_required(session, priv_key);
 
 		signat_len = sizeof(signat);
 		rv = p11->C_Sign(session, datas[j], data_lens[j], signat, &signat_len);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -305,7 +305,6 @@ static char *		opt_key_type = NULL;
 static char *		opt_sig_format = NULL;
 static int		opt_is_private = 0;
 static int		opt_test_hotplug = 0;
-static int		opt_login = 0;
 static int		opt_login_type = -1;
 static int		opt_key_usage_sign = 0;
 static int		opt_key_usage_decrypt = 0;
@@ -449,6 +448,7 @@ int main(int argc, char * argv[])
 	int do_test_fork = 0;
 #endif
 	int need_session = 0;
+	int opt_login = 0;
 	int do_init_token = 0;
 	int do_init_pin = 0;
 	int do_change_pin = 0;
@@ -4128,17 +4128,8 @@ static int test_signature(CK_SESSION_HANDLE sess)
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
 	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		if (opt_login) {
-			int r;
-			r = login(sess, CKU_CONTEXT_SPECIFIC);
-			if (r != 0){
-				printf("Signatures: failed to login, skipping signature tests\n");
-				return errors;
-			}
-		} else {
-			printf("Signatures: not logged in, skipping signature tests\n");
-			return errors;
-		}
+		printf("Signatures: not logged in, skipping signature tests\n");
+		return errors;
 	}
 
 	if (!find_mechanism(sessionInfo.slotID, CKF_SIGN | CKF_HW, mechTypes, mechTypes_num, &firstMechType)) {
@@ -4450,17 +4441,8 @@ static int test_verify(CK_SESSION_HANDLE sess)
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
 	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		if (opt_login) {
-			int r;
-			r = login(sess, CKU_CONTEXT_SPECIFIC);
-			if (r != 0){
-				printf("Verify: failed to login, skipping verify tests\n");
-				return errors;
-			}
-		} else {
-			printf("Verify: not logged in, skipping verify tests\n");
-			return errors;
-		}
+		printf("Verify: not logged in, skipping verify tests\n");
+		return errors;
 	}
 
 	if (!find_mechanism(sessionInfo.slotID, CKF_VERIFY, NULL, 0, &first_mech_type)) {
@@ -4790,17 +4772,8 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 	if (rv != CKR_OK)
 		p11_fatal("C_OpenSession", rv);
 	if ((sessionInfo.state & CKS_RO_USER_FUNCTIONS) == 0) {
-		if (opt_login) {
-			int r;
-			r = login(sess, CKU_CONTEXT_SPECIFIC);
-			if (r != 0){
-				printf("Decryption: failed to login, skipping decryption tests\n");
-				return errors;
-			}
-		} else {
-			printf("Decryption: not logged in, skipping decryption tests\n");
-			return errors;
-		}
+		printf("Decryption: not logged in, skipping decryption tests\n");
+		return errors;
 	}
 
 	num_mechs = get_mechanisms(sessionInfo.slotID, &mechs, CKF_DECRYPT);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1246,7 +1246,7 @@ static int login(CK_SESSION_HANDLE session, int login_type)
 
 		r = util_getpass(&pin, &len, stdin);
 		if (r < 0)
-			util_fatal("No PIN entered");
+			util_fatal("util_getpass error");
 		pin_allocated = 1;
 	}
 


### PR DESCRIPTION
Currently slots without user_consent fail pkcs11-tool test (--test) in the following situations:

- Pinpad is in use. pkcs11-tool is not triggered by CKA_ALWAYS_AUTHENTICATE to reauthenticate, but it is needed since OpenSC will not cache the pin.
- Number of authentications required is above the current (pin_cache configuration + 1). pin_cache is by default 10 and pkcs11-tool --test requires, at least for my test card, 12 authentication attempts.

This pull request fixes the first issue by checking also for CKF_PROTECTED_AUTHENTICATION_PATH.
It doesn't fix the second issue.

I believe OpenSC pkcs11 lib should dynamically report CKA_ALWAYS_AUTHENTICATE as (user_consent || pin_cache_expired). 

When the pin_cache is expired (also seen as "expired" if it is always disabled), from the pkcs11 layer a next attempt without login will fail, so it makes no sense to be reporting CKA_ALWAYS_AUTHENTICATE as 0.