### PR TITLE
set dummy serial number

### DIFF
--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -47,8 +47,8 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 
 	p15card->tokeninfo->label = strdup("JPKI");
 	p15card->tokeninfo->manufacturer_id = strdup("JPKI");
-	/* set NULL until we found serial number */
-	p15card->tokeninfo->serial_number = NULL;
+	/* set dummy until we found serial number */
+	p15card->tokeninfo->serial_number = strdup("00000000");
 
 	/* Select application directory */
 	if (drvdata->selected != SELECT_JPKI_AP) {


### PR DESCRIPTION
tokeninfo->serial_number = NULL; doesn't work with OSX tokend.
see https://github.com/OpenSC/OpenSC.tokend/blob/96b89d1bedfd00d095fdac7e3a9628127e227a78/OpenSC/OpenSCToken.cpp#L304
Also PKCS#11 spec doesn't allow this.
http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html

> serialNumber       character-string serial number of the device.  MUST be padded with the blank character (‘ ).  MUST NOT be null-terminated.

Thank you.