### PR TITLE
reader-pcsc: removed cardmod driver

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -769,7 +769,7 @@ app onepin-opensc-pkcs11 {
 	}
 }
 
-# Used by OpenSC.tokend on Mac OS X only.
+# Used by OpenSC.tokend on Mac OS X only
 app tokend {
 	# The file to which debug log will be written
 	# Default: /tmp/opensc-tokend.log
@@ -785,14 +785,6 @@ app tokend {
 	}
 }
 
-# XXX: remove cardmod pseudodriver
+# Used by OpenSC minidriver on Windows only
 app cardmod {
-	# cardmod app name use special pcsc reader subset
-	# fix options for this reader driver here.
-
-	reader_driver cardmod {
-		# Enable pinpad if detected (PC/SC v2.0.2 Part 10)
-		# Default: true
-		# enable_pinpad = false;
-	}
 }

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -56,10 +56,8 @@ int _sc_delete_reader(sc_context_t *ctx, sc_reader_t *reader)
 	}
 	if (reader->ops->release)
 			reader->ops->release(reader);
-	if (reader->name)
-		free(reader->name);
-	if (reader->vendor)
-		free(reader->vendor);
+	free(reader->name);
+	free(reader->vendor);
 	list_delete(&ctx->readers, reader);
 	free(reader);
 	return SC_SUCCESS;
@@ -796,11 +794,6 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 
 #ifdef ENABLE_PCSC
 	ctx->reader_driver = sc_get_pcsc_driver();
-/* XXX: remove cardmod pseudoreader driver */
-#ifdef ENABLE_MINIDRIVER
-	if(strcmp(ctx->app_name, "cardmod") == 0)
-		ctx->reader_driver = sc_get_cardmod_driver();
-#endif
 #elif defined(ENABLE_CRYPTOTOKENKIT)
 	ctx->reader_driver = sc_get_cryptotokenkit_driver();
 #elif defined(ENABLE_CTAPI)

--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -129,10 +129,10 @@ int _sc_match_atr(struct sc_card *card, struct sc_atr_table *table, int *type_ou
 
 int _sc_card_add_algorithm(struct sc_card *card, const struct sc_algorithm_info *info);
 int _sc_card_add_rsa_alg(struct sc_card *card, unsigned int key_length,
-			 unsigned long flags, unsigned long exponent);
+		unsigned long flags, unsigned long exponent);
 int _sc_card_add_ec_alg(struct sc_card *card, unsigned int key_length,
-			 unsigned long flags, unsigned long ext_flags,
-			 struct sc_object_id *curve_oid);
+		unsigned long flags, unsigned long ext_flags,
+		struct sc_object_id *curve_oid);
 
 /********************************************************************/
 /*                 pkcs1 padding/encoding functions                 */
@@ -157,7 +157,7 @@ int sc_pkcs1_strip_digest_info_prefix(unsigned int *algorithm,
  * @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
-	const u8 *in, size_t inlen, u8 *out, size_t *outlen, size_t modlen);
+		const u8 *in, size_t inlen, u8 *out, size_t *outlen, size_t modlen);
 /**
  * Get the necessary padding and sec. env. flags.
  * @param  ctx     IN  sc_contex_t object
@@ -168,8 +168,8 @@ int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
  * @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_get_encoding_flags(sc_context_t *ctx,
-	unsigned long iflags, unsigned long caps,
-	unsigned long *pflags, unsigned long *salg);
+		unsigned long iflags, unsigned long caps,
+		unsigned long *pflags, unsigned long *salg);
 
 /********************************************************************/
 /*             mutex functions                                      */
@@ -231,7 +231,7 @@ unsigned long sc_thread_id(const sc_context_t *ctx);
  * @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_apdu_get_octets(sc_context_t *ctx, const sc_apdu_t *apdu, u8 **buf,
-	size_t *len, unsigned int proto);
+		size_t *len, unsigned int proto);
 /**
  * Sets the status bytes and return data in the APDU
  * @param  ctx     sc_context_t object
@@ -241,7 +241,7 @@ int sc_apdu_get_octets(sc_context_t *ctx, const sc_apdu_t *apdu, u8 **buf,
  * @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_apdu_set_resp(sc_context_t *ctx, sc_apdu_t *apdu, const u8 *buf,
-	size_t len);
+		size_t len);
 /**
  * Logs APDU
  * @param  ctx          sc_context_t object
@@ -256,7 +256,6 @@ int sc_apdu_set_resp(sc_context_t *ctx, sc_apdu_t *apdu, const u8 *buf,
 extern struct sc_reader_driver *sc_get_pcsc_driver(void);
 extern struct sc_reader_driver *sc_get_ctapi_driver(void);
 extern struct sc_reader_driver *sc_get_openct_driver(void);
-extern struct sc_reader_driver *sc_get_cardmod_driver(void);
 extern struct sc_reader_driver *sc_get_cryptotokenkit_driver(void);
 
 #ifdef __cplusplus

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -5816,7 +5816,7 @@ static int associate_card(PCARD_DATA pCardData)
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	/*
 	 * set the addresses of the reader and card handles
-	 * Our cardmod pcsc code will use these  when we call sc_ctx_use_reader
+	 * Our pcsc code will use these  when we call sc_ctx_use_reader
 	 * We use the address of the handles as provided in the pCardData
 	 */
 	vs->hSCardCtx = pCardData->hSCardCtx;
@@ -5834,7 +5834,7 @@ static int associate_card(PCARD_DATA pCardData)
 	}
 
 	/* set the provided reader and card handles into ctx */
-	logprintf(pCardData, 5, "cardmod_use_handles %d\n", sc_ctx_use_reader(vs->ctx, &vs->hSCardCtx, &vs->hScard));
+	logprintf(pCardData, 5, "sc_ctx_use_reader %d\n", sc_ctx_use_reader(vs->ctx, &vs->hSCardCtx, &vs->hScard));
 
 	/* should be only one reader */
 	logprintf(pCardData, 5, "sc_ctx_get_reader_count(ctx): %d\n", sc_ctx_get_reader_count(vs->ctx));


### PR DESCRIPTION
- pcsc driver takes over all the functionality
- no dedicated reader driver config values for cardmod, use application specific blocks to define a different behavior for the pcsc reader if needed
- removes legacy code; requiring at least libpcsclite 1.6.5

Fixes https://github.com/OpenSC/OpenSC/issues/892

Tested with:
- `certutil -scinfo` (Windows 7)
- `pkcs11-tool --test --login` (pcsc-lite version 1.8.20)
- Safari Client authentication (macoOS Sierra)