### PR TITLE
pkcs11-tool: Add feature to get random data.

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -482,6 +482,14 @@
                                         </para></listitem>
 				</varlistentry>
 
+				<varlistentry>
+					<term>
+						<option>--generate-random</option> <replaceable>num</replaceable>
+					</term>
+					<listitem><para>Get <replaceable>num</replaceable> bytes of random data.
+                                        </para></listitem>
+				</varlistentry>
+
 			</variablelist>
 		</para>
 	</refsect1>


### PR DESCRIPTION
Getting random data is an essential part of the PKCS11 API.
This patch provides a new command line parameter to get
random data from the pkcs11-tool.

Tested with a Yubikey (PIV applet) and the following command line:

$ pkcs11-tool --slot=0 --generate-random=128 | hexdump -C
  00000000  0c 35 85 2e 85 68 ab ce  e8 56 b3 f6 f3 33 e6 37  |.5...h...V...3.7|
  00000010  12 10 eb fd 8a 1e 75 b7  3f 4d fa 61 8f ab d8 bf  |......u.?M.a....|
  00000020  f7 2c 7d ba 07 a5 45 6e  a7 85 1c 47 3b 46 01 2c  |.,}...En...G;F.,|
  00000030  79 18 6e 51 4d c4 ae 20  37 37 1d 7b 7e b0 d5 18  |y.nQM.. 77.{~...|
  00000040  ef a4 3c 09 91 68 db dd  2a a8 fc b9 34 06 2a ee  |..<..h..*...4.*.|
  00000050  5a 86 55 54 11 1f ef 4e  07 73 79 27 0a e4 58 cf  |Z.UT...N.sy'..X.|
  00000060  f4 bd bc 2f ad 27 b1 a7  a4 fa c7 1a 7b 31 de a3  |.../.'......{1..|
  00000070  e8 dc 85 28 18 82 00 45  3c f8 eb 48 a4 20 e4 3b  |...(...E<..H. .;|
  00000080

Signed-off-by: Christoph Müllner <christophm30@gmail.com>