### PR TITLE
react better to zero-length pin entering

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1486,8 +1486,8 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 		if (ulPinLen == 0)
 			pPin = NULL;
 	}
-	else if (ulPinLen > pin_info->attrs.pin.max_length)   {
-		return CKR_ARGUMENTS_BAD;
+	else if (ulPinLen > pin_info->attrs.pin.max_length || ulPinLen < pin_info->attrs.pin.min_length)   {
+		return CKR_PIN_LEN_RANGE; //The specified PIN is too long or too short.
 	}
 
 

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1094,6 +1094,10 @@ static int do_verify(int argc, char **argv)
 			printf("Please enter PIN: ");
 			r = util_getpass(&pin, &len, stdin);
 			if (r < 0) {
+				printf("util_getpass error.\n");
+				return -1;
+			}
+			if (r < 1) {
 				printf("No PIN entered - aborting VERIFY.\n");
 				return -1;
 			}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1245,6 +1245,8 @@ static int login(CK_SESSION_HANDLE session, int login_type)
 
 		r = util_getpass(&pin, &len, stdin);
 		if (r < 0)
+			util_fatal("util_getpass error");
+		if (r < 1)
 			util_fatal("No PIN entered");
 		pin_allocated = 1;
 	}


### PR DESCRIPTION
Considering a PIN which have a min length of 4 (eg), in a card with iso7816 support, the following happens:

| Entered PIN length      | pkcs11-tool                                             | pkcs15-tool                                                                   |
|-------------------------|---------------------------------------------------------|-------------------------------------------------------------------------------|
| 0 (just return pressed) | dies with "No PIN entered" (after this pull request)    | attempts a zero-length pin login at the card and corresponding Verification failure. |
| 1-3                     | dies with "CKR_PIN_LEN_RANGE" (after this pull request) | prompts with "PIN code too short, try again."                                 |
| 4+                      | OK                                                      | OK    

So in the pkcs15-tool with zero-length case, the behavior is not good.

Unfortunately fixing this requires a little thinking. Starting by, is the pin length max and min to be respected? Shall opensc refuse to try a authentication with a pin length that is not within the expected valid range to avoid at (almost) all cost verification failures and eventual PIN 0-tries left lock?

Can this verification be taken down until iso7816.c (if supported) or pkcs15-pin.c?

Depending on this a common strategy for all tools might be better defined.

