### PR TITLE
Add plaintext communication for ePass2003 PKI Java card

### DIFF
--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -49,23 +49,23 @@ static struct sc_atr_table entersafe_atrs[] = {
 		"EJAVA/PK-01C-T0",SC_CARD_TYPE_ENTERSAFE_EJAVA_PK_01C_T0,0,NULL},
 	{
 		"3B:FC:18:00:00:81:31:80:45:90:67:46:4A:21:28:8C:58:00:00:00:00:B7",
-		"ff:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff",
+		"ff:00:00:00:00:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:00",
 		"EJAVA/H10CR/PK-01C-T1",SC_CARD_TYPE_ENTERSAFE_EJAVA_H10CR_PK_01C_T1,0,NULL},
 	{
 		"3B:FC:18:00:00:81:31:80:45:90:67:46:4A:20:25:c3:30:00:00:00:00",
-		"ff:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff",
+		"ff:00:00:00:00:00:00:00:00:ff:ff:ff:ff:00:00:00:00:00:00:00:00",
 		"EJAVA/D11CR/PK-01C-T1",SC_CARD_TYPE_ENTERSAFE_EJAVA_D11CR_PK_01C_T1,0,NULL},
 	{
 		"3B:FC:18:00:00:81:31:80:45:90:67:46:4A:00:6A:04:24:00:00:00:00:20",
-		"ff:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff",
+		"ff:00:00:00:00:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:00",
 		"EJAVA/C21C/PK-01C-T1",SC_CARD_TYPE_ENTERSAFE_EJAVA_C21C_PK_01C_T1,0,NULL},
 	{
 		"3B:FC:18:00:00:81:31:80:45:90:67:46:4A:00:68:08:04:00:00:00:00:0E",
-		"ff:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff",
+		"ff:00:00:00:00:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:00",
 		"EJAVA/A22CR/PK-01C-T1",SC_CARD_TYPE_ENTERSAFE_EJAVA_A22CR_PK_01C_T1,0,NULL},
 	{
 		"3B:FC:18:00:00:81:31:80:45:90:67:46:4A:10:27:61:30:00:00:00:00:0C",
-		"ff:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff",
+		"ff:00:00:00:00:00:00:00:00:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:00",
 		"EJAVA/A40CR/PK-01C-T1",SC_CARD_TYPE_ENTERSAFE_EJAVA_A40CR_PK_01C_T1,0,NULL},
 	{
 		"3b:fc:18:00:00:81:31:80:45:90:67:46:4a:00:68:08:06:00:00:00:00:0c",

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -1163,10 +1163,8 @@ epass2003_init(struct sc_card *card)
 	else
 		exdata->smtype = KEY_TYPE_DES;
 
-	if (0x84 == data[14])
-	{
-		if (0x00 == data[16])
-		{ 
+	if (0x84 == data[14]) {
+		if (0x00 == data[16]) { 
 			exdata->sm = SM_PLAIN;
 		}
 	}

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -865,9 +865,9 @@ epass2003_sm_wrap_apdu(struct sc_card *card, struct sc_apdu *plain, struct sc_ap
 	case 0x00:
 	case 0x04:
 		sm->datalen = plain->datalen;
-		memcpy((void *)sm->data,plain->data,plain->datalen);
+		memcpy(sm->data, plain->data, plain->datalen);
 		sm->resplen = plain->resplen;
-		memcpy(sm->resp,plain->resp,plain->resplen);
+		memcpy(sm->resp, plain->resp, plain->resplen);
 		break;
 	case 0x0C:
 		memset(buf, 0, sizeof(buf));

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -865,7 +865,7 @@ epass2003_sm_wrap_apdu(struct sc_card *card, struct sc_apdu *plain, struct sc_ap
 	case 0x00:
 	case 0x04:
 		sm->datalen = plain->datalen;
-		memcpy(sm->data, plain->data, plain->datalen);
+		memcpy((void *)sm->data, plain->data, plain->datalen);
 		sm->resplen = plain->resplen;
 		memcpy(sm->resp, plain->resp, plain->resplen);
 		break;

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -865,10 +865,8 @@ epass2003_sm_wrap_apdu(struct sc_card *card, struct sc_apdu *plain, struct sc_ap
 	case 0x00:
 	case 0x04:
 		sm->datalen = plain->datalen;
-		//sm->data = plain->data;
 		memcpy((void *)sm->data,plain->data,plain->datalen);
 		sm->resplen = plain->resplen;
-		//sm->resp = plain->resp;
 		memcpy(sm->resp,plain->resp,plain->resplen);
 		break;
 	case 0x0C:
@@ -1002,13 +1000,11 @@ epass2003_sm_free_wrapped_apdu(struct sc_card *card,
 	if (plain)
 		rv = epass2003_sm_unwrap_apdu(card, *sm_apdu, plain);
 
-	if ((*sm_apdu)->data)
-	{
+	if ((*sm_apdu)->data) {
 		unsigned char * p = (unsigned char *)((*sm_apdu)->data);
 		free(p);
 	}
-	if ((*sm_apdu)->resp)
-	{
+	if ((*sm_apdu)->resp) {
 		free((*sm_apdu)->resp);
 	}
 
@@ -1060,7 +1056,6 @@ epass2003_sm_get_wrapped_apdu(struct sc_card *card,
 
 	*sm_apdu = apdu;
 	apdu = NULL;
-	LOG_FUNC_RETURN(ctx, rv);
 err:
 	if (apdu) {
 		free((unsigned char *) apdu->data);


### PR DESCRIPTION
The old code only support encrypted communication for ePass2003 USB PKI
Token, now add plaintext communication support, the code now can using
ePass2003 USB PKI Token and ePass2003 PKI applet with java card.