### PR TITLE
Pkcs11-tool.c  -t fails in RSA-X-509 verification

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4301,6 +4301,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 
 	/* Fill in data[0] and dataLens[0] */
 	dataLen = modLenBytes;
+	data[0] = 0x00;
 	data[1] = 0x01;
 	memset(data + 2, 0xFF, dataLen - 3 - dataLens[1]);
 	data[dataLen - 36] = 0x00;


### PR DESCRIPTION
The test_signature routine reuses data array and fails to reset data[0] = 0
when creating a PKCS hash to be pased to OpenSSL.

 Date:	     Mon Feb 13 11:48:00 2017 -0600

 On branch pkcs11-tool-pkcs
 Changes to be committed:
	modified:   tools/pkcs11-tool.c