### PR TITLE
login state preservation for JPKI card

### DIFF
--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -214,11 +214,13 @@ jpki_read_binary(sc_card_t * card, unsigned int idx,
 }
 
 static int
-jpki_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data, int *tries_left)
+jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 {
 	int rc;
 	sc_path_t path;
 	sc_apdu_t apdu;
+	struct jpki_private_data *priv = JPKI_DRVDATA(card);
+	int max_tries = 0;
 
 	LOG_FUNC_CALLED(card->ctx);
 
@@ -231,11 +233,13 @@ jpki_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data, int *tries_left)
 		sc_format_path(JPKI_AUTH_PIN, &path);
 		path.type = SC_PATH_TYPE_FILE_ID;
 		rc = sc_select_file(card, &path, NULL);
+		max_tries = JPKI_AUTH_PIN_MAX_TRIES;
 		break;
 	case 2:
 		sc_format_path(JPKI_SIGN_PIN, &path);
 		path.type = SC_PATH_TYPE_FILE_ID;
 		rc = sc_select_file(card, &path, NULL);
+		max_tries = JPKI_SIGN_PIN_MAX_TRIES;
 		break;
 	default:
 		sc_log(card->ctx, "Unknown PIN reference: %d", data->pin_reference);
@@ -252,6 +256,14 @@ jpki_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data, int *tries_left)
 		rc = sc_transmit_apdu(card, &apdu);
 		LOG_TEST_RET(card->ctx, rc, "APDU transmit failed");
 		rc = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		if (rc == SC_SUCCESS) {
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_IN;
+			data->pin1.tries_left = max_tries;
+		} else {
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_OUT;
+			data->pin1.tries_left = apdu.sw2 & 0xF;
+		}
+		priv->logged_in = data->pin1.logged_in;
 		LOG_TEST_RET(card->ctx, rc, "VERIFY failed");
 		break;
 	case SC_PIN_CMD_GET_INFO:
@@ -262,8 +274,10 @@ jpki_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data, int *tries_left)
 			sc_log(card->ctx, "VERIFY GET_INFO error");
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_CARD_CMD_FAILED);
 		}
+		data->pin1.logged_in = priv->logged_in;
+		data->pin1.tries_left = apdu.sw2 & 0xF;
 		if (tries_left) {
-			*tries_left = apdu.sw2 - 0xC0;
+			*tries_left = data->pin1.tries_left;
 		}
 		break;
 	default:

--- a/src/libopensc/jpki.h
+++ b/src/libopensc/jpki.h
@@ -27,15 +27,18 @@
 #define AID_JPKI "D392f000260100000001"
 #define JPKI_AUTH_KEY "0017"
 #define JPKI_AUTH_PIN "0018"
+#define JPKI_AUTH_PIN_MAX_TRIES 3
 
 #define JPKI_SIGN_KEY "001A"
 #define JPKI_SIGN_PIN "001B"
+#define JPKI_SIGN_PIN_MAX_TRIES 5
 
 #define JPKI_DRVDATA(card) ((struct jpki_private_data *) ((card)->drv_data))
 
 struct jpki_private_data {
 	sc_file_t *mf;
 	int selected;
+	int logged_in;
 };
 
 int jpki_select_ap(struct sc_card *card);

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -99,7 +99,10 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		static const int jpki_pin_ref[2] = { 1, 2 };
 		static const int jpki_pin_authid[2] = { 1, 2 };
 		static const int jpki_pin_flags[2] = { 0, 0 };
-		static const int jpki_pin_max_tries[2] = { 5, 3 };
+		static const int jpki_pin_max_tries[2] = {
+			JPKI_AUTH_PIN_MAX_TRIES,
+			JPKI_SIGN_PIN_MAX_TRIES
+		};
 
 		struct sc_pkcs15_auth_info pin_info;
 		struct sc_pkcs15_object pin_obj;


### PR DESCRIPTION
Hi,
Since some time or another, JPKI card driver no longer able to get login state from C_GetSessionInfo().
Probably It may relate to the issue #830
I've just tried to preservation login state like a PIV card.
Could you review the code. Thank you.