### PR TITLE
Verify pubkey as spki

### DIFF
--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -391,7 +391,8 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 {
 	int res;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	EVP_PKEY *pkey;
+	EVP_PKEY *pkey = NULL;
+	const unsigned char *pubkey_tmp;
 
 	if (mech == CKM_GOSTR3410)
 	{
@@ -405,7 +406,20 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 #endif
 	}
 
-	pkey = d2i_PublicKey(EVP_PKEY_RSA, NULL, &pubkey, pubkey_len);
+	/*
+	 * PKCS#11 does not define CKA_VALUE for public keys, and different cards
+	 * return either the direct or spki versions as defined in PKCS#15
+	 * And we need to support more then just RSA.
+	 * We can use d2i_PUBKEY which works for SPKI and any key type. 
+	 */
+	pubkey_tmp = pubkey; /* pass in so pubkey pointer is not modified */
+	pkey = d2i_PUBKEY(NULL, &pubkey_tmp, pubkey_len);
+
+	/* if failed, try old way that only works for RSA */
+	if  (pkey == NULL) {
+		pubkey_tmp = pubkey;
+		pkey = d2i_PublicKey(EVP_PKEY_RSA, NULL, &pubkey_tmp, pubkey_len);
+	}
 	if (pkey == NULL)
 		return CKR_GENERAL_ERROR;
 
@@ -435,6 +449,7 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 		 case CKM_RSA_X_509:
 		 	pad = RSA_NO_PADDING;
 		 	break;
+		/* TODO support more then RSA */
 		 default:
 			EVP_PKEY_free(pkey);
 		 	return CKR_ARGUMENTS_BAD;


### PR DESCRIPTION
Fix pkcs11/openssl.c to allow for the CKA_VALUE of a public key to be in spki format. 

Note that PKCS#11 does not define the CKA_VALUE for a public key, but OpenSC does, and it can be in either "direct" or "spki" format as defined in PKCS#15. "spki" is the same as on X.509 subjectPublicKeyInfo  and d2i_PUBKEY can be used to create a EVP_KEY. 

So either format is now supported by sc_pkcs11_verify_data.

The problem was found while testing pkcs11-tool -t -l  where the  verify tests would fail with a CKR_GENERAL_ERROR because  the card driver stored the public key as a spki.

