### PR TITLE
Improve hash handling for PtEID and other cards - version 2

### DIFF
--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -84,6 +84,7 @@ static const u8 gemsafe_def_aid[] = {0xA0, 0x00, 0x00, 0x00, 0x63, 0x50,
 typedef struct gemsafe_exdata_st {
 	u8	aid[16];
 	size_t	aid_len;
+	u8	alg_ref; /* from last set_securuty_env */
 } gemsafe_exdata;
 
 static int get_conf_aid(sc_card_t *card, u8 *aid, size_t *len)
@@ -206,27 +207,24 @@ static int gemsafe_init(struct sc_card *card)
 		flags |= SC_ALGORITHM_ONBOARD_KEY_GEN;
 		flags |= SC_ALGORITHM_RSA_HASH_NONE;
 
+		/* Card has 36 byte limit on size of data to pad. */
+		card->restrict_to_these_hashes  = SC_ALGORITHM_RSA_HASH_SHA1;
+		card->restrict_to_these_hashes |= SC_ALGORITHM_RSA_HASH_MD5;
+		card->restrict_to_these_hashes |= SC_ALGORITHM_RSA_HASH_MD5_SHA1;
+		card->restrict_to_these_hashes |= SC_ALGORITHM_RSA_HASH_RIPEMD160;
+
+
 		/* GemSAFE V3 cards support SHA256 */
+		/* by sending only hash and flag to tell card add the SHA256 prefix */
+		
 		if (card->type == SC_CARD_TYPE_GEMSAFEV1_PTEID ||
 		    card->type == SC_CARD_TYPE_GEMSAFEV1_SEEID)
-			flags |= SC_ALGORITHM_RSA_HASH_SHA256;
+			card->restrict_to_these_hashes |= SC_ALGORITHM_RSA_HASH_SHA256;
 
 		_sc_card_add_rsa_alg(card,  512, flags, 0);
 		_sc_card_add_rsa_alg(card,  768, flags, 0);
 		_sc_card_add_rsa_alg(card, 1024, flags, 0);
 		_sc_card_add_rsa_alg(card, 2048, flags, 0);
-
-		/* fake algorithm to persuade register_mechanisms()
-		 * to register these hashes */
-		if (card->type == SC_CARD_TYPE_GEMSAFEV1_PTEID ||
-		    card->type == SC_CARD_TYPE_GEMSAFEV1_SEEID) {
-			flags  = SC_ALGORITHM_RSA_HASH_SHA1;
-			flags |= SC_ALGORITHM_RSA_HASH_MD5;
-			flags |= SC_ALGORITHM_RSA_HASH_MD5_SHA1;
-			flags |= SC_ALGORITHM_RSA_HASH_RIPEMD160;
-
-			_sc_card_add_rsa_alg(card,  512, flags, 0);
-		}
 	}
 
 	card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO;
@@ -386,9 +384,21 @@ static int gemsafe_process_fci(struct sc_card *card, struct sc_file *file,
 static u8 gemsafe_flags2algref(struct sc_card *card, const struct sc_security_env *env)
 {
 	u8 ret = 0;
+	unsigned int hash_algorithm_flags = 0;
+	unsigned int tmp_algorithm_flags = 0;
 
 	if (env->operation == SC_SEC_OPERATION_SIGN) {
-		if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA256)
+		hash_algorithm_flags = env->algorithm_flags | env->algorithm_flags_original;
+		/* if no hash, pkcs#11 caller may have sent a hash see if we know it */
+		 
+		if ((hash_algorithm_flags & SC_ALGORITHM_RSA_HASHES) == 0) {
+			if(sc_pkcs1_strip_digest_info_prefix(&tmp_algorithm_flags,
+				    env->in_data, env->in_datalen, NULL, NULL) == SC_SUCCESS) {
+				hash_algorithm_flags = tmp_algorithm_flags;
+			}
+		}
+
+		if (hash_algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA256)
 			ret = GEMSAFEV3_ALG_REF_SHA256;
 		else if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1)
 			ret = (card->type == SC_CARD_TYPE_GEMSAFEV1_PTEID ||
@@ -428,9 +438,11 @@ static int gemsafe_set_security_env(struct sc_card *card,
 				    const struct sc_security_env *env,
 				    int se_num)
 {
+	gemsafe_exdata *exdata = (gemsafe_exdata *)card->drv_data;
 	u8 alg_ref;
 	struct sc_security_env se_env = *env;
 	struct sc_context *ctx = card->ctx;
+	exdata->alg_ref =  0;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -440,6 +452,7 @@ static int gemsafe_set_security_env(struct sc_card *card,
 		if (alg_ref) {
 			se_env.algorithm_ref = alg_ref;
 			se_env.flags |= SC_SEC_ENV_ALG_REF_PRESENT;
+			exdata->alg_ref = alg_ref;
 		}
 	}
 	if (!(se_env.flags & SC_SEC_ENV_ALG_REF_PRESENT))
@@ -452,17 +465,31 @@ static int gemsafe_set_security_env(struct sc_card *card,
 static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 	size_t data_len, u8 * out, size_t outlen)
 {
-	int r, len;
+	gemsafe_exdata *exdata = (gemsafe_exdata *)card->drv_data;
+	int r;
 	struct sc_apdu apdu;
-	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
 	u8 sbuf[SC_MAX_APDU_BUFFER_SIZE];
 	sc_context_t *ctx = card->ctx;
+	const u8 *sdata;
+	size_t sdata_len;
+	u8 sdatabuf[SC_MAX_APDU_BUFFER_SIZE];
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
 
 	/* the card can sign 36 bytes of free form data */
-	if (data_len > 36) {
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "error: input data too long: %lu bytes\n", data_len);
+	/* TODO verify if this is correct */
+	/* If doing SHA256, strip off digest header, and let card add it back in */
+	if (exdata->alg_ref == 0x42) {
+		r = sc_pkcs1_strip_digest_info_prefix(NULL, data, data_len, sdatabuf, &sdata_len);
+		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "error: strip of digest header failed");
+		sdata = sdatabuf;
+	} else {
+		sdata = data;
+		sdata_len = data_len;
+	   }
+ 
+	if (sdata_len > 36) {
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "error: input data too long: %lu bytes\n", sdata_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -474,17 +501,17 @@ static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 	} else {
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x9E, 0xAC);
 		apdu.cla |= 0x80;
-		apdu.resp = rbuf;
-		apdu.resplen = sizeof(rbuf);
-		apdu.le      = 256;
+		apdu.resp = out;
+		apdu.resplen = outlen;
+		apdu.le      = (outlen < 256) ? outlen : 256;
 	}
 	/* we sign a digestInfo object => tag 0x90 */
 	sbuf[0] = 0x90;
-	sbuf[1] = (u8)data_len;
-	memcpy(sbuf + 2, data, data_len);
+	sbuf[1] = (u8)sdata_len;
+	memcpy(sbuf + 2, sdata, sdata_len);
 	apdu.data = sbuf;
-	apdu.lc   = data_len + 2;
-	apdu.datalen = data_len + 2;
+	apdu.lc   = sdata_len + 2;
+	apdu.datalen = sdata_len + 2;
 
 	r = sc_transmit_apdu(card, &apdu);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "APDU transmit failed");
@@ -493,9 +520,9 @@ static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 		   card->type == SC_CARD_TYPE_GEMSAFEV1_SEEID) {
 			/* finalize the exchange */
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x2A, 0x9E, 0x9A);
-			apdu.le = 128; /* 1024 bit keys */
-			apdu.resp = rbuf;
-			apdu.resplen = sizeof(rbuf);
+			apdu.le = (outlen < 256) ? outlen : 256; /* out and outlen match key size */
+			apdu.resp = out;
+			apdu.resplen = outlen;
 			if(card->type == SC_CARD_TYPE_GEMSAFEV1_SEEID) {
 			  /* cla 0x80 not supported */
 			  apdu.cla = 0x00;
@@ -505,10 +532,8 @@ static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 			if(apdu.sw1 != 0x90 || apdu.sw2 != 0x00)
 				SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, sc_check_sw(card, apdu.sw1, apdu.sw2));
 		}
-		len = apdu.resplen > outlen ? outlen : apdu.resplen;
 
-		memcpy(out, apdu.resp, len);
-		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, len);
+		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, apdu.resplen);
 	}
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, sc_check_sw(card, apdu.sw1, apdu.sw2));
 }

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -168,6 +168,10 @@ typedef struct sc_security_env {
 	struct sc_path file_ref;
 	unsigned char key_ref[8];
 	size_t key_ref_len;
+	/* data and flags passed into crypto operation */
+	unsigned int algorithm_flags_original;
+	const u8 *in_data;
+	size_t in_datalen;
 
 	struct sc_supported_algo_info supported_algos[SC_MAX_SUPPORTED_ALGORITHMS];
 } sc_security_env_t;
@@ -506,6 +510,11 @@ typedef struct sc_card {
 	struct sm_context sm_ctx;
 #endif
 
+	/* 
+	 * When creating software supported pkcs11 mechanism for hashes 
+	 * if not 0, can can only handle these hashes 
+	 */
+	unsigned long  restrict_to_these_hashes;
 	unsigned int magic;
 } sc_card_t;
 

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -321,6 +321,15 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	LOG_TEST_RET(ctx, r, "Could not initialize security environment");
 	senv.operation = SC_SEC_OPERATION_SIGN;
 
+	/* 
+	 * Is input know hash? Some cards need to know for set_security_env
+	 * even if the calling application did the hash and set SC_ALGORITHM_RSA_HASH_NONE
+	 * let card driver's set_security_env have a look at flags, in and inlen
+	 */
+	senv.algorithm_flags_original = flags;
+	senv.in_data = in;
+	senv.in_datalen = inlen;
+
 	switch (obj->type) {
 		case SC_PKCS15_TYPE_PRKEY_RSA:
 			modlen = prkey->modulus_length / 8;
@@ -383,7 +392,6 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 		r = sc_pkcs15_decipher(p15card, obj,flags, buf, modlen, out, outlen);
 		LOG_FUNC_RETURN(ctx, r);
 	}
-
 
 	/* If the card doesn't support the requested algorithm, see if we
 	 * can strip the input so a more restrictive algo can be used */

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4723,9 +4723,18 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		/* Only if card did not lists the hashs, will we
 		 * help it a little, by adding all the OpenSSL hashes
 		 * that have PKCS#11 mechanisms.
+		 *
+		 * The card lists what hashes it can do on the card,
+		 * but it may only accept some hashes done in software 
+		 * So restrict to this set of hashes first.
 		 */
+		if (card->restrict_to_these_hashes & SC_ALGORITHM_RSA_HASHES) {
+			rsa_flags |=  (card->restrict_to_these_hashes & SC_ALGORITHM_RSA_HASHES);
+		}
+		/* card must accept some hash, so if non specified, wil accept all */
 		if (!(rsa_flags & SC_ALGORITHM_RSA_HASHES)) {
 			rsa_flags |= SC_ALGORITHM_RSA_HASHES;
+
 #if OPENSSL_VERSION_NUMBER <  0x00908000L
 		/* turn off hashes not in openssl 0.9.8 */
 			rsa_flags &= ~(SC_ALGORITHM_RSA_HASH_SHA256 | SC_ALGORITHM_RSA_HASH_SHA384 | SC_ALGORITHM_RSA_HASH_SHA512 | SC_ALGORITHM_RSA_HASH_SHA224);

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -170,6 +170,9 @@ static void * dup_mem(void *in, size_t in_len)
 void
 sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
+    sc_card_t *card = p11card->card;
+    unsigned long hashes;
+
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE)
 	ENGINE *e;
 /* crypto locking removed in 1.1 */
@@ -180,6 +183,11 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 	if (locking_cb)
 		CRYPTO_set_locking_callback(NULL);
 #endif
+
+    if (card->restrict_to_these_hashes & SC_ALGORITHM_RSA_HASHES)
+	    hashes = card->restrict_to_these_hashes;
+    else 
+	    hashes = SC_ALGORITHM_RSA_HASHES;
 
 	e = ENGINE_by_id("gost");
 	if (!e)
@@ -216,20 +224,32 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 #endif
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE) */
 
-	openssl_sha1_mech.mech_data = EVP_sha1();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	if (hashes & SC_ALGORITHM_RSA_HASH_SHA1) {
+		openssl_sha1_mech.mech_data = EVP_sha1();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	}
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L
-	openssl_sha256_mech.mech_data = EVP_sha256();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
-	openssl_sha384_mech.mech_data = EVP_sha384();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
-	openssl_sha512_mech.mech_data = EVP_sha512();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	if (hashes & SC_ALGORITHM_RSA_HASH_SHA256) {
+		openssl_sha256_mech.mech_data = EVP_sha256();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
+	}
+	if (hashes & SC_ALGORITHM_RSA_HASH_SHA384) {
+		openssl_sha384_mech.mech_data = EVP_sha384();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
+	}
+	if (hashes & SC_ALGORITHM_RSA_HASH_SHA512) {
+		openssl_sha512_mech.mech_data = EVP_sha512();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	}
 #endif
-	openssl_md5_mech.mech_data = EVP_md5();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
-	openssl_ripemd160_mech.mech_data = EVP_ripemd160();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+	if (hashes & SC_ALGORITHM_RSA_HASH_MD5) {
+		openssl_md5_mech.mech_data = EVP_md5();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
+	}
+	if (hashes & SC_ALGORITHM_RSA_HASH_RIPEMD160) {
+		openssl_ripemd160_mech.mech_data = EVP_ripemd160();
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+	}
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));


### PR DESCRIPTION
This is a complete replacement for pull request for #969. To addresses @frankmorgner concerns.   

It replaces the  `negate_hashes` with `restrict_to_these_hashes`  which lists all the hashes  the card driver and card can support. If the flag is all zero, it means there are no restrictions. Thus the code has no impact on existing cards. 

It adds less code to the OpenSC base then #969 by passing  to the card driver's set_security_env the address of the data to be signed and its length and the original algorithm_flags.  The card driver can then look at the data to see if it is a hash with digest if it chooses to do so.   

The changes to card-gemsafeV1.c  for the PTEID card was rewritten to use the above. 

Since I do not have a PTEID card, this code is untested. @nunojpg and @l1k need to approve these changes. 

@frankmorgner commented that _sc_card_add_rsa_alg could be used to provide the additional information, i.e. the `restrict_to_these_hashes`. That is true, but would require changes to the _sc_card_add_rsa_alg parameters
 and major changes to framework-pkcs15.c and openssl.c. I chose to pass it by `card->restrict_to_these_hashes` to framework-pkcs15.c and openssl.c.

`restrict_to_these_hashes` could have a better name. 

#969 can be closed when this PR is accepted.  