### PR TITLE
Add the final NUL to the CN used for token label

### DIFF
--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -117,7 +117,10 @@ sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 				sc_pkcs15_get_name_from_dn(card->ctx, cert->subject,
 					cert->subject_len, &cn_oid, &cn_name, &cn_len);
 				if (cn_len > 0) {
-					set_string(&p15card->tokeninfo->label, (const char*)cn_name);
+					char *token_name = malloc(cn_len+1);
+					memcpy(token_name, cn_name, cn_len);
+					token_name[cn_len] = 0;
+					set_string(&p15card->tokeninfo->label, (const char*)token_name);
 				}
 				free(cn_name);
 				sc_pkcs15_free_certificate(cert);


### PR DESCRIPTION
Arbitrary strings were shown in PKCS#11 apps (even though the field is cut to 32 characters)