### PR TITLE
Improve hash handling for PtEID and other cards

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -163,6 +163,7 @@ typedef struct sc_security_env {
 	unsigned long flags;
 	int operation;
 	unsigned int algorithm, algorithm_flags;
+	unsigned int algorithm_hash;
 
 	unsigned int algorithm_ref;
 	struct sc_path file_ref;
@@ -506,6 +507,7 @@ typedef struct sc_card {
 	struct sm_context sm_ctx;
 #endif
 
+	unsigned long  negate_hashes; /*  Dont create pkcs11 mechanisms for these hashes */
 	unsigned int magic;
 } sc_card_t;
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4726,6 +4726,11 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		 */
 		if (!(rsa_flags & SC_ALGORITHM_RSA_HASHES)) {
 			rsa_flags |= SC_ALGORITHM_RSA_HASHES;
+
+		/* if card can not handle some hashes do not register the hash */
+		if (card->negate_hashes)
+		    rsa_flags &= ~(card->negate_hashes);
+
 #if OPENSSL_VERSION_NUMBER <  0x00908000L
 		/* turn off hashes not in openssl 0.9.8 */
 			rsa_flags &= ~(SC_ALGORITHM_RSA_HASH_SHA256 | SC_ALGORITHM_RSA_HASH_SHA384 | SC_ALGORITHM_RSA_HASH_SHA512 | SC_ALGORITHM_RSA_HASH_SHA224);

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -170,6 +170,8 @@ static void * dup_mem(void *in, size_t in_len)
 void
 sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
+    sc_card_t *card = p11card->card;
+
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE)
 	ENGINE *e;
 /* crypto locking removed in 1.1 */
@@ -216,20 +218,32 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 #endif
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE) */
 
-	openssl_sha1_mech.mech_data = EVP_sha1();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_SHA1)) {
+		openssl_sha1_mech.mech_data = EVP_sha1();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	}
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L
-	openssl_sha256_mech.mech_data = EVP_sha256();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
-	openssl_sha384_mech.mech_data = EVP_sha384();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
-	openssl_sha512_mech.mech_data = EVP_sha512();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_SHA256)) {
+		openssl_sha256_mech.mech_data = EVP_sha256();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
+	}
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_SHA384)) {
+		openssl_sha384_mech.mech_data = EVP_sha384();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
+	}
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_SHA512)) {
+		openssl_sha512_mech.mech_data = EVP_sha512();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	}
 #endif
-	openssl_md5_mech.mech_data = EVP_md5();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
-	openssl_ripemd160_mech.mech_data = EVP_ripemd160();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_MD5)) {
+		openssl_md5_mech.mech_data = EVP_md5();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
+	}
+	if (!(card->negate_hashes & SC_ALGORITHM_RSA_HASH_RIPEMD160)) {
+		openssl_ripemd160_mech.mech_data = EVP_ripemd160();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+	}
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));


### PR DESCRIPTION
The Pull request has two commits: https://github.com/OpenSC/OpenSC/commit/dbbe26c1866052c993b51fba65c84ddf692209d6
are changes to the base OpenSC that introduce two new unsigned long variables, that are initialized to zero by existing code. This allows for the introduction of these flags to be used by selected drivers.
This appears to work with any card, as the code was designed to not cause problems with other drivers.  

https://github.com/OpenSC/OpenSC/commit/4086aa51e9c26c0d7680b8c98da678e7a468ec25
are change to card-gemsafeV1.c for the PtEID card to use the above flags. 

Over the last few weeks @nunojpg, @l1k and myself have been working on issue of the
PtEid card with handing SHA256 and with handling 2048bit RSA keys. @nunojpg has been testing changes with his PtEid card and @l1k was the last to make changes for this card.

@nunojpg had posted on OpenSSH problems with using SHA512. It turns out the card can not
support SHA512, as the digest header + hash  is 81 bytes, and the hash by itself is 64 bytes. 
The card has a limit of 35 bytes. It also turned OpenSSH was using SHA512 and could use SHA256 which the PtEid card can use if the digest header is striped and only the 32 byte hash sent to the card.
The card would then add the SHA256 digest header then pad and sign.   

So these card-gemsafev1.c part of the pull request still needs more testing, but the Improved hash handling could be useful for other cards too. 

card-gemsafeV1.c is used by other cards, including the SEEID card. So these changes may effect or improve the usefullness of these cards.




