### PR TITLE
Uncontroversial changes from PR #850

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,12 @@ AC_DEFINE_UNQUOTED([DEBUG_FILE], ["${DEBUG_FILE}"], [Debug file])
 AC_DEFINE_UNQUOTED([PROFILE_DIR], ["${PROFILE_DIR}"], [Directory of profiles])
 AC_DEFINE_UNQUOTED([PROFILE_DIR_DEFAULT], ["${PROFILE_DIR_DEFAULT}"], [Default directory of profiles])
 
+case "${host}" in
+	*-mingw*)
+		CPPFLAGS="${CPPFLAGS} -D__USE_MINGW_ANSI_STDIO=1"
+	;;
+esac
+
 AC_ARG_ENABLE(
 	[strict],
 	[AS_HELP_STRING([--disable-strict],[disable strict compile mode @<:@disabled@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -409,8 +409,12 @@ if test "${enable_minidriver}" = "yes"; then
 	AC_CHECK_HEADER(
 		[cardmod.h],
 		,
-		[AC_MSG_ERROR([cardmod.h is not found and required for minidriver])]
-	)
+		[AC_MSG_ERROR([cardmod.h from CNG is required for minidriver])],
+		[#if defined(__MINGW32__)
+#include "${srcdir}/src/minidriver/cardmod-mingw-compat.h"
+#endif
+	])
+
 	AC_DEFINE([ENABLE_MINIDRIVER], [1], [Enable minidriver support])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -556,23 +556,6 @@ else
 	OPENSSL_LIBS=""
 fi
 
-if test "${enable_sm}" = "yes"; then
-	AC_DEFINE([ENABLE_SM], [1], [Enable secure messaging support])
-
-	DEFAULT_SM_MODULE="${LIB_PRE}smm-local${DYN_LIB_EXT}"
-	case "${host}" in
-		*-mingw*|*-winnt*|*-cygwin*)
-			DEFAULT_SM_MODULE_PATH="\# module_path = \"\";"
-		;;
-		*)
-			DEFAULT_SM_MODULE="libsmm-local.so"
-			DEFAULT_SM_MODULE_PATH="module_path = \$(libdir);"
-		;;
-	esac
-	AC_DEFINE_UNQUOTED([DEFAULT_SM_MODULE], ["${DEFAULT_SM_MODULE}"], [Default SM module])
-	AC_DEFINE_UNQUOTED([DEFAULT_SM_MODULE_PATH], ["${DEFAULT_SM_MODULE_PATH}"], [Default SM module path])
-fi
-
 if test "${enable_openct}" = "yes"; then
 	PKG_CHECK_MODULES(
 		[OPENCT],
@@ -651,6 +634,22 @@ case "${host}" in
 		;;
 esac
 
+if test "${enable_sm}" = "yes"; then
+	AC_DEFINE([ENABLE_SM], [1], [Enable secure messaging support])
+
+	DEFAULT_SM_MODULE="${LIB_PRE}smm-local${DYN_LIB_EXT}"
+	case "${host}" in
+		*-mingw*|*-winnt*|*-cygwin*)
+			DEFAULT_SM_MODULE_PATH="\# module_path = \"\";"
+		;;
+		*)
+			DEFAULT_SM_MODULE="libsmm-local.so"
+			DEFAULT_SM_MODULE_PATH="module_path = \$(libdir);"
+		;;
+	esac
+	AC_DEFINE_UNQUOTED([DEFAULT_SM_MODULE], ["${DEFAULT_SM_MODULE}"], [Default SM module])
+	AC_DEFINE_UNQUOTED([DEFAULT_SM_MODULE_PATH], ["${DEFAULT_SM_MODULE_PATH}"], [Default SM module path])
+fi
 
 if test "${with_pkcs11_provider}" = "detect"; then
 	DEFAULT_PKCS11_PROVIDER="opensc-pkcs11${DYN_LIB_EXT}"

--- a/configure.ac
+++ b/configure.ac
@@ -704,6 +704,18 @@ if test "${enable_ctapi}" = "yes"; then
 	OPENSC_FEATURES="${OPENSC_FEATURES} ctapi"
 fi
 
+if test "${enable_minidriver}" = "yes"; then
+	AC_MSG_CHECKING([WiX SDK])
+	AC_CHECK_HEADERS([wcautil.h],[enable_minidriver_ca="yes"],[enable_minidriver_ca="no"])
+	if test "${enable_minidriver_ca}" = "yes"; then
+		AC_MSG_RESULT([found, minidriver setup custom action will be built])
+	else
+		AC_MSG_RESULT([not found, minidriver setup custom action will be skipped])
+	fi
+else
+	enable_minidriver_ca="no"
+fi
+
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_MAJOR], [${OPENSC_VERSION_MAJOR}], [OpenSC version major component])
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_MINOR], [${OPENSC_VERSION_MINOR}], [OpenSC version minor component])
 AC_DEFINE_UNQUOTED([OPENSC_VERSION_FIX], [${OPENSC_VERSION_FIX}], [OpenSC version fix component])
@@ -768,6 +780,7 @@ AM_CONDITIONAL([ENABLE_DOC], [test "${enable_doc}" = "yes"])
 AM_CONDITIONAL([WIN32], [test "${WIN32}" = "yes"])
 AM_CONDITIONAL([CYGWIN], [test "${CYGWIN}" = "yes"])
 AM_CONDITIONAL([ENABLE_MINIDRIVER], [test "${enable_minidriver}" = "yes"])
+AM_CONDITIONAL([ENABLE_MINIDRIVER_SETUP_CUSTOMACTION], [test "${enable_minidriver_ca}" = "yes"])
 AM_CONDITIONAL([ENABLE_SM], [test "${enable_sm}" = "yes"])
 AM_CONDITIONAL([ENABLE_DNIE_UI], [test "${enable_dnie_ui}" = "yes"])
 AM_CONDITIONAL([GIT_CHECKOUT], [test "${GIT_CHECKOUT}" = "yes"])

--- a/doc/tools/opensc-tool.1.xml
+++ b/doc/tools/opensc-tool.1.xml
@@ -100,6 +100,13 @@
 				</varlistentry>
 				<varlistentry>
 					<term>
+						<option>--reset</option>[=<replaceable>type</replaceable>],
+					</term>
+					<listitem><para>Resets the card in reader.
+					The default reset type is <literal>cold</literal>, but warm reset is also possible.</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>--send-apdu</option> <replaceable>apdu</replaceable>,
 						<option>-s</option> <replaceable>apdu</replaceable>
 					</term>

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = -DOPENSC_CONF_PATH=\"$(sysconfdir)/opensc.conf\" \
 AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(OPTIONAL_OPENCT_CFLAGS) \
 	$(OPTIONAL_PCSC_CFLAGS) $(OPTIONAL_ZLIB_CFLAGS)
 
-libopensc_la_SOURCES = \
+libopensc_la_SOURCES_BASE = \
 	sc.c ctx.c log.c errors.c \
 	asn1.c base64.c sec.c card.c iso7816.c dir.c ef-atr.c padding.c apdu.c \
 	simpletlv.c \
@@ -53,8 +53,10 @@ libopensc_la_SOURCES = \
 	pkcs15-coolkey.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c \
 	compression.c p15card-helper.c sm.c \
-	aux-data.c \
+	aux-data.c
+libopensc_la_SOURCES = $(libopensc_la_SOURCES_BASE) \
 	libopensc.exports
+libopensc_static_la_SOURCES = $(libopensc_la_SOURCES_BASE)
 if WIN32
 libopensc_la_SOURCES += $(top_builddir)/win32/versioninfo.rc
 endif
@@ -67,6 +69,7 @@ libopensc_la_LIBADD = $(OPTIONAL_OPENSSL_LIBS) $(OPTIONAL_OPENCT_LIBS) \
 if WIN32
 libopensc_la_LIBADD += -lws2_32
 endif
+libopensc_static_la_LIBADD = $(libopensc_la_LIBADD)
 libopensc_la_LDFLAGS = $(AM_LDFLAGS) \
 	-version-info @OPENSC_LT_CURRENT@:@OPENSC_LT_REVISION@:@OPENSC_LT_AGE@ \
 	-export-symbols "$(srcdir)/libopensc.exports" \
@@ -77,4 +80,8 @@ if WIN32
 mylibdir=$(libdir)
 mylib_DATA=.libs/@WIN_LIBPREFIX@opensc-@OPENSC_LT_OLDEST@.dll.def
 .libs/@WIN_LIBPREFIX@opensc-@OPENSC_LT_OLDEST@.dll.def:	libopensc.la
+
+if ENABLE_MINIDRIVER
+noinst_LTLIBRARIES = libopensc_static.la
+endif
 endif

--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -372,8 +372,10 @@ sc_single_transmit(struct sc_card *card, struct sc_apdu *apdu)
 	if (card->reader->ops->transmit == NULL)
 		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "cannot transmit APDU");
 
-	sc_log(ctx, "CLA:%X, INS:%X, P1:%X, P2:%X, data(%i) %p",
-			apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen, apdu->data);
+	sc_log(ctx,
+	       "CLA:%X, INS:%X, P1:%X, P2:%X, data(%"SC_FORMAT_LEN_SIZE_T"u) %p",
+	       apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen,
+	       apdu->data);
 #ifdef ENABLE_SM
 	if (card->sm_ctx.sm_mode == SM_MODE_TRANSMIT)
 		return sc_sm_single_transmit(card, apdu);
@@ -659,8 +661,9 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 
 	if (!len) {
 		apdu->cse = SC_APDU_CASE_1;
-		sc_log(ctx, "CASE_1 APDU: %lu bytes:\tins=%02x p1=%02x p2=%02x lc=%04x le=%04x",
-			(unsigned long) len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
+		sc_log(ctx,
+		       "CASE_1 APDU: %"SC_FORMAT_LEN_SIZE_T"u bytes:\tins=%02x p1=%02x p2=%02x lc=%04"SC_FORMAT_LEN_SIZE_T"x le=%04"SC_FORMAT_LEN_SIZE_T"x",
+		       len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
 		return SC_SUCCESS;
 	}
 
@@ -681,7 +684,9 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 			apdu->lc += *p++;
 			len -= 3;
 			if (len < apdu->lc) {
-				sc_log(ctx, "APDU too short (need %lu more bytes)", (unsigned long) apdu->lc - len);
+				sc_log(ctx,
+				       "APDU too short (need %"SC_FORMAT_LEN_SIZE_T"u more bytes)",
+				       apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
 			apdu->data = p;
@@ -719,7 +724,9 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 			apdu->lc = *p++;
 			len--;
 			if (len < apdu->lc) {
-				sc_log(ctx, "APDU too short (need %lu more bytes)", (unsigned long) apdu->lc - len);
+				sc_log(ctx,
+				       "APDU too short (need %"SC_FORMAT_LEN_SIZE_T"u more bytes)",
+				       apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
 			apdu->data = p;
@@ -743,10 +750,12 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 		return SC_ERROR_INVALID_DATA;
 	}
 
-	sc_log(ctx, "Case %d %s APDU, %lu bytes:\tins=%02x p1=%02x p2=%02x lc=%04x le=%04x",
-			apdu->cse & SC_APDU_SHORT_MASK,
-			(apdu->cse & SC_APDU_EXT) != 0 ? "extended" : "short",
-			(unsigned long) len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
+	sc_log(ctx,
+	       "Case %d %s APDU, %"SC_FORMAT_LEN_SIZE_T"u bytes:\tins=%02x p1=%02x p2=%02x lc=%04"SC_FORMAT_LEN_SIZE_T"x le=%04"SC_FORMAT_LEN_SIZE_T"x",
+	       apdu->cse & SC_APDU_SHORT_MASK,
+	       (apdu->cse & SC_APDU_EXT) != 0 ? "extended" : "short",
+	       len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc,
+	       apdu->le);
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -415,8 +415,9 @@ const u8 *sc_asn1_skip_tag(sc_context_t *ctx, const u8 ** buf, size_t *buflen,
 		return NULL;
 	len -= (p - *buf);	/* header size */
 	if (taglen > len) {
-		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "too long ASN.1 object (size %d while only %d available)\n",
-		      taglen, len);
+		sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+			 "too long ASN.1 object (size %"SC_FORMAT_LEN_SIZE_T"u while only %"SC_FORMAT_LEN_SIZE_T"u available)\n",
+			 taglen, len);
 		return NULL;
 	}
 	*buflen -= (p - *buf) + taglen;
@@ -1276,7 +1277,9 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_BOOLEAN:
 		if (parm != NULL) {
 			if (objlen != 1) {
-				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "invalid ASN.1 object length: %d\n", objlen);
+				sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+					 "invalid ASN.1 object length: %"SC_FORMAT_LEN_SIZE_T"u\n",
+					 objlen);
 				r = SC_ERROR_INVALID_ASN1_OBJECT;
 			} else
 				*((int *) parm) = obj[0] ? 1 : 0;
@@ -1444,10 +1447,9 @@ static int asn1_decode(sc_context_t *ctx, struct sc_asn1_entry *asn1,
 	struct sc_asn1_entry *entry = asn1;
 	size_t left = len, objlen;
 
-	sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*scalled, left=%u, depth %d%s\n",
-			       	depth, depth, "",
-				left, depth,
-				choice ? ", choice" : "");
+	sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+		 "%*.*scalled, left=%"SC_FORMAT_LEN_SIZE_T"u, depth %d%s\n",
+		 depth, depth, "", left, depth, choice ? ", choice" : "");
 
 	if (!p)
 		return SC_ERROR_ASN1_OBJECT_NOT_FOUND;
@@ -1553,9 +1555,10 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 		(entry->flags & SC_ASN1_PRESENT)? "" : " (not present)");
 	if (!(entry->flags & SC_ASN1_PRESENT))
 		goto no_object;
-	sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*stype=%d, tag=0x%02x, parm=%p, len=%u\n",
-		depth, depth, "",
-		entry->type, entry->tag, parm, len? *len : 0);
+	sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+		 "%*.*stype=%d, tag=0x%02x, parm=%p, len=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 depth, depth, "", entry->type, entry->tag, parm,
+		 len ? *len : 0);
 
 	if (entry->type == SC_ASN1_CHOICE) {
 		const struct sc_asn1_entry *list, *choice = NULL;
@@ -1733,7 +1736,9 @@ no_object:
 	if (buf)
 		free(buf);
 	if (r >= 0)
-		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*slength of encoded item=%u\n", depth, depth, "", *objlen);
+		sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+			 "%*.*slength of encoded item=%"SC_FORMAT_LEN_SIZE_T"u\n",
+			 depth, depth, "", *objlen);
 	return r;
 }
 
@@ -1916,8 +1921,10 @@ sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx, unsigned char *in, size
 	memcpy(buf + (halflen - r_len), r, r_len);
 	memcpy(buf + (buflen - s_len), s, s_len);
 
-	sc_log(ctx, "r(%i): %s", halflen, sc_dump_hex(buf, halflen));
-	sc_log(ctx, "s(%i): %s", halflen, sc_dump_hex(buf + halflen, halflen));
+	sc_log(ctx, "r(%"SC_FORMAT_LEN_SIZE_T"u): %s", halflen,
+	       sc_dump_hex(buf, halflen));
+	sc_log(ctx, "s(%"SC_FORMAT_LEN_SIZE_T"u): %s", halflen,
+	       sc_dump_hex(buf + halflen, halflen));
 
 	rv = SC_SUCCESS;
 done:

--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -157,7 +157,9 @@ sc_aux_data_get_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_da
 		strlcat(guid, "}", sizeof(guid));
 
 	if (*out_size < strlen(guid))   {
-		sc_log(ctx, "aux-data: buffer too small: out_size:%i < guid-length:%i", *out_size, strlen(guid));
+		sc_log(ctx,
+		       "aux-data: buffer too small: out_size:%"SC_FORMAT_LEN_SIZE_T"u < guid-length:%"SC_FORMAT_LEN_SIZE_T"u",
+		       *out_size, strlen(guid));
 		LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
 	}
 

--- a/src/libopensc/card-atrust-acos.c
+++ b/src/libopensc/card-atrust-acos.c
@@ -393,11 +393,12 @@ static int atrust_acos_select_file(struct sc_card *card,
 		pbuf[0] = '\0';
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"current path (%s, %s): %s (len: %u)\n",
-		(card->cache.current_path.type==SC_PATH_TYPE_DF_NAME?"aid":"path"),
-		(card->cache.valid?"valid":"invalid"), pbuf,
-		card->cache.current_path.len);
-  
+		 "current path (%s, %s): %s (len: %"SC_FORMAT_LEN_SIZE_T"u)\n",
+		 card->cache.current_path.type == SC_PATH_TYPE_DF_NAME ?
+		 "aid" : "path",
+		 card->cache.valid ? "valid" : "invalid", pbuf,
+		 card->cache.current_path.len);
+
 	memcpy(path, in_path->value, in_path->len);
 	pathlen = in_path->len;
 

--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -642,7 +642,9 @@ static int get_carddata(sc_card_t *card, u8* carddata_loc, unsigned int carddata
 		return r;
 	}
 	if(apdu.resplen < carddataloc_len) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "GetCardData: card returned %d bytes rather than expected %d\n", apdu.resplen, carddataloc_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "GetCardData: card returned %"SC_FORMAT_LEN_SIZE_T"u bytes rather than expected %d\n",
+			 apdu.resplen, carddataloc_len);
 		return SC_ERROR_WRONG_LENGTH;
 	}
 

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -333,8 +333,10 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "%02x %02x %02x %d : %d %d\n",
-		 ins, p1, p2, sendbuflen, card->max_send_size, card->max_recv_size);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "%02x %02x %02x %"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u\n",
+		 ins, p1, p2, sendbuflen, card->max_send_size,
+		 card->max_recv_size);
 
 	rbuf = rbufinitbuf;
 	rbuflen = sizeof(rbufinitbuf);
@@ -363,14 +365,16 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 		 apdu.resplen = 0;
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"calling sc_transmit_apdu flags=%x le=%d, resplen=%d, resp=%p",
-		apdu.flags, apdu.le, apdu.resplen, apdu.resp);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "calling sc_transmit_apdu flags=%lx le=%"SC_FORMAT_LEN_SIZE_T"u, resplen=%"SC_FORMAT_LEN_SIZE_T"u, resp=%p",
+		 apdu.flags, apdu.le, apdu.resplen, apdu.resp);
 
 	/* with new adpu.c and chaining, this actually reads the whole object */
 	r = sc_transmit_apdu(card, &apdu);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"result r=%d apdu.resplen=%d sw1=%02x sw2=%02x",
-			r, apdu.resplen, apdu.sw1, apdu.sw2);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "result r=%d apdu.resplen=%"SC_FORMAT_LEN_SIZE_T"u sw1=%02x sw2=%02x",
+		 r, apdu.resplen, apdu.sw1, apdu.sw2);
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"Transmit failed");
 		goto err;
@@ -431,7 +435,7 @@ static int cac_read_file(sc_card_t *card, int file_type, u8 **out_buf, size_t *o
 
 	left = size = lebytes2ushort(count);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-		 "got %d bytes out_ptr=%p count&=%p count[0]=0x%02x count[1]=0x%02x, len=0x%04x (%d)",
+		 "got %"SC_FORMAT_LEN_SIZE_T"u bytes out_ptr=%p count&=%p count[0]=0x%02x count[1]=0x%02x, len=0x%04"SC_FORMAT_LEN_SIZE_T"x (%"SC_FORMAT_LEN_SIZE_T"u)",
 		 len, out_ptr, &count, count[0], count[1], size, size);
 	out = out_ptr = malloc(size);
 	if (out == NULL) {
@@ -564,7 +568,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if we didn't return it all last time, return the remainder */
 	if (priv->cached) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"returning cached value idx=%d count=%d",idx, count);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "returning cached value idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
+			 idx, count);
 		if (idx > priv->cache_buf_len) {
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_FILE_END_REACHED);
 		}
@@ -573,7 +579,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, len);
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"clearing cache idx=%d count=%d",idx, count);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "clearing cache idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
+		 idx, count);
 	if (priv->cache_buf) {
 		free(priv->cache_buf);
 		priv->cache_buf = NULL;
@@ -641,7 +649,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	case CAC_OBJECT_TYPE_CERT:
 		/* read file */
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL," obj= cert_file, val_len=%d (0x%04x)", val_len, val_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 " obj= cert_file, val_len=%"SC_FORMAT_LEN_SIZE_T"u (0x%04"SC_FORMAT_LEN_SIZE_T"x)",
+			 val_len, val_len);
 		cert_len = 0;
 		cert_ptr = NULL;
 		cert_type = 0;
@@ -805,7 +815,8 @@ static int cac_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"challenge len=%d",len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "challenge len=%"SC_FORMAT_LEN_SIZE_T"u", len);
 
 	r = sc_lock(card);
 	if (r != SC_SUCCESS)
@@ -841,9 +852,11 @@ static int cac_set_security_env(sc_card_t *card, const sc_security_env_t *env, i
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"flags=%08x op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%d\n",
-			env->flags, env->operation, env->algorithm, env->algorithm_flags,
-			env->algorithm_ref, env->key_ref[0], env->key_ref_len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "flags=%08lx op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 env->flags, env->operation, env->algorithm,
+		 env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
+		 env->key_ref_len);
 
 	if (env->algorithm != SC_ALGORITHM_RSA) {
 		 r = SC_ERROR_NO_CARD_SUPPORT;
@@ -871,7 +884,9 @@ static int cac_rsa_op(sc_card_t *card,
 	size_t rbuflen, outplen;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"datalen=%d outlen=%d\n", datalen, outlen);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 datalen, outlen);
 
 	outp = out;
 	outplen = outlen;
@@ -979,11 +994,14 @@ static int cac_select_file_by_type(sc_card_t *card, const sc_path_t *in_path, sc
 	pathlen = in_path->len;
 	pathtype = in_path->type;
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"path->aid=%x %x %x %x %x %x %x  len=%d, path->value = %x %x %x %x len=%d path->type=%d (%x)",
-		in_path->aid.value[0], in_path->aid.value[1], in_path->aid.value[2], in_path->aid.value[3],
-		in_path->aid.value[4], in_path->aid.value[5], in_path->aid.value[6], in_path->aid.len,
-		in_path->value[0], in_path->value[1], in_path->value[2], in_path->value[3], in_path->len,
-		in_path->type, in_path->type);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+		 "path->aid=%x %x %x %x %x %x %x  len=%"SC_FORMAT_LEN_SIZE_T"u, path->value = %x %x %x %x len=%"SC_FORMAT_LEN_SIZE_T"u path->type=%d (%x)",
+		 in_path->aid.value[0], in_path->aid.value[1],
+		 in_path->aid.value[2], in_path->aid.value[3],
+		 in_path->aid.value[4], in_path->aid.value[5],
+		 in_path->aid.value[6], in_path->aid.len, in_path->value[0],
+		 in_path->value[1], in_path->value[2], in_path->value[3],
+		 in_path->len, in_path->type, in_path->type);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "file_out=%p index=%d count=%d\n",
 		 file_out, in_path->index, in_path->count);
 
@@ -1135,14 +1153,18 @@ static int cac_path_from_cardurl(sc_card_t *card, sc_path_t *path, cac_card_url_
 	memcpy(path->value, &val->objectID, sizeof(val->objectID));
 	path->len = sizeof(val->objectID);
 	path->type = SC_PATH_TYPE_FILE_ID;
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"path->aid=%x %x %x %x %x %x %x  len=%d, path->value = %x %x len=%d path->type=%d (%x)",
-		path->aid.value[0], path->aid.value[1], path->aid.value[2], path->aid.value[3],
-		path->aid.value[4], path->aid.value[5], path->aid.value[6],
-		path->aid.len, path->value[0], path->value[1], path->len, path->type, path->type);
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"rid=%x %x %x %x %x  len=%d appid= %x %x len=%d objid= %x %x len=%d",
-		val->rid[0], val->rid[1], val->rid[2], val->rid[3], val->rid[4], sizeof(val->rid),
-		val->applicationID[0], val->applicationID[1], sizeof(val->applicationID),
-		val->objectID[0], val->objectID[1], sizeof(val->objectID));
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+		 "path->aid=%x %x %x %x %x %x %x  len=%"SC_FORMAT_LEN_SIZE_T"u, path->value = %x %x len=%"SC_FORMAT_LEN_SIZE_T"u path->type=%d (%x)",
+		 path->aid.value[0], path->aid.value[1], path->aid.value[2],
+		 path->aid.value[3], path->aid.value[4], path->aid.value[5],
+		 path->aid.value[6], path->aid.len, path->value[0],
+		 path->value[1], path->len, path->type, path->type);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+		 "rid=%x %x %x %x %x  len=%"SC_FORMAT_LEN_SIZE_T"u appid= %x %x len=%"SC_FORMAT_LEN_SIZE_T"u objid= %x %x len=%"SC_FORMAT_LEN_SIZE_T"u",
+		 val->rid[0], val->rid[1], val->rid[2], val->rid[3],
+		 val->rid[4], sizeof(val->rid), val->applicationID[0],
+		 val->applicationID[1], sizeof(val->applicationID),
+		 val->objectID[0], val->objectID[1], sizeof(val->objectID));
 
 	return SC_SUCCESS;
 }
@@ -1205,7 +1227,10 @@ static int cac_parse_cuid(sc_card_t *card, cac_private_data_t *priv, cac_cuid_t 
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "manufacture id=%x", val->manufacturer_id);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "cac_type=%d", val->card_type);
 	card_id_len = len - (&val->card_id - (u8 *)val);
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "card_id=%s (%d)",sc_dump_hex(&val->card_id, card_id_len),card_id_len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+		 "card_id=%s (%"SC_FORMAT_LEN_SIZE_T"u)",
+		 sc_dump_hex(&val->card_id, card_id_len),
+		 card_id_len);
 	priv->cuid = *val;
 	priv->cac_id = malloc(card_id_len);
 	if (priv->cac_id == NULL) {

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -430,8 +430,9 @@ static int cac_read_file(sc_card_t *card, int file_type, u8 **out_buf, size_t *o
 		goto fail;
 
 	left = size = lebytes2ushort(count);
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "got %d bytes out_ptr=%lx count&=%lx count[0]=0x%02x count[1]=0x%02x, len=0x%04x (%d)",
-		len, (unsigned long) out_ptr, (unsigned long)&count, count[0], count[1], size, size);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+		 "got %d bytes out_ptr=%p count&=%p count[0]=0x%02x count[1]=0x%02x, len=0x%04x (%d)",
+		 len, out_ptr, &count, count[0], count[1], size, size);
 	out = out_ptr = malloc(size);
 	if (out == NULL) {
 		r = SC_ERROR_OUT_OF_MEMORY;
@@ -983,8 +984,8 @@ static int cac_select_file_by_type(sc_card_t *card, const sc_path_t *in_path, sc
 		in_path->aid.value[4], in_path->aid.value[5], in_path->aid.value[6], in_path->aid.len,
 		in_path->value[0], in_path->value[1], in_path->value[2], in_path->value[3], in_path->len,
 		in_path->type, in_path->type);
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"file_out=%lx index=%d count=%d\n",(unsigned long) file_out,
-		in_path->index, in_path->count);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "file_out=%p index=%d count=%d\n",
+		 file_out, in_path->index, in_path->count);
 
 	/* Sigh, sc_key_select expects paths to keys to have specific formats. There is no override.
 	 * we have to add some bytes to the path to make it happy. A better fix would be to give sc_key_file

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -1211,8 +1211,12 @@ cardos_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data,
 	data->pin_reference |= 0x80;
 
 	sc_log(ctx, "PIN_CMD(cmd:%i, ref:%i)", data->cmd, data->pin_reference);
-	sc_log(ctx, "PIN1(max:%i, min:%i)", data->pin1.max_length, data->pin1.min_length);
-	sc_log(ctx, "PIN2(max:%i, min:%i)", data->pin2.max_length, data->pin2.min_length);
+	sc_log(ctx,
+	       "PIN1(max:%"SC_FORMAT_LEN_SIZE_T"u, min:%"SC_FORMAT_LEN_SIZE_T"u)",
+	       data->pin1.max_length, data->pin1.min_length);
+	sc_log(ctx,
+	       "PIN2(max:%"SC_FORMAT_LEN_SIZE_T"u, min:%"SC_FORMAT_LEN_SIZE_T"u)",
+	       data->pin2.max_length, data->pin2.min_length);
 
 	/* FIXME: the following values depend on what pin length was
 	 * used when creating the BS objects */

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -931,8 +931,10 @@ static int coolkey_apdu_io(sc_card_t *card, int cla, int ins, int p1, int p2,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "%02x %02x %02x %d : %d %d\n",
-		 ins, p1, p2, sendbuflen , card->max_send_size, card->max_recv_size);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "%02x %02x %02x %"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u\n",
+		 ins, p1, p2, sendbuflen, card->max_send_size,
+		 card->max_recv_size);
 
 	rbuf = rbufinitbuf;
 	rbuflen = sizeof(rbufinitbuf);
@@ -994,14 +996,16 @@ static int coolkey_apdu_io(sc_card_t *card, int cla, int ins, int p1, int p2,
 		 apdu.resplen = 0;
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"calling sc_transmit_apdu flags=%x le=%d, resplen=%d, resp=%p",
-		apdu.flags, apdu.le, apdu.resplen, apdu.resp);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "calling sc_transmit_apdu flags=%lx le=%"SC_FORMAT_LEN_SIZE_T"u, resplen=%"SC_FORMAT_LEN_SIZE_T"u, resp=%p",
+		 apdu.flags, apdu.le, apdu.resplen, apdu.resp);
 
 	/* with new adpu.c and chaining, this actually reads the whole object */
 	r = sc_transmit_apdu(card, &apdu);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"result r=%d apdu.resplen=%d sw1=%02x sw2=%02x",
-			r, apdu.resplen, apdu.sw1, apdu.sw2);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "result r=%d apdu.resplen=%"SC_FORMAT_LEN_SIZE_T"u sw1=%02x sw2=%02x",
+		 r, apdu.resplen, apdu.sw1, apdu.sw2);
 
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"Transmit failed");
@@ -1198,13 +1202,17 @@ static int coolkey_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if we've already read the data, just return it */
 	if (priv->obj->data) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"returning cached value idx=%d count=%d",idx, count);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "returning cached value idx=%u count=%"SC_FORMAT_LEN_SIZE_T"u",
+			 idx, count);
 		len = MIN(count, priv->obj->length-idx);
 		memcpy(buf, &priv->obj->data[idx], len);
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, len);
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"clearing cache idx=%d count=%d",idx, count);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "clearing cache idx=%u count=%"SC_FORMAT_LEN_SIZE_T"u",
+		 idx, count);
 
 	data = malloc(priv->obj->length);
 	if (data == NULL) {
@@ -1603,7 +1611,8 @@ static int coolkey_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"challenge len=%d",len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "challenge len=%"SC_FORMAT_LEN_SIZE_T"u", len);
 
 	r = sc_lock(card);
 	if (r != SC_SUCCESS)
@@ -1640,9 +1649,11 @@ static int coolkey_set_security_env(sc_card_t *card, const sc_security_env_t *en
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"flags=%08x op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%d\n",
-			env->flags, env->operation, env->algorithm, env->algorithm_flags,
-			env->algorithm_ref, env->key_ref[0], env->key_ref_len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "flags=%08lx op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 env->flags, env->operation, env->algorithm,
+		 env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
+		 env->key_ref_len);
 
 	if ((env->algorithm != SC_ALGORITHM_RSA) && (env->algorithm != SC_ALGORITHM_EC)) {
 		 r = SC_ERROR_NO_CARD_SUPPORT;
@@ -1697,7 +1708,9 @@ static int coolkey_rsa_op(sc_card_t *card,
 	u8 *buf_out;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"datalen=%d outlen=%d\n", datalen, max_out_len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 datalen, max_out_len);
 
 	crypt_in = data;
 	crypt_in_len = datalen;
@@ -1798,7 +1811,9 @@ static int coolkey_ecc_op(sc_card_t *card,
 	u8 key_number;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,"datalen=%d outlen=%d\n", datalen, outlen);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 datalen, outlen);
 
 	crypt_in = data;
 	crypt_in_len = datalen;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -618,7 +618,7 @@ get_info_end:
 		bufferlen=0;
 	}
 	if (msg)
-		sc_log(card->ctx,msg);
+		sc_log(card->ctx, "%s", msg);
         LOG_FUNC_RETURN(card->ctx, res);
 }
 

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -964,7 +964,8 @@ static u8 *dnie_uncompress(sc_card_t * card, u8 * from, size_t *len)
 	*len = uncompressed;
 	sc_log(card->ctx, "Compressed data:\n%s\n",
 	       sc_dump_hex(from + 8, compressed));
-	sc_log(card->ctx, "Uncompress() done. Before:'%lu' After: '%lu'",
+	sc_log(card->ctx,
+	       "Uncompress() done. Before:'%"SC_FORMAT_LEN_SIZE_T"u' After: '%"SC_FORMAT_LEN_SIZE_T"u'",
 	       compressed, uncompressed);
 	sc_log(card->ctx, "Uncompressed data:\n%s\n",
 	       sc_dump_hex(upt, uncompressed));
@@ -1091,7 +1092,9 @@ static int dnie_fill_cache(sc_card_t * card)
 	/* ok: as final step, set correct cache data into dnie_priv structures */
 	GET_DNIE_PRIV_DATA(card)->cache = pt;
 	GET_DNIE_PRIV_DATA(card)->cachelen = len;
-	sc_log(ctx, "fill_cache() done. length '%d' bytes", len);
+	sc_log(ctx,
+	       "fill_cache() done. length '%"SC_FORMAT_LEN_SIZE_T"u' bytes",
+	       len);
 	LOG_FUNC_RETURN(ctx,len);
 }
 
@@ -1684,7 +1687,7 @@ static int dnie_compute_signature(struct sc_card *card,
 	   data and feed them into sign() command
 	 */
 	sc_log(card->ctx,
-	       "Compute signature len: '%d' bytes:\n%s\n============================================================",
+	       "Compute signature len: '%"SC_FORMAT_LEN_SIZE_T"u' bytes:\n%s\n============================================================",
 	       datalen, sc_dump_hex(data, datalen));
 
 	/*INS: 0x2A  PERFORM SECURITY OPERATION

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -685,13 +685,14 @@ static int entersafe_select_file(sc_card_t *card,
 	  r = sc_path_print(pbuf, sizeof(pbuf), &card->cache.current_path);
 	  if (r != SC_SUCCESS)
 		 pbuf[0] = '\0';
-		
+
 	  sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"current path (%s, %s): %s (len: %u)\n",
-		   (card->cache.current_path.type==SC_PATH_TYPE_DF_NAME?"aid":"path"),
-		   (card->cache.valid?"valid":"invalid"), pbuf,
+		   "current path (%s, %s): %s (len: %"SC_FORMAT_LEN_SIZE_T"u)\n",
+		   card->cache.current_path.type == SC_PATH_TYPE_DF_NAME ?
+		   "aid" : "path",
+		   card->cache.valid ? "valid" : "invalid", pbuf,
 		   card->cache.current_path.len);
-	 
+
 	 switch(in_path->type)
 	 {
 	 case SC_PATH_TYPE_FILE_ID:

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -978,7 +978,9 @@ epass2003_sm_unwrap_apdu(struct sc_card *card, struct sc_apdu *sm, struct sc_apd
 	plain->sw1 = sm->sw1;
 	plain->sw2 = sm->sw2;
 
-	sc_log(card->ctx, "unwrapped APDU: resplen %i, SW %02X%02X", plain->resplen, plain->sw1, plain->sw2);
+	sc_log(card->ctx,
+	       "unwrapped APDU: resplen %"SC_FORMAT_LEN_SIZE_T"u, SW %02X%02X",
+	       plain->resplen, plain->sw1, plain->sw2);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
@@ -1529,9 +1531,12 @@ epass2003_select_file(struct sc_card *card, const sc_path_t * in_path,
 	if (r != SC_SUCCESS)
 		pbuf[0] = '\0';
 
-	sc_log(card->ctx, "current path (%s, %s): %s (len: %u)\n",
-			(card->cache.current_path.type == SC_PATH_TYPE_DF_NAME ? "aid" : "path"),
-			(card->cache.valid ? "valid" : "invalid"), pbuf, card->cache.current_path.len);
+	sc_log(card->ctx,
+	       "current path (%s, %s): %s (len: %"SC_FORMAT_LEN_SIZE_T"u)\n",
+	       card->cache.current_path.type == SC_PATH_TYPE_DF_NAME ?
+	       "aid" : "path",
+	       card->cache.valid ? "valid" : "invalid", pbuf,
+	       card->cache.current_path.len);
 
 	switch (in_path->type) {
 	case SC_PATH_TYPE_FILE_ID:
@@ -1697,7 +1702,8 @@ epass2003_process_fci(struct sc_card *card, sc_file_t * file, const u8 * buf, si
 		file->size = tag[0];
 		if (taglen == 2)
 			file->size = (file->size << 8) + tag[1];
-		sc_log(ctx, "  bytes in file: %d", file->size);
+		sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u",
+		       file->size);
 	}
 
 	if (tag == NULL) {

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -641,7 +641,9 @@ static int cryptoflex_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		if (r)
 			return r;
 		if (apdu.resplen != 4) {
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "expected 4 bytes, got %d.\n", apdu.resplen);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+				 "expected 4 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
+				 apdu.resplen);
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 		memcpy(buf, rbuf + 2, 2);
@@ -676,7 +678,9 @@ static int cyberflex_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		if (r)
 			return r;
 		if (apdu.resplen != 6) {
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "expected 6 bytes, got %d.\n", apdu.resplen);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+				 "expected 6 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
+				 apdu.resplen);
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 		memcpy(buf, rbuf + 4, 2);
@@ -845,7 +849,8 @@ cyberflex_construct_file_attrs(sc_card_t *card, const sc_file_t *file,
 		break;
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Creating %02x:%02x, size %d %02x:%02x\n",
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "Creating %02x:%02x, size %"SC_FORMAT_LEN_SIZE_T"u %02"SC_FORMAT_LEN_SIZE_T"x:%02"SC_FORMAT_LEN_SIZE_T"x\n",
 		 file->id >> 8,
 		 file->id & 0xFF,
 		 size,
@@ -983,7 +988,9 @@ cryptoflex_compute_signature(sc_card_t *card, const u8 *data,
 	size_t i, i2;
 	
 	if (data_len != 64 && data_len != 96 && data_len != 128  && data_len != 256) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Illegal input length: %d\n", data_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "Illegal input length: %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	if (outlen < data_len) {
@@ -1042,7 +1049,9 @@ cyberflex_compute_signature(sc_card_t *card, const u8 *data,
 	case 96:  alg_id = 0xC6; break;
 	case 128: alg_id = 0xC8; break;
 	default:
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Illegal input length: %d\n", data_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "Illegal input length: %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	key_id = prv->rsa_key_ref + 1; /* Why? */

--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -462,7 +462,9 @@ static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 
 	/* the card can sign 36 bytes of free form data */
 	if (data_len > 36) {
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "error: input data too long: %lu bytes\n", data_len);
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+			 "error: input data too long: %"SC_FORMAT_LEN_SIZE_T"u bytes\n",
+			 data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -214,8 +214,9 @@ static int gids_get_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"Got args: fileIdentifier=%x, dataObjectIdentifier=%x, response=%x, responselen=%d\n",
-		fileIdentifier, dataObjectIdentifier, response, responselen ? *responselen : 0);
+		 "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 fileIdentifier, dataObjectIdentifier, response,
+		 responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_GET_DATA, (fileIdentifier&0xFF00)>>8, (fileIdentifier&0xFF));
@@ -250,8 +251,8 @@ static int gids_put_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	u8* p = buffer;
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"Got args: fileIdentifier=%x, dataObjectIdentifier=%x, data=%x, datalen=%d\n",
-		fileIdentifier, dataObjectIdentifier, data, datalen);
+		 "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, data=%p, datalen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 fileIdentifier, dataObjectIdentifier, data, datalen);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, INS_PUT_DATA, (fileIdentifier&0xFF00)>>8, (fileIdentifier&0xFF));
 
@@ -278,8 +279,8 @@ static int gids_select_aid(sc_card_t* card, u8* aid, size_t aidlen, u8* response
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"Got args: aid=%x, aidlen=%d, response=%x, responselen=%d\n",
-		aid, aidlen, response, responselen ? *responselen : 0);
+		 "Got args: aid=%p, aidlen=%"SC_FORMAT_LEN_SIZE_T"u, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 aid, aidlen, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_SELECT, P1_SELECT_DF_BY_NAME, P2_SELECT_FIRST_OR_ONLY_OCCURENCE);
@@ -851,8 +852,8 @@ static int gids_read_public_key (struct sc_card *card , unsigned int algorithm,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"Got args: key_reference=%x, response=%x, responselen=%d\n",
-		key_reference, response, responselen ? *responselen : 0);
+		 "Got args: key_reference=%x, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 key_reference, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_GET_DATA, 0x3F, 0xFF);
@@ -998,7 +999,9 @@ static int gids_read_binary(sc_card_t *card, unsigned int offset,
 				SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
 			}
 			if (data->buffersize != expectedsize) {
-				sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "expected size: %d real size: %d", expectedsize, data->buffersize);
+				sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+					 "expected size: %"SC_FORMAT_LEN_SIZE_T"u real size: %"SC_FORMAT_LEN_SIZE_T"u",
+					 expectedsize, data->buffersize);
 				SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_DATA);
 			}
 		} else {
@@ -1115,7 +1118,9 @@ gids_select_key_reference(sc_card_t *card, sc_pkcs15_prkey_info_t* key_info) {
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 		}
 		if (i > recordsnum) {
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "container num is not allowed %d %d", i, recordsnum);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+				 "container num is not allowed %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u",
+				 i, recordsnum);
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 		}
 	}
@@ -1254,7 +1259,9 @@ static int gids_create_keyfile(sc_card_t *card, sc_pkcs15_object_t *object) {
 		keymaprecordnum = (keymapbuffersize - 1) / sizeof(struct gids_keymap_record);
 		if (keymaprecordnum != recordnum) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL , "Error: Unable to create the key file because the keymap and cmapfile are inconsistent");
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL , "keymaprecordnum = %u recordnum = %u", (unsigned long) keymaprecordnum, (unsigned long) recordnum);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL ,
+				 "keymaprecordnum = %"SC_FORMAT_LEN_SIZE_T"u recordnum = %"SC_FORMAT_LEN_SIZE_T"u",
+				 keymaprecordnum, recordnum);
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INTERNAL);
 		}
 	}

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -1235,8 +1235,8 @@ gpk_compute_signature(sc_card_t *card, const u8 *data,
 
 	if (data_len > priv->sec_mod_len) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-			"Data length (%u) does not match key modulus %u.\n",
-			data_len, priv->sec_mod_len);
+			 "Data length (%"SC_FORMAT_LEN_SIZE_T"u) does not match key modulus %u.\n",
+			 data_len, priv->sec_mod_len);
 		return SC_ERROR_INTERNAL;
 	}
 	if (sizeof(cardsig) < priv->sec_mod_len)
@@ -1289,8 +1289,8 @@ gpk_decipher(sc_card_t *card, const u8 *in, size_t inlen,
 
 	if (inlen != priv->sec_mod_len) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-			"Data length (%u) does not match key modulus %u.\n",
-			inlen, priv->sec_mod_len);
+			 "Data length (%"SC_FORMAT_LEN_SIZE_T"u) does not match key modulus %u.\n",
+			 inlen, priv->sec_mod_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -394,7 +394,9 @@ static int iasecc_parse_ef_atr(struct sc_card *card)
 	if (card->max_send_size > 0xFF)
 		card->max_send_size -= 5;
 
-	sc_log(ctx, "EF.ATR: max send/recv sizes %X/%X", card->max_send_size, card->max_recv_size);
+	sc_log(ctx,
+	       "EF.ATR: max send/recv sizes %"SC_FORMAT_LEN_SIZE_T"X/%"SC_FORMAT_LEN_SIZE_T"X",
+	       card->max_send_size, card->max_recv_size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -686,7 +688,9 @@ iasecc_read_binary(struct sc_card *card, unsigned int offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_read_binary(card:%p) offs %i; count %i", card, offs, count);
+	sc_log(ctx,
+	       "iasecc_read_binary(card:%p) offs %i; count %"SC_FORMAT_LEN_SIZE_T"u",
+	       card, offs, count);
 	if (offs > 0x7fff) {
 		sc_log(ctx, "invalid EF offset: 0x%X > 0x7FFF", offs);
 		return SC_ERROR_OFFSET_TOO_LARGE;
@@ -701,7 +705,9 @@ iasecc_read_binary(struct sc_card *card, unsigned int offs,
 	LOG_TEST_RET(ctx, rv, "APDU transmit failed");
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(ctx, rv, "iasecc_read_binary() failed");
-	sc_log(ctx, "iasecc_read_binary() apdu.resplen %i", apdu.resplen);
+	sc_log(ctx,
+	       "iasecc_read_binary() apdu.resplen %"SC_FORMAT_LEN_SIZE_T"u",
+	       apdu.resplen);
 
 	if (apdu.resplen == IASECC_READ_BINARY_LENGTH_MAX && apdu.resplen < count)   {
 		rv = iasecc_read_binary(card, offs + apdu.resplen, buf + apdu.resplen, count - apdu.resplen, flags);
@@ -723,7 +729,9 @@ iasecc_erase_binary(struct sc_card *card, unsigned int offs, size_t count, unsig
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_erase_binary(card:%p) count %i", card, count);
+	sc_log(ctx,
+	       "iasecc_erase_binary(card:%p) count %"SC_FORMAT_LEN_SIZE_T"u",
+	       card, count);
 	if (!count)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "'ERASE BINARY' failed: invalid size to erase");
 
@@ -749,7 +757,9 @@ _iasecc_sm_read_binary(struct sc_card *card, unsigned int offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_sm_read_binary() card:%p offs:%i count:%i ", card, offs, count);
+	sc_log(ctx,
+	       "iasecc_sm_read_binary() card:%p offs:%i count:%"SC_FORMAT_LEN_SIZE_T"u ",
+	       card, offs, count);
 	if (offs > 0x7fff)
 		LOG_TEST_RET(ctx, SC_ERROR_OFFSET_TOO_LARGE, "Invalid arguments");
 
@@ -788,7 +798,9 @@ _iasecc_sm_update_binary(struct sc_card *card, unsigned int offs,
 		return SC_SUCCESS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_sm_read_binary() card:%p offs:%i count:%i ", card, offs, count);
+	sc_log(ctx,
+	       "iasecc_sm_read_binary() card:%p offs:%i count:%"SC_FORMAT_LEN_SIZE_T"u ",
+	       card, offs, count);
 	sc_print_cache(card);
 
 	if (card->cache.valid && card->cache.current_ef)   {
@@ -857,8 +869,9 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 	if (file_out)
 		*file_out = NULL;
 
-	sc_log(ctx, "iasecc_select_file(card:%p) path.len %i; path.type %i; aid_len %i",
-			card, path->len, path->type, path->aid.len);
+	sc_log(ctx,
+	       "iasecc_select_file(card:%p) path.len %"SC_FORMAT_LEN_SIZE_T"u; path.type %i; aid_len %"SC_FORMAT_LEN_SIZE_T"u",
+	       card, path->len, path->type, path->aid.len);
 	sc_log(ctx, "iasecc_select_file() path:%s", sc_print_path(path));
 
 	sc_print_cache(card);
@@ -878,7 +891,9 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 		struct sc_file *file = NULL;
 		struct sc_path ppath;
 
-		sc_log(ctx, "iasecc_select_file() select parent AID:%p/%i", lpath.aid.value, lpath.aid.len);
+		sc_log(ctx,
+		       "iasecc_select_file() select parent AID:%p/%"SC_FORMAT_LEN_SIZE_T"u",
+		       lpath.aid.value, lpath.aid.len);
 		sc_log(ctx, "iasecc_select_file() select parent AID:%s", sc_dump_hex(lpath.aid.value, lpath.aid.len));
 		memset(&ppath, 0, sizeof(ppath));
 		memcpy(ppath.value, lpath.aid.value, lpath.aid.len);
@@ -1019,7 +1034,9 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 
 		LOG_TEST_RET(ctx, rv, "iasecc_select_file() check SW failed");
 
-		sc_log(ctx, "iasecc_select_file() apdu.resp %i", apdu.resplen);
+		sc_log(ctx,
+		       "iasecc_select_file() apdu.resp %"SC_FORMAT_LEN_SIZE_T"u",
+		       apdu.resplen);
 		if (apdu.resplen)   {
 			sc_log(ctx, "apdu.resp %02X:%02X:%02X...", apdu.resp[0], apdu.resp[1], apdu.resp[2]);
 
@@ -1107,7 +1124,7 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 	tag = sc_asn1_find_tag(ctx,  buf, buflen, 0x6F, &taglen);
 	sc_log(ctx, "processing FCI: 0x6F tag %p", tag);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %i", taglen);
+		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
@@ -1115,7 +1132,7 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 	tag = sc_asn1_find_tag(ctx,  buf, buflen, 0x62, &taglen);
 	sc_log(ctx, "processing FCI: 0x62 tag %p", tag);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %i", taglen);
+		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
@@ -1136,11 +1153,14 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 		acls = sc_asn1_find_tag(ctx, buf, buflen, IASECC_DOCP_TAG_ACLS_CONTACT, &taglen);
 
 	if (!acls)   {
-		sc_log(ctx, "ACLs not found in data(%i) %s", buflen, sc_dump_hex(buf, buflen));
+		sc_log(ctx,
+		       "ACLs not found in data(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+		       buflen, sc_dump_hex(buf, buflen));
 		LOG_TEST_RET(ctx, SC_ERROR_OBJECT_NOT_FOUND, "ACLs tag missing");
 	}
 
-	sc_log(ctx, "ACLs(%i) '%s'", taglen, sc_dump_hex(acls, taglen));
+	sc_log(ctx, "ACLs(%"SC_FORMAT_LEN_SIZE_T"u) '%s'", taglen,
+	       sc_dump_hex(acls, taglen));
 	mask = 0x40, offs = 1;
 	for (ii = 0; ii < 7; ii++, mask /= 2)  {
 		unsigned char op = file->type == SC_FILE_TYPE_DF ? ops_DF[ii] : ops_EF[ii];
@@ -1239,7 +1259,9 @@ iasecc_fcp_encode(struct sc_card *card, struct sc_file *file, unsigned char *out
 			LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Non supported AC method");
 
 		amb |= mask;
-		sc_log(ctx, "%i: AMB %X; nn_smb %i", ii, amb, nn_smb);
+		sc_log(ctx,
+		       "%"SC_FORMAT_LEN_SIZE_T"u: AMB %"SC_FORMAT_LEN_SIZE_T"X; nn_smb %"SC_FORMAT_LEN_SIZE_T"u",
+		       ii, amb, nn_smb);
 	}
 
 	/* TODO: Encode contactless ACLs and life cycle status for all IAS/ECC cards */
@@ -1650,7 +1672,7 @@ iasecc_set_security_env(struct sc_card *card,
 
 	/* To made by iasecc_sdo_convert_to_file() */
 	prv->key_size = *(sdo.docp.size.value + 0) * 0x100 + *(sdo.docp.size.value + 1);
-	sc_log(ctx, "prv->key_size 0x%X", prv->key_size);
+	sc_log(ctx, "prv->key_size 0x%"SC_FORMAT_LEN_SIZE_T"X", prv->key_size);
 
 	rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_PSO_COMPUTE_SIGNATURE, &sign_meth, &sign_ref);
 	LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_SIGN acl");
@@ -1686,8 +1708,10 @@ iasecc_set_security_env(struct sc_card *card,
 	}
 
 	sc_log(ctx, "senv.algorithm 0x%X, senv.algorithm_ref 0x%X", env->algorithm, env->algorithm_ref);
-	sc_log(ctx, "se_num %i, operation 0x%X, algorithm 0x%X, algorithm_ref 0x%X, flags 0x%X; key size %i",
-					se_num, operation, env->algorithm, env->algorithm_ref, env->algorithm_flags, prv->key_size);
+	sc_log(ctx,
+	       "se_num %i, operation 0x%X, algorithm 0x%X, algorithm_ref 0x%X, flags 0x%X; key size %"SC_FORMAT_LEN_SIZE_T"u",
+	       se_num, operation, env->algorithm, env->algorithm_ref,
+	       env->algorithm_flags, prv->key_size);
 	switch (operation)  {
 	case SC_SEC_OPERATION_SIGN:
 		if (!(env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1))
@@ -1955,7 +1979,9 @@ iasecc_pin_verify(struct sc_card *card, unsigned type, unsigned reference,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "Verify PIN(type:%X,ref:%i,data(len:%i,%p)", type, reference, data_len, data);
+	sc_log(ctx,
+	       "Verify PIN(type:%X,ref:%i,data(len:%"SC_FORMAT_LEN_SIZE_T"u,%p)",
+	       type, reference, data_len, data);
 
 	if (type == SC_AC_AUT)   {
 		rv =  iasecc_sm_external_authentication(card, reference, tries_left);
@@ -2053,8 +2079,14 @@ iasecc_chv_change_pinpad(struct sc_card *card, unsigned reference, int *tries_le
 	memcpy(&pin_cmd.pin2, &pin_cmd.pin1, sizeof(pin_cmd.pin1));
 	pin_cmd.pin2.data = pin2_data;
 
-	sc_log(ctx, "PIN1 max/min/stored: %i/%i/%i", pin_cmd.pin1.max_length, pin_cmd.pin1.min_length, pin_cmd.pin1.stored_length);
-	sc_log(ctx, "PIN2 max/min/stored: %i/%i/%i", pin_cmd.pin2.max_length, pin_cmd.pin2.min_length, pin_cmd.pin2.stored_length);
+	sc_log(ctx,
+	       "PIN1 max/min/stored: %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
+	       pin_cmd.pin1.max_length, pin_cmd.pin1.min_length,
+	       pin_cmd.pin1.stored_length);
+	sc_log(ctx,
+	       "PIN2 max/min/stored: %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
+	       pin_cmd.pin2.max_length, pin_cmd.pin2.min_length,
+	       pin_cmd.pin2.stored_length);
 	rv = iso_ops->pin_cmd(card, &pin_cmd, tries_left);
 
 	LOG_FUNC_RETURN(ctx, rv);
@@ -2160,7 +2192,9 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 	if (sdo.docp.acls_contact.size == 0)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Extremely strange ... there is no ACLs");
 
-	sc_log(ctx, "iasecc_pin_get_policy() sdo.docp.size.size %i", sdo.docp.size.size);
+	sc_log(ctx,
+	       "iasecc_pin_get_policy() sdo.docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
+	       sdo.docp.size.size);
 	for (ii=0; ii<sizeof(sdo.docp.scbs); ii++)   {
 		struct iasecc_se_info se;
 		unsigned char scb = sdo.docp.scbs[ii];
@@ -2225,9 +2259,10 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 	data->pin1.offset = 5;
 	data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 
-	sc_log(ctx, "PIN policy: size max/min %i/%i, tries max/left %i/%i",
-				data->pin1.max_length, data->pin1.min_length,
-				data->pin1.max_tries, data->pin1.tries_left);
+	sc_log(ctx,
+	       "PIN policy: size max/min %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u, tries max/left %i/%i",
+	       data->pin1.max_length, data->pin1.min_length,
+	       data->pin1.max_tries, data->pin1.tries_left);
 	iasecc_sdo_free_fields(card, &sdo);
 
 	if (save_current_df)   {
@@ -3029,7 +3064,9 @@ iasecc_decipher(struct sc_card *card,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(card->ctx, "crgram_len %i;  outlen %i", in_len, out_len);
+	sc_log(card->ctx,
+	       "crgram_len %"SC_FORMAT_LEN_SIZE_T"u;  outlen %"SC_FORMAT_LEN_SIZE_T"u",
+	       in_len, out_len);
 	if (!out || !out_len || in_len > SC_MAX_APDU_BUFFER_SIZE)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
@@ -3078,7 +3115,9 @@ iasecc_qsign_data_sha1(struct sc_context *ctx, const unsigned char *in, size_t i
 	if (!in || !in_len || !out)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "sc_pkcs15_get_qsign_data() input data length %i", in_len);
+	sc_log(ctx,
+	       "sc_pkcs15_get_qsign_data() input data length %"SC_FORMAT_LEN_SIZE_T"u",
+	       in_len);
 	memset(out, 0, sizeof(struct iasecc_qsign_data));
 
 	SHA1_Init(&sha);
@@ -3102,7 +3141,9 @@ iasecc_qsign_data_sha1(struct sc_context *ctx, const unsigned char *in, size_t i
 	if (sha.num)   {
 		memcpy(out->last_block, in + in_len - sha.num, sha.num);
 		out->last_block_size = sha.num;
-		sc_log(ctx, "Last block(%i):%s", out->last_block_size, sc_dump_hex(out->last_block, out->last_block_size));
+		sc_log(ctx, "Last block(%"SC_FORMAT_LEN_SIZE_T"u):%s",
+		       out->last_block_size,
+		       sc_dump_hex(out->last_block, out->last_block_size));
 	}
 
 	SHA1_Final(out->hash, &sha);
@@ -3127,7 +3168,9 @@ iasecc_qsign_data_sha256(struct sc_context *ctx, const unsigned char *in, size_t
 	if (!in || !in_len || !out)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "sc_pkcs15_get_qsign_data() input data length %i", in_len);
+	sc_log(ctx,
+	       "sc_pkcs15_get_qsign_data() input data length %"SC_FORMAT_LEN_SIZE_T"u",
+	       in_len);
 	memset(out, 0, sizeof(struct iasecc_qsign_data));
 
 	SHA256_Init(&sha256);
@@ -3151,7 +3194,9 @@ iasecc_qsign_data_sha256(struct sc_context *ctx, const unsigned char *in, size_t
 	if (sha256.num)   {
 		memcpy(out->last_block, in + in_len - sha256.num, sha256.num);
 		out->last_block_size = sha256.num;
-		sc_log(ctx, "Last block(%i):%s", out->last_block_size, sc_dump_hex(out->last_block, out->last_block_size));
+		sc_log(ctx, "Last block(%"SC_FORMAT_LEN_SIZE_T"u):%s",
+		       out->last_block_size,
+		       sc_dump_hex(out->last_block, out->last_block_size));
 	}
 
 	SHA256_Final(out->hash, &sha256);
@@ -3178,7 +3223,9 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	int rv = SC_SUCCESS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_compute_signature_dst() input length %i", in_len);
+	sc_log(ctx,
+	       "iasecc_compute_signature_dst() input length %"SC_FORMAT_LEN_SIZE_T"u",
+	       in_len);
 	if (env->operation != SC_SEC_OPERATION_SIGN)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "It's not SC_SEC_OPERATION_SIGN");
 	else if (!(prv->key_size & 0x1E0) || (prv->key_size & ~0x1E0))
@@ -3199,7 +3246,9 @@ iasecc_compute_signature_dst(struct sc_card *card,
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Need RSA_HASH_SHA1 or RSA_HASH_SHA256 algorithm");
 	LOG_TEST_RET(ctx, rv, "Cannot get QSign data");
 
-	sc_log(ctx, "iasecc_compute_signature_dst() hash_len %i; key_size %i", hash_len, prv->key_size);
+	sc_log(ctx,
+	       "iasecc_compute_signature_dst() hash_len %"SC_FORMAT_LEN_SIZE_T"u; key_size %"SC_FORMAT_LEN_SIZE_T"u",
+	       hash_len, prv->key_size);
 
 	memset(sbuf, 0, sizeof(sbuf));
 	sbuf[offs++] = 0x90;
@@ -3219,7 +3268,9 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	memcpy(sbuf + offs, qsign_data.last_block, qsign_data.last_block_size);
 	offs += qsign_data.last_block_size;
 
-	sc_log(ctx, "iasecc_compute_signature_dst() offs %i; OP(meth:%X,ref:%X)", offs, prv->op_method, prv->op_ref);
+	sc_log(ctx,
+	       "iasecc_compute_signature_dst() offs %"SC_FORMAT_LEN_SIZE_T"u; OP(meth:%X,ref:%X)",
+	       offs, prv->op_method, prv->op_ref);
 	if (prv->op_method == SC_AC_SCB && (prv->op_ref & IASECC_SCB_METHOD_SM))
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Not yet");
 
@@ -3245,7 +3296,9 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(ctx, rv, "Compute signature failed");
 
-	sc_log(ctx, "iasecc_compute_signature_dst() DST resplen %i", apdu.resplen);
+	sc_log(ctx,
+	       "iasecc_compute_signature_dst() DST resplen %"SC_FORMAT_LEN_SIZE_T"u",
+	       apdu.resplen);
 	if (apdu.resplen > out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "Result buffer too small for the DST signature");
 
@@ -3327,7 +3380,9 @@ iasecc_compute_signature(struct sc_card *card,
 	env = &prv->security_env;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "inlen %i, outlen %i", in_len, out_len);
+	sc_log(ctx,
+	       "inlen %"SC_FORMAT_LEN_SIZE_T"u, outlen %"SC_FORMAT_LEN_SIZE_T"u",
+	       in_len, out_len);
 
 	if (env->operation == SC_SEC_OPERATION_SIGN)
 		return iasecc_compute_signature_dst(card, in, in_len, out,  out_len);
@@ -3436,10 +3491,14 @@ iasecc_get_free_reference(struct sc_card *card, struct iasecc_ctl_get_free_refer
 			LOG_TEST_RET(ctx, rv, "get new key reference failed");
 
 		sz = *(sdo->docp.size.value + 0) * 0x100 + *(sdo->docp.size.value + 1);
-		sc_log(ctx, "SDO(idx:%i) size %i; key_size %i", idx, sz, ctl_data->key_size);
+		sc_log(ctx,
+		       "SDO(idx:%i) size %"SC_FORMAT_LEN_SIZE_T"u; key_size %"SC_FORMAT_LEN_SIZE_T"u",
+		       idx, sz, ctl_data->key_size);
 
 		if (sz != ctl_data->key_size / 8)   {
-			sc_log(ctx, "key index %i ignored: different key sizes %i/%i", idx, sz, ctl_data->key_size / 8);
+			sc_log(ctx,
+			       "key index %i ignored: different key sizes %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
+			       idx, sz, ctl_data->key_size / 8);
 			continue;
 		}
 

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -145,8 +145,9 @@ jpki_select_file(struct sc_card *card,
 	struct sc_file *file = NULL;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "jpki_select_file: path=%s, len=%d",
-			sc_print_path(path), path->len);
+	sc_log(card->ctx,
+	       "jpki_select_file: path=%s, len=%"SC_FORMAT_LEN_SIZE_T"u",
+	       sc_print_path(path), path->len);
 	if (path->len == 2 && memcmp(path->value, "\x3F\x00", 2) == 0) {
 		drvdata->selected = SELECT_MF;
 		if (file_out) {
@@ -301,10 +302,10 @@ jpki_set_security_env(sc_card_t * card,
 
 	LOG_FUNC_CALLED(card->ctx);
 	sc_log(card->ctx,
-		"flags=%08x op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%d",
-		env->flags, env->operation, env->algorithm,
-		env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
-		env->key_ref_len);
+	       "flags=%08lx op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u",
+	       env->flags, env->operation, env->algorithm,
+	       env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
+	       env->key_ref_len);
 
 	switch (env->operation) {
 	case SC_SEC_OPERATION_SIGN:

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1084,7 +1084,7 @@ mcrd_select_file(sc_card_t * card, const sc_path_t * path, sc_file_t ** file)
 			linep += 4;
 		}
 		strcpy(linep, "\n");
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, line);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "%s", line);
 	}
 
 	if (path->type == SC_PATH_TYPE_DF_NAME) {
@@ -1147,7 +1147,7 @@ mcrd_select_file(sc_card_t * card, const sc_path_t * path, sc_file_t ** file)
 			linep += 4;
 		}
 		strcpy(linep, "\n");
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, line);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "%s", line);
 	}
 	return r;
 }

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1359,7 +1359,7 @@ static int mcrd_compute_signature(sc_card_t * card,
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		 "Will compute signature (%d) for %d (0x%02x) bytes using key %d algorithm %d flags %d\n",
+		 "Will compute signature (%d) for %"SC_FORMAT_LEN_SIZE_T"u (0x%02"SC_FORMAT_LEN_SIZE_T"x) bytes using key %d algorithm %d flags %d\n",
 		 env->operation, datalen, datalen, env->key_ref[0],
 		 env->algorithm, env->algorithm_flags);
 

--- a/src/libopensc/card-miocos.c
+++ b/src/libopensc/card-miocos.c
@@ -472,7 +472,7 @@ static int miocos_card_ctl(sc_card_t *card, unsigned long cmd,
 	case SC_CARDCTL_MIOCOS_CREATE_AC:
 		return miocos_create_ac(card, (struct sc_cardctl_miocos_ac_info *) arg);
 	}
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "card_ctl command 0x%X not supported\n", cmd);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "card_ctl command 0x%lX not supported\n", cmd);
 	return SC_ERROR_NOT_SUPPORTED;
 }
 

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -384,7 +384,9 @@ auth_process_fci(struct sc_card *card, struct sc_file *file,
 		else if (file->size==2048)
 			file->size = PUBKEY_2048_ASN1_SIZE;
 		else   {
-			sc_log(card->ctx, "Not supported public key size: %i", file->size);
+			sc_log(card->ctx,
+			       "Not supported public key size: %"SC_FORMAT_LEN_SIZE_T"u",
+			       file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
 		}
 		break;
@@ -540,11 +542,12 @@ auth_select_file(struct sc_card *card, const struct sc_path *in_path,
 					path.value[offs + 1] != auth_current_df->path.value[offs + 1])
 				break;
 
-		sc_log(card->ctx, "offs %i", offs);
+		sc_log(card->ctx, "offs %"SC_FORMAT_LEN_SIZE_T"u", offs);
 		if (offs && offs < auth_current_df->path.len)   {
 			size_t deep = auth_current_df->path.len - offs;
 
-			sc_log(card->ctx, "deep %i", deep);
+			sc_log(card->ctx, "deep %"SC_FORMAT_LEN_SIZE_T"u",
+			       deep);
 			for (ii=0; ii<deep; ii+=2)   {
 				struct sc_path tmp_path;
 
@@ -746,8 +749,9 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 	unsigned char  ops[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "id %04X; size %i; type 0x%X/0x%X",
-			file->id, file->size, file->type, file->ef_structure);
+	sc_log(card->ctx,
+	       "id %04X; size %"SC_FORMAT_LEN_SIZE_T"u; type 0x%X/0x%X",
+	       file->id, file->size, file->type, file->ef_structure);
 
 	if (*buflen < 0x18)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
@@ -825,7 +829,9 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 		else if (file->size == PUBKEY_2048_ASN1_SIZE || file->size == 2048)
 			size = 2048;
 		else   {
-			sc_log(card->ctx, "incorrect RSA size %X", file->size);
+			sc_log(card->ctx,
+			       "incorrect RSA size %"SC_FORMAT_LEN_SIZE_T"X",
+			       file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
 		}
 	}
@@ -838,7 +844,9 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 		else if (file->size == 24 || file->size == 192)
 			size = 192;
 		else   {
-			sc_log(card->ctx, "incorrect DES size %i", file->size);
+			sc_log(card->ctx,
+			       "incorrect DES size %"SC_FORMAT_LEN_SIZE_T"u",
+			       file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
 		}
 	}
@@ -937,8 +945,8 @@ auth_create_file(struct sc_card *card, struct sc_file *file)
 	sc_log(card->ctx, " create path=%s", pbuf);
 
 	sc_log(card->ctx,
-		"id %04X; size %i; type 0x%X; ef 0x%X",
-		file->id, file->size, file->type, file->ef_structure);
+	       "id %04X; size %"SC_FORMAT_LEN_SIZE_T"u; type 0x%X; ef 0x%X",
+	       file->id, file->size, file->type, file->ef_structure);
 
 	if (file->id==0x0000 || file->id==0xFFFF || file->id==0x3FFF)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
@@ -1015,9 +1023,10 @@ auth_set_security_env(struct sc_card *card,
 	};
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "op %i; path %s; key_ref 0x%X; algos 0x%X; flags 0x%X",
-			env->operation, sc_print_path(&env->file_ref), env->key_ref[0],
-			env->algorithm_flags, env->flags);
+	sc_log(card->ctx,
+	       "op %i; path %s; key_ref 0x%X; algos 0x%X; flags 0x%lX",
+	       env->operation, sc_print_path(&env->file_ref), env->key_ref[0],
+	       env->algorithm_flags, env->flags);
 
 	memset(auth_senv, 0, sizeof(struct auth_senv));
 
@@ -1027,8 +1036,9 @@ auth_set_security_env(struct sc_card *card,
 	switch (env->algorithm)   {
 	case SC_ALGORITHM_DES:
 	case SC_ALGORITHM_3DES:
-		sc_log(card->ctx, "algo SC_ALGORITHM_xDES: ref %X, flags %X",
-				env->algorithm_ref, env->flags);
+		sc_log(card->ctx,
+		       "algo SC_ALGORITHM_xDES: ref %X, flags %lX",
+		       env->algorithm_ref, env->flags);
 
 		if (env->operation == SC_SEC_OPERATION_DECIPHER)   {
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xB8);
@@ -1049,7 +1059,7 @@ auth_set_security_env(struct sc_card *card,
 		}
 
 		if (pads & (~supported_pads))   {
-			sc_log(card->ctx, "No support for PAD %X",pads);
+			sc_log(card->ctx, "No support for PAD %lX", pads);
 			LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "No padding support.");
 		}
 
@@ -1109,12 +1119,16 @@ auth_compute_signature(struct sc_card *card, const unsigned char *in, size_t ile
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	else if (ilen > 96)   {
-		sc_log(card->ctx, "Illegal input length %d", ilen);
+		sc_log(card->ctx,
+		       "Illegal input length %"SC_FORMAT_LEN_SIZE_T"u",
+		       ilen);
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "Illegal input length");
 	}
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "inlen %i, outlen %i", ilen, olen);
+	sc_log(card->ctx,
+	       "inlen %"SC_FORMAT_LEN_SIZE_T"u, outlen %"SC_FORMAT_LEN_SIZE_T"u",
+	       ilen, olen);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x9E, 0x9A);
 	apdu.datalen = ilen;
@@ -1130,8 +1144,9 @@ auth_compute_signature(struct sc_card *card, const unsigned char *in, size_t ile
 	LOG_TEST_RET(card->ctx, rv, "Compute signature failed");
 
 	if (apdu.resplen > olen)   {
-		sc_log(card->ctx, "Compute signature failed: invalide response length %i",
-				apdu.resplen);
+		sc_log(card->ctx,
+		       "Compute signature failed: invalid response length %"SC_FORMAT_LEN_SIZE_T"u",
+		       apdu.resplen);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_CARD_CMD_FAILED);
 	}
 
@@ -1150,7 +1165,9 @@ auth_decipher(struct sc_card *card, const unsigned char *in, size_t inlen,
 	int rv, _inlen = inlen;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,"crgram_len %i;  outlen %i", inlen, outlen);
+	sc_log(card->ctx,
+	       "crgram_len %"SC_FORMAT_LEN_SIZE_T"u;  outlen %"SC_FORMAT_LEN_SIZE_T"u",
+	       inlen, outlen);
 	if (!out || !outlen || inlen > SC_MAX_APDU_BUFFER_SIZE)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
@@ -1304,7 +1321,8 @@ auth_generate_key(struct sc_card *card, int use_sm,
 	data->pubkey_len = apdu.resplen;
 	free(apdu.resp);
 
-	sc_log(card->ctx, "resulted public key len %i", apdu.resplen);
+	sc_log(card->ctx, "resulted public key len %"SC_FORMAT_LEN_SIZE_T"u",
+	       apdu.resplen);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
@@ -1481,7 +1499,8 @@ auth_read_component(struct sc_card *card, enum SC_CARDCTL_OBERTHUR_KEY_TYPE type
 	unsigned char resp[256];
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "num %i, outlen %i, type %i", num, outlen, type);
+	sc_log(card->ctx, "num %i, outlen %"SC_FORMAT_LEN_SIZE_T"u, type %i",
+	       num, outlen, type);
 
 	if (!outlen || type!=SC_CARDCTL_OBERTHUR_KEY_RSA_PUBLIC)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
@@ -2012,7 +2031,8 @@ write_publickey (struct sc_card *card, unsigned int offset,
 	sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
 		buf, count, debug_buf, sizeof(debug_buf));
 	sc_log(card->ctx,
-		"write_publickey in %d bytes :\n%s", count, debug_buf);
+	       "write_publickey in %"SC_FORMAT_LEN_SIZE_T"u bytes :\n%s",
+	       count, debug_buf);
 
 	if (1+offset > sizeof(rsa_der))
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid offset value");
@@ -2030,7 +2050,7 @@ write_publickey (struct sc_card *card, unsigned int offset,
 			der_size = rsa_der[1];
 	}
 
-	sc_log(card->ctx, "der_size %i",der_size);
+	sc_log(card->ctx, "der_size %"SC_FORMAT_LEN_SIZE_T"u", der_size);
 	if (offset + len < der_size + 2)
 		LOG_FUNC_RETURN(card->ctx, len);
 
@@ -2066,7 +2086,8 @@ auth_update_binary(struct sc_card *card, unsigned int offset,
 	int rv = 0;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "offset %i; count %i", offset, count);
+	sc_log(card->ctx, "offset %i; count %"SC_FORMAT_LEN_SIZE_T"u", offset,
+	       count);
 	sc_log(card->ctx, "last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 
@@ -2103,7 +2124,9 @@ auth_read_binary(struct sc_card *card, unsigned int offset,
 	char debug_buf[2048];
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,"offset %i; size %i; flags 0x%lX", offset, count, flags);
+	sc_log(card->ctx,
+	       "offset %i; size %"SC_FORMAT_LEN_SIZE_T"u; flags 0x%lX",
+	       offset, count, flags);
 	sc_log(card->ctx,"last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 
@@ -2153,8 +2176,8 @@ auth_read_binary(struct sc_card *card, unsigned int offset,
 			sc_hex_dump(card->ctx, SC_LOG_DEBUG_NORMAL,
 				buf, rv, debug_buf, sizeof(debug_buf));
 			sc_log(card->ctx,
-				"write_publickey in %d bytes :\n%s",
-				count, debug_buf);
+			       "write_publickey in %"SC_FORMAT_LEN_SIZE_T"u bytes :\n%s",
+			       count, debug_buf);
 		}
 
 		if (bn[0].data)
@@ -2180,7 +2203,9 @@ auth_read_record(struct sc_card *card, unsigned int nr_rec,
 	int rv = 0;
 	unsigned char recvbuf[SC_MAX_APDU_BUFFER_SIZE];
 
-	sc_log(card->ctx, "auth_read_record(): nr_rec %i; count %i", nr_rec, count);
+	sc_log(card->ctx,
+	       "auth_read_record(): nr_rec %i; count %"SC_FORMAT_LEN_SIZE_T"u",
+	       nr_rec, count);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xB2, nr_rec, 0);
 	apdu.p2 = (flags & SC_RECORD_EF_ID_MASK) << 3;

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -962,7 +962,9 @@ pgp_get_blob(sc_card_t *card, pgp_blob_t *blob, unsigned int id,
 			return SC_SUCCESS;
 		}
 		else
-			sc_log(card->ctx, "Not enough memory to create blob for DO %X");
+			sc_log(card->ctx,
+			       "Not enough memory to create blob for DO %X",
+			       id);
 	}
 
 	return SC_ERROR_FILE_NOT_FOUND;
@@ -1361,7 +1363,9 @@ gnuk_write_certificate(sc_card_t *card, const u8 *buf, size_t length)
 		size_t plen = MIN(length - i*256, 256);
 		u8 roundbuf[256];	/* space to build APDU data with even length for Gnuk */
 
-		sc_log(card->ctx, "Write part %d from offset 0x%X, len %d", i+1, part, plen);
+		sc_log(card->ctx,
+		       "Write part %"SC_FORMAT_LEN_SIZE_T"u from offset 0x%"SC_FORMAT_LEN_SIZE_T"X, len %"SC_FORMAT_LEN_SIZE_T"u",
+		       i+1, i*256, plen);
 
 		/* 1st chunk: P1 = 0x85, further chunks: P1 = chunk no */
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xD6, (i == 0) ? 0x85 : i, 0);
@@ -1480,7 +1484,9 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 	 * If we check here, the driver may be stuck to a limit version number of card.
 	 * 7F21 size is soft-coded, so we can check it. */
 	if (tag == DO_CERT && buf_len > priv->max_cert_size) {
-		sc_log(card->ctx, "Data size %ld exceeds DO size limit %ld.", buf_len, priv->max_cert_size);
+		sc_log(card->ctx,
+		       "Data size %"SC_FORMAT_LEN_SIZE_T"u exceeds DO size limit %"SC_FORMAT_LEN_SIZE_T"u.",
+		       buf_len, priv->max_cert_size);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_WRONG_LENGTH);
 	}
 
@@ -1791,9 +1797,13 @@ pgp_update_new_algo_attr(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_
 	r = pgp_seek_blob(card, priv->mf, (0x00C0 | key_info->keytype), &algo_blob);
 	LOG_TEST_RET(card->ctx, r, "Cannot get old algorithm attributes");
 	old_modulus_len = bebytes2ushort(algo_blob->data + 1);  /* modulus length is coded in byte 2 & 3 */
-	sc_log(card->ctx, "Old modulus length %d, new %d.", old_modulus_len, key_info->modulus_len);
+	sc_log(card->ctx,
+	       "Old modulus length %d, new %"SC_FORMAT_LEN_SIZE_T"u.",
+	       old_modulus_len, key_info->modulus_len);
 	old_exponent_len = bebytes2ushort(algo_blob->data + 3);  /* exponent length is coded in byte 3 & 4 */
-	sc_log(card->ctx, "Old exponent length %d, new %d.", old_exponent_len, key_info->exponent_len);
+	sc_log(card->ctx,
+	       "Old exponent length %d, new %"SC_FORMAT_LEN_SIZE_T"u.",
+	       old_exponent_len, key_info->exponent_len);
 
 	/* Modulus */
 	/* If passed modulus_len is zero, it means using old key size */
@@ -2103,7 +2113,9 @@ pgp_update_card_algorithms(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *ke
 	LOG_FUNC_CALLED(card->ctx);
 
 	if (id > card->algorithm_count) {
-		sc_log(card->ctx, "This key ID %d is out of the card's algorithm list.");
+		sc_log(card->ctx,
+		       "This key ID %u is out of the card's algorithm list.",
+		       (unsigned int)id);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 	}
 
@@ -2486,7 +2498,9 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 
 	/* we only support exponent of maximum 32 bits */
 	if (key_info->e_len > 4) {
-		sc_log(card->ctx, "Exponent %bit (>32) is not supported.", key_info->e_len*8);
+		sc_log(card->ctx,
+		       "Exponent %"SC_FORMAT_LEN_SIZE_T"u-bit (>32) is not supported.",
+		       key_info->e_len * 8);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 	}
 

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -483,8 +483,10 @@ static int piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx, "%02x %02x %02x %d : %d %d",
-		 ins, p1, p2, sendbuflen, card->max_send_size, card->max_recv_size);
+	sc_log(card->ctx,
+	       "%02x %02x %02x %"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u",
+	       ins, p1, p2, sendbuflen, card->max_send_size,
+	       card->max_recv_size);
 
 	rbuf = rbufinitbuf;
 	rbuflen = sizeof(rbufinitbuf);
@@ -523,14 +525,16 @@ static int piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 		 apdu.resplen = 0;
 	}
 
-	sc_log(card->ctx, "calling sc_transmit_apdu flags=%x le=%d, resplen=%d, resp=%p",
-		apdu.flags, apdu.le, apdu.resplen, apdu.resp);
+	sc_log(card->ctx,
+	       "calling sc_transmit_apdu flags=%lx le=%"SC_FORMAT_LEN_SIZE_T"u, resplen=%"SC_FORMAT_LEN_SIZE_T"u, resp=%p",
+	       apdu.flags, apdu.le, apdu.resplen, apdu.resp);
 
 	/* with new adpu.c and chaining, this actually reads the whole object */
 	r = sc_transmit_apdu(card, &apdu);
 
-	sc_log(card->ctx, "DEE r=%d apdu.resplen=%d sw1=%02x sw2=%02x",
-			r, apdu.resplen, apdu.sw1, apdu.sw2);
+	sc_log(card->ctx,
+	       "DEE r=%d apdu.resplen=%"SC_FORMAT_LEN_SIZE_T"u sw1=%02x sw2=%02x",
+	       r, apdu.resplen, apdu.sw1, apdu.sw2);
 	if (r < 0) {
 		sc_log(card->ctx, "Transmit failed");
 		goto err;
@@ -575,7 +579,9 @@ static int piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 		/* if using internal buffer, alloc new one */
 		if (rbuf == rbufinitbuf) {
 			*recvbuf = malloc(rbuflen);
-				sc_log(card->ctx, "DEE got buffer %p len %d",*recvbuf,  rbuflen);
+				sc_log(card->ctx,
+				       "DEE got buffer %p len %"SC_FORMAT_LEN_SIZE_T"u",
+				       *recvbuf, rbuflen);
 			if (*recvbuf == NULL) {
 				r = SC_ERROR_OUT_OF_MEMORY;
 				goto err;
@@ -718,8 +724,9 @@ static int piv_select_aid(sc_card_t* card, u8* aid, size_t aidlen, u8* response,
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "Got args: aid=%x, aidlen=%d, response=%x, responselen=%d",
-		aid, aidlen, response, responselen ? *responselen : 0);
+	sc_log(card->ctx,
+	       "Got args: aid=%p, aidlen=%"SC_FORMAT_LEN_SIZE_T"u, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u",
+	       aid, aidlen, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
@@ -945,7 +952,9 @@ piv_get_data(sc_card_t * card, int enumtag, u8 **buf, size_t *buf_len)
 		}
 	}
 
-	sc_log(card->ctx, "buffer for #%d *buf=0x%p len=%d", enumtag, *buf, *buf_len);
+	sc_log(card->ctx,
+	       "buffer for #%d *buf=0x%p len=%"SC_FORMAT_LEN_SIZE_T"u",
+	       enumtag, *buf, *buf_len);
 	if (*buf == NULL && *buf_len > 0) {
 		*buf = malloc(*buf_len);
 		if (*buf == NULL ) {
@@ -978,12 +987,13 @@ piv_get_cached_data(sc_card_t * card, int enumtag, u8 **buf, size_t *buf_len)
 	/* see if we have it cached */
 	if (priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_VALID) {
 
-		sc_log(card->ctx, "found #%d %p:%d %p:%d",
-				enumtag,
-				priv->obj_cache[enumtag].obj_data,
-				priv->obj_cache[enumtag].obj_len,
-				priv->obj_cache[enumtag].internal_obj_data,
-				priv->obj_cache[enumtag].internal_obj_len);
+		sc_log(card->ctx,
+		       "found #%d %p:%"SC_FORMAT_LEN_SIZE_T"u %p:%"SC_FORMAT_LEN_SIZE_T"u",
+		       enumtag,
+		       priv->obj_cache[enumtag].obj_data,
+		       priv->obj_cache[enumtag].obj_len,
+		       priv->obj_cache[enumtag].internal_obj_data,
+		       priv->obj_cache[enumtag].internal_obj_len);
 
 
 		if (priv->obj_cache[enumtag].obj_len == 0) {
@@ -1020,12 +1030,13 @@ piv_get_cached_data(sc_card_t * card, int enumtag, u8 **buf, size_t *buf_len)
 		*buf = rbuf;
 		*buf_len = r;
 
-		sc_log(card->ctx, "added #%d  %p:%d %p:%d",
-				enumtag,
-				priv->obj_cache[enumtag].obj_data,
-				priv->obj_cache[enumtag].obj_len,
-				priv->obj_cache[enumtag].internal_obj_data,
-				priv->obj_cache[enumtag].internal_obj_len);
+		sc_log(card->ctx,
+		       "added #%d  %p:%"SC_FORMAT_LEN_SIZE_T"u %p:%"SC_FORMAT_LEN_SIZE_T"u",
+		       enumtag,
+		       priv->obj_cache[enumtag].obj_data,
+		       priv->obj_cache[enumtag].obj_len,
+		       priv->obj_cache[enumtag].internal_obj_data,
+		       priv->obj_cache[enumtag].internal_obj_len);
 
 	} else if (r == 0 || r == SC_ERROR_FILE_NOT_FOUND) {
 		r = SC_ERROR_FILE_NOT_FOUND;
@@ -1053,9 +1064,11 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
 
 	/* if already cached */
 	if (priv->obj_cache[enumtag].internal_obj_data && priv->obj_cache[enumtag].internal_obj_len) {
-		sc_log(card->ctx, "#%d found internal %p:%d", enumtag,
-				priv->obj_cache[enumtag].internal_obj_data,
-				priv->obj_cache[enumtag].internal_obj_len);
+		sc_log(card->ctx,
+		       "#%d found internal %p:%"SC_FORMAT_LEN_SIZE_T"u",
+		       enumtag,
+		       priv->obj_cache[enumtag].internal_obj_data,
+		       priv->obj_cache[enumtag].internal_obj_len);
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 	}
 
@@ -1127,9 +1140,10 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 	}
 
-	sc_log(card->ctx, "added #%d internal %p:%d", enumtag,
-		priv->obj_cache[enumtag].internal_obj_data,
-		priv->obj_cache[enumtag].internal_obj_len);
+	sc_log(card->ctx, "added #%d internal %p:%"SC_FORMAT_LEN_SIZE_T"u",
+	       enumtag,
+	       priv->obj_cache[enumtag].internal_obj_data,
+	       priv->obj_cache[enumtag].internal_obj_len);
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
@@ -1166,7 +1180,9 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 				r = SC_ERROR_FILE_NOT_FOUND;
 				goto err;
 			}
-			sc_log(card->ctx, "DEE rbuf=%p,rbuflen=%d,",rbuf, rbuflen);
+			sc_log(card->ctx,
+			       "DEE rbuf=%p,rbuflen=%"SC_FORMAT_LEN_SIZE_T"u,",
+			       rbuf, rbuflen);
 			body = sc_asn1_find_tag(card->ctx, rbuf, rbuflen, rbuf[0], &bodylen);
 			if (body == NULL) {
 				/* if missing, assume its the body */
@@ -1176,8 +1192,9 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 				goto err;
 			}
 			if (bodylen > body - rbuf + rbuflen) {
-				sc_log(card->ctx, " ***** tag length > then data: %d>%d+%d",
-					bodylen , body - rbuf, rbuflen);
+				sc_log(card->ctx,
+				       " ***** tag length > then data: %"SC_FORMAT_LEN_SIZE_T"u>%"SC_FORMAT_LEN_PTRDIFF_T"u+%"SC_FORMAT_LEN_SIZE_T"u",
+				       bodylen, body - rbuf, rbuflen);
 				r = SC_ERROR_INVALID_DATA;
 				goto err;
 			}
@@ -1264,7 +1281,7 @@ piv_write_certificate(sc_card_t *card, const u8* buf, size_t count, unsigned lon
 	size_t sbuflen;
 	size_t taglen;
 
-	sc_log(card->ctx, "DEE cert len=%d",count);
+	sc_log(card->ctx, "DEE cert len=%"SC_FORMAT_LEN_SIZE_T"u", count);
 	taglen = put_tag_and_len(0x70, count, NULL)
 		+ put_tag_and_len(0x71, 1, NULL)
 		+ put_tag_and_len(0xFE, 0, NULL);
@@ -1285,7 +1302,8 @@ piv_write_certificate(sc_card_t *card, const u8* buf, size_t count, unsigned lon
 	*p++ = (flags)? 0x01:0x00; /* certinfo, i.e. gziped? */
 	put_tag_and_len(0xFE,0,&p); /* LRC tag */
 
-	sc_log(card->ctx, "DEE buf %p len %d %d", sbuf, p -sbuf, sbuflen);
+	sc_log(card->ctx, "DEE buf %p len %"SC_FORMAT_LEN_PTRDIFF_T"u %"SC_FORMAT_LEN_SIZE_T"u",
+	       sbuf, p - sbuf, sbuflen);
 
 	enumtag = piv_objects[priv->selected_obj].enumtag;
 	r = piv_put_data(card, enumtag, sbuf, sbuflen);
@@ -1691,8 +1709,9 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	 */
 	nonce = malloc(witness_len);
 	if(!nonce) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "OOM allocating nonce\n",
-				witness_len, plain_text_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+			 "OOM allocating nonce (%"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u)\n",
+			 witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
@@ -1700,8 +1719,9 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 
 	r = RAND_bytes(nonce, witness_len);
 	if(!r) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Generating random for nonce\n",
-				witness_len, plain_text_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+			 "Generating random for nonce (%"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u)\n",
+			 witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
@@ -2090,8 +2110,9 @@ piv_get_serial_nr_from_CHUI(sc_card_t* card, sc_serial_number_t* serial)
 					gbits = gbits | guid[i]; /* if all are zero, gbits will be zero */
 				}
 			}
-			sc_log(card->ctx, "fascn=%p,fascnlen=%d,guid=%p,guidlen=%d,gbits=%2.2x",
-					fascn, fascnlen, guid, guidlen, gbits);
+			sc_log(card->ctx,
+			       "fascn=%p,fascnlen=%"SC_FORMAT_LEN_SIZE_T"u,guid=%p,guidlen=%"SC_FORMAT_LEN_SIZE_T"u,gbits=%2.2x",
+			       fascn, fascnlen, guid, guidlen, gbits);
 
 			if (fascn && fascnlen == 25) {
 				/* test if guid and the fascn starts with ;9999 (in ISO 4bit + partiy code) */
@@ -2205,7 +2226,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx, "challenge len=%d",len);
+	sc_log(card->ctx, "challenge len=%"SC_FORMAT_LEN_SIZE_T"u", len);
 
 	r = sc_lock(card);
 	if (r != SC_SUCCESS)
@@ -2258,9 +2279,10 @@ piv_set_security_env(sc_card_t *card, const sc_security_env_t *env, int se_num)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx, "flags=%08x op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%d",
-			env->flags, env->operation, env->algorithm, env->algorithm_flags,
-			env->algorithm_ref, env->key_ref[0], env->key_ref_len);
+	sc_log(card->ctx,
+	       "flags=%08lx op=%d alg=%d algf=%08x algr=%08x kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u",
+	       env->flags, env->operation, env->algorithm, env->algorithm_flags,
+	       env->algorithm_ref, env->key_ref[0], env->key_ref_len);
 
 	priv->operation = env->operation;
 	priv->algorithm = env->algorithm;
@@ -2401,7 +2423,9 @@ piv_compute_signature(sc_card_t *card, const u8 * data, size_t datalen,
 	if (priv->alg_id == 0x11 || priv->alg_id == 0x14 ) {
 		nLen = (priv->key_size + 7) / 8;
 		if (outlen < 2*nLen) {
-			sc_log(card->ctx, " output too small for EC signature %d < %d", outlen, 2*nLen);
+			sc_log(card->ctx,
+			       " output too small for EC signature %"SC_FORMAT_LEN_SIZE_T"u < %"SC_FORMAT_LEN_SIZE_T"u",
+			       outlen, 2 * nLen);
 			r = SC_ERROR_INVALID_DATA;
 			goto err;
 		}
@@ -2582,7 +2606,8 @@ static int piv_process_discovery(sc_card_t *card)
 		goto err;
 	}
 
-	sc_log(card->ctx, "Discovery = %p:%d",rbuf, rbuflen);
+	sc_log(card->ctx, "Discovery = %p:%"SC_FORMAT_LEN_SIZE_T"u", rbuf,
+	       rbuflen);
 	/* the object is now cached, see what we have */
 	if (rbuflen != 0) {
 		body = rbuf;
@@ -2592,11 +2617,14 @@ static int piv_process_discovery(sc_card_t *card)
 			goto err;
 		}
 
-	sc_log(card->ctx, "Discovery 0x%2.2x 0x%2.2x %p:%d", cla_out, tag_out, body, bodylen);
+	sc_log(card->ctx,
+	       "Discovery 0x%2.2x 0x%2.2x %p:%"SC_FORMAT_LEN_SIZE_T"u",
+	       cla_out, tag_out, body, bodylen);
 	if ( cla_out+tag_out == 0x7E && body != NULL && bodylen != 0) {
 		aidlen = 0;
 		aid = sc_asn1_find_tag(card->ctx, body, bodylen, 0x4F, &aidlen);
-		sc_log(card->ctx, "Discovery aid=%p:%d",aid,aidlen);
+		sc_log(card->ctx, "Discovery aid=%p:%"SC_FORMAT_LEN_SIZE_T"u",
+		       aid, aidlen);
 			if (aid == NULL || aidlen < piv_aids[0].len_short ||
 				memcmp(aid,piv_aids[0].value,piv_aids[0].len_short) != 0) { /*TODO look at long */
 				sc_log(card->ctx, "Discovery object not PIV");
@@ -2604,7 +2632,9 @@ static int piv_process_discovery(sc_card_t *card)
 				goto err;
 			}
 			pinp = sc_asn1_find_tag(card->ctx, body, bodylen, 0x5F2F, &pinplen);
-			sc_log(card->ctx, "Discovery pinp=%p:%d",pinp,pinplen);
+			sc_log(card->ctx,
+			       "Discovery pinp=%p:%"SC_FORMAT_LEN_SIZE_T"u",
+			       pinp, pinplen);
 			if (pinp && pinplen == 2) {
 				sc_log(card->ctx, "Discovery pinp flags=0x%2.2x 0x%2.2x",*pinp, *(pinp+1));
 				r = SC_SUCCESS;
@@ -2831,10 +2861,11 @@ piv_process_history(sc_card_t *card)
 
 			certobj = NULL;
 
-			sc_log(card->ctx, "Added from off card file #%d %p:%d 0x%02X",
-				enumtag,
-				priv->obj_cache[enumtag].obj_data,
-				priv->obj_cache[enumtag].obj_len, *keyref);
+			sc_log(card->ctx,
+			       "Added from off card file #%d %p:%"SC_FORMAT_LEN_SIZE_T"u 0x%02X",
+			       enumtag,
+			       priv->obj_cache[enumtag].obj_data,
+			       priv->obj_cache[enumtag].obj_len, *keyref);
 
 			bodylen -= (seqlen + seq - seqtag);
 			seq += seqlen;
@@ -2861,10 +2892,13 @@ piv_finish(sc_card_t *card)
 		if (priv->offCardCertURL)
 			free(priv->offCardCertURL);
 		for (i = 0; i < PIV_OBJ_LAST_ENUM - 1; i++) {
-			sc_log(card->ctx, "DEE freeing #%d, 0x%02x %p:%d %p:%d", i,
-				priv->obj_cache[i].flags,
-				priv->obj_cache[i].obj_data, priv->obj_cache[i].obj_len,
-				priv->obj_cache[i].internal_obj_data, priv->obj_cache[i].internal_obj_len);
+			sc_log(card->ctx,
+			       "DEE freeing #%d, 0x%02x %p:%"SC_FORMAT_LEN_SIZE_T"u %p:%"SC_FORMAT_LEN_SIZE_T"u",
+			       i, priv->obj_cache[i].flags,
+			       priv->obj_cache[i].obj_data,
+			       priv->obj_cache[i].obj_len,
+			       priv->obj_cache[i].internal_obj_data,
+			       priv->obj_cache[i].internal_obj_len);
 			if (priv->obj_cache[i].obj_data)
 				free(priv->obj_cache[i].obj_data);
 			if (priv->obj_cache[i].internal_obj_data)
@@ -2994,8 +3028,9 @@ static int piv_init(sc_card_t *card)
 	if (!priv || card->type == -1)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NO_CARD_SUPPORT);
 
-	sc_log(card->ctx, "Max send = %d recv = %d card->type = %d",
-			card->max_send_size, card->max_recv_size, card->type);
+	sc_log(card->ctx,
+	       "Max send = %"SC_FORMAT_LEN_SIZE_T"u recv = %"SC_FORMAT_LEN_SIZE_T"u card->type = %d",
+	       card->max_send_size, card->max_recv_size, card->type);
 	card->cla = 0x00;
 	if(card->name == NULL)
 		card->name = "PIV-II card";

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1676,8 +1676,9 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	plain_text_len += tmplen;
 
 	if (plain_text_len != witness_len) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Encrypted and decrypted lengths do not match: %zu:%zu\n",
-				witness_len, plain_text_len);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+			 "Encrypted and decrypted lengths do not match: %"SC_FORMAT_LEN_SIZE_T"u:%"SC_FORMAT_LEN_SIZE_T"u\n",
+			 witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
@@ -1801,8 +1802,9 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	decrypted_reponse_len += tmplen;
 
 	if (decrypted_reponse_len != nonce_len || memcmp(nonce, decrypted_reponse, nonce_len) != 0) {
-		sc_log(card->ctx, "mutual authentication failed, card returned wrong value %zu:%zu",
-				decrypted_reponse_len, nonce_len);
+		sc_log(card->ctx,
+		       "mutual authentication failed, card returned wrong value %"SC_FORMAT_LEN_SIZE_T"u:%"SC_FORMAT_LEN_SIZE_T"u",
+		       decrypted_reponse_len, nonce_len);
 		r = SC_ERROR_DECRYPT_FAILED;
 		goto err;
 	}
@@ -2005,7 +2007,7 @@ static int piv_general_external_authenticate(sc_card_t *card,
 	/* Sanity check the lengths again */
 	if(output_len != (size_t)tmplen) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Allocated and computed lengths do not match! "
-				"Expected %zd, found: %d\n", output_len, tmplen);
+			 "Expected %"SC_FORMAT_LEN_SIZE_T"d, found: %d\n", output_len, tmplen);
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}

--- a/src/libopensc/card-rtecp.c
+++ b/src/libopensc/card-rtecp.c
@@ -435,7 +435,8 @@ static int rtecp_change_reference_data(sc_card_t *card, unsigned int type,
 	int transmits_num, r;
 
 	assert(card && card->ctx && newref);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "newlen = %u\n", newlen);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "newlen = %"SC_FORMAT_LEN_SIZE_T"u\n", newlen);
 	if (newlen > 0xFFFF)
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 	if (type == SC_AC_CHV && old && oldlen != 0)

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -550,8 +550,9 @@ static int set_sec_attr_from_acl(sc_card_t *card, sc_file_t *file)
 		{
 			/* AccessMode.[conv_attr[i].sec_attr_pos] */
 			attr[0] |= 1 << conv_attr[i].sec_attr_pos;
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "AccessMode.%u, attr[0]=0x%x",
-					conv_attr[i].sec_attr_pos, attr[0]);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+				 "AccessMode.%"SC_FORMAT_LEN_SIZE_T"u, attr[0]=0x%x",
+				 conv_attr[i].sec_attr_pos, attr[0]);
 			attr[1 + conv_attr[i].sec_attr_pos] = (u8)entry->method;
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "method %u", (u8)entry->method);
 			if (entry->method == SC_AC_CHV)
@@ -979,7 +980,9 @@ static int rutoken_cipher_p(sc_card_t *card, const u8 * crgram, size_t crgram_le
 	sc_apdu_t apdu;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_NORMAL);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, ": crgram_len %i; outlen %i", crgram_len, outlen);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 ": crgram_len %"SC_FORMAT_LEN_SIZE_T"u; outlen %"SC_FORMAT_LEN_SIZE_T"u",
+		 crgram_len, outlen);
 
 	if (!out)
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
@@ -1022,7 +1025,9 @@ static int rutoken_cipher_p(sc_card_t *card, const u8 * crgram, size_t crgram_le
 			}
 		}
 	} while (ret == SC_SUCCESS  &&  crgram_len != 0);
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "len out cipher %d\n", outlen - outlen_tail);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "len out cipher %"SC_FORMAT_LEN_SIZE_T"u\n",
+		 outlen - outlen_tail);
 	if (ret == SC_SUCCESS)
 		ret = (outlen_tail == 0) ? (int)outlen : SC_ERROR_WRONG_LENGTH;
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, ret);
@@ -1240,7 +1245,7 @@ static int rutoken_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 			ret = rutoken_format(card, 0x7b); /* APDU: FORMAT END */
 			break;
 		default:
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "cmd = %d", cmd);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "cmd = %lu", cmd);
 			ret = SC_ERROR_NOT_SUPPORTED;
 			break;
 		}

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -486,7 +486,9 @@ static int sc_hsm_decode_ecdsa_signature(sc_card_t *card,
 		fieldsizebytes = 64;
 	}
 
-	sc_log(card->ctx, "Field size %d, signature buffer size %d", fieldsizebytes, outlen);
+	sc_log(card->ctx,
+	       "Field size %"SC_FORMAT_LEN_SIZE_T"u, signature buffer size %"SC_FORMAT_LEN_SIZE_T"u",
+	       fieldsizebytes, outlen);
 
 	if (outlen < (fieldsizebytes * 2)) {
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_DATA, "output too small for EC signature");

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -272,7 +272,8 @@ static int process_fci_v3_4(sc_context_t *ctx, sc_file_t *file,
 	size_t taglen, len = buflen;
 	const u8 *tag = NULL, *p;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "processing %d FCI bytes\n", buflen);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "processing %"SC_FORMAT_LEN_SIZE_T"u FCI bytes\n", buflen);
 
 	if (buflen < 2)
 		return SC_ERROR_INTERNAL;
@@ -307,7 +308,8 @@ static int process_fcp_v3_4(sc_context_t *ctx, sc_file_t *file,
 	size_t taglen, len = buflen;
 	const u8 *tag = NULL, *p;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "processing %d FCP bytes\n", buflen);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "processing %"SC_FORMAT_LEN_SIZE_T"u FCP bytes\n", buflen);
 
 	if (buflen < 2)
 		return SC_ERROR_INTERNAL;
@@ -640,11 +642,12 @@ static int starcos_select_file(sc_card_t *card,
 		pbuf[0] = '\0';
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"current path (%s, %s): %s (len: %u)\n",
-		(card->cache.current_path.type==SC_PATH_TYPE_DF_NAME?"aid":"path"),
-		(card->cache.valid?"valid":"invalid"), pbuf,
-		card->cache.current_path.len);
-  
+		 "current path (%s, %s): %s (len: %"SC_FORMAT_LEN_SIZE_T"u)\n",
+		 card->cache.current_path.type == SC_PATH_TYPE_DF_NAME ?
+		 "aid" : "path",
+		 card->cache.valid ? "valid" : "invalid", pbuf,
+		 card->cache.current_path.len);
+
 	memcpy(path, in_path->value, in_path->len);
 	pathlen = in_path->len;
 

--- a/src/libopensc/card-tcos.c
+++ b/src/libopensc/card-tcos.c
@@ -472,8 +472,8 @@ static int tcos_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, r, "List Dir failed");
 		if (apdu.resplen > buflen) return SC_ERROR_BUFFER_TOO_SMALL;
 		sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
-			"got %d %s-FileIDs\n", apdu.resplen/2,
-			p1==1 ? "DF" : "EF");
+			 "got %"SC_FORMAT_LEN_SIZE_T"u %s-FileIDs\n",
+			 apdu.resplen / 2, p1 == 1 ? "DF" : "EF");
 
 		memcpy(buf, apdu.resp, apdu.resplen);
 		buf += apdu.resplen;
@@ -530,8 +530,8 @@ static int tcos_set_security_env(sc_card_t *card, const sc_security_env_t *env, 
 			"No Key-Reference in SecEnvironment\n");
 	else
 		sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
-			"Key-Reference %02X (len=%d)\n",
-			env->key_ref[0], env->key_ref_len);
+			 "Key-Reference %02X (len=%"SC_FORMAT_LEN_SIZE_T"u)\n",
+			 env->key_ref[0], env->key_ref_len);
 	/* Key-Reference 0x80 ?? */
 	default_key= !(env->flags & SC_SEC_ENV_KEY_REF_PRESENT) || (env->key_ref_len==1 && env->key_ref[0]==0x80);
 	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -600,7 +600,7 @@ static int westcos_create_file(sc_card_t *card, struct sc_file *file)
 		p2 = (file->id) % 256;
 	}
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"create file %s, id %X size %d\n",
+		 "create file %s, id %X size %"SC_FORMAT_LEN_SIZE_T"u\n",
 		 file->path.value, file->id, file->size);
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xE0, p1, p2);
 	apdu.cla = 0x80;
@@ -866,7 +866,7 @@ static int westcos_card_ctl(sc_card_t * card, unsigned long cmd, void *ptr)
 	if (card == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"westcos_card_ctl cmd = %X\n", cmd);
+		"westcos_card_ctl cmd = %lX\n", cmd);
 	priv_data = (priv_data_t *) card->drv_data;
 	switch (cmd) {
 	case SC_CARDCTL_GET_DEFAULT_KEY:
@@ -1110,9 +1110,11 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 
 	if (card == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
+
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"westcos_sign_decipher outlen=%d\n", outlen);
-	
+		 "westcos_sign_decipher outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
+		 outlen);
+
 #ifndef ENABLE_OPENSSL
 	r = SC_ERROR_NOT_SUPPORTED;
 #else
@@ -1176,7 +1178,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 	BIO_set_mem_eof_return(mem, -1);
 	if (!d2i_RSAPrivateKey_bio(mem, &rsa)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-			"RSA key invalid, %d\n", ERR_get_error());
+			"RSA key invalid, %lu\n", ERR_get_error());
 		r = SC_ERROR_UNKNOWN;
 		goto out;
 	}
@@ -1199,7 +1201,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 
 #endif
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-				"Decipher error %d\n", ERR_get_error());
+				"Decipher error %lu\n", ERR_get_error());
 			r = SC_ERROR_UNKNOWN;
 			goto out;
 		}
@@ -1215,7 +1217,7 @@ static int westcos_sign_decipher(int mode, sc_card_t *card,
 
 #endif
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-				"Signature error %d\n", ERR_get_error());
+				"Signature error %lu\n", ERR_get_error());
 			r = SC_ERROR_UNKNOWN;
 			goto out;
 		}

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -300,8 +300,10 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 	card->max_recv_size = sc_get_max_recv_size(card);
 	card->max_send_size = sc_get_max_send_size(card);
 
-	sc_log(ctx, "card info name:'%s', type:%i, flags:0x%X, max_send/recv_size:%i/%i",
-		card->name, card->type, card->flags, card->max_send_size, card->max_recv_size);
+	sc_log(ctx,
+	       "card info name:'%s', type:%i, flags:0x%lX, max_send/recv_size:%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
+	       card->name, card->type, card->flags, card->max_send_size,
+	       card->max_recv_size);
 
 #ifdef ENABLE_SM
         /* Check, if secure messaging module present. */
@@ -496,7 +498,9 @@ int sc_create_file(sc_card_t *card, sc_file_t *file)
 	if (r != SC_SUCCESS)
 		pbuf[0] = '\0';
 
-	sc_log(card->ctx, "called; type=%d, path=%s, id=%04i, size=%u",  in_path->type, pbuf, file->id, file->size);
+	sc_log(card->ctx,
+	       "called; type=%d, path=%s, id=%04i, size=%"SC_FORMAT_LEN_SIZE_T"u",
+	       in_path->type, pbuf, file->id, file->size);
 	/* ISO 7816-4: "Number of data bytes in the file, including structural information if any"
 	 * can not be bigger than two bytes */
 	if (file->size > 0xFFFF)
@@ -535,7 +539,8 @@ int sc_read_binary(sc_card_t *card, unsigned int idx,
 	int r;
 
 	assert(card != NULL && card->ops != NULL && buf != NULL);
-	sc_log(card->ctx, "called; %d bytes at index %d", count, idx);
+	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
+	       count, idx);
 	if (count == 0)
 		return 0;
 
@@ -585,7 +590,8 @@ int sc_write_binary(sc_card_t *card, unsigned int idx,
 	int r;
 
 	assert(card != NULL && card->ops != NULL && buf != NULL);
-	sc_log(card->ctx, "called; %d bytes at index %d", count, idx);
+	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
+	       count, idx);
 	if (count == 0)
 		LOG_FUNC_RETURN(card->ctx, 0);
 	if (card->ops->write_binary == NULL)
@@ -628,7 +634,8 @@ int sc_update_binary(sc_card_t *card, unsigned int idx,
 	int r;
 
 	assert(card != NULL && card->ops != NULL && buf != NULL);
-	sc_log(card->ctx, "called; %d bytes at index %d", count, idx);
+	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
+	       count, idx);
 	if (count == 0)
 		return 0;
 
@@ -679,7 +686,9 @@ int sc_erase_binary(struct sc_card *card, unsigned int offs, size_t count,  unsi
 	int r;
 
 	assert(card != NULL && card->ops != NULL);
-	sc_log(card->ctx, "called; erase %d bytes from offset %d", count, offs);
+	sc_log(card->ctx,
+	       "called; erase %"SC_FORMAT_LEN_SIZE_T"u bytes from offset %d",
+	       count, offs);
 
 	if (card->ops->erase_binary == NULL)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
@@ -1181,9 +1190,11 @@ void sc_print_cache(struct sc_card *card)   {
 				sc_print_path(&card->cache.current_ef->path));
 
 	if (card->cache.current_df)
-		sc_log(ctx, "current_df(type=%i, aid_len=%i) %s", card->cache.current_df->path.type,
-				card->cache.current_df->path.aid.len,
-				sc_print_path(&card->cache.current_df->path));
+		sc_log(ctx,
+		       "current_df(type=%i, aid_len=%"SC_FORMAT_LEN_SIZE_T"u) %s",
+		       card->cache.current_df->path.type,
+		       card->cache.current_df->path.aid.len,
+		       sc_print_path(&card->cache.current_df->path));
 }
 
 int sc_copy_ec_params(struct sc_ec_parameters *dst, struct sc_ec_parameters *src)

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -1239,7 +1239,7 @@ sc_card_sm_load(struct sc_card *card, const char *module_path, const char *in_mo
 	char *module = NULL;
 #ifdef _WIN32
 	char temp_path[PATH_MAX];
-	int temp_len;
+	size_t temp_len;
 	const char path_delim = '\\';
 #else
 	const char path_delim = '/';

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -427,7 +427,7 @@ static void *load_dynamic_driver(sc_context_t *ctx, void **dll, const char *name
 	const char *(**tmodv)(void) = &modversion;
 
 	if (name == NULL) { /* should not occurr, but... */
-		sc_log(ctx, "No module specified", name);
+		sc_log(ctx, "No module specified");
 		return NULL;
 	}
 	libname = find_library(ctx, name);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -140,8 +140,7 @@ sc_ctx_win32_get_config_value(char *name_env, char *name_reg, char *name_key,
 #ifdef _WIN32
 	char temp[PATH_MAX + 1];
 	char *value = NULL;
-	int temp_len = PATH_MAX;
-	int rv = SC_ERROR_INTERNAL;
+	DWORD temp_len = PATH_MAX;
 	long rc;
 	HKEY hKey;
 

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -349,7 +349,7 @@ int dnie_read_file(sc_card_t * card,
 	}
  dnie_read_file_end:
 	if (msg)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	LOG_FUNC_RETURN(ctx, res);
 }
 
@@ -398,7 +398,7 @@ static int dnie_read_certificate(sc_card_t * card, char *certpath, X509 ** cert)
 	sc_file_free(file);
 	file = NULL;
 	if (msg)
-		sc_log(card->ctx, msg);
+		sc_log(card->ctx, "%s", msg);
 	LOG_FUNC_RETURN(card->ctx, res);
 }
 

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -327,7 +327,8 @@ int dnie_read_file(sc_card_t * card,
 		goto dnie_read_file_err;
 	}
 	/* call sc_read_binary() to retrieve data */
-	sc_log(ctx, "read_binary(): expected '%d' bytes", fsize);
+	sc_log(ctx, "read_binary(): expected '%"SC_FORMAT_LEN_SIZE_T"u' bytes",
+	       fsize);
 	res = sc_read_binary(card, 0, data, fsize, 0L);
 	if (res < 0) {		/* read_binary returns number of bytes readed */
 		res = SC_ERROR_CARD_CMD_FAILED;

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -414,7 +414,7 @@ static int cwa_verify_icc_certificates(sc_card_t * card,
 	if (sub_ca_key)
 		EVP_PKEY_free(sub_ca_key);
 	if (res != SC_SUCCESS)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	LOG_FUNC_RETURN(ctx, res);
 }
 
@@ -707,7 +707,7 @@ static int cwa_prepare_external_auth(sc_card_t * card,
 	}
 
 	if (res != SC_SUCCESS)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	LOG_FUNC_RETURN(ctx, res);
 }
 
@@ -822,7 +822,7 @@ static int cwa_compute_session_keys(sc_card_t * card)
 		free(sha_data);
 	}
 	if (res != SC_SUCCESS)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	else {
 		sc_log(ctx, "Kenc: %s", sc_dump_hex(sm->session_enc, 16));
 		sc_log(ctx, "Kmac: %s", sc_dump_hex(sm->session_mac, 16));
@@ -1015,7 +1015,7 @@ static int cwa_verify_internal_auth(sc_card_t * card,
 	if (sigbn)
 		BN_free(sigbn);
 	if (res != SC_SUCCESS)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	LOG_FUNC_RETURN(ctx, res);
 }
 
@@ -1096,7 +1096,7 @@ int cwa_create_secure_channel(sc_card_t * card,
 		res = provider->cwa_create_pre_ops(card, provider);
 		if (res != SC_SUCCESS) {
 			msg = "Create SM: provider pre_ops() failed";
-			sc_log(ctx, msg);
+			sc_log(ctx, "%s", msg);
 			goto csc_end;
 		}
 	}
@@ -1107,12 +1107,12 @@ int cwa_create_secure_channel(sc_card_t * card,
 		res = provider->cwa_get_sn_icc(card);
 		if (res != SC_SUCCESS) {
 			msg = "Retrieve ICC failed";
-			sc_log(ctx, msg);
+			sc_log(ctx, "%s", msg);
 			goto csc_end;
 		}
 	} else {
 		msg = "Don't know how to obtain ICC serial number";
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 		res = SC_ERROR_INTERNAL;
 		goto csc_end;
 	}
@@ -1386,7 +1386,7 @@ int cwa_create_secure_channel(sc_card_t * card,
 		EVP_PKEY_free(ifd_privkey);
 	/* setup SM state according result */
 	if (res != SC_SUCCESS) {
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 		card->sm_ctx.sm_mode = SM_MODE_NONE;
 	} else {
 		card->sm_ctx.sm_mode = SM_MODE_TRANSMIT;
@@ -1593,7 +1593,7 @@ encode_end:
 		free(apdubuf);
 encode_end_apdu_valid:
 	if (msg)
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	free(msgbuf);
 	free(cryptbuf);
 	free(ccbuf);
@@ -1852,7 +1852,7 @@ int cwa_decode_response(sc_card_t * card,
 	if (ccbuf)
 		free(ccbuf);
 	if (msg) {
-		sc_log(ctx, msg);
+		sc_log(ctx, "%s", msg);
 	} else {
 		cwa_trace_apdu(card, apdu, 1);
 	}			/* trace apdu response */

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -120,19 +120,19 @@ static void cwa_trace_apdu(sc_card_t * card, sc_apdu_t * apdu, int flag)
 		if (apdu->datalen > 0) {	/* apdu data to show */
 			buf = cwa_hexdump(apdu->data, apdu->datalen);
 			sc_log(card->ctx,
-			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02X Le: %02X DATA: [%5u bytes]\n%s======================================================================\n",
+			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02"SC_FORMAT_LEN_SIZE_T"X Le: %02"SC_FORMAT_LEN_SIZE_T"X DATA: [%5"SC_FORMAT_LEN_SIZE_T"u bytes]\n%s======================================================================\n",
 			       apdu->cla, apdu->ins, apdu->p1, apdu->p2,
 			       apdu->lc, apdu->le, apdu->datalen, buf);
 		} else {	/* apdu data field is empty */
 			sc_log(card->ctx,
-			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02X Le: %02X (NO DATA)\n======================================================================\n",
+			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02"SC_FORMAT_LEN_SIZE_T"X Le: %02"SC_FORMAT_LEN_SIZE_T"X (NO DATA)\n======================================================================\n",
 			       apdu->cla, apdu->ins, apdu->p1, apdu->p2,
 			       apdu->lc, apdu->le);
 		}
 	} else {		/* apdu response */
 		buf = cwa_hexdump(apdu->resp, apdu->resplen);
 		sc_log(card->ctx,
-		       "\nAPDU response after decode: ==========================================\nSW1: %02X SW2: %02X RESP: [%5u bytes]\n%s======================================================================\n",
+		       "\nAPDU response after decode: ==========================================\nSW1: %02X SW2: %02X RESP: [%5"SC_FORMAT_LEN_SIZE_T"u bytes]\n%s======================================================================\n",
 		       apdu->sw1, apdu->sw2, apdu->resplen, buf);
 	}
 #endif
@@ -338,7 +338,7 @@ static int cwa_parse_tlv(sc_card_t * card,
 		}
 		tlv->data = buffer + n + j;
 		tlv->buflen = j + tlv->len;;
-		sc_log(ctx, "Found Tag: '0x%02X': Length: '%d 'Value:\n%s",
+		sc_log(ctx, "Found Tag: '0x%02X': Length: '%"SC_FORMAT_LEN_SIZE_T"u' Value:\n%s",
 		       tlv->tag, tlv->len, sc_dump_hex(tlv->data, tlv->len));
 		/* set index to next Tag to jump to */
 		next = tlv->buflen;
@@ -1571,7 +1571,7 @@ int cwa_encode_apdu(sc_card_t * card,
 
 	/* compose and add computed MAC TLV to result buffer */
 	tlv_len = (card->atr.value[15] >= DNIE_30_VERSION)? 8 : 4;
-	sc_log(ctx, "Using TLV lenght: %d", tlv_len);
+	sc_log(ctx, "Using TLV lenght: %"SC_FORMAT_LEN_SIZE_T"u", tlv_len);
 	res = cwa_compose_tlv(card, 0x8E, tlv_len, macbuf, &apdubuf, &apdulen);
 	if (res != SC_SUCCESS) {
 		msg = "Encode APDU compose_tlv(0x87) failed";

--- a/src/libopensc/ef-atr.c
+++ b/src/libopensc/ef-atr.c
@@ -64,8 +64,10 @@ sc_parse_ef_atr_content(struct sc_card *card, unsigned char *buf, size_t buflen)
 		ef_atr.df_selection =  *(tag + 0);
 		ef_atr.unit_size = *(tag + 1);
 		ef_atr.card_capabilities = *(tag + 2);
-		sc_log(ctx, "EF.ATR: DF selection %X, unit_size %X, card caps %X", 
-				ef_atr.df_selection, ef_atr.unit_size, ef_atr.card_capabilities);
+		sc_log(ctx,
+		       "EF.ATR: DF selection %X, unit_size %"SC_FORMAT_LEN_SIZE_T"X, card caps %X",
+		       ef_atr.df_selection, ef_atr.unit_size,
+		       ef_atr.card_capabilities);
 	}
 
 	if (ef_atr.card_capabilities & ISO7816_CAP_EXTENDED_LENGTH_INFO) {
@@ -77,9 +79,10 @@ sc_parse_ef_atr_content(struct sc_card *card, unsigned char *buf, size_t buflen)
 			 * We skip parsing the nested DOs and jump directly to the numbers */
 			ef_atr.max_command_apdu = bebytes2ushort(tag + 2);
 			ef_atr.max_response_apdu = bebytes2ushort(tag + 6);
-			sc_log(ctx, "EF.ATR: Biggest command APDU %u bytes, response APDU %u", 
-					(unsigned long) ef_atr.max_command_apdu,
-					(unsigned long) ef_atr.max_response_apdu);
+			sc_log(ctx,
+			       "EF.ATR: Biggest command APDU %"SC_FORMAT_LEN_SIZE_T"u bytes, response APDU %"SC_FORMAT_LEN_SIZE_T"u",
+			       ef_atr.max_command_apdu,
+			       ef_atr.max_response_apdu);
 		}
 	}
 

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -330,7 +330,9 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 
 		data += size_size + 1;
 		data_len = size;
-		sc_log(ctx, "IASECC_SDO_TEMPLATE: size %i, size_size %i",  size, size_size);
+		sc_log(ctx,
+		       "IASECC_SDO_TEMPLATE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %"SC_FORMAT_LEN_SIZE_T"u",
+		       size, size_size);
 
 		if (*data != IASECC_SDO_TAG_HEADER)
 			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
@@ -346,11 +348,15 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 
 		data += 3 + size_size;
 		data_len = size;
-		sc_log(ctx, "IASECC_SDO_TEMPLATE SE: size %i, size_size %i",  size, size_size);
+		sc_log(ctx,
+		       "IASECC_SDO_TEMPLATE SE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %"SC_FORMAT_LEN_SIZE_T"u",
+		       size, size_size);
 	}
 
 	if (*data != IASECC_SDO_CLASS_SE)   {
-		sc_log(ctx, "Invalid SE tag 0x%X; data length %i", *data, data_len);
+		sc_log(ctx,
+		       "Invalid SE tag 0x%X; data length %"SC_FORMAT_LEN_SIZE_T"u",
+		       *data, data_len);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
 	}
 
@@ -423,7 +429,9 @@ iasecc_parse_get_tlv(struct sc_card *card, unsigned char *data, struct iasecc_ex
 
 	tlv->on_card = 1;
 
-	sc_log(ctx, "iasecc_parse_get_tlv() parsed %i bytes", tag_len + size_len + tlv->size);
+	sc_log(ctx,
+	       "iasecc_parse_get_tlv() parsed %"SC_FORMAT_LEN_SIZE_T"u bytes",
+	       tag_len + size_len + tlv->size);
 	return tag_len + size_len + tlv->size;
 }
 
@@ -442,7 +450,9 @@ iasecc_parse_chv(struct sc_card *card, unsigned char *data, size_t data_len, str
 		rv = iasecc_parse_get_tlv(card, data + offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_chv() get and parse TLV error");
 
-		sc_log(ctx, "iasecc_parse_chv() get and parse TLV returned %i; tag %X; size %i",  rv, tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_parse_chv() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_CHV_TAG_SIZE_MAX)
 			chv->size_max = tlv;
@@ -474,7 +484,9 @@ iasecc_parse_prvkey(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_prvkey() get and parse TLV error");
 
-		sc_log(ctx, "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %i",  rv, tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_PRVKEY_TAG_COMPULSORY)
 			prvkey->compulsory = tlv;
@@ -502,7 +514,9 @@ iasecc_parse_pubkey(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_pubkey() get and parse TLV error");
 
-		sc_log(ctx, "iasecc_parse_pubkey() get and parse TLV returned %i; tag %X; size %i",  rv, tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_parse_pubkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_PUBKEY_TAG_N)
 			pubkey->n = tlv;
@@ -538,7 +552,9 @@ iasecc_parse_keyset(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_keyset() get and parse TLV error");
 
-		sc_log(ctx, "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %i",  rv, tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_KEYSET_TAG_COMPULSORY)
 			keyset->compulsory = tlv;
@@ -566,7 +582,9 @@ iasecc_parse_docp(struct sc_card *card, unsigned char *data, size_t data_len, st
 		rv = iasecc_parse_get_tlv(card, data + offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_get_tlv() get and parse TLV error");
 
-		sc_log(ctx, "iasecc_parse_docp() parse_get_tlv retuned %i; tag %X; size %i",  rv, tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_parse_docp() parse_get_tlv retuned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_DOCP_TAG_ACLS)   {
 			int _rv = iasecc_parse_docp(card, tlv.value, tlv.size, sdo);
@@ -629,7 +647,9 @@ iasecc_sdo_parse_data(struct sc_card *card, unsigned char *data, struct iasecc_s
 
 	sc_log(ctx, "iasecc_sdo_parse_data() tlv.tag 0x%X", tlv.tag);
 	if (tlv.tag == IASECC_DOCP_TAG)   {
-		sc_log(ctx, "iasecc_sdo_parse_data() parse IASECC_DOCP_TAG: 0x%X; size %i", tlv.tag, tlv.size);
+		sc_log(ctx,
+		       "iasecc_sdo_parse_data() parse IASECC_DOCP_TAG: 0x%X; size %"SC_FORMAT_LEN_SIZE_T"u",
+		       tlv.tag, tlv.size);
 		rv = iasecc_parse_docp(card, tlv.value, tlv.size, sdo);
 		sc_log(ctx, "iasecc_sdo_parse_data() parsed IASECC_DOCP_TAG rv %i", rv);
 		free(tlv.value);
@@ -707,7 +727,9 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 
 		data += size_size + 1;
 		data_len = size;
-		sc_log(ctx, "IASECC_SDO_TEMPLATE: size %i, size_size %i",  size, size_size);
+		sc_log(ctx,
+		       "IASECC_SDO_TEMPLATE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %"SC_FORMAT_LEN_SIZE_T"u",
+		       size, size_size);
 	}
 
 	if (*data != IASECC_SDO_TAG_HEADER)
@@ -725,7 +747,9 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 	if (data_len != size + size_size + 3)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: invalide SDO data size");
 
-	sc_log(ctx, "sz %i, sz_size %i",  size, size_size);
+	sc_log(ctx,
+	       "sz %"SC_FORMAT_LEN_SIZE_T"u, sz_size %"SC_FORMAT_LEN_SIZE_T"u",
+	       size, size_size);
 
 	offs = 3 + size_size;
 	for (; offs < data_len;)   {
@@ -738,7 +762,9 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 	if (offs != data_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: not totaly parsed");
 
-	sc_log(ctx, "docp.acls_contact.size %i, docp.size.size %i", sdo->docp.acls_contact.size, sdo->docp.size.size);
+	sc_log(ctx,
+	       "docp.acls_contact.size %"SC_FORMAT_LEN_SIZE_T"u, docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
+	       sdo->docp.acls_contact.size, sdo->docp.size.size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -779,7 +805,9 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 	if (data_len != size + size_size + 3)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: invalide SDO data size");
 
-	sc_log(ctx, "sz %i, sz_size %i",  size, size_size);
+	sc_log(ctx,
+	       "sz %"SC_FORMAT_LEN_SIZE_T"u, sz_size %"SC_FORMAT_LEN_SIZE_T"u",
+	       size, size_size);
 
 	offs = 3 + size_size;
 	for (; offs < data_len;)   {
@@ -792,7 +820,9 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 	if (offs != data_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: not totaly parsed");
 
-	sc_log(ctx, "docp.acls_contact.size %i; docp.size.size %i", sdo->docp.acls_contact.size, sdo->docp.size.size);
+	sc_log(ctx,
+	       "docp.acls_contact.size %"SC_FORMAT_LEN_SIZE_T"u; docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
+	       sdo->docp.acls_contact.size, sdo->docp.size.size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -1095,7 +1125,9 @@ iasecc_sdo_encode_rsa_update(struct sc_context *ctx, struct iasecc_sdo *sdo, str
 		sc_log(ctx, "prv_key.compulsory.on_card %i", sdo->data.prv_key.compulsory.on_card);
 		if (!sdo->data.prv_key.compulsory.on_card)   {
 			if (sdo->data.prv_key.compulsory.value)   {
-				sc_log(ctx, "sdo_prvkey->data.prv_key.compulsory.size %i", sdo->data.prv_key.compulsory.size);
+				sc_log(ctx,
+				       "sdo_prvkey->data.prv_key.compulsory.size %"SC_FORMAT_LEN_SIZE_T"u",
+				       sdo->data.prv_key.compulsory.size);
 				sdo_update->fields[indx].parent_tag = IASECC_SDO_PRVKEY_TAG;
 				sdo_update->fields[indx].tag = IASECC_SDO_PRVKEY_TAG_COMPULSORY;
 				sdo_update->fields[indx].value = sdo->data.prv_key.compulsory.value;

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -97,7 +97,7 @@ iasecc_sm_transmit_apdus(struct sc_card *card, struct sc_remote_data *rdata,
 	sc_log(ctx, "iasecc_sm_transmit_apdus() rdata-length %i", rdata->length);
 
 	while (rapdu)   {
-		sc_log(ctx, "iasecc_sm_transmit_apdus() rAPDU flags 0x%X", rapdu->apdu.flags);
+		sc_log(ctx, "iasecc_sm_transmit_apdus() rAPDU flags 0x%lX", rapdu->apdu.flags);
 		rv = sc_transmit_apdu(card, &rapdu->apdu);
 		LOG_TEST_RET(ctx, rv, "iasecc_sm_transmit_apdus() failed to execute r-APDU");
 		rv = sc_check_sw(card, rapdu->apdu.sw1, rapdu->apdu.sw2);
@@ -270,7 +270,7 @@ iasecc_sm_get_challenge(struct sc_card *card, unsigned char *out, size_t len)
 	unsigned char rbuf[SC_MAX_APDU_BUFFER_SIZE];
 	int rv;
 
-	sc_log(ctx, "SM get challenge: length %i",len);
+	sc_log(ctx, "SM get challenge: length %"SC_FORMAT_LEN_SIZE_T"u", len);
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x84, 0, 0);
 	apdu.le = len;
 	apdu.resplen = len;
@@ -339,7 +339,9 @@ iasecc_sm_initialize(struct sc_card *card, unsigned se_num, unsigned cmd)
 
 	rdata.free(&rdata);
 
-	sc_log(ctx, "MA data(len:%i) '%s'", cwa_session->mdata_len, sc_dump_hex(cwa_session->mdata, cwa_session->mdata_len));
+	sc_log(ctx, "MA data(len:%"SC_FORMAT_LEN_SIZE_T"u) '%s'",
+	       cwa_session->mdata_len,
+	       sc_dump_hex(cwa_session->mdata, cwa_session->mdata_len));
 	if (cwa_session->mdata_len != 0x48)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "iasecc_sm_initialize() invalid MUTUAL AUTHENTICATE result data");
 
@@ -374,7 +376,9 @@ iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 	for (rapdu = rdata->data; rapdu; rapdu = rapdu->next)   {
 		struct sc_apdu *apdu = &rapdu->apdu;
 
-		sc_log(ctx, "iasecc_sm_cmd() apdu->ins:0x%X, resplen %i", apdu->ins, apdu->resplen);
+		sc_log(ctx,
+		       "iasecc_sm_cmd() apdu->ins:0x%X, resplen %"SC_FORMAT_LEN_SIZE_T"u",
+		       apdu->ins, apdu->resplen);
 		if (!apdu->ins)
 			break;
 		rv = sc_transmit_apdu(card, apdu);
@@ -388,7 +392,9 @@ iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 			sc_log(ctx, "iasecc_sm_cmd() APDU error rv:%i", rv);
 			break;
 		}
-		sc_log(ctx, "iasecc_sm_cmd() apdu->resplen %i", apdu->resplen);
+		sc_log(ctx,
+		       "iasecc_sm_cmd() apdu->resplen %"SC_FORMAT_LEN_SIZE_T"u",
+		       apdu->resplen);
 	}
 
 	LOG_FUNC_RETURN(ctx, rv);
@@ -579,7 +585,9 @@ iasecc_sm_create_file(struct sc_card *card, unsigned se_num, unsigned char *fcp,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "iasecc_sm_create_file() SE#%i, fcp(%i) '%s'", se_num, fcp_len, sc_dump_hex(fcp, fcp_len));
+	sc_log(ctx,
+	       "iasecc_sm_create_file() SE#%i, fcp(%"SC_FORMAT_LEN_SIZE_T"u) '%s'",
+	       se_num, fcp_len, sc_dump_hex(fcp, fcp_len));
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_CREATE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_create_file() SM INITIALIZE failed");
@@ -614,7 +622,9 @@ iasecc_sm_read_binary(struct sc_card *card, unsigned se_num, size_t offs, unsign
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "SM read binary: acl:%X, offs:%i, count:%i", se_num, offs, count);
+	sc_log(ctx,
+	       "SM read binary: acl:%X, offs:%"SC_FORMAT_LEN_SIZE_T"u, count:%"SC_FORMAT_LEN_SIZE_T"u",
+	       se_num, offs, count);
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_READ);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_read_binary() SM INITIALIZE failed");
@@ -653,7 +663,9 @@ iasecc_sm_update_binary(struct sc_card *card, unsigned se_num, size_t offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "SM update binary: acl:%X, offs:%i, count:%i", se_num, offs, count);
+	sc_log(ctx,
+	       "SM update binary: acl:%X, offs:%"SC_FORMAT_LEN_SIZE_T"u, count:%"SC_FORMAT_LEN_SIZE_T"u",
+	       se_num, offs, count);
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_UPDATE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_update_binary() SM INITIALIZE failed");

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -20,6 +20,7 @@
  */
 
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "internal.h"
@@ -693,7 +694,7 @@ iasecc_sm_delete_file(struct sc_card *card, unsigned se_num, unsigned int file_i
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_DELETE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_delete_file() SM INITIALIZE failed");
 
-	sm_info->cmd_data = (void *)(long)file_id;
+	sm_info->cmd_data = (void *)(uintptr_t)file_id;
 
 	sc_remote_data_init(&rdata);
 	rv = iasecc_sm_cmd(card, &rdata);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -359,7 +359,8 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 			continue;
 
 		file->size = size;
-		sc_log(ctx, "  bytes in file: %d", file->size);
+		sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u",
+		       file->size);
 		break;
 	}
 
@@ -900,8 +901,9 @@ iso7816_compute_signature(struct sc_card *card,
 
 	assert(card != NULL && data != NULL && out != NULL);
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "ISO7816 compute signature: in-len %i, out-len %i",
-		datalen, outlen);
+	sc_log(card->ctx,
+	       "ISO7816 compute signature: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
+	       datalen, outlen);
 
 	/* INS: 0x2A  PERFORM SECURITY OPERATION
 	 * P1:  0x9E  Resp: Digital Signature
@@ -939,7 +941,9 @@ iso7816_decipher(struct sc_card *card,
 
 	assert(card != NULL && crgram != NULL && out != NULL);
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "ISO7816 decipher: in-len %i, out-len %i", crgram_len, outlen);
+	sc_log(card->ctx,
+	       "ISO7816 decipher: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
+	       crgram_len, outlen);
 
 	sbuf = malloc(crgram_len + 1);
 	if (sbuf == NULL)

--- a/src/libopensc/log.h
+++ b/src/libopensc/log.h
@@ -52,11 +52,24 @@ enum {
 #define sc_log _sc_log
 #endif
 
-void sc_do_log(struct sc_context *ctx, int level, const char *file, int line, const char *func, 
+#if defined(__GNUC__)
+/* GCC can check format and param correctness for us */
+void sc_do_log(struct sc_context *ctx, int level, const char *file, int line,
+	       const char *func, const char *format, ...)
+	__attribute__ ((format (printf, 6, 7)));
+void sc_do_log_noframe(sc_context_t *ctx, int level, const char *format,
+		       va_list args) __attribute__ ((format (printf, 3, 0)));
+void _sc_debug(struct sc_context *ctx, int level, const char *format, ...)
+	__attribute__ ((format (printf, 3, 4)));
+void _sc_log(struct sc_context *ctx, const char *format, ...)
+	__attribute__ ((format (printf, 2, 3)));
+#else
+void sc_do_log(struct sc_context *ctx, int level, const char *file, int line, const char *func,
 		const char *format, ...);
 void sc_do_log_noframe(sc_context_t *ctx, int level, const char *format, va_list args);
 void _sc_debug(struct sc_context *ctx, int level, const char *format, ...);
 void _sc_log(struct sc_context *ctx, const char *format, ...);
+#endif
 /** 
  * @brief Log binary data to a sc context
  * 

--- a/src/libopensc/log.h
+++ b/src/libopensc/log.h
@@ -53,16 +53,22 @@ enum {
 #endif
 
 #if defined(__GNUC__)
+#if defined(__MINGW32__) && defined (__MINGW_PRINTF_FORMAT)
+#define SC_PRINTF_FORMAT __MINGW_PRINTF_FORMAT
+#else
+#define SC_PRINTF_FORMAT printf
+#endif
+
 /* GCC can check format and param correctness for us */
 void sc_do_log(struct sc_context *ctx, int level, const char *file, int line,
 	       const char *func, const char *format, ...)
-	__attribute__ ((format (printf, 6, 7)));
+	__attribute__ ((format (SC_PRINTF_FORMAT, 6, 7)));
 void sc_do_log_noframe(sc_context_t *ctx, int level, const char *format,
-		       va_list args) __attribute__ ((format (printf, 3, 0)));
+		       va_list args) __attribute__ ((format (SC_PRINTF_FORMAT, 3, 0)));
 void _sc_debug(struct sc_context *ctx, int level, const char *format, ...)
-	__attribute__ ((format (printf, 3, 4)));
+	__attribute__ ((format (SC_PRINTF_FORMAT, 3, 4)));
 void _sc_log(struct sc_context *ctx, const char *format, ...)
-	__attribute__ ((format (printf, 2, 3)));
+	__attribute__ ((format (SC_PRINTF_FORMAT, 2, 3)));
 #else
 void sc_do_log(struct sc_context *ctx, int level, const char *file, int line, const char *func,
 		const char *format, ...);

--- a/src/libopensc/muscle.c
+++ b/src/libopensc/muscle.c
@@ -58,7 +58,9 @@ int msc_list_objects(sc_card_t* card, u8 next, mscfs_file_t* file) {
 	if(apdu.resplen == 0) /* No more left */
 		return 0;
 	if (apdu.resplen != 14) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "expected 14 bytes, got %d.\n", apdu.resplen);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "expected 14 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
+			 apdu.resplen);
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 	memcpy(file->objectId.id, fileData, 4);
@@ -79,7 +81,8 @@ int msc_partial_read_object(sc_card_t *card, msc_id objectId, int offset, u8 *da
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x56, 0x00, 0x00);
 	
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"READ: Offset: %x\tLength: %i\n", offset, dataLength);
+		"READ: Offset: %x\tLength: %"SC_FORMAT_LEN_SIZE_T"u\n", offset,
+		 dataLength);
 	memcpy(buffer, objectId.id, 4);
 	ulong2bebytes(buffer + 4, offset);
 	buffer[8] = (u8)dataLength;
@@ -183,7 +186,9 @@ int msc_partial_update_object(sc_card_t *card, msc_id objectId, int offset, cons
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x54, 0x00, 0x00);
 	apdu.lc = dataLength + 9;
 	if (card->ctx->debug >= 2)
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "WRITE: Offset: %x\tLength: %i\n", offset, dataLength);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "WRITE: Offset: %x\tLength: %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 offset, dataLength);
 	
 	memcpy(buffer, objectId.id, 4);
 	ulong2bebytes(buffer + 4, offset);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -44,6 +44,12 @@ extern "C" {
 #include "libopensc/sm.h"
 #endif
 
+#if defined(_WIN32)
+#define SC_FORMAT_LEN_SIZE_T "I"
+#else
+/* hope SUSv3 one works */
+#define SC_FORMAT_LEN_SIZE_T "z"
+#endif
 
 #define SC_SEC_OPERATION_DECIPHER	0x0001
 #define SC_SEC_OPERATION_SIGN		0x0002

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -46,9 +46,11 @@ extern "C" {
 
 #if defined(_WIN32)
 #define SC_FORMAT_LEN_SIZE_T "I"
+#define SC_FORMAT_LEN_PTRDIFF_T "I"
 #else
-/* hope SUSv3 one works */
+/* hope SUSv3 ones work */
 #define SC_FORMAT_LEN_SIZE_T "z"
+#define SC_FORMAT_LEN_PTRDIFF_T "t"
 #endif
 
 #define SC_SEC_OPERATION_DECIPHER	0x0001

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -44,7 +44,7 @@ extern "C" {
 #include "libopensc/sm.h"
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !(defined(__MINGW32__) && defined (__MINGW_PRINTF_FORMAT))
 #define SC_FORMAT_LEN_SIZE_T "I"
 #define SC_FORMAT_LEN_PTRDIFF_T "I"
 #else

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -173,7 +173,8 @@ sc_pkcs1_strip_02_padding(sc_context_t *ctx, const u8 *data, size_t len, u8 *out
 	*out_len = len - n;
 	memmove(out, data + n, *out_len);
 
-	sc_log(ctx, "stripped output(%i): %s", len - n, sc_dump_hex(out, len - n));
+	sc_log(ctx, "stripped output(%"SC_FORMAT_LEN_SIZE_T"u): %s", len - n,
+	       sc_dump_hex(out, len - n));
 	LOG_FUNC_RETURN(ctx, len - n);
 }
 
@@ -284,7 +285,7 @@ int sc_get_encoding_flags(sc_context_t *ctx,
 	if (pflags == NULL || sflags == NULL)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "iFlags 0x%X, card capabilities 0x%X", iflags, caps);
+	sc_log(ctx, "iFlags 0x%lX, card capabilities 0x%lX", iflags, caps);
 	for (i = 0; digest_info_prefix[i].algorithm != 0; i++) {
 		if (iflags & digest_info_prefix[i].algorithm) {
 			if (digest_info_prefix[i].algorithm != SC_ALGORITHM_RSA_HASH_NONE &&
@@ -313,6 +314,6 @@ int sc_get_encoding_flags(sc_context_t *ctx,
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "unsupported algorithm");
 	}
 
-	sc_log(ctx, "pad flags 0x%X, secure algorithm flags 0x%X", *pflags, *sflags);
+	sc_log(ctx, "pad flags 0x%lX, secure algorithm flags 0x%lX", *pflags, *sflags);
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }

--- a/src/libopensc/pkcs15-algo.c
+++ b/src/libopensc/pkcs15-algo.c
@@ -267,7 +267,9 @@ asn1_decode_ec_params(sc_context_t *ctx, void **paramp,
 	struct sc_asn1_entry asn1_ec_params[4];
 	struct sc_ec_parameters *ecp;
 
-	sc_debug(ctx, SC_LOG_DEBUG_ASN1, "DEE - asn1_decode_ec_params %p:%d %d", buf, buflen, depth);
+	sc_debug(ctx, SC_LOG_DEBUG_ASN1,
+		 "DEE - asn1_decode_ec_params %p:%"SC_FORMAT_LEN_SIZE_T"u %d",
+		 buf, buflen, depth);
 
 	memset(&curve, 0, sizeof(curve));
 

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -336,8 +336,9 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		}
 		cert_info.path.count = cert_der.len;
 
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "cert len=%d, cert_info.path.count=%d r=%d\n",
-					cert_der.len, cert_info.path.count, r);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "cert len=%"SC_FORMAT_LEN_SIZE_T"u, cert_info.path.count=%d r=%d\n",
+			 cert_der.len, cert_info.path.count, r);
 		sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "cert", cert_der.value, cert_der.len);
 
 		/* cache it using the PKCS15 emulation objects */

--- a/src/libopensc/pkcs15-cache.c
+++ b/src/libopensc/pkcs15-cache.c
@@ -209,7 +209,9 @@ int sc_pkcs15_cache_file(struct sc_pkcs15_card *p15card,
 	c = fwrite(buf, 1, bufsize, f);
 	fclose(f);
 	if (c != bufsize) {
-		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "fwrite() wrote only %d bytes", c);
+		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "fwrite() wrote only %"SC_FORMAT_LEN_SIZE_T"u bytes",
+			 c);
 		unlink(fname);
 		return SC_ERROR_INTERNAL;
 	}

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -487,8 +487,8 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 	
 		for (j = 0; j < num_keyinfo; j++) {
 			if (sc_pkcs15_compare_id(&kinfo[j].id, &prkey_info.id))  {
-				sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "found key in file %d for id %d", 
-						kinfo[j].fileid, prkey_info.id);
+				sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "found key in file %d for id %s",
+					 kinfo[j].fileid, prkeys[i].id);
 				prkey_info.path.value[0] = kinfo[j].fileid >> 8;
 				prkey_info.path.value[1] = kinfo[j].fileid & 0xff;
 				break;

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -185,9 +185,11 @@ static int gemsafe_get_cert_len(sc_card_t *card)
 	 * (allocated EF space is much greater!)
 	 */
 	objlen = (((size_t) ibuf[0]) << 8) | ibuf[1];
-	sc_log(card->ctx, "Stored object is of size: %d", objlen);
+	sc_log(card->ctx, "Stored object is of size: %"SC_FORMAT_LEN_SIZE_T"u",
+	       objlen);
 	if (objlen < 1 || objlen > GEMSAFE_MAX_OBJLEN) {
-	    sc_log(card->ctx, "Invalid object size: %d", objlen);
+	    sc_log(card->ctx, "Invalid object size: %"SC_FORMAT_LEN_SIZE_T"u",
+		   objlen);
 	    return SC_ERROR_INTERNAL;
 	}
 
@@ -259,7 +261,9 @@ static int gemsafe_get_cert_len(sc_card_t *card)
 			if (ind+3 >= sizeof ibuf)
 				return SC_ERROR_INVALID_DATA;
 			certlen = ((((size_t) ibuf[ind+2]) << 8) | ibuf[ind+3]) + 4;
-			sc_log(card->ctx, "Found certificate of key container %d at offset %d, len %d", i+1, ind, certlen);
+			sc_log(card->ctx,
+			       "Found certificate of key container %d at offset %d, len %"SC_FORMAT_LEN_SIZE_T"u",
+			       i+1, ind, certlen);
 			gemsafe_cert[i].index = ind;
 			gemsafe_cert[i].count = certlen;
 			ind += certlen;

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -51,7 +51,8 @@ static int sc_pkcs15emu_gids_add_prkey(sc_pkcs15_card_t * p15card, sc_cardctl_gi
 	int r;
 	char ch_tmp[10];
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		"Got args: containerIndex=%x\n", container->containernum);
+		"Got args: containerIndex=%"SC_FORMAT_LEN_SIZE_T"x\n",
+		 container->containernum);
 
 	memset(&prkey_info, 0, sizeof(prkey_info));
 	memset(&prkey_obj,  0, sizeof(prkey_obj));

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -389,7 +389,9 @@ sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card,
 		struct container *cont;
 		unsigned char *ptr =  buff + offs + 2;
 
-		sc_log(ctx, "parse contaniers offs:%i, len:%i", offs, len);
+		sc_log(ctx,
+		       "parse contaniers offs:%"SC_FORMAT_LEN_SIZE_T"u, len:%"SC_FORMAT_LEN_SIZE_T"u",
+		       offs, len);
 		if (*(buff + offs) != 'R')
 			return SC_ERROR_INVALID_DATA;
 
@@ -1019,8 +1021,9 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 				&oberthur_infos[ii].content, &oberthur_infos[ii].len, 1);
 		LOG_TEST_RET(ctx, rv, "Oberthur init failed: read oberthur file error");
 
-		sc_log(ctx, "Oberthur init: parse %s file, content length %i",
-				oberthur_infos[ii].name, oberthur_infos[ii].len);
+		sc_log(ctx,
+		       "Oberthur init: parse %s file, content length %"SC_FORMAT_LEN_SIZE_T"u",
+		       oberthur_infos[ii].name, oberthur_infos[ii].len);
 		rv = oberthur_infos[ii].parser(p15card, oberthur_infos[ii].content, oberthur_infos[ii].len,
 				oberthur_infos[ii].postpone_allowed);
 		LOG_TEST_RET(ctx, rv, "Oberthur init failed: parse error");

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -991,6 +991,15 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 
 		strncpy(obj.label, PIN_DOMAIN_LABEL, SC_PKCS15_MAX_LABEL_SIZE-1);
 		obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
+		if (sopin_reference == 0x84) {
+			/*
+			 * auth_pin_reset_oberthur_style() in card-oberthur.c
+			 * always uses PUK with reference 0x84 for
+			 * unblocking of User PIN
+			 */
+			obj.auth_id.len = 1;
+			obj.auth_id.value[0] = 0xFF;
+		}
 
 		sc_format_path(AWP_PIN_DF, &auth_info.path);
 		auth_info.path.type = SC_PATH_TYPE_PATH;

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -231,6 +231,10 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 
 		strlcpy(pin_obj.label, pin_cfg[i].label, sizeof(pin_obj.label));
 		pin_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
+		if (i < 2) {
+			pin_obj.auth_id.len = 1;
+			pin_obj.auth_id.value[0] = 3;
+		}
 
 		r = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
 		if (r < 0)

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -318,8 +318,10 @@ _sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *p
 	struct sc_pin_cmd_data data;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "PIN(type:%X; method:%X; value(%p:%i)", auth_info->auth_type, auth_info->auth_method,
-		pincode, pinlen);
+	sc_log(ctx,
+	       "PIN(type:%X; method:%X; value(%p:%"SC_FORMAT_LEN_SIZE_T"u)",
+	       auth_info->auth_type, auth_info->auth_method,
+	       pincode, pinlen);
 
 	if (pinlen > SC_MAX_PIN_SIZE)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_PIN_LENGTH, "Invalid PIN size");

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -934,6 +934,14 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 		strncpy(pin_obj.label, label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 		pin_obj.flags = pins[i].obj_flags;
+		if (i == 0 && pin_info.attrs.pin.reference == 0x80) {
+			/*
+			 * according to description of "RESET RETRY COUNTER"
+			 * command in specs PUK can only unblock PIV PIN
+			 */
+			pin_obj.auth_id.len = 1;
+			pin_obj.auth_id.value[0] = 2;
+		}
 
 		r = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
 		if (r < 0)

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -505,7 +505,8 @@ sc_pkcs15_prkey_attrs_from_cert(struct sc_pkcs15_card *p15card, struct sc_pkcs15
 	ERR_load_ERR_strings();
 	ERR_load_crypto_strings();
 
-	sc_log(ctx, "CertValue(%i) %p", cert_object->content.len, cert_object->content.value);
+	sc_log(ctx, "CertValue(%"SC_FORMAT_LEN_SIZE_T"u) %p",
+	       cert_object->content.len, cert_object->content.value);
 	mem = BIO_new_mem_buf(cert_object->content.value, cert_object->content.len);
 	if (!mem)
 		LOG_TEST_RET(ctx, SC_ERROR_INTERNAL, "MEM buffer allocation error");

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -726,7 +726,8 @@ sc_pkcs15_decode_pubkey_ec(sc_context_t *ctx,
 	if (*ecpoint_data != 0x04)
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Supported only uncompressed EC pointQ value");
 
-	sc_log(ctx, "decode-EC key=%p, buf=%p, buflen=%d", key, buf, buflen);
+	sc_log(ctx, "decode-EC key=%p, buf=%p, buflen=%"SC_FORMAT_LEN_SIZE_T"u",
+	       key, buf, buflen);
 
 	key->ecpointQ.len = ecpoint_len;
 	key->ecpointQ.value = ecpoint_data;
@@ -755,7 +756,9 @@ sc_pkcs15_encode_pubkey_ec(sc_context_t *ctx, struct sc_pkcs15_pubkey_ec *key,
 	r = sc_asn1_encode(ctx, asn1_ec_pointQ, buf, buflen);
 	LOG_TEST_RET(ctx, r, "ASN.1 encoding failed");
 
-	sc_log(ctx, "EC key->ecpointQ=%p:%d *buf=%p:%d", key->ecpointQ.value, key->ecpointQ.len, *buf, *buflen);
+	sc_log(ctx,
+	       "EC key->ecpointQ=%p:%"SC_FORMAT_LEN_SIZE_T"u *buf=%p:%"SC_FORMAT_LEN_SIZE_T"u",
+	       key->ecpointQ.value, key->ecpointQ.len, *buf, *buflen);
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
@@ -1304,7 +1307,9 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 	unsigned char *tmp_buf = NULL;
 	int r;
 
-	sc_log(ctx, "sc_pkcs15_pubkey_from_spki_fields() called: %p:%d\n%s", buf, buflen, sc_dump_hex(buf, buflen));
+	sc_log(ctx,
+	       "sc_pkcs15_pubkey_from_spki_fields() called: %p:%"SC_FORMAT_LEN_SIZE_T"u\n%s",
+	       buf, buflen, sc_dump_hex(buf, buflen));
 
 	tmp_buf = malloc(buflen);
 	if (!tmp_buf) {
@@ -1515,7 +1520,8 @@ sc_pkcs15_fix_ec_parameters(struct sc_context *ctx, struct sc_ec_parameters *ecp
 			sc_format_oid(&ecparams->id, ec_curve_infos[ii].oid_str);
 
 		ecparams->field_length = ec_curve_infos[ii].size;
-		sc_log(ctx, "Curve length %i", ecparams->field_length);
+		sc_log(ctx, "Curve length %"SC_FORMAT_LEN_SIZE_T"u",
+		       ecparams->field_length);
 	}
 	else if (ecparams->named_curve)   {	/* it can be name of curve or OID in ASCII form */
 		for (ii=0; ec_curve_infos[ii].name; ii++)   {

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -876,6 +876,8 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 	pin_info.tries_left = 3;
 	pin_info.max_tries = 3;
 
+	pin_obj.auth_id.len = 1;
+	pin_obj.auth_id.value[0] = 2;
 	strlcpy(pin_obj.label, "UserPIN", sizeof(pin_obj.label));
 	pin_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE|SC_PKCS15_CO_FLAG_MODIFIABLE;
 

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -149,7 +149,9 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_RSA:
 			*alg_info_out = sc_card_find_rsa_alg(p15card->card, prkey->modulus_length);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx, "Card does not support RSA with key length %d", prkey->modulus_length);
+				sc_log(ctx,
+				       "Card does not support RSA with key length %"SC_FORMAT_LEN_SIZE_T"u",
+				       prkey->modulus_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_RSA;
@@ -158,7 +160,9 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_GOSTR3410:
 			*alg_info_out = sc_card_find_gostr3410_alg(p15card->card, prkey->modulus_length);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx, "Card does not support GOSTR3410 with key length %d", prkey->modulus_length);
+				sc_log(ctx,
+				       "Card does not support GOSTR3410 with key length %"SC_FORMAT_LEN_SIZE_T"u",
+				       prkey->modulus_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_GOSTR3410;
@@ -167,7 +171,9 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_EC:
 			*alg_info_out = sc_card_find_ec_alg(p15card->card, prkey->field_length, NULL);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx, "Card does not support EC with field_size %d", prkey->field_length);
+				sc_log(ctx,
+				       "Card does not support EC with field_size %"SC_FORMAT_LEN_SIZE_T"u",
+				       prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_EC;
@@ -409,7 +415,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	}
 	senv.algorithm_flags = sec_flags;
 
-	sc_log(ctx, "DEE flags:0x%8.8x alg_info->flags:0x%8.8x pad:0x%8.8x sec:0x%8.8x",
+	sc_log(ctx, "DEE flags:0x%8.8lx alg_info->flags:0x%8.8x pad:0x%8.8lx sec:0x%8.8lx",
 		flags, alg_info->flags, pad_flags, sec_flags);
 
 	/* add the padding bytes (if necessary) */

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -97,9 +97,12 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 				strlcpy(pin_obj.label, "Unblock",
 					sizeof(pin_obj.label));
 
-			else
+			else {
 				strlcpy(pin_obj.label, "User",
 					sizeof(pin_obj.label));
+				pin_obj.auth_id.len = 1;
+				pin_obj.auth_id.value[0] = 2;
+			}
 			pin_obj.flags =
 				SC_PKCS15_CO_FLAG_MODIFIABLE |
 				SC_PKCS15_CO_FLAG_PRIVATE;

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -344,8 +344,8 @@ static int refresh_attributes(sc_reader_t *reader)
 	state = priv->reader_state.dwEventState;
 	prev_state = priv->reader_state.dwCurrentState;
 
-	sc_log(reader->ctx, "current  state: 0x%08X", state);
-	sc_log(reader->ctx, "previous state: 0x%08X", prev_state);
+	sc_log(reader->ctx, "current  state: 0x%08X", (unsigned int)state);
+	sc_log(reader->ctx, "previous state: 0x%08X", (unsigned int)prev_state);
 
 	if (state & SCARD_STATE_UNKNOWN) {
 		/* State means "reader unknown", but we have listed it at least once.
@@ -559,7 +559,9 @@ static int pcsc_connect(sc_reader_t *reader)
 			sc_log(reader->ctx, "Reconnecting to force protocol");
 			r = pcsc_reconnect(reader, SCARD_UNPOWER_CARD);
 			if (r != SC_SUCCESS) {
-				sc_log(reader->ctx, "pcsc_reconnect (to force protocol) failed", r);
+				sc_log(reader->ctx,
+				       "pcsc_reconnect (to force protocol) failed (%d)",
+				       r);
 				return r;
 			}
 		}
@@ -611,7 +613,8 @@ static int pcsc_lock(sc_reader_t *reader)
 		case SCARD_E_READER_UNAVAILABLE:
 			r = pcsc_connect(reader);
 			if (r != SC_SUCCESS) {
-				sc_log(reader->ctx, "pcsc_connect failed", r);
+				sc_log(reader->ctx, "pcsc_connect failed (%d)",
+				       r);
 				return r;
 			}
 			/* return failure so that upper layers will be notified and try to lock again */
@@ -621,7 +624,8 @@ static int pcsc_lock(sc_reader_t *reader)
 			PCSC_TRACE(reader, "SCardBeginTransaction calling pcsc_reconnect", rv);
 			r = pcsc_reconnect(reader, SCARD_LEAVE_CARD);
 			if (r != SC_SUCCESS) {
-				sc_log(reader->ctx, "pcsc_reconnect failed", r);
+				sc_log(reader->ctx,
+				       "pcsc_reconnect failed (%d)", r);
 				return r;
 			}
 			/* return failure so that upper layers will be notified and try to lock again */
@@ -764,10 +768,14 @@ static int pcsc_init(sc_context_t *ctx)
 		gpriv->provider_library =
 		    scconf_get_str(conf_block, "provider_library", gpriv->provider_library);
 	}
-	sc_log(ctx, "PC/SC options: connect_exclusive=%d disconnect_action=%d transaction_end_action=%d"
-		     " reconnect_action=%d enable_pinpad=%d enable_pace=%d",
-		gpriv->connect_exclusive, gpriv->disconnect_action, gpriv->transaction_end_action,
-		gpriv->reconnect_action, gpriv->enable_pinpad, gpriv->enable_pace);
+	sc_log(ctx,
+	       "PC/SC options: connect_exclusive=%d disconnect_action=%u transaction_end_action=%u"
+	       " reconnect_action=%u enable_pinpad=%d enable_pace=%d",
+	       gpriv->connect_exclusive,
+	       (unsigned int)gpriv->disconnect_action,
+	       (unsigned int)gpriv->transaction_end_action,
+	       (unsigned int)gpriv->reconnect_action, gpriv->enable_pinpad,
+	       gpriv->enable_pace);
 
 	gpriv->dlhandle = sc_dlopen(gpriv->provider_library);
 	if (gpriv->dlhandle == NULL) {
@@ -1104,7 +1112,10 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 				}
 			}
 			else   {
-				sc_log(ctx, "Returned PIN properties structure has bad length (%d/%d)", rcount, sizeof(PIN_PROPERTIES_STRUCTURE));
+				sc_log(ctx,
+				       "Returned PIN properties structure has bad length (%lu/%"SC_FORMAT_LEN_SIZE_T"u)",
+				       (unsigned long)rcount,
+				       sizeof(PIN_PROPERTIES_STRUCTURE));
 			}
 		}
 	}
@@ -1324,7 +1335,9 @@ static int pcsc_detect_readers(sc_context_t *ctx)
 				reader->max_recv_size = scconf_get_int(conf_block, "max_recv_size", reader->max_recv_size);
 			}
 
-			sc_log(ctx, "reader's max-send-size: %i, max-recv-size: %i", reader->max_send_size, reader->max_recv_size);
+			sc_log(ctx,
+			       "reader's max-send-size: %"SC_FORMAT_LEN_SIZE_T"u, max-recv-size: %"SC_FORMAT_LEN_SIZE_T"u",
+			       reader->max_send_size, reader->max_recv_size);
 		}
 
 		continue;
@@ -1449,8 +1462,10 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 		*event = 0;
 		for (i = 0, rsp = rgReaderStates; i < num_watch; i++, rsp++) {
 			DWORD state, prev_state;
-			sc_log(ctx, "'%s' before=0x%08X now=0x%08X", rsp->szReader,
-					rsp->dwCurrentState, rsp->dwEventState);
+			sc_log(ctx, "'%s' before=0x%08X now=0x%08X",
+			       rsp->szReader,
+			       (unsigned int)rsp->dwCurrentState,
+			       (unsigned int)rsp->dwEventState);
 			prev_state = rsp->dwCurrentState;
 			state = rsp->dwEventState;
 			rsp->dwCurrentState = rsp->dwEventState;
@@ -2368,7 +2383,9 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 	gpriv->pcsc_ctx = *(SCARDCONTEXT *)pcsc_context_handle;
 	card_handle =  *(SCARDHANDLE *)pcsc_card_handle;
 
-	sc_log(ctx, "gpriv->pcsc_ctx = %X, card_handle = %X", gpriv->pcsc_ctx, card_handle);
+	sc_log(ctx, "gpriv->pcsc_ctx = %llX, card_handle = %llX",
+	       (unsigned long long)gpriv->pcsc_ctx,
+	       (unsigned long long)card_handle);
 
 	if(gpriv->SCardGetAttrib(card_handle, SCARD_ATTR_DEVICE_SYSTEM_NAME_A, \
 			reader_name, &reader_name_size) == SCARD_S_SUCCESS)
@@ -2414,7 +2431,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 			&state, &prot, atr, &atr_len);
 		if (rv != SCARD_S_SUCCESS)
 		{
-			sc_log(ctx, "SCardStatus failed %08x", rv);
+			sc_log(ctx, "SCardStatus failed %08lx", rv);
 			prot = SCARD_PROTOCOL_T0;
 		}
 		sc_log(ctx, "Set protocole to %s", \
@@ -2434,7 +2451,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 			rv = gpriv->SCardControl(card_handle, CM_IOCTL_GET_FEATURE_REQUEST, NULL, 0, feature_buf, sizeof(feature_buf), &feature_len);
 			if (rv != SCARD_S_SUCCESS)
 			{
-				sc_log(ctx, "SCardControl failed %08x", rv);
+				sc_log(ctx, "SCardControl failed %08lx", rv);
 			}
 			else
 			{
@@ -2530,7 +2547,10 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 							}
 							else
 							{
-								sc_log(ctx, "Returned PIN properties structure has bad length (%d/%d)", rcount, sizeof(PIN_PROPERTIES_STRUCTURE));
+								sc_log(ctx,
+								       "Returned PIN properties structure has bad length (%lu/%"SC_FORMAT_LEN_SIZE_T"u)",
+								       (unsigned long)rcount,
+								       sizeof(PIN_PROPERTIES_STRUCTURE));
 							}
 						}
 					}

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1069,7 +1069,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	if (priv->verify_ioctl || (priv->verify_ioctl_start && priv->verify_ioctl_finish)) {
 		const char *log_text = "Reader supports pinpad PIN verification";
 		if (priv->gpriv->enable_pinpad) {
-			sc_log(ctx, log_text);
+			sc_log(ctx, "%s", log_text);
 			reader->capabilities |= SC_READER_CAP_PIN_PAD;
 		} else {
 			sc_log(ctx, "%s %s", log_text, log_disabled);
@@ -1079,7 +1079,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	if (priv->modify_ioctl || (priv->modify_ioctl_start && priv->modify_ioctl_finish)) {
 		const char *log_text = "Reader supports pinpad PIN modification";
 		if (priv->gpriv->enable_pinpad) {
-			sc_log(ctx, log_text);
+			sc_log(ctx, "%s", log_text);
 			reader->capabilities |= SC_READER_CAP_PIN_PAD;
 		} else {
 			sc_log(ctx, "%s %s", log_text, log_disabled);
@@ -1126,7 +1126,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 			reader->capabilities |= part10_detect_pace_capabilities(reader, card_handle);
 
 			if (reader->capabilities & SC_READER_CAP_PACE_GENERIC)
-				sc_log(ctx, log_text);
+				sc_log(ctx, "%s", log_text);
 		}
 		else {
 			sc_log(ctx, "%s %s", log_text, log_disabled);
@@ -2511,7 +2511,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 					if (priv->verify_ioctl || (priv->verify_ioctl_start && priv->verify_ioctl_finish)) {
 						char *log_text = "Reader supports pinpad PIN verification";
 						if (priv->gpriv->enable_pinpad) {
-							sc_log(ctx, log_text);
+							sc_log(ctx, "%s", log_text);
 							reader->capabilities |= SC_READER_CAP_PIN_PAD;
 						} else {
 							sc_log(ctx, "%s %s", log_text, log_disabled);
@@ -2521,7 +2521,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 					if (priv->modify_ioctl || (priv->modify_ioctl_start && priv->modify_ioctl_finish)) {
 						char *log_text = "Reader supports pinpad PIN modification";
 						if (priv->gpriv->enable_pinpad) {
-							sc_log(ctx, log_text);
+							sc_log(ctx, "%s", log_text);
 							reader->capabilities |= SC_READER_CAP_PIN_PAD;
 						} else {
 							sc_log(ctx, "%s %s", log_text, log_disabled);
@@ -2558,7 +2558,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 					if (priv->pace_ioctl) {
 						char *log_text = "Reader supports PACE";
 						if (priv->gpriv->enable_pace) {
-							sc_log(ctx, log_text);
+							sc_log(ctx, "%s", log_text);
 							reader->capabilities |= SC_READER_CAP_PACE_GENERIC;
 						} else {
 							sc_log(ctx, "%s %s", log_text, log_disabled);

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -49,12 +49,28 @@
 
 #define SCARD_CLASS_SYSTEM     0x7fff
 #define SCARD_ATTR_VALUE(Class, Tag) ((((ULONG)(Class)) << 16) | ((ULONG)(Tag)))
+
+#ifndef SCARD_ATTR_DEVICE_FRIENDLY_NAME_A
 #define SCARD_ATTR_DEVICE_FRIENDLY_NAME_A SCARD_ATTR_VALUE(SCARD_CLASS_SYSTEM, 0x0003)
+#endif
+
+#ifndef SCARD_ATTR_DEVICE_SYSTEM_NAME_A
 #define SCARD_ATTR_DEVICE_SYSTEM_NAME_A SCARD_ATTR_VALUE(SCARD_CLASS_SYSTEM, 0x0004)
+#endif
+
 #define SCARD_CLASS_VENDOR_INFO 1
+
+#ifndef SCARD_ATTR_VENDOR_NAME
 #define SCARD_ATTR_VENDOR_NAME SCARD_ATTR_VALUE(SCARD_CLASS_VENDOR_INFO, 0x0100) /**< Vendor name. */
+#endif
+
+#ifndef SCARD_ATTR_VENDOR_IFD_TYPE
 #define SCARD_ATTR_VENDOR_IFD_TYPE SCARD_ATTR_VALUE(SCARD_CLASS_VENDOR_INFO, 0x0101) /**< Vendor-supplied interface device type (model designation of reader). */
+#endif
+
+#ifndef SCARD_ATTR_VENDOR_IFD_VERSION
 #define SCARD_ATTR_VENDOR_IFD_VERSION SCARD_ATTR_VALUE(SCARD_CLASS_VENDOR_INFO, 0x0102) /**< Vendor-supplied interface device version (DWORD in the form 0xMMmmbbbb where MM = major version, mm = minor version, and bbbb = build number). */
+#endif
 
 /* Logging */
 #define PCSC_TRACE(reader, desc, rv) do { sc_log(reader->ctx, "%s:" desc ": 0x%08lx\n", reader->name, (unsigned long)((ULONG)rv)); } while (0)
@@ -834,7 +850,7 @@ static int pcsc_finish(sc_context_t *ctx)
 	LOG_FUNC_CALLED(ctx);
 
 	if (gpriv) {
-		if (gpriv->pcsc_ctx != -1 && !(ctx->flags & SC_CTX_FLAG_TERMINATE))
+		if (gpriv->pcsc_ctx != (SCARDCONTEXT)-1 && !(ctx->flags & SC_CTX_FLAG_TERMINATE))
 			gpriv->SCardReleaseContext(gpriv->pcsc_ctx);
 		if (gpriv->dlhandle != NULL)
 			sc_dlclose(gpriv->dlhandle);
@@ -1168,7 +1184,7 @@ static int pcsc_detect_readers(sc_context_t *ctx)
 	sc_log(ctx, "Probing PC/SC readers");
 
 	do {
-		if (gpriv->pcsc_ctx == -1) {
+		if (gpriv->pcsc_ctx == (SCARDCONTEXT)-1) {
 			/*
 			 * Cannot call SCardListReaders with -1
 			 * context as in Windows ERROR_INVALID_HANDLE
@@ -1218,7 +1234,7 @@ static int pcsc_detect_readers(sc_context_t *ctx)
 		goto out;
 	}
 	for (reader_name = reader_buf; *reader_name != '\x0'; reader_name += strlen(reader_name) + 1) {
-		sc_reader_t *reader = NULL, *old_reader;
+		sc_reader_t *reader = NULL, *old_reader = NULL;
 		struct pcsc_private_data *priv = NULL;
 		scconf_block *conf_block = NULL;
 		int found = 0;
@@ -2222,8 +2238,6 @@ static int cardmod_connect(sc_reader_t *reader)
 
 static int cardmod_disconnect(sc_reader_t * reader)
 {
-	struct pcsc_private_data *priv = GET_PRIV_DATA(reader);
-
 	reader->flags = 0;
 	return SC_SUCCESS;
 }
@@ -2330,8 +2344,8 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 	scconf_block *conf_block = NULL;
 	struct pcsc_global_private_data *gpriv = (struct pcsc_global_private_data *) ctx->reader_drv_data;
 	LONG rv;
-	char reader_name[128];
-	DWORD rcount, feature_len, display_ioctl, reader_name_size = sizeof(reader_name);
+	BYTE reader_name[128];
+	DWORD rcount, feature_len, display_ioctl = 0, reader_name_size = sizeof(reader_name);
 	int ret = SC_ERROR_INTERNAL;
 	unsigned int i;
 
@@ -2380,7 +2394,7 @@ int cardmod_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcs
 		reader->drv_data = priv;
 		reader->ops = &cardmod_ops;
 		reader->driver = &cardmod_drv;
-		if ((reader->name = strdup(reader_name)) == NULL) {
+		if ((reader->name = strdup((const char *)reader_name)) == NULL) {
 			ret = SC_ERROR_OUT_OF_MEMORY;
 			goto err1;
 		}

--- a/src/libsm/sm-common.c
+++ b/src/libsm/sm-common.c
@@ -308,7 +308,9 @@ sm_encrypt_des_cbc3(struct sc_context *ctx, unsigned char *key,
 	size_t data_len, st;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "SM encrypt_des_cbc3: not_force_pad:%i,in_len:%i", not_force_pad, in_len);
+	sc_log(ctx,
+	       "SM encrypt_des_cbc3: not_force_pad:%i,in_len:%"SC_FORMAT_LEN_SIZE_T"u",
+	       not_force_pad, in_len);
 	if (!out || !out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "SM encrypt_des_cbc3: invalid input arguments");
 
@@ -328,7 +330,9 @@ sm_encrypt_des_cbc3(struct sc_context *ctx, unsigned char *key,
 	memcpy(data + in_len, "\x80\0\0\0\0\0\0\0", 8);
 	data_len = in_len + (not_force_pad ? 7 : 8);
 	data_len -= (data_len%8);
-	sc_log(ctx, "SM encrypt_des_cbc3: data to encrypt (len:%i,%s)", data_len, sc_dump_hex(data, data_len));
+	sc_log(ctx,
+	       "SM encrypt_des_cbc3: data to encrypt (len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
+	       data_len, sc_dump_hex(data, data_len));
 
 	*out_len = data_len;
 	*out = malloc(data_len + 8);

--- a/src/minidriver/Makefile.am
+++ b/src/minidriver/Makefile.am
@@ -12,12 +12,14 @@ else
 dist_noinst_DATA = opensc-minidriver.inf minidriver-westcos.reg minidriver-sc-hsm.reg minidriver-feitian.reg
 endif
 
+AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
 opensc_minidriver@LIBRARY_BITNESS@_la_SOURCES = minidriver.c minidriver.exports versioninfo-minidriver.rc
 opensc_minidriver@LIBRARY_BITNESS@_la_LIBADD =  \
-	$(top_builddir)/src/libopensc/libopensc.la \
-	-lcrypt32
+	$(top_builddir)/src/libopensc/libopensc_static.la \
+	$(OPTIONAL_OPENSSL_LIBS) \
+	-lbcrypt -lcrypt32 -lrpcrt4
 opensc_minidriver@LIBRARY_BITNESS@_la_LDFLAGS = $(AM_LDFLAGS) \
 	-export-symbols "$(srcdir)/minidriver.exports" \
 	-module -avoid-version -no-undefined

--- a/src/minidriver/cardmod-mingw-compat.h
+++ b/src/minidriver/cardmod-mingw-compat.h
@@ -1,0 +1,47 @@
+/*
+ * cardmod-mingw-compat.h: Compat defines to make minidriver with cardmod.h
+ *			   buildable under mingw
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#define __deref
+#define __deref_opt_inout_bcount_part_opt(x,y)
+#define __deref_opt_out_bcount(x)
+#define __deref_out_bcount(x)
+#define __deref_out_bcount_opt(x)
+#define __deref_out_ecount(x)
+#define __in
+#define __in_bcount(x)
+#define __in_bcount_opt(x)
+#define __in_ecount(x)
+#define __in_opt
+#define __inout
+#define __inout_bcount_full(x)
+#define __inout_bcount_opt(x)
+#define __out
+#define __out_bcount(x)
+#define __out_bcount_full(x)
+#define __out_bcount_part_opt(x,y)
+#define __out_bcount_part_opt(x,y)
+#define __out_ecount(x)
+#define __out_opt
+#define __struct_bcount(x)
+#define __success(x)
+#define _Printf_format_string_
+
+#ifndef NTE_BUFFER_TOO_SMALL
+#define NTE_BUFFER_TOO_SMALL _HRESULT_TYPEDEF_(0x80090028)
+#endif

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -30,12 +30,13 @@
 #pragma managed(push, off)
 #endif
 
+#define MINGW_HAS_SECURE_API 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
 #include <windows.h>
-#include "cardmod.h"
 
 #include "libopensc/asn1.h"
 #include "libopensc/cardctl.h"
@@ -54,9 +55,10 @@
 #endif
 
 #if defined(__MINGW32__)
-/* Part of the build svn project in the include directory */
 #include "cardmod-mingw-compat.h"
 #endif
+
+#include "cardmod.h"
 
 /* store the instance given at DllMain when attached to access internal resources */
 HINSTANCE g_inst;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2945,16 +2945,30 @@ DWORD WINAPI CardUnblockPin(__in PCARD_DATA  pCardData,
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardUnblockPin\n");
 
-	if (pwszUserId == NULL)
+	if (pwszUserId == NULL) {
+		logprintf(pCardData, 1, "no user ID\n");
 		return SCARD_E_INVALID_PARAMETER;
-	if (wcscmp(wszCARD_USER_USER, pwszUserId) != 0 && wcscmp(wszCARD_USER_ADMIN,pwszUserId) != 0)
+	}
+	if (wcscmp(wszCARD_USER_USER, pwszUserId) != 0 && wcscmp(wszCARD_USER_ADMIN,pwszUserId) != 0) {
+		logprintf(pCardData, 1, "unknown user ID %S\n", pwszUserId);
 		return SCARD_E_INVALID_PARAMETER;
-	if (wcscmp(wszCARD_USER_ADMIN, pwszUserId) == 0)
+	}
+	if (wcscmp(wszCARD_USER_ADMIN, pwszUserId) == 0) {
+		logprintf(pCardData, 1, "unlocking admin not supported\n");
 		return SCARD_E_UNSUPPORTED_FEATURE;
-	if (dwFlags & CARD_AUTHENTICATE_PIN_CHALLENGE_RESPONSE)
-		return SCARD_E_UNSUPPORTED_FEATURE;
-	if (dwFlags)
+	}
+	if (dwFlags & CARD_AUTHENTICATE_PIN_CHALLENGE_RESPONSE) {
+		logprintf(pCardData, 1,
+			  "challenge / response not supported, we'll treat response as a PUK\n");
+		logprintf(pCardData, 1,
+			  "note that you'll need to type PUK in hex (replace every PUK digit X with '3X') in Win CAD unblock dialog response field\n");
+		dwFlags &= ~CARD_AUTHENTICATE_PIN_CHALLENGE_RESPONSE;
+	}
+	if (dwFlags) {
+		logprintf(pCardData, 1, "flags of %x not supported\n",
+			  (unsigned int)dwFlags);
 		return SCARD_E_INVALID_PARAMETER;
+	}
 
 	logprintf(pCardData, 1, "UserID('%S'), AuthData(%p, %u), NewPIN(%p, %u), Retry(%u), dwFlags(0x%X)\n",
 			pwszUserId, pbAuthenticationData, cbAuthenticationData, pbNewPinData, cbNewPinData,

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2982,15 +2982,6 @@ DWORD WINAPI CardGetChallenge(__in PCARD_DATA pCardData,
 	if (!ppbChallengeData || !pcbChallengeData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "Asked challenge length %lu, buffer %p\n",
-		  (unsigned long)*pcbChallengeData, *ppbChallengeData);
-	if (pcbChallengeData == NULL)   {
-		*ppbChallengeData = NULL;
-
-		logprintf(pCardData, 7, "returns zero bytes\n");
-		return SCARD_S_SUCCESS;
-	}
-
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
 	check_reader_status(pCardData);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -241,7 +241,6 @@ static const struct sc_asn1_entry c_asn1_md_container[C_ASN1_MD_CONTAINER_SIZE] 
 
 static int associate_card(PCARD_DATA pCardData);
 static int disassociate_card(PCARD_DATA pCardData);
-static DWORD md_get_cardcf(PCARD_DATA pCardData, CARD_CACHE_FILE_FORMAT **out);
 static DWORD md_pkcs15_delete_object(PCARD_DATA pCardData, struct sc_pkcs15_object *obj);
 static DWORD md_fs_init(PCARD_DATA pCardData);
 
@@ -325,17 +324,6 @@ static void loghex(PCARD_DATA pCardData, int level, PBYTE data, size_t len)
 	}
 	if (i%32 != 0)
 		logprintf(pCardData, level, " %04X  %s\n", a, line);
-}
-
-static void print_werror(PCARD_DATA pCardData, PSTR str)
-{
-	void *buf;
-	FormatMessageA(
-		FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL, GetLastError(), 0, (LPSTR) &buf, 0, NULL);
-
-	logprintf(pCardData, 0, "%s%s\n", str, (PSTR) buf);
-	LocalFree(buf);
 }
 
 /*
@@ -532,25 +520,6 @@ md_is_supports_container_key_import(PCARD_DATA pCardData)
 	return md_get_config_bool(pCardData, "md_supports_container_key_import", MD_STATIC_FLAG_CREATE_CONTAINER_KEY_IMPORT, TRUE);
 }
 
-
-/* Check if specified PIN has been verified */
-static BOOL
-md_is_pin_set(PCARD_DATA pCardData, DWORD role)
-{
-	VENDOR_SPECIFIC *vs;
-	CARD_CACHE_FILE_FORMAT *cardcf = NULL;
-
-	if (!pCardData)
-		return FALSE;
-	vs = pCardData->pvVendorSpecific;
-
-	if (md_get_cardcf(pCardData, &cardcf) != SCARD_S_SUCCESS)
-		return FALSE;
-
-	return IS_PIN_SET(cardcf->bPinsFreshness, role);
-}
-
-
 /* generate unique key label (GUID)*/
 static VOID md_generate_guid( __in_ecount(MAX_CONTAINER_NAME_LEN+1) PSTR szGuid) {
 	RPC_CSTR szRPCGuid = NULL;
@@ -618,21 +587,6 @@ md_contguid_delete_conversion(PCARD_DATA pCardData, __in_ecount(MAX_CONTAINER_NA
 	}
 }
 
-/* this function take the guid in input and search if it should be replaced
-Return if it has been replaced or not */
-static BOOL
-md_contguid_find_conversion(PCARD_DATA pCardData, __in_ecount(MAX_CONTAINER_NAME_LEN+1) PSTR szGuid)
-{
-	int i;
-	for (i = 0; i < MD_MAX_CONVERSIONS; i++) {
-		if (strcmp(md_static_conversions[i].szOpenSCGuid,szGuid) == 0) {
-			strcpy_s(szGuid, MAX_CONTAINER_NAME_LEN+1, md_static_conversions[i].szWindowsGuid);
-			return TRUE;
-		}
-	}
-	return FALSE;
-}
-
 /* build key args from the minidriver guid */
 static VOID
 md_contguid_build_key_args_from_cont_guid(PCARD_DATA pCardData, __in_ecount(MAX_CONTAINER_NAME_LEN+1) PSTR szGuid,
@@ -658,11 +612,8 @@ md_contguid_build_key_args_from_cont_guid(PCARD_DATA pCardData, __in_ecount(MAX_
 static DWORD
 md_contguid_build_cont_guid_from_key(PCARD_DATA pCardData, struct sc_pkcs15_object *key_obj, __in_ecount(MAX_CONTAINER_NAME_LEN+1) PSTR szGuid)
 {
-	VENDOR_SPECIFIC *vs;
 	struct sc_pkcs15_prkey_info *prkey_info = (struct sc_pkcs15_prkey_info *)key_obj->data;
 	DWORD dwret = SCARD_S_SUCCESS;
-
-	vs = (VENDOR_SPECIFIC*) pCardData->pvVendorSpecific;
 
 	szGuid[0] = '\0';
 	/* priorize the use of the key id over the key label as a container name */
@@ -724,7 +675,7 @@ md_fs_find_directory(PCARD_DATA pCardData, struct md_directory *parent, char *na
 		dir = parent->subdirs;
 		while(dir)   {
 			if (strlen(name) > sizeof dir->name
-					|| !strncmp(dir->name, name, sizeof dir->name))
+					|| !strncmp((char *)dir->name, name, sizeof dir->name))
 				break;
 			dir = dir->next;
 		}
@@ -756,7 +707,7 @@ md_fs_add_directory(PCARD_DATA pCardData, struct md_directory **head, char *name
 		return SCARD_E_NO_MEMORY;
 	memset(new_dir, 0, sizeof(struct md_directory));
 
-	strncpy_s(new_dir->name, sizeof(new_dir->name), name, sizeof(new_dir->name) - 1);
+	strncpy_s((char *)new_dir->name, sizeof(new_dir->name), name, sizeof(new_dir->name) - 1);
 	new_dir->acl = acl;
 
 	if (*head == NULL)   {
@@ -780,7 +731,6 @@ md_fs_add_directory(PCARD_DATA pCardData, struct md_directory **head, char *name
 static DWORD
 md_fs_find_file(PCARD_DATA pCardData, char *parent, char *name, struct md_file **out)
 {
-	VENDOR_SPECIFIC *vs;
 	struct md_file *file = NULL;
 	struct md_directory *dir = NULL;
 	DWORD dwret;
@@ -790,8 +740,6 @@ md_fs_find_file(PCARD_DATA pCardData, char *parent, char *name, struct md_file *
 
 	if (!pCardData || !name)
 		return SCARD_E_INVALID_PARAMETER;
-
-	vs = pCardData->pvVendorSpecific;
 
 	dwret = md_fs_find_directory(pCardData, NULL, parent, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
@@ -805,7 +753,7 @@ md_fs_find_file(PCARD_DATA pCardData, char *parent, char *name, struct md_file *
 
 	for (file = dir->files; file!=NULL;)   {
 		if (sizeof file->name < strlen(name)
-				|| !strncmp(file->name, name, sizeof file->name))
+				|| !strncmp((char *)file->name, name, sizeof file->name))
 			break;
 		file = file->next;
 	}
@@ -834,7 +782,7 @@ md_fs_add_file(PCARD_DATA pCardData, struct md_file **head, char *name, CARD_FIL
 		return SCARD_E_NO_MEMORY;
 	memset(new_file, 0, sizeof(struct md_file));
 
-	strncpy_s(new_file->name, sizeof(new_file->name), name, sizeof(new_file->name) - 1);
+	strncpy_s((char *)new_file->name, sizeof(new_file->name), name, sizeof(new_file->name) - 1);
 	new_file->size = size;
 	new_file->acl = acl;
 
@@ -911,7 +859,7 @@ md_fs_delete_file(PCARD_DATA pCardData, char *parent, char *name)
 	}
 
 	if (sizeof dir->files->name < strlen(name)
-			|| !strncmp(dir->files->name, name, sizeof dir->files->name))   {
+			|| !strncmp((char *)dir->files->name, name, sizeof dir->files->name))   {
 		file_to_rm = dir->files;
 		dir->files = dir->files->next;
 		md_fs_free_file(pCardData, file_to_rm);
@@ -922,7 +870,7 @@ md_fs_delete_file(PCARD_DATA pCardData, char *parent, char *name)
 			if (!file->next)
 				break;
 			if (sizeof file->next->name < strlen(name)
-					|| !strncmp(file->next->name, name, sizeof file->next->name))   {
+					|| !strncmp((char *)file->next->name, name, sizeof file->next->name))   {
 				file_to_rm = file->next;
 				file->next = file->next->next;
 				md_fs_free_file(pCardData, file_to_rm);
@@ -995,7 +943,6 @@ md_pkcs15_update_containers(PCARD_DATA pCardData, unsigned char *blob, size_t si
 {
 	VENDOR_SPECIFIC *vs;
 	CONTAINER_MAP_RECORD *pp;
-	DWORD dwret = SCARD_F_INTERNAL_ERROR;
 	int nn_records, idx;
 
 	if (!pCardData || !blob || size < sizeof(CONTAINER_MAP_RECORD))
@@ -1109,7 +1056,7 @@ md_fs_set_content(PCARD_DATA pCardData, struct md_file *file, unsigned char *blo
 	CopyMemory(file->blob, blob, size);
 	file->size = size;
 
-	if (!strcmp(file->name, "cmapfile"))
+	if (!strcmp((char *)file->name, "cmapfile"))
 		return md_pkcs15_update_containers(pCardData, blob, size);
 
 	return SCARD_S_SUCCESS;
@@ -1167,14 +1114,12 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 {
 	CERT_BLOB dbStore = {0};
 	HCERTSTORE hCertStore = NULL;
-	DWORD dwret = 0;
 	VENDOR_SPECIFIC *vs;
 	int rv, ii, cert_num;
 	struct sc_pkcs15_object *prkey_objs[MD_MAX_KEY_CONTAINERS];
 
 	hCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, (HCRYPTPROV_LEGACY) NULL, 0, NULL);
 	if (!hCertStore) {
-		dwret = GetLastError();
 		goto Ret;
 	}
 
@@ -1213,14 +1158,12 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 			CERT_STORE_SAVE_TO_MEMORY,
 				&dbStore,
 		0)) {
-		dwret = GetLastError();
 		goto Ret;
 	}
 
 	dbStore.pbData = (PBYTE) pCardData->pfnCspAlloc(dbStore.cbData);
 
 	if (NULL == dbStore.pbData) {
-		dwret = ERROR_NOT_ENOUGH_MEMORY;
 		goto Ret;
 	}
 
@@ -1231,7 +1174,6 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 				&dbStore,
 				0))
 	{
-		dwret = GetLastError();
 		goto Ret;
 	}
 	file->size = dbStore.cbData;
@@ -1272,12 +1214,12 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 		return;
 	}
 
-	if (!strcmp(dir->name, "mscp"))   {
+	if (!strcmp((char *)dir->name, "mscp"))   {
 		int idx, rv;
 
-		if(sscanf_s(file->name, "ksc%d", &idx) > 0)   {
+		if(sscanf_s((char *)file->name, "ksc%d", &idx) > 0)   {
 		}
-		else if(sscanf_s(file->name, "kxc%d", &idx) > 0)   {
+		else if(sscanf_s((char *)file->name, "kxc%d", &idx) > 0)   {
 		}
 		else   {
 			idx = -1;
@@ -1300,7 +1242,7 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 			CopyMemory(file->blob, cert->data.value, cert->data.len);
 			sc_pkcs15_free_certificate(cert);
 		}
-		if (!strcmp(file->name, "msroot")) {
+		if (!strcmp((char *)file->name, "msroot")) {
 			md_fs_read_msroot_file(pCardData, parent, file);
 		}
 	}
@@ -1319,16 +1261,11 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 static DWORD
 md_set_cardcf(PCARD_DATA pCardData, struct md_file *file)
 {
-	VENDOR_SPECIFIC *vs;
-	char *last_update = NULL;
 	CARD_CACHE_FILE_FORMAT empty = {0};
-	size_t empty_len = sizeof(empty);
 	DWORD dwret;
 
 	if (!pCardData || !file)
 		return SCARD_E_INVALID_PARAMETER;
-
-	vs = pCardData->pvVendorSpecific;
 
 	dwret = md_fs_set_content(pCardData, file, (unsigned char *)(&empty), MD_CARDCF_LENGTH);
 	if (dwret != SCARD_S_SUCCESS)
@@ -1338,31 +1275,6 @@ md_set_cardcf(PCARD_DATA pCardData, struct md_file *file)
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
-
-/*
- * Return content of the 'soft' 'cardcf' file
- */
-static DWORD
-md_get_cardcf(PCARD_DATA pCardData, CARD_CACHE_FILE_FORMAT **out)
-{
-	struct md_file *file = NULL;
-
-	if (!pCardData)
-		return SCARD_E_INVALID_PARAMETER;
-
-	md_fs_find_file(pCardData, NULL, "cardcf", &file);
-	if (!file)   {
-		logprintf(pCardData, 2, "file 'cardcf' not found\n");
-		return SCARD_E_FILE_NOT_FOUND;
-	}
-	if (!file->blob || file->size < MD_CARDCF_LENGTH)
-		return SCARD_E_INVALID_VALUE;
-	if (out)
-		*out = (CARD_CACHE_FILE_FORMAT *)file->blob;
-
-	return SCARD_S_SUCCESS;
-}
-
 
 static DWORD
 md_set_cardapps(PCARD_DATA pCardData, struct md_file *file)
@@ -1429,7 +1341,6 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 {
 	VENDOR_SPECIFIC *vs;
 	PCONTAINER_MAP_RECORD p;
-	sc_pkcs15_pubkey_t *pubkey = NULL;
 	unsigned char *cmap_buf = NULL;
 	size_t cmap_len;
 	DWORD dwret;
@@ -1459,7 +1370,7 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 
 	/* Initialize the P15 container array with the existing keys */
 	for(ii = 0; ii < conts_num; ii++)   {
-		struct sc_pkcs15_object *key_obj = prkey_objs[ii], *cert_obj = NULL;
+		struct sc_pkcs15_object *key_obj = prkey_objs[ii];
 		struct sc_pkcs15_prkey_info *prkey_info = (struct sc_pkcs15_prkey_info *)key_obj->data;
 		struct md_pkcs15_container *cont = &vs->p15_containers[ii];
 
@@ -1566,8 +1477,6 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 		/* Initialize 'CMAPFILE' content from the P15 containers */
 		p = (PCONTAINER_MAP_RECORD)cmap_buf;
 		for (ii=0; ii<MD_MAX_KEY_CONTAINERS; ii++)   {
-			struct sc_pkcs15_object *cert_obj = NULL;
-
 			if (!(vs->p15_containers[ii].flags & CONTAINER_MAP_VALID_CONTAINER))
 				continue;
 
@@ -1930,15 +1839,15 @@ md_pkcs15_generate_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, DWORD ke
 		if ((key_type == AT_ECDSA_P256)|| (key_type == AT_ECDHE_P256)) {
 			keygen_args.prkey_args.key.u.ec.params.named_curve = "secp256r1";
 			keygen_args.prkey_args.key.u.ec.params.der.len = 10;
-			keygen_args.prkey_args.key.u.ec.params.der.value = "\x06\x08\x2A\x86\x48\xCE\x3D\x03\x01\x07";
+			keygen_args.prkey_args.key.u.ec.params.der.value = (unsigned char *)"\x06\x08\x2A\x86\x48\xCE\x3D\x03\x01\x07";
 		} else if ((key_type == AT_ECDSA_P384)|| (key_type == AT_ECDHE_P384)) {
 			keygen_args.prkey_args.key.u.ec.params.named_curve = "secp384r1";
 			keygen_args.prkey_args.key.u.ec.params.der.len = 7;
-			keygen_args.prkey_args.key.u.ec.params.der.value = "\x06\x05\x2B\x81\x04\x00\x22";
+			keygen_args.prkey_args.key.u.ec.params.der.value = (unsigned char *)"\x06\x05\x2B\x81\x04\x00\x22";
 		} else if ((key_type == AT_ECDSA_P521)|| (key_type == AT_ECDHE_P521)) {
 			keygen_args.prkey_args.key.u.ec.params.named_curve = "secp521r1";
 			keygen_args.prkey_args.key.u.ec.params.der.len = 7;
-			keygen_args.prkey_args.key.u.ec.params.der.value = "\x06\x05\x2B\x81\x04\x00\x23";
+			keygen_args.prkey_args.key.u.ec.params.der.value = (unsigned char *)"\x06\x05\x2B\x81\x04\x00\x23";
 		}
 	}
 
@@ -2033,7 +1942,7 @@ md_pkcs15_store_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, BYTE *blob,
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	card = vs->p15card->card;
 
-	pkey = b2i_PrivateKey(&ptr, blob_size);
+	pkey = b2i_PrivateKey((const unsigned char **)&ptr, blob_size);
 	if (!pkey)   {
 		logprintf(pCardData, 1, "MdStoreKey() MSBLOB key parse error");
 		return SCARD_E_INVALID_PARAMETER;
@@ -2172,10 +2081,9 @@ md_pkcs15_store_certificate(PCARD_DATA pCardData, char *file_name, unsigned char
 
 	/* use container's ID as ID of certificate to store */
 	idx = -1;
-	if(sscanf_s(file_name, "ksc%d", &idx) > 0)
-		;
-	else if(sscanf_s(file_name, "kxc%d", &idx) > 0)
-		;
+	if(sscanf_s(file_name, "ksc%d", &idx) > 0) {
+	} else if(sscanf_s(file_name, "kxc%d", &idx) > 0) {
+	}
 
 	if (idx >= 0 && idx < MD_MAX_KEY_CONTAINERS)   {
 		cont = &(vs->p15_containers[idx]);
@@ -2223,7 +2131,7 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 {
 	VENDOR_SPECIFIC *vs = NULL;
 	struct sc_algorithm_info* algo_info;
-	int count = 0, i, key_algo = 0, keysize = 0, flag;
+	int count = 0, i, keysize = 0, flag;
 	if (!pKeySizes)
 		return SCARD_E_INVALID_PARAMETER;
 
@@ -2453,7 +2361,6 @@ md_dialog_perform_pin_operation(PCARD_DATA pCardData, int operation, struct sc_p
 {
 	LONG_PTR parameter[10];
 	INT_PTR result = 0;
-	HWND hWndDlg = 0;
 	int rv = 0;
 	VENDOR_SPECIFIC* pv = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	/* stack the parameters */
@@ -2652,12 +2559,10 @@ DWORD WINAPI CardCreateContainer(__in PCARD_DATA pCardData,
 	__in DWORD dwKeySize,
 	__in PBYTE pbKeyData)
 {
-	VENDOR_SPECIFIC *vs = NULL;
 	DWORD dwret;
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
-	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardCreateContainer(idx:%i,flags:%X,type:%X,size:%i,data:%p)\n",
@@ -2745,7 +2650,7 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 		return SCARD_E_INVALID_PARAMETER;
 	if (bContainerIndex >= MD_MAX_KEY_CONTAINERS)
 		return SCARD_E_NO_KEY_CONTAINER;
-	if (pContainerInfo->dwVersion < 0 || pContainerInfo->dwVersion >  CONTAINER_INFO_CURRENT_VERSION)
+	if (pContainerInfo->dwVersion > CONTAINER_INFO_CURRENT_VERSION)
 		return ERROR_REVISION_MISMATCH;
 
 	pContainerInfo->dwVersion = CONTAINER_INFO_CURRENT_VERSION;
@@ -3189,8 +3094,6 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 	__deref_out_bcount_opt(*pcbData) PBYTE *ppbData,
 	__out PDWORD pcbData)
 {
-	VENDOR_SPECIFIC *vs;
-	struct md_directory *dir = NULL;
 	struct md_file *file = NULL;
 
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
@@ -3200,8 +3103,6 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 		return SCARD_E_INVALID_PARAMETER;
 	if (!ppbData || !pcbData)
 		return SCARD_E_INVALID_PARAMETER;
-
-	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
 	logprintf(pCardData, 2, "pszDirectoryName = %s, pszFileName = %s, dwFlags = %X, pcbData=%u, *ppbData=%X\n",
 		NULLSTR(pszDirectoryName), NULLSTR(pszFileName), dwFlags, *pcbData, *ppbData);
@@ -3290,7 +3191,6 @@ DWORD WINAPI CardDeleteFile(__in PCARD_DATA pCardData,
 	__in LPSTR pszFileName,
 	__in DWORD dwFlags)
 {
-	struct md_file *file = NULL;
 	DWORD dwret;
 
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
@@ -3351,8 +3251,8 @@ DWORD WINAPI CardEnumFiles(__in PCARD_DATA pCardData,
 	file = dir->files;
 	for (offs = 0; file != NULL && offs < sizeof(mstr) - 10;)   {
 		logprintf(pCardData, 2, "enum files(): file name '%s'\n", file->name);
-		strcpy_s(mstr+offs, sizeof(mstr) - offs, file->name);
-		offs += strlen(file->name) + 1;
+		strcpy_s(mstr+offs, sizeof(mstr) - offs, (char *)file->name);
+		offs += strlen((char *)file->name) + 1;
 		file = file->next;
 	}
 	mstr[offs] = 0;
@@ -3373,14 +3273,10 @@ DWORD WINAPI CardGetFileInfo(__in PCARD_DATA pCardData,
 	__in LPSTR pszFileName,
 	__inout PCARD_FILE_INFO pCardFileInfo)
 {
-	VENDOR_SPECIFIC *vs = NULL;
-	struct md_directory *dir = NULL;
 	struct md_file *file = NULL;
 
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetFileInfo(dirName:'%s',fileName:'%s', out %p)\n", NULLSTR(pszDirectoryName), NULLSTR(pszFileName), pCardFileInfo);
-
-	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
 	md_fs_find_file(pCardData, pszDirectoryName, pszFileName, &file);
 	if (!file)   {
@@ -3399,7 +3295,6 @@ DWORD WINAPI CardGetFileInfo(__in PCARD_DATA pCardData,
 DWORD WINAPI CardQueryFreeSpace(__in PCARD_DATA pCardData, __in DWORD dwFlags,
 	__inout PCARD_FREE_SPACE_INFO pCardFreeSpaceInfo)
 {
-	VENDOR_SPECIFIC *vs;
 	DWORD dwret;
 
 	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
@@ -3408,8 +3303,6 @@ DWORD WINAPI CardQueryFreeSpace(__in PCARD_DATA pCardData, __in DWORD dwFlags,
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
-
-	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
 	check_reader_status(pCardData);
 
@@ -3461,7 +3354,6 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 	VENDOR_SPECIFIC *vs;
 	struct sc_pkcs15_prkey_info *prkey_info;
 	BYTE *pbuf = NULL, *pbuf2 = NULL;
-	DWORD lg= 0, lg2 = 0;
 	struct sc_pkcs15_object *pkey = NULL;
 	struct sc_algorithm_info *alg_info = NULL;
 
@@ -3506,7 +3398,6 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 	if (!pbuf)
 		return SCARD_E_NO_MEMORY;
 
-	lg2 = pInfo->cbData;
 	pbuf2 = pCardData->pfnCspAlloc(pInfo->cbData);
 	if (!pbuf2) {
 		pCardData->pfnCspFree(pbuf);
@@ -4355,7 +4246,6 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 	__inout PCARD_DERIVE_KEY pAgreementInfo)
 {
 	VENDOR_SPECIFIC *vs;
-	DWORD dwAgreementIndex = 0;
 	struct md_dh_agreement* agreement = NULL;
 	NCryptBufferDesc* parameters = NULL;
 	ULONG i;
@@ -4977,7 +4867,6 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 	else if (wcscmp(CP_CARD_SERIAL_NO, wszProperty) == 0)   {
 		unsigned char buf[64];
 		size_t buf_len = sizeof(buf);
-		size_t sn_len = strlen(vs->p15card->tokeninfo->serial_number)/2;
 
 		if (sc_hex_to_bin(vs->p15card->tokeninfo->serial_number, buf, &buf_len))   {
 			buf_len = strlen(vs->p15card->tokeninfo->serial_number);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -276,16 +276,8 @@ static void logprintf(PCARD_DATA pCardData, int level, _Printf_format_string_ co
 	va_start(arg, format);
 	if(pCardData != NULL)   {
 		vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
-		if(vs != NULL && vs->ctx != NULL)   {
-#ifdef _MSC_VER
+		if(vs != NULL && vs->ctx != NULL)
 			sc_do_log_noframe(vs->ctx, level, format, arg);
-#else
-			/* FIXME: trouble in vsprintf with %S arg under mingw32 */
-			if(vs->ctx->debug>=level) {
-				vfprintf(vs->ctx->debug_file, format, arg);
-			}
-#endif
-		}
 	}
 	va_end(arg);
 }

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -238,6 +238,8 @@ static const struct sc_asn1_entry c_asn1_md_container[C_ASN1_MD_CONTAINER_SIZE] 
 	{ NULL, 0, 0, 0, NULL, NULL }
 };
 
+static DWORD md_translate_OpenSC_to_Windows_error(int OpenSCerror,
+						  DWORD dwDefaulCode);
 static int associate_card(PCARD_DATA pCardData);
 static int disassociate_card(PCARD_DATA pCardData);
 static DWORD md_pkcs15_delete_object(PCARD_DATA pCardData, struct sc_pkcs15_object *obj);
@@ -1125,25 +1127,31 @@ md_set_cardid(PCARD_DATA pCardData, struct md_file *file)
 }
 
 /* fill the msroot file from root certificates */
-static void
-md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
+static DWORD
+md_fs_read_msroot_file(PCARD_DATA pCardData, struct md_file *file)
 {
 	CERT_BLOB dbStore = {0};
-	HCERTSTORE hCertStore = NULL;
+	HCERTSTORE hCertStore;
 	VENDOR_SPECIFIC *vs;
 	int rv, ii, cert_num;
 	struct sc_pkcs15_object *prkey_objs[MD_MAX_KEY_CONTAINERS];
+	DWORD dwret = SCARD_F_INTERNAL_ERROR;
 
-	hCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, (HCRYPTPROV_LEGACY) NULL, 0, NULL);
-	if (!hCertStore) {
-		goto Ret;
-	}
+	if (!pCardData || !file)
+		return SCARD_E_INVALID_PARAMETER;
 
 	vs = (VENDOR_SPECIFIC *) pCardData->pvVendorSpecific;
+	if (!vs)
+		return SCARD_E_INVALID_PARAMETER;
+
+	hCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, (HCRYPTPROV_LEGACY)NULL, 0, NULL);
+	if (!hCertStore)
+		goto Ret;
 
 	rv = sc_pkcs15_get_objects(vs->p15card, SC_PKCS15_TYPE_CERT_X509, prkey_objs, MD_MAX_KEY_CONTAINERS);
 	if (rv < 0)   {
 		logprintf(pCardData, 0, "certificate enumeration failed: %s\n", sc_strerror(rv));
+		dwret = md_translate_OpenSC_to_Windows_error(rv, dwret);
 		goto Ret;
 	}
 	cert_num = rv;
@@ -1182,6 +1190,7 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 	dbStore.pbData = (PBYTE) pCardData->pfnCspAlloc(dbStore.cbData);
 
 	if (NULL == dbStore.pbData) {
+		dwret = SCARD_E_NO_MEMORY;
 		goto Ret;
 	}
 
@@ -1197,17 +1206,21 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 	file->size = dbStore.cbData;
 	file->blob = dbStore.pbData;
 	dbStore.pbData = NULL;
+	dwret = SCARD_S_SUCCESS;
+
 Ret:
 	if (dbStore.pbData)
 		pCardData->pfnCspFree(dbStore.pbData);
 	if (hCertStore)
 		CertCloseStore(hCertStore, CERT_CLOSE_STORE_FORCE_FLAG);
+
+	return dwret;
 }
 
 /*
  * Return content of the 'soft' file.
  */
-static void
+static DWORD
 md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 {
 	VENDOR_SPECIFIC *vs;
@@ -1215,22 +1228,21 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 	DWORD dwret;
 
 	if (!pCardData || !file)
-		return;
+		return SCARD_E_INVALID_PARAMETER;
 
 	vs = pCardData->pvVendorSpecific;
+	if (!vs || !vs->p15card)
+		return SCARD_E_INVALID_PARAMETER;
 
 	dwret = md_fs_find_directory(pCardData, NULL, parent, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
 		logprintf(pCardData, 2, "find directory '%s' error: %lX\n",
 			  parent ? parent : "<null>", (unsigned long)dwret);
-		return;
+		return dwret;
 	}
 	else if (!dir)   {
 		logprintf(pCardData, 2, "directory '%s' not found\n", parent ? parent : "<null>");
-		return;
-	}
-	if (vs->p15card == NULL) {
-		return;
+		return SCARD_E_DIR_NOT_FOUND;
 	}
 
 	if (!strcmp((char *)dir->name, "mscp"))   {
@@ -1253,21 +1265,26 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 			if(rv)   {
 				logprintf(pCardData, 2, "Cannot read certificate idx:%i: sc-error %d\n", idx, rv);
 				logprintf(pCardData, 2, "set cardcf from 'DATA' pkcs#15 object\n");
-				return;
+				return md_translate_OpenSC_to_Windows_error(rv,
+									    SCARD_F_INTERNAL_ERROR);
 			}
 
-			file->size = cert->data.len;
 			file->blob = pCardData->pfnCspAlloc(cert->data.len);
-			CopyMemory(file->blob, cert->data.value, cert->data.len);
+			if (file->blob) {
+				CopyMemory(file->blob, cert->data.value, cert->data.len);
+				file->size = cert->data.len;
+				dwret = SCARD_S_SUCCESS;
+			} else
+				dwret = SCARD_E_NO_MEMORY;
+
 			sc_pkcs15_free_certificate(cert);
-		}
-		if (!strcmp((char *)file->name, "msroot")) {
-			md_fs_read_msroot_file(pCardData, parent, file);
-		}
+
+			return dwret;
+		} else if (!strcmp((char *)file->name, "msroot"))
+			return md_fs_read_msroot_file(pCardData, file);
 	}
-	else   {
-		return;
-	}
+
+	return SCARD_E_FILE_NOT_FOUND;
 }
 
 /*
@@ -2434,7 +2451,8 @@ md_dialog_perform_pin_operation(PCARD_DATA pCardData, int operation, struct sc_p
 	return (int) result;
 }
 
-DWORD md_translate_OpenSC_to_Windows_error(int OpenSCerror, DWORD dwDefaulCode)
+static DWORD md_translate_OpenSC_to_Windows_error(int OpenSCerror,
+						  DWORD dwDefaulCode)
 {
 	switch(OpenSCerror)
 	{
@@ -2478,7 +2496,7 @@ DWORD md_translate_OpenSC_to_Windows_error(int OpenSCerror, DWORD dwDefaulCode)
 			return SCARD_W_CHV_BLOCKED;
 		case SC_ERROR_PIN_CODE_INCORRECT:
 			return SCARD_W_WRONG_CHV;
-		
+
 		/* Returned by OpenSC library when called with invalid arguments */
 		case SC_ERROR_INVALID_ARGUMENTS:
 			return ERROR_INVALID_PARAMETER;
@@ -3231,13 +3249,11 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
-	if (!ppbData || !pcbData)
-		return SCARD_E_INVALID_PARAMETER;
 
 	logprintf(pCardData, 2,
-		  "pszDirectoryName = %s, pszFileName = %s, dwFlags = %lX, pcbData=%lu, ppbData=%p\n",
+		  "pszDirectoryName = %s, pszFileName = %s, dwFlags = %lX, pcbData=%p, ppbData=%p\n",
 		  NULLSTR(pszDirectoryName), NULLSTR(pszFileName),
-		  (unsigned long)dwFlags, (unsigned long)*pcbData, ppbData);
+		  (unsigned long)dwFlags, pcbData, ppbData);
 
 	if (!pszFileName || !strlen(pszFileName))
 		return SCARD_E_INVALID_PARAMETER;
@@ -3252,17 +3268,27 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 		return SCARD_E_FILE_NOT_FOUND;
 	}
 
-	if (!file->blob)
-		md_fs_read_content(pCardData, pszDirectoryName, file);
+	if (!file->blob) {
+		DWORD dwret;
 
-	*ppbData = pCardData->pfnCspAlloc(file->size);
-	if(!*ppbData)
-		return SCARD_E_NO_MEMORY;
-	*pcbData = (DWORD) file->size;
-	memcpy(*ppbData, file->blob, file->size);
+		dwret = md_fs_read_content(pCardData, pszDirectoryName, file);
+		if (dwret != SCARD_S_SUCCESS)
+			return dwret;
+	}
+
+	if (ppbData) {
+		*ppbData = pCardData->pfnCspAlloc(file->size);
+		if(!*ppbData)
+			return SCARD_E_NO_MEMORY;
+
+		memcpy(*ppbData, file->blob, file->size);
+	}
+
+	if (pcbData)
+		*pcbData = (DWORD)file->size;
 
 	logprintf(pCardData, 7, "returns '%s' content:\n",  NULLSTR(pszFileName));
-	loghex(pCardData, 7, *ppbData, *pcbData);
+	loghex(pCardData, 7, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
 

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -247,6 +247,11 @@ static DWORD md_fs_init(PCARD_DATA pCardData);
 #define snprintf _snprintf
 #endif
 
+#if defined(__GNUC__)
+static void logprintf(PCARD_DATA pCardData, int level, const char* format, ...)
+	__attribute__ ((format (SC_PRINTF_FORMAT, 3, 4)));
+#endif
+
 static void logprintf(PCARD_DATA pCardData, int level, _Printf_format_string_ const char* format, ...)
 {
 	va_list arg;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -297,7 +297,8 @@ static void loghex(PCARD_DATA pCardData, int level, PBYTE data, size_t len)
 	unsigned int i, a;
 	unsigned char * p;
 
-	logprintf(pCardData, level, "--- %p:%d\n", data, len);
+	logprintf(pCardData, level, "--- %p:%"SC_FORMAT_LEN_SIZE_T"u\n",
+		  data, len);
 
 	if (data == NULL || len <= 0) return;
 
@@ -348,10 +349,13 @@ check_reader_status(PCARD_DATA pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
 	logprintf(pCardData, 7, "pCardData->hSCardCtx:0x%08X hScard:0x%08X\n",
-			pCardData->hSCardCtx, pCardData->hScard);
+		  (unsigned int)pCardData->hSCardCtx,
+		  (unsigned int)pCardData->hScard);
 
 	if (pCardData->hSCardCtx != vs->hSCardCtx || pCardData->hScard != vs->hScard) {
-		logprintf (pCardData, 1, "HANDLES CHANGED from 0x%08X 0x%08X\n", vs->hSCardCtx, vs->hScard);
+		logprintf(pCardData, 1, "HANDLES CHANGED from 0x%08X 0x%08X\n",
+			  (unsigned int)vs->hSCardCtx,
+			  (unsigned int)vs->hScard);
 
 		/* Basically a mini AcquireContext */
 		r = disassociate_card(pCardData);
@@ -367,7 +371,9 @@ check_reader_status(PCARD_DATA pCardData)
 	else if (vs->reader) {
 		/* This should always work, as BaseCSP should be checking for removal too */
 		r = sc_detect_card_presence(vs->reader);
-		logprintf(pCardData, 2, "check_reader_status r=%d flags 0x%08X\n", r, vs->reader->flags);
+		logprintf(pCardData, 2,
+			  "check_reader_status r=%d flags 0x%08X\n", r,
+			  (unsigned int)vs->reader->flags);
 	}
 
 	return r;
@@ -748,7 +754,8 @@ md_fs_find_file(PCARD_DATA pCardData, char *parent, char *name, struct md_file *
 
 	dwret = md_fs_find_directory(pCardData, NULL, parent, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 2, "find directory '%s' error: %X\n", parent ? parent : "<null>", dwret);
+		logprintf(pCardData, 2, "find directory '%s' error: %lX\n",
+			  parent ? parent : "<null>", (unsigned long)dwret);
 		return dwret;
 	}
 	else if (!dir)   {
@@ -851,7 +858,8 @@ md_fs_delete_file(PCARD_DATA pCardData, char *parent, char *name)
 
 	dwret = md_fs_find_directory(pCardData, NULL, parent, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 2, "find directory '%s' error: %X\n", parent ? parent : "<null>", dwret);
+		logprintf(pCardData, 2, "find directory '%s' error: %lX\n",
+			  parent ? parent : "<null>", (unsigned long)dwret);
 		return dwret;
 	}
 	else if (!dir)   {
@@ -898,7 +906,9 @@ md_fs_delete_file(PCARD_DATA pCardData, char *parent, char *name)
 			dwret = md_pkcs15_delete_object(pCardData, vs->p15_containers[idx].cert_obj);
 			vs->p15_containers[idx].cert_obj = NULL;
 			if(dwret != SCARD_S_SUCCESS)
-				logprintf(pCardData, 2, "Cannot delete certificate PKCS#15 object #%i: dwret 0x%X\n", idx, dwret);
+				logprintf(pCardData, 2,
+					  "Cannot delete certificate PKCS#15 object #%i: dwret 0x%lX\n",
+					  idx, (unsigned long)dwret);
 		}
 	}
 
@@ -1108,7 +1118,8 @@ md_set_cardid(PCARD_DATA pCardData, struct md_file *file)
 			return dwret;
 	}
 
-	logprintf(pCardData, 3, "cardid(%i)\n", file->size);
+	logprintf(pCardData, 3, "cardid(%"SC_FORMAT_LEN_SIZE_T"u)\n",
+		  file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1152,7 +1163,9 @@ md_fs_read_msroot_file(PCARD_DATA pCardData, char *parent, struct md_file *file)
 				CertFreeCertificateContext(wincert);
 			}
 			else {
-				logprintf(pCardData, 2, "unable to load the certificate from windows 0x%08X\n", GetLastError());
+				logprintf(pCardData, 2,
+					  "unable to load the certificate from Windows 0x%08X\n",
+					  (unsigned int)GetLastError());
 			}
 			sc_pkcs15_free_certificate(cert);
 		}
@@ -1208,7 +1221,8 @@ md_fs_read_content(PCARD_DATA pCardData, char *parent, struct md_file *file)
 
 	dwret = md_fs_find_directory(pCardData, NULL, parent, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 2, "find directory '%s' error: %X\n", parent ? parent : "<null>", dwret);
+		logprintf(pCardData, 2, "find directory '%s' error: %lX\n",
+			  parent ? parent : "<null>", (unsigned long)dwret);
 		return;
 	}
 	else if (!dir)   {
@@ -1276,7 +1290,8 @@ md_set_cardcf(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "'cardcf' content(%i)\n", file->size);
+	logprintf(pCardData, 3, "'cardcf' content(%"SC_FORMAT_LEN_SIZE_T"u)\n",
+		  file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1294,7 +1309,7 @@ md_set_cardapps(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "mscp(%i)\n", file->size);
+	logprintf(pCardData, 3, "mscp(%"SC_FORMAT_LEN_SIZE_T"u)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1424,7 +1439,9 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 		}
 
 		logprintf(pCardData, 7, "Container[%i]'s guid=%.*s\n", ii, (int) sizeof cont->guid, cont->guid);
-		logprintf(pCardData, 7, "Container[%i]'s key-exchange:%i, sign:%i\n", ii, cont->size_key_exchange, cont->size_sign);
+		logprintf(pCardData, 7,
+			  "Container[%i]'s key-exchange:%"SC_FORMAT_LEN_SIZE_T"u, sign:%"SC_FORMAT_LEN_SIZE_T"u\n",
+			  ii, cont->size_key_exchange, cont->size_sign);
 
 		cont->id = prkey_info->id;
 		cont->prkey_obj = prkey_objs[ii];
@@ -1529,7 +1546,7 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "cmap(%i)\n", file->size);
+	logprintf(pCardData, 3, "cmap(%"SC_FORMAT_LEN_SIZE_T"u)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1583,9 +1600,12 @@ md_fs_init(PCARD_DATA pCardData)
 		return dwret;
 
 #ifdef OPENSSL_VERSION_NUMBER
-	logprintf(pCardData, 3, "MD virtual file system initialized; OPENSSL_VERSION_NUMBER 0x%Xl\n", OPENSSL_VERSION_NUMBER);
+	logprintf(pCardData, 3,
+		  "MD virtual file system initialized; OPENSSL_VERSION_NUMBER 0x%lX\n",
+		  OPENSSL_VERSION_NUMBER);
 #else
-	logprintf(pCardData, 3, "MD virtual file system initialized; Without OPENSSL\n");
+	logprintf(pCardData, 3,
+		  "MD virtual file system initialized; Without OPENSSL\n");
 #endif
 	return SCARD_S_SUCCESS;
 }
@@ -1690,7 +1710,8 @@ md_check_key_compatibility(PCARD_DATA pCardData, DWORD flags, DWORD key_type,
 			key_algo = SC_ALGORITHM_EC;
 			break;
 		default:
-			logprintf(pCardData, 3, "Unsupported key type: 0x%X\n", key_type);
+			logprintf(pCardData, 3, "Unsupported key type: 0x%lX\n",
+				  (unsigned long)key_type);
 			return SCARD_E_UNSUPPORTED_FEATURE;
 	}
 
@@ -1726,7 +1747,8 @@ md_check_key_compatibility(PCARD_DATA pCardData, DWORD flags, DWORD key_type,
 				return SCARD_E_INVALID_PARAMETER;
 			}
 
-			logprintf(pCardData, 3, "Set key size to %i\n", key_size);
+			logprintf(pCardData, 3, "Set key size to %lu\n",
+				  (unsigned long)key_size);
 		} else if (key_algo == SC_ALGORITHM_EC) {
 			BCRYPT_ECCKEY_BLOB *pub_ecc = (BCRYPT_ECCKEY_BLOB *)pbKeyData;
 			switch(key_type) {
@@ -1774,7 +1796,8 @@ md_check_key_compatibility(PCARD_DATA pCardData, DWORD flags, DWORD key_type,
 					break;
 			}
 		}
-		logprintf(pCardData, 3, "Set key size to %i\n", key_size);
+		logprintf(pCardData, 3, "Set key size to %lu\n",
+			  (unsigned long)key_size);
 	}
 
 	count = vs->p15card->card->algorithm_count;
@@ -1785,7 +1808,9 @@ md_check_key_compatibility(PCARD_DATA pCardData, DWORD flags, DWORD key_type,
 		return SCARD_S_SUCCESS;
 	}
 
-	logprintf(pCardData, 3, "No card support for key(type:0x%X,size:0x%X)\n", key_type, key_size);
+	logprintf(pCardData, 3,
+		  "No card support for key(type:0x%lX,size:0x%lX)\n",
+		  (unsigned long)key_type, (unsigned long)key_size);
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
 
@@ -1838,7 +1863,9 @@ md_pkcs15_generate_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, DWORD ke
 		keygen_args.prkey_args.x509_usage = MD_KEY_USAGE_KEYEXCHANGE_ECC;
 	}
 	else    {
-		logprintf(pCardData, 3, "MdGenerateKey(): unsupported key type: 0x%X\n", key_type);
+		logprintf(pCardData, 3,
+			  "MdGenerateKey(): unsupported key type: 0x%lX\n",
+			  (unsigned long)key_type);
 		return SCARD_E_UNSUPPORTED_FEATURE;
 	}
 	if (pub_args.key.algorithm == SC_ALGORITHM_EC) {
@@ -1915,8 +1942,10 @@ md_pkcs15_generate_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, DWORD ke
 	cont->index = idx;
 	cont->flags = CONTAINER_MAP_VALID_CONTAINER;
 
-	logprintf(pCardData, 3, "MdGenerateKey(): generated key(idx:%i,id:%s,guid:%.*s)\n",
-			idx, sc_pkcs15_print_id(&cont->id),(int) sizeof cont->guid, cont->guid);
+	logprintf(pCardData, 3,
+		  "MdGenerateKey(): generated key(idx:%lu,id:%s,guid:%.*s)\n",
+		  (unsigned long)idx, sc_pkcs15_print_id(&cont->id),
+		  (int) sizeof cont->guid, cont->guid);
 
 done:
 	sc_pkcs15init_unbind(profile);
@@ -1978,7 +2007,9 @@ md_pkcs15_store_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, BYTE *blob,
 		pubkey_args.x509_usage = MD_KEY_USAGE_KEYEXCHANGE;
 	}
 	else    {
-		logprintf(pCardData, 3, "MdStoreKey(): unsupported key type: 0x%X\n", key_type);
+		logprintf(pCardData, 3,
+			  "MdStoreKey(): unsupported key type: 0x%lX\n",
+			  (unsigned long)key_type);
 		return SCARD_E_INVALID_PARAMETER;
 	}
 
@@ -2048,7 +2079,10 @@ md_pkcs15_store_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, BYTE *blob,
 	cont->index = idx;
 	cont->flags |= CONTAINER_MAP_VALID_CONTAINER;
 
-	logprintf(pCardData, 3, "MdStoreKey(): stored key(idx:%i,id:%s,guid:%.*s)\n", idx, sc_pkcs15_print_id(&cont->id),(int) sizeof cont->guid,cont->guid);
+	logprintf(pCardData, 3,
+		  "MdStoreKey(): stored key(idx:%lu,id:%s,guid:%.*s)\n",
+		  (unsigned long)idx, sc_pkcs15_print_id(&cont->id),
+		  (int) sizeof cont->guid, cont->guid);
 
 done:
 	sc_pkcs15init_unbind(profile);
@@ -2145,7 +2179,8 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 	if (pKeySizes->dwVersion != CARD_KEY_SIZES_CURRENT_VERSION && pKeySizes->dwVersion != 0)
 		return ERROR_REVISION_MISMATCH;
 
-	logprintf(pCardData, 1, "md_query_key_sizes: store dwKeySpec '%u'\n", dwKeySpec);
+	logprintf(pCardData, 1, "md_query_key_sizes: store dwKeySpec '%lu'\n",
+		  (unsigned long)dwKeySpec);
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	count = vs->p15card->card->algorithm_count;
 
@@ -2161,7 +2196,6 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 		for (i = 0; i < count; i++) {
 			algo_info = vs->p15card->card->algorithms + i;
 			if (algo_info->algorithm == SC_ALGORITHM_RSA) {
-				
 				if (pKeySizes->dwMinimumBitlen == 0 || pKeySizes->dwMinimumBitlen > algo_info->key_length) {
 					pKeySizes->dwMinimumBitlen = algo_info->key_length;
 				}
@@ -2231,17 +2265,23 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 				pKeySizes->dwMaximumBitlen = keysize;
 				pKeySizes->dwIncrementalBitlen = 1;
 			} else {
-				logprintf(pCardData, 0, "No ECC key found (keyspec=%u)\n", dwKeySpec);
+				logprintf(pCardData, 0,
+					  "No ECC key found (keyspec=%lu)\n",
+					  (unsigned long)dwKeySpec);
 				return SCARD_E_INVALID_PARAMETER;
 			}
 		}
 	}
-	
+
 	logprintf(pCardData, 3, "Key compatible with the card capabilities\n");
-	logprintf(pCardData, 3, " dwMinimumBitlen: %u\n", pKeySizes->dwMinimumBitlen);
-	logprintf(pCardData, 3, " dwDefaultBitlen: %u\n", pKeySizes->dwDefaultBitlen);
-	logprintf(pCardData, 3, " dwMaximumBitlen: %u\n", pKeySizes->dwMaximumBitlen);
-	logprintf(pCardData, 3, " dwIncrementalBitlen: %u\n", pKeySizes->dwIncrementalBitlen);
+	logprintf(pCardData, 3, " dwMinimumBitlen: %lu\n",
+		  (unsigned long)pKeySizes->dwMinimumBitlen);
+	logprintf(pCardData, 3, " dwDefaultBitlen: %lu\n",
+		  (unsigned long)pKeySizes->dwDefaultBitlen);
+	logprintf(pCardData, 3, " dwMaximumBitlen: %lu\n",
+		  (unsigned long)pKeySizes->dwMaximumBitlen);
+	logprintf(pCardData, 3, " dwIncrementalBitlen: %lu\n",
+		  (unsigned long)pKeySizes->dwIncrementalBitlen);
 	return SCARD_S_SUCCESS;
 }
 
@@ -2468,8 +2508,12 @@ DWORD WINAPI CardDeleteContext(__inout PCARD_DATA  pCardData)
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p hScard=0x%08X hSCardCtx=0x%08X CardDeleteContext\n",
-			GetCurrentProcessId(), GetCurrentThreadId(), pCardData, pCardData->hScard, pCardData->hSCardCtx);
+	logprintf(pCardData, 1,
+		  "\nP:%lu T:%lu pCardData:%p hScard=0x%08X hSCardCtx=0x%08X CardDeleteContext\n",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData,
+		  (unsigned int)pCardData->hScard,
+		  (unsigned int)pCardData->hSCardCtx);
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	if(!vs)
@@ -2498,7 +2542,9 @@ DWORD WINAPI CardQueryCapabilities(__in PCARD_DATA pCardData,
 {
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "pCardCapabilities=%p\n", pCardCapabilities);
 
 	if (!pCardData || !pCardCapabilities)
@@ -2520,8 +2566,11 @@ DWORD WINAPI CardDeleteContainer(__in PCARD_DATA pCardData,
 	VENDOR_SPECIFIC *vs = NULL;
 	DWORD dwret;
 	struct md_pkcs15_container* cont;
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardDeleteContainer(idx:%i)\n", bContainerIndex);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "CardDeleteContainer(idx:%u)\n",
+		  (unsigned int)bContainerIndex);
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -2571,9 +2620,13 @@ DWORD WINAPI CardCreateContainer(__in PCARD_DATA pCardData,
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardCreateContainer(idx:%i,flags:%X,type:%X,size:%i,data:%p)\n",
-			bContainerIndex, dwFlags, dwKeySpec, dwKeySize, pbKeyData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardCreateContainerEx(idx:%u,flags:%lX,type:%lX,size:%lu,data:%p)\n",
+		  (unsigned int)bContainerIndex, (unsigned long)dwFlags,
+		  (unsigned long)dwKeySpec, (unsigned long)dwKeySize, pbKeyData);
 
 	if (pbKeyData)   {
 		logprintf(pCardData, 7, "Key data\n");
@@ -2618,7 +2671,8 @@ DWORD WINAPI CardCreateContainer(__in PCARD_DATA pCardData,
 		logprintf(pCardData, 1, "key imported\n");
 	}
 	else   {
-		logprintf(pCardData, 1, "Invalid dwFlags value: 0x%X\n", dwFlags);
+		logprintf(pCardData, 1, "Invalid dwFlags value: 0x%lX\n",
+			  (unsigned long)dwFlags);
 		return SCARD_E_INVALID_PARAMETER;
 	}
 
@@ -2647,11 +2701,15 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 	if (!pContainerInfo)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardGetContainerInfo bContainerIndex=%u, dwFlags=0x%08X, " \
-		"dwVersion=%u, cbSigPublicKey=%u, cbKeyExPublicKey=%u\n", \
-		bContainerIndex, dwFlags, pContainerInfo->dwVersion, \
-		pContainerInfo->cbSigPublicKey, pContainerInfo->cbKeyExPublicKey);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardGetContainerInfo bContainerIndex=%u, dwFlags=0x%08X, dwVersion=%lu, cbSigPublicKey=%lu, cbKeyExPublicKey=%lu\n",
+		  (unsigned int)bContainerIndex, (unsigned int)dwFlags,
+		  (unsigned long)pContainerInfo->dwVersion,
+		  (unsigned long)pContainerInfo->cbSigPublicKey,
+		  (unsigned long)pContainerInfo->cbKeyExPublicKey);
 
 	if (dwFlags)
 		return SCARD_E_INVALID_PARAMETER;
@@ -2666,7 +2724,8 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 	cont = &vs->p15_containers[bContainerIndex];
 
 	if (!cont->prkey_obj)   {
-		logprintf(pCardData, 7, "Container %i is empty\n", bContainerIndex);
+		logprintf(pCardData, 7, "Container %u is empty\n",
+			  (unsigned int)bContainerIndex);
 		return SCARD_E_NO_KEY_CONTAINER;
 	}
 
@@ -2728,7 +2787,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 			sc_pkcs15_free_certificate(cert);
 		}
 		else   {
-			logprintf(pCardData, 1, "certificate '%d' read error %d\n", bContainerIndex, rv);
+			logprintf(pCardData, 1,
+				  "certificate '%u' read error %d\n",
+				  (unsigned int)bContainerIndex, rv);
 			ret = SCARD_E_FILE_NOT_FOUND;
 		}
 	}
@@ -2739,7 +2800,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 	}
 
 	if (ret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 7, "GetContainerInfo(idx:%i) failed; error %X", bContainerIndex, ret);
+		logprintf(pCardData, 7,
+			  "GetContainerInfo(idx:%u) failed; error %lX",
+			  (unsigned int)bContainerIndex, (unsigned long)ret);
 		return ret;
 	}
 
@@ -2765,7 +2828,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				pContainerInfo->cbSigPublicKey = sz;
 				pContainerInfo->pbSigPublicKey = (PBYTE)publicKey;
 
-				logprintf(pCardData, 3, "return info on SIGN_CONTAINER_INDEX %i\n", bContainerIndex);
+				logprintf(pCardData, 3,
+					  "return info on SIGN_CONTAINER_INDEX %u\n",
+					  (unsigned int)bContainerIndex);
 			}
 
 			if (cont->size_key_exchange)   {
@@ -2780,7 +2845,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				pContainerInfo->cbKeyExPublicKey = sz;
 				pContainerInfo->pbKeyExPublicKey = (PBYTE)publicKey;
 
-				logprintf(pCardData, 3, "return info on KEYX_CONTAINER_INDEX %i\n", bContainerIndex);
+				logprintf(pCardData, 3,
+					  "return info on KEYX_CONTAINER_INDEX %u\n",
+					  (unsigned int)bContainerIndex);
 			}
 		}
 	} else if (prkey_info->field_length > 0) {
@@ -2804,7 +2871,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 					dwMagic = BCRYPT_ECDSA_PUBLIC_P521_MAGIC;
 					break;
 				default:
-					logprintf(pCardData, 3, "Unable to match the ECC public size to one of Microsoft algorithm %i\n", cont->size_sign);
+					logprintf(pCardData, 3,
+						  "Unable to match the ECC public size to one of Microsoft algorithm %"SC_FORMAT_LEN_SIZE_T"u\n",
+						  cont->size_sign);
 					return SCARD_F_INTERNAL_ERROR;
 				}
 
@@ -2818,8 +2887,10 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				pContainerInfo->cbSigPublicKey = sz;
 				pContainerInfo->pbSigPublicKey = (PBYTE)publicKey;
 				memcpy(((PBYTE)publicKey) + sizeof(BCRYPT_ECCKEY_BLOB),  pubkey_der.value + 3,  pubkey_der.len -3);
-				
-				logprintf(pCardData, 3, "return info on ECC SIGN_CONTAINER_INDEX %i\n", bContainerIndex);
+
+				logprintf(pCardData, 3,
+					  "return info on ECC SIGN_CONTAINER_INDEX %u\n",
+					  (unsigned int)bContainerIndex);
 			}
 			if (cont->size_key_exchange)   {
 				sz = (DWORD) (sizeof(BCRYPT_ECCKEY_BLOB) +  pubkey_der.len -3);
@@ -2836,7 +2907,9 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 					dwMagic = BCRYPT_ECDH_PUBLIC_P521_MAGIC;
 					break;
 				default:
-					logprintf(pCardData, 3, "Unable to match the ECC public size to one of Microsoft algorithm %i\n", cont->size_key_exchange);
+					logprintf(pCardData, 3,
+						  "Unable to match the ECC public size to one of Microsoft algorithm %"SC_FORMAT_LEN_SIZE_T"u\n",
+						  cont->size_key_exchange);
 					return SCARD_F_INTERNAL_ERROR;
 				}
 
@@ -2850,14 +2923,16 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				pContainerInfo->cbKeyExPublicKey = sz;
 				pContainerInfo->pbKeyExPublicKey = (PBYTE)publicKey;
 				memcpy(((PBYTE)publicKey) + sizeof(BCRYPT_ECCKEY_BLOB),  pubkey_der.value + 3,  pubkey_der.len -3);
-				
-				logprintf(pCardData, 3, "return info on ECC KEYX_CONTAINER_INDEX %i\n", bContainerIndex);
+
+				logprintf(pCardData, 3,
+					  "return info on ECC KEYX_CONTAINER_INDEX %u\n",
+					  (unsigned int)bContainerIndex);
 			}
-			
 		}
 	}
 
-	logprintf(pCardData, 7, "returns container(idx:%i) info", bContainerIndex);
+	logprintf(pCardData, 7, "returns container(idx:%u) info",
+		  (unsigned int)bContainerIndex);
 	return SCARD_S_SUCCESS;
 }
 
@@ -2868,8 +2943,11 @@ DWORD WINAPI CardAuthenticatePin(__in PCARD_DATA pCardData,
 	__out_opt PDWORD pcAttemptsRemaining)
 {
 	PIN_ID PinId = 0;
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardAuthenticatePin '%S':%d\n", NULLWSTR(pwszUserId), cbPin);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "CardAuthenticatePin '%S':%lu\n",
+		  NULLWSTR(pwszUserId), (unsigned long)cbPin);
 
 	if (wcscmp(pwszUserId, wszCARD_USER_USER) == 0)	{
 		PinId = ROLE_USER;
@@ -2894,7 +2972,9 @@ DWORD WINAPI CardGetChallenge(__in PCARD_DATA pCardData,
 	VENDOR_SPECIFIC *vs;
 	int rv;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetChallenge\n");
 
 	if(!pCardData)
@@ -2902,7 +2982,8 @@ DWORD WINAPI CardGetChallenge(__in PCARD_DATA pCardData,
 	if (!ppbChallengeData || !pcbChallengeData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "Asked challenge length %i, buffer %p\n", *pcbChallengeData, *ppbChallengeData);
+	logprintf(pCardData, 1, "Asked challenge length %lu, buffer %p\n",
+		  (unsigned long)*pcbChallengeData, *ppbChallengeData);
 	if (pcbChallengeData == NULL)   {
 		*ppbChallengeData = NULL;
 
@@ -2928,7 +3009,8 @@ DWORD WINAPI CardGetChallenge(__in PCARD_DATA pCardData,
 		return SCARD_E_UNEXPECTED;
 	}
 
-	logprintf(pCardData, 7, "returns %i bytes:\n", *pcbChallengeData);
+	logprintf(pCardData, 7, "returns %lu bytes:\n",
+		  (unsigned long)*pcbChallengeData);
 	loghex(pCardData, 7, *ppbChallengeData, *pcbChallengeData);
 	return SCARD_S_SUCCESS;
 }
@@ -2939,7 +3021,9 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
 	__in DWORD  cbResponseData,
 	__out_opt PDWORD pcAttemptsRemaining)
 {
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardAuthenticateChallenge - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -2957,7 +3041,9 @@ DWORD WINAPI CardUnblockPin(__in PCARD_DATA  pCardData,
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardUnblockPin\n");
 
 	if (pwszUserId == NULL) {
@@ -2985,11 +3071,20 @@ DWORD WINAPI CardUnblockPin(__in PCARD_DATA  pCardData,
 		return SCARD_E_INVALID_PARAMETER;
 	}
 
-	logprintf(pCardData, 1, "UserID('%S'), AuthData(%p, %u), NewPIN(%p, %u), Retry(%u), dwFlags(0x%X)\n",
-			pwszUserId, pbAuthenticationData, cbAuthenticationData, pbNewPinData, cbNewPinData,
-			cRetryCount, dwFlags);
+	logprintf(pCardData, 1,
+		  "UserID('%S'), AuthData(%p, %lu), NewPIN(%p, %lu), Retry(%lu), dwFlags(0x%lX)\n",
+		  pwszUserId, pbAuthenticationData,
+		  (unsigned long)cbAuthenticationData, pbNewPinData,
+		  (unsigned long)cbNewPinData, (unsigned long)cRetryCount,
+		  (unsigned long)dwFlags);
 
-	return CardChangeAuthenticatorEx(pCardData, PIN_CHANGE_FLAG_UNBLOCK | CARD_PIN_SILENT_CONTEXT, ROLE_ADMIN, pbAuthenticationData, cbAuthenticationData, ROLE_USER, pbNewPinData, cbNewPinData, cRetryCount, NULL);
+	return CardChangeAuthenticatorEx(pCardData,
+					 PIN_CHANGE_FLAG_UNBLOCK |
+					 CARD_PIN_SILENT_CONTEXT,
+					 ROLE_ADMIN, pbAuthenticationData,
+					 cbAuthenticationData, ROLE_USER,
+					 pbNewPinData, cbNewPinData,
+					 cRetryCount, NULL);
 }
 
 
@@ -3007,7 +3102,9 @@ DWORD WINAPI CardChangeAuthenticator(__in PCARD_DATA  pCardData,
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardChangeAuthenticator\n");
 
 	if (pwszUserId == NULL)
@@ -3024,16 +3121,24 @@ DWORD WINAPI CardChangeAuthenticator(__in PCARD_DATA  pCardData,
 	if (wcscmp(wszCARD_USER_USER, pwszUserId) != 0 && wcscmp(wszCARD_USER_ADMIN, pwszUserId) != 0)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "UserID('%S'), CurrentPIN(%p, %u), NewPIN(%p, %u), Retry(%u), dwFlags(0x%X)\n",
-			pwszUserId, pbCurrentAuthenticator, cbCurrentAuthenticator, pbNewAuthenticator, cbNewAuthenticator,
-			cRetryCount, dwFlags);
+	logprintf(pCardData, 1,
+		  "UserID('%S'), CurrentPIN(%p, %lu), NewPIN(%p, %lu), Retry(%lu), dwFlags(0x%lX)\n",
+		  pwszUserId, pbCurrentAuthenticator,
+		  (unsigned long)cbCurrentAuthenticator, pbNewAuthenticator,
+		  (unsigned long)cbNewAuthenticator, (unsigned long)cRetryCount,
+		  (unsigned long)dwFlags);
 
 	if (wcscmp(wszCARD_USER_USER, pwszUserId) == 0)
 		pinid = ROLE_USER;
 	else
 		pinid = ROLE_ADMIN;
 
-	return CardChangeAuthenticatorEx(pCardData, PIN_CHANGE_FLAG_CHANGEPIN | CARD_PIN_SILENT_CONTEXT, pinid, pbCurrentAuthenticator, cbCurrentAuthenticator, pinid, pbNewAuthenticator, cbNewAuthenticator, cRetryCount, pcAttemptsRemaining);
+	return CardChangeAuthenticatorEx(pCardData, PIN_CHANGE_FLAG_CHANGEPIN |
+					 CARD_PIN_SILENT_CONTEXT, pinid,
+					 pbCurrentAuthenticator,
+					 cbCurrentAuthenticator, pinid,
+					 pbNewAuthenticator, cbNewAuthenticator,
+					 cRetryCount, pcAttemptsRemaining);
 }
 
 /* this function is not called on purpose.
@@ -3046,8 +3151,11 @@ DWORD WINAPI CardDeauthenticate(__in PCARD_DATA pCardData,
 {
 	VENDOR_SPECIFIC* vs = NULL;
 	int rv;
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardDeauthenticate(%S) %d\n", NULLWSTR(pwszUserId), dwFlags);
+	logprintf(pCardData, 1, "\nP:%ld T:%ld pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "CardDeauthenticate(%S) %lu\n",
+		  NULLWSTR(pwszUserId), (unsigned long)dwFlags);
 
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -3068,7 +3176,9 @@ DWORD WINAPI CardCreateDirectory(__in PCARD_DATA pCardData,
 	__in LPSTR pszDirectoryName,
 	__in CARD_DIRECTORY_ACCESS_CONDITION AccessCondition)
 {
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardCreateDirectory - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -3076,7 +3186,9 @@ DWORD WINAPI CardCreateDirectory(__in PCARD_DATA pCardData,
 DWORD WINAPI CardDeleteDirectory(__in PCARD_DATA pCardData,
 	__in LPSTR pszDirectoryName)
 {
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardDeleteDirectory(%s) - unsupported\n", NULLSTR(pszDirectoryName));
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -3090,9 +3202,13 @@ DWORD WINAPI CardCreateFile(__in PCARD_DATA pCardData,
 	struct md_directory *dir = NULL;
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardCreateFile(%s::%s, size %i, acl:0x%X) called\n",
-			NULLSTR(pszDirectoryName), NULLSTR(pszFileName), cbInitialCreationSize, AccessCondition);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardCreateFile(%s::%s, size %lu, acl:0x%X) called\n",
+		  NULLSTR(pszDirectoryName), NULLSTR(pszFileName),
+		  (unsigned long)cbInitialCreationSize, AccessCondition);
 
 	dwret = md_fs_find_directory(pCardData, NULL, pszDirectoryName, &dir);
 	if (dwret != SCARD_S_SUCCESS)   {
@@ -3117,7 +3233,9 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 {
 	struct md_file *file = NULL;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardReadFile\n");
 
 	if(!pCardData)
@@ -3125,8 +3243,10 @@ DWORD WINAPI CardReadFile(__in PCARD_DATA pCardData,
 	if (!ppbData || !pcbData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 2, "pszDirectoryName = %s, pszFileName = %s, dwFlags = %X, pcbData=%u, *ppbData=%X\n",
-		NULLSTR(pszDirectoryName), NULLSTR(pszFileName), dwFlags, *pcbData, *ppbData);
+	logprintf(pCardData, 2,
+		  "pszDirectoryName = %s, pszFileName = %s, dwFlags = %lX, pcbData=%lu, ppbData=%p\n",
+		  NULLSTR(pszDirectoryName), NULLSTR(pszFileName),
+		  (unsigned long)dwFlags, (unsigned long)*pcbData, ppbData);
 
 	if (!pszFileName || !strlen(pszFileName))
 		return SCARD_E_INVALID_PARAMETER;
@@ -3169,13 +3289,16 @@ DWORD WINAPI CardWriteFile(__in PCARD_DATA pCardData,
 	if(!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardWriteFile() dirName:'%s', fileName:'%s' \n", NULLSTR(pszDirectoryName), NULLSTR(pszFileName));
 
 	check_reader_status(pCardData);
 
 	if (pbData && cbData)   {
-		logprintf(pCardData, 1, "CardWriteFile try to write (%i):\n", cbData);
+		logprintf(pCardData, 1, "CardWriteFile try to write (%lu):\n",
+			  (unsigned long)cbData);
 		loghex(pCardData, 2, pbData, cbData);
 	}
 
@@ -3190,7 +3313,8 @@ DWORD WINAPI CardWriteFile(__in PCARD_DATA pCardData,
 
 	dwret = md_fs_set_content(pCardData, file, pbData, cbData);
 	if (dwret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 1, "cannot set file content: %li\n", dwret);
+		logprintf(pCardData, 1, "cannot set file content: %lu\n",
+			  (unsigned long)dwret);
 		return dwret;
 	}
 
@@ -3214,7 +3338,9 @@ DWORD WINAPI CardDeleteFile(__in PCARD_DATA pCardData,
 {
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardDeleteFile(%s, %s) called\n", NULLSTR(pszDirectoryName), NULLSTR(pszFileName));
 
 	if(!pCardData)
@@ -3224,7 +3350,9 @@ DWORD WINAPI CardDeleteFile(__in PCARD_DATA pCardData,
 
 	dwret = md_fs_delete_file(pCardData, pszDirectoryName, pszFileName);
 	if (dwret != SCARD_S_SUCCESS)   {
-		logprintf(pCardData, 2, "CardDeleteFile(): delete file error: %X\n", dwret);
+		logprintf(pCardData, 2,
+			  "CardDeleteFile(): delete file error: %lX\n",
+			  (unsigned long)dwret);
 		return dwret;
 	}
 
@@ -3244,7 +3372,9 @@ DWORD WINAPI CardEnumFiles(__in PCARD_DATA pCardData,
 	struct md_file *file = NULL;
 	size_t offs;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardEnumFiles() directory '%s'\n", NULLSTR(pszDirectoryName));
 
 	if (!pCardData)
@@ -3252,7 +3382,9 @@ DWORD WINAPI CardEnumFiles(__in PCARD_DATA pCardData,
 	if (!pmszFileNames || !pdwcbFileName)
 		return SCARD_E_INVALID_PARAMETER;
 	if (dwFlags)   {
-		logprintf(pCardData, 1, "CardEnumFiles() dwFlags not 'zero' -- %X\n", dwFlags);
+		logprintf(pCardData, 1,
+			  "CardEnumFiles() dwFlags not 'zero' -- %lX\n",
+			  (unsigned long)dwFlags);
 		return SCARD_E_INVALID_PARAMETER;
 	}
 
@@ -3296,7 +3428,9 @@ DWORD WINAPI CardGetFileInfo(__in PCARD_DATA pCardData,
 {
 	struct md_file *file = NULL;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetFileInfo(dirName:'%s',fileName:'%s', out %p)\n", NULLSTR(pszDirectoryName), NULLSTR(pszFileName), pCardFileInfo);
 
 	md_fs_find_file(pCardData, pszDirectoryName, pszFileName, &file);
@@ -3318,9 +3452,13 @@ DWORD WINAPI CardQueryFreeSpace(__in PCARD_DATA pCardData, __in DWORD dwFlags,
 {
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardQueryFreeSpace %p, dwFlags=%X, version=%X\n",
-		pCardFreeSpaceInfo, dwFlags, pCardFreeSpaceInfo->dwVersion);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardQueryFreeSpace %p, dwFlags=%lX, version=%lX\n",
+		  pCardFreeSpaceInfo, (unsigned long)dwFlags,
+		  (unsigned long)pCardFreeSpaceInfo->dwVersion);
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -3346,8 +3484,13 @@ DWORD WINAPI CardQueryKeySizes(__in PCARD_DATA pCardData,
 {
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardQueryKeySizes dwKeySpec=%X, dwFlags=%X, version=%X\n",  dwKeySpec, dwFlags, (pKeySizes?pKeySizes->dwVersion:0));
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardQueryKeySizes dwKeySpec=%lX, dwFlags=%lX, version=%lX\n",
+		  (unsigned long)dwKeySpec, (unsigned long)dwFlags,
+		  pKeySizes ? (unsigned long)pKeySizes->dwVersion : 0);
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -3378,7 +3521,9 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 	struct sc_pkcs15_object *pkey = NULL;
 	struct sc_algorithm_info *alg_info = NULL;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardRSADecrypt\n");
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -3402,11 +3547,18 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 
 	check_reader_status(pCardData);
 
-	logprintf(pCardData, 2, "CardRSADecrypt dwVersion=%u, bContainerIndex=%u,dwKeySpec=%u pbData=%p, cbData=%u\n",
-		pInfo->dwVersion,pInfo->bContainerIndex ,pInfo->dwKeySpec, pInfo->pbData,  pInfo->cbData);
+	logprintf(pCardData, 2,
+		  "CardRSADecrypt dwVersion=%lu, bContainerIndex=%u, dwKeySpec=%lu pbData=%p, cbData=%lu\n",
+		  (unsigned long)pInfo->dwVersion,
+		  (unsigned int)pInfo->bContainerIndex,
+		  (unsigned long)pInfo->dwKeySpec, pInfo->pbData,
+		  (unsigned long)pInfo->cbData);
 
 	if (pInfo->dwVersion >= CARD_RSA_KEY_DECRYPT_INFO_VERSION_TWO)
-		logprintf(pCardData, 2, "  pPaddingInfo=%p dwPaddingType=0x%08X\n", pInfo->pPaddingInfo, pInfo->dwPaddingType);
+		logprintf(pCardData, 2,
+			  "  pPaddingInfo=%p dwPaddingType=0x%08X\n",
+			  pInfo->pPaddingInfo,
+			  (unsigned int)pInfo->dwPaddingType);
 
 	pkey = vs->p15_containers[pInfo->bContainerIndex].prkey_obj;
 	if (!pkey)   {
@@ -3434,7 +3586,9 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 	prkey_info = (struct sc_pkcs15_prkey_info *)(pkey->data);
 	alg_info = sc_card_find_rsa_alg(vs->p15card->card, (unsigned int) prkey_info->modulus_length);
 	if (!alg_info)   {
-		logprintf(pCardData, 2, "Cannot get appropriate RSA card algorithm for key size %i\n", prkey_info->modulus_length);
+		logprintf(pCardData, 2,
+			  "Cannot get appropriate RSA card algorithm for key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			  prkey_info->modulus_length);
 		pCardData->pfnCspFree(pbuf);
 		pCardData->pfnCspFree(pbuf2);
 		return SCARD_F_INTERNAL_ERROR;
@@ -3458,7 +3612,9 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		if (r > 0) {
 			/* Need to handle padding */
 			if (pInfo->dwVersion >= CARD_RSA_KEY_DECRYPT_INFO_VERSION_TWO) {
-				logprintf(pCardData, 2, "sc_pkcs15_decipher: DECRYPT-INFO dwVersion=%u\n", pInfo->dwVersion);
+				logprintf(pCardData, 2,
+					  "sc_pkcs15_decipher: DECRYPT-INFO dwVersion=%lu\n",
+					  (unsigned long)pInfo->dwVersion);
 				if (pInfo->dwPaddingType == CARD_PADDING_PKCS1)   {
 					size_t temp = pInfo->cbData;
 					logprintf(pCardData, 2, "sc_pkcs15_decipher: stripping PKCS1 padding\n");
@@ -3522,7 +3678,8 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		return md_translate_OpenSC_to_Windows_error(r, SCARD_E_INVALID_VALUE);
 	}
 
-	logprintf(pCardData, 2, "decrypted data(%i):\n", pInfo->cbData);
+	logprintf(pCardData, 2, "decrypted data(%lu):\n",
+		  (unsigned long)pInfo->cbData);
 	loghex(pCardData, 7, pbuf2, pInfo->cbData);
 
 	/*inversion donnees */
@@ -3545,7 +3702,9 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 	size_t dataToSignLen = sizeof(dataToSign);
 	sc_pkcs15_object_t *pkey;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardSignData\n");
 
 	if (!pCardData || !pInfo)
@@ -3572,10 +3731,16 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 	if (pInfo->dwSigningFlags & ~(CARD_PADDING_INFO_PRESENT | CARD_PADDING_NONE | CARD_BUFFER_SIZE_ONLY | CARD_PADDING_PKCS1 | CARD_PADDING_PSS | CARD_PADDING_OAEP))
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 2, "CardSignData dwVersion=%u, bContainerIndex=%u, dwKeySpec=%u, dwSigningFlags=0x%08X, aiHashAlg=0x%08X\n",
-		pInfo->dwVersion,pInfo->bContainerIndex ,pInfo->dwKeySpec, pInfo->dwSigningFlags, pInfo->aiHashAlg);
+	logprintf(pCardData, 2,
+		  "CardSignData dwVersion=%lu, bContainerIndex=%u, dwKeySpec=%lu, dwSigningFlags=0x%08X, aiHashAlg=0x%08X\n",
+		  (unsigned long)pInfo->dwVersion,
+		  (unsigned int)pInfo->bContainerIndex,
+		  (unsigned long)pInfo->dwKeySpec,
+		  (unsigned int)pInfo->dwSigningFlags,
+		  (unsigned int)pInfo->aiHashAlg);
 
-	logprintf(pCardData, 7, "pInfo->pbData(%i) ", pInfo->cbData);
+	logprintf(pCardData, 7, "pInfo->pbData(%lu) ",
+		  (unsigned long)pInfo->cbData);
 	loghex(pCardData, 7, pInfo->pbData, pInfo->cbData);
 
 	hashAlg = pInfo->aiHashAlg;
@@ -3591,7 +3756,8 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 
 	check_reader_status(pCardData);
 
-	logprintf(pCardData, 2, "pInfo->dwVersion = %d\n", pInfo->dwVersion);
+	logprintf(pCardData, 2, "pInfo->dwVersion = %lu\n",
+		  (unsigned long)pInfo->dwVersion);
 
 	if (dataToSignLen < pInfo->cbData)
 		return SCARD_E_INSUFFICIENT_BUFFER;
@@ -3713,7 +3879,9 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 				pInfo->cbSignedData = 132;
 				break;
 			default:
-				logprintf(pCardData, 0, "unknown ECC key size %i\n", prkey_info->field_length);
+				logprintf(pCardData, 0,
+					  "unknown ECC key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+					  prkey_info->field_length);
 				return SCARD_E_INVALID_VALUE;
 		}
 	} else {
@@ -3721,7 +3889,8 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 		return SCARD_E_INVALID_VALUE;
 	}
 
-	logprintf(pCardData, 3, "pInfo->cbSignedData = %d\n", pInfo->cbSignedData);
+	logprintf(pCardData, 3, "pInfo->cbSignedData = %lu\n",
+		  (unsigned long)pInfo->cbSignedData);
 
 	if(!(pInfo->dwSigningFlags&CARD_BUFFER_SIZE_ONLY))   {
 		int r,i;
@@ -3729,7 +3898,7 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 		DWORD lg;
 
 		lg = pInfo->cbSignedData;
-		logprintf(pCardData, 3, "lg = %d\n", lg);
+		logprintf(pCardData, 3, "lg = %lu\n", (unsigned long)lg);
 		pbuf = pCardData->pfnCspAlloc(lg);
 		if (!pbuf)
 			return SCARD_E_NO_MEMORY;
@@ -3769,8 +3938,12 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 		loghex(pCardData, 7, pInfo->pbSignedData, pInfo->cbSignedData);
 	}
 
-	logprintf(pCardData, 3, "CardSignData, dwVersion=%u, name=%S, hScard=0x%08X, hSCardCtx=0x%08X\n",
-			pCardData->dwVersion, NULLWSTR(pCardData->pwszCardName),pCardData->hScard, pCardData->hSCardCtx);
+	logprintf(pCardData, 3,
+		  "CardSignData, dwVersion=%lu, name=%S, hScard=0x%08X, hSCardCtx=0x%08X\n",
+		  (unsigned long)pCardData->dwVersion,
+		  NULLWSTR(pCardData->pwszCardName),
+		  (unsigned int)pCardData->hScard,
+		  (unsigned int)pCardData->hSCardCtx);
 
 	return SCARD_S_SUCCESS;
 }
@@ -3789,7 +3962,9 @@ DWORD WINAPI CardConstructDHAgreement(__in PCARD_DATA pCardData,
 	struct md_dh_agreement* temp = NULL;
 	BYTE i;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardConstructDHAgreement\n");
 
 	if (!pCardData)
@@ -3812,8 +3987,11 @@ DWORD WINAPI CardConstructDHAgreement(__in PCARD_DATA pCardData,
 
 	check_reader_status(pCardData);
 
-	logprintf(pCardData, 2, "CardConstructDHAgreement dwVersion=%u, dwKeySpec=%u pbData=%p, cbData=%u\n",
-		pAgreementInfo->dwVersion,pAgreementInfo->bContainerIndex , pAgreementInfo->pbPublicKey,  pAgreementInfo->dwPublicKey);
+	logprintf(pCardData, 2, "CardConstructDHAgreement dwVersion=%lu, dwKeySpec=%u pbData=%p, cbData=%lu\n",
+		  (unsigned long)pAgreementInfo->dwVersion,
+		  (unsigned int)pAgreementInfo->bContainerIndex,
+		  pAgreementInfo->pbPublicKey,
+		  (unsigned long)pAgreementInfo->dwPublicKey);
 
 	pkey = vs->p15_containers[pAgreementInfo->bContainerIndex].prkey_obj;
 	if (!pkey)   {
@@ -3909,7 +4087,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 
 	dwReturn = BCryptOpenAlgorithmProvider(&hAlgorithm, szAlgorithm, NULL, (pbHmacKey?BCRYPT_ALG_HANDLE_HMAC_FLAG:0));
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to find a provider for the algorithm %S 0x%08X\n", szAlgorithm, dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to find a provider for the algorithm %S 0x%08X\n",
+			  szAlgorithm, (unsigned int)dwReturn);
 		goto cleanup;
 	}
 	dwSize = sizeof(DWORD);
@@ -3932,7 +4112,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 	dwSize = sizeof(DWORD);
 	dwReturn = BCryptGetProperty(hAlgorithm, BCRYPT_OBJECT_LENGTH, (PUCHAR)&dwBufferSize, dwSize, &dwSize, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to get the buffer length 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to get the buffer length 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 
@@ -3948,7 +4130,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 		dwReturn = BCryptCreateHash(hAlgorithm, &hHash, pbBuffer, dwBufferSize, NULL, 0, 0);
 	}
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to create the alg object 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to create the alg object 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 
@@ -3959,7 +4143,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 			if (buffer->BufferType == KDF_SECRET_PREPEND) {
 				dwReturn = BCryptHashData(hHash, (PUCHAR)buffer->pvBuffer, buffer->cbBuffer, 0);
 				if (dwReturn) {
-					logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+					logprintf(pCardData, 0,
+						  "CardDeriveKey: unable to hash data 0x%08X\n",
+						  (unsigned int)dwReturn);
 					goto cleanup;
 				}
 			}
@@ -3968,7 +4154,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 
 	dwReturn = BCryptHashData(hHash, (PUCHAR)agreement->pbAgreement, agreement->dwSize, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to hash data 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 
@@ -3978,7 +4166,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 			if (buffer->BufferType == KDF_SECRET_APPEND) {
 				dwReturn = BCryptHashData(hHash, (PUCHAR)buffer->pvBuffer, buffer->cbBuffer, 0);
 				if (dwReturn) {
-					logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+					logprintf(pCardData, 0,
+						  "CardDeriveKey: unable to hash data 0x%08X\n",
+						  (unsigned int)dwReturn);
 					goto cleanup;
 				}
 			}
@@ -3987,7 +4177,9 @@ DWORD WINAPI CardDeriveHashOrHMAC(__in PCARD_DATA pCardData,
 
 	dwReturn = BCryptFinishHash(hHash, pAgreementInfo->pbDerivedKey, pAgreementInfo->cbDerivedKey, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to finish hash 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to finish hash 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 
@@ -4014,11 +4206,13 @@ DWORD HashDataWithBCrypt(__in PCARD_DATA pCardData, BCRYPT_ALG_HANDLE hAlgorithm
 	DWORD dwReturn, dwSize, dwBufferSize;
 	BCRYPT_HASH_HANDLE hHash = NULL;
 	PBYTE pbBuffer = NULL;
-	
+
 	dwSize = sizeof(DWORD);
 	dwReturn = BCryptGetProperty(hAlgorithm, BCRYPT_OBJECT_LENGTH, (PUCHAR)&dwBufferSize, dwSize, &dwSize, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to get the buffer length 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to get the buffer length 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 	pbBuffer = (PBYTE)LocalAlloc(0, dwBufferSize);
@@ -4028,33 +4222,43 @@ DWORD HashDataWithBCrypt(__in PCARD_DATA pCardData, BCRYPT_ALG_HANDLE hAlgorithm
 	}
 	dwReturn = BCryptCreateHash(hAlgorithm, &hHash, pbBuffer, dwBufferSize, pbSecret, dwSecretSize, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to create the alg object 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to create the alg object 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 	if (pbData1) {
 		dwReturn = BCryptHashData(hHash, pbData1, dwDataSize1, 0);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: unable to hash data 0x%08X\n",
+				  (unsigned int)dwReturn);
 			goto cleanup;
 		}
 	}
 	if (pbData2) {
 		dwReturn = BCryptHashData(hHash, pbData2, dwDataSize2, 0);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: unable to hash data 0x%08X\n",
+				  (unsigned int)dwReturn);
 			goto cleanup;
 		}
 	}
 	if (pbData3) {
 		dwReturn = BCryptHashData(hHash, pbData3, dwDataSize3, 0);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: unable to hash data 0x%08X\n", dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: unable to hash data 0x%08X\n",
+				  (unsigned int)dwReturn);
 			goto cleanup;
 		}
 	}
 	dwReturn = BCryptFinishHash(hHash, pbOuput, dwOutputSize, 0);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to finish hash 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to finish hash 0x%08X\n",
+			  (unsigned int)dwReturn);
 		goto cleanup;
 	}
 cleanup:
@@ -4082,10 +4286,12 @@ DWORD WINAPI DoTlsPrf(__in PCARD_DATA pCardData,
 	PBYTE pbBuffer = NULL;
 	/* TLS intermediate results */
 	PBYTE pbAx = NULL;
-	
+
 	dwReturn = BCryptOpenAlgorithmProvider(&hAlgorithm, szAlgorithm, NULL, BCRYPT_ALG_HANDLE_HMAC_FLAG);
 	if (dwReturn) {
-		logprintf(pCardData, 0, "CardDeriveKey: unable to find a provider for the algorithm %S 0x%08X\n", szAlgorithm, dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveKey: unable to find a provider for the algorithm %S 0x%08X\n",
+			  szAlgorithm, (unsigned int)dwReturn);
 		goto cleanup;
 	}
 	dwSize = sizeof(DWORD);
@@ -4094,7 +4300,7 @@ DWORD WINAPI DoTlsPrf(__in PCARD_DATA pCardData,
 		logprintf(pCardData, 0, "CardDeriveKey: unable to get the hash length\n");
 		goto cleanup;
 	}
-	
+
 	/* size is always 48 */
 	dwLastRoundSize = TLS_DERIVE_KEY_SIZE % dwHashSize;
 	if (dwLastRoundSize == 0) dwLastRoundSize = dwHashSize;
@@ -4131,7 +4337,9 @@ DWORD WINAPI DoTlsPrf(__in PCARD_DATA pCardData,
 					NULL, 0);
 		}
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: unable to hash Ax 0x%08X\n", szAlgorithm, dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: unable to hash %S 0x%08X\n",
+				  szAlgorithm, (unsigned int)dwReturn);
 			goto cleanup;
 		}
 		if (dwNumberOfRounds -1 == i) {
@@ -4150,11 +4358,12 @@ DWORD WINAPI DoTlsPrf(__in PCARD_DATA pCardData,
 					pbSeed, 64);
 		}
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: unable to hash Ax 0x%08X\n", szAlgorithm, dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: unable to hash %S 0x%08X\n",
+				  szAlgorithm, (unsigned int)dwReturn);
 			goto cleanup;
 		}
 	}
-	
 
 cleanup:
 	if (pbBuffer)
@@ -4190,7 +4399,9 @@ DWORD WINAPI CardDeriveTlsPrf(__in PCARD_DATA pCardData,
 			return SCARD_E_INVALID_PARAMETER;
 		}
 	} else {
-		logprintf(pCardData, 0, "CardDeriveTlsPrf: TLS protocol unknwon 0x%08X\n", dwReturn);
+		logprintf(pCardData, 0,
+			  "CardDeriveTlsPrf: TLS protocol unknown 0x%08X\n",
+			  (unsigned int)dwReturn);
 		return SCARD_E_INVALID_PARAMETER;
 	}
 	/* size is always 48 according to msdn */
@@ -4215,7 +4426,9 @@ DWORD WINAPI CardDeriveTlsPrf(__in PCARD_DATA pCardData,
 						pbLabel, dwLabelSize,
 						pbSeed);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n", szAlgorithm, dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n",
+				  szAlgorithm, (unsigned int)dwReturn);
 			pCardData->pfnCspFree(pAgreementInfo->pbDerivedKey );
 			pAgreementInfo->pbDerivedKey  = NULL;
 			return dwReturn;
@@ -4234,7 +4447,9 @@ DWORD WINAPI CardDeriveTlsPrf(__in PCARD_DATA pCardData,
 						pbLabel, dwLabelSize,
 						pbSeed);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n", szAlgorithm, dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n",
+				  szAlgorithm, (unsigned int)dwReturn);
 			LocalFree(pbBuffer);
 			pCardData->pfnCspFree(pAgreementInfo->pbDerivedKey );
 			pAgreementInfo->pbDerivedKey  = NULL;
@@ -4254,7 +4469,9 @@ DWORD WINAPI CardDeriveTlsPrf(__in PCARD_DATA pCardData,
 						pbLabel, dwLabelSize,
 						pbSeed);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n", szAlgorithm, dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveTlsPrf: unable to DoTlsPrf with %S 0x%08X\n",
+				  szAlgorithm, (unsigned int)dwReturn);
 			pCardData->pfnCspFree(pAgreementInfo->pbDerivedKey );
 			pAgreementInfo->pbDerivedKey  = NULL;
 			return dwReturn;
@@ -4279,9 +4496,10 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 	DWORD dwLabelSize = 0;
 	PBYTE pbSeed = NULL;
 	DWORD dwProtocol = 0;
-	
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardDeriveKey\n");
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -4343,7 +4561,9 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 					} else if (wcscmp((PWSTR) buffer->pvBuffer, BCRYPT_MD5_ALGORITHM) == 0) {
 						szAlgorithm = BCRYPT_MD5_ALGORITHM;
 					} else {
-						logprintf(pCardData, 0, "CardDeriveKey: unsupported algorithm %S\n", buffer->pvBuffer);
+						logprintf(pCardData, 0,
+							  "CardDeriveKey: unsupported algorithm %S\n",
+							  (PWSTR)buffer->pvBuffer);
 						return SCARD_E_INVALID_PARAMETER;
 					}
 					break;
@@ -4374,7 +4594,9 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 					}
 					if (buffer->cbBuffer != 64)
 					{
-						logprintf(pCardData, 0, "CardDeriveKey: invalid seed size %u\n", buffer->cbBuffer);
+						logprintf(pCardData, 0,
+							  "CardDeriveKey: invalid seed size %lu\n",
+							  buffer->cbBuffer);
 						return SCARD_E_INVALID_PARAMETER;
 					}
 					pbSeed = (PBYTE)buffer->pvBuffer;
@@ -4389,7 +4611,9 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 				case KDF_SUPPPRIVINFO:
 					break;*/
 				default:
-					logprintf(pCardData, 0, "CardDeriveKey: unknown buffer type %u\n", (parameters->pBuffers + i)->BufferType);
+					logprintf(pCardData, 0,
+						  "CardDeriveKey: unknown buffer type %lu\n",
+						  (parameters->pBuffers + i)->BufferType);
 					return SCARD_E_INVALID_PARAMETER;
 			}
 		}
@@ -4398,7 +4622,7 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 	if (szAlgorithm == NULL && wcscmp(pAgreementInfo->pwszKDF, BCRYPT_KDF_TLS_PRF) != 0) {
 		szAlgorithm = BCRYPT_SHA1_ALGORITHM;
 	}
-	
+
 	/* check the values with the KDF choosen */
 	if (wcscmp(pAgreementInfo->pwszKDF, BCRYPT_KDF_HASH) == 0) {
 	}
@@ -4425,17 +4649,21 @@ DWORD WINAPI CardDeriveKey(__in PCARD_DATA pCardData,
 	/* do the job for the KDF Hash & Hmac */
 	if (wcscmp(pAgreementInfo->pwszKDF, BCRYPT_KDF_HASH) == 0 ||
 		wcscmp(pAgreementInfo->pwszKDF, BCRYPT_KDF_HMAC) == 0 ) {
-		
+
 		dwReturn = CardDeriveHashOrHMAC(pCardData, pAgreementInfo, agreement, szAlgorithm, pbHmacKey, dwHmacKeySize);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: got an error while deriving the Key (hash or HMAC) 0x%08X\n", dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: got an error while deriving the Key (hash or HMAC) 0x%08X\n",
+				  (unsigned int)dwReturn);
 			return dwReturn;
 		}
 
 	} else if (wcscmp(pAgreementInfo->pwszKDF, BCRYPT_KDF_TLS_PRF) == 0) {
 		dwReturn = CardDeriveTlsPrf(pCardData, pAgreementInfo, agreement, dwProtocol, szAlgorithm, pbLabel, dwLabelSize, pbSeed);
 		if (dwReturn) {
-			logprintf(pCardData, 0, "CardDeriveKey: got an error while deriving the Key (TlsPrf) 0x%08X\n", dwReturn);
+			logprintf(pCardData, 0,
+				  "CardDeriveKey: got an error while deriving the Key (TlsPrf) 0x%08X\n",
+				  (unsigned int)dwReturn);
 			return dwReturn;
 		}
 	}
@@ -4455,7 +4683,9 @@ DWORD WINAPI CardDestroyDHAgreement(
 	VENDOR_SPECIFIC *vs;
 	struct md_dh_agreement* agreement = NULL;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardDestroyDHAgreement\n");
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
@@ -4484,7 +4714,9 @@ DWORD WINAPI CardGetChallengeEx(__in PCARD_DATA pCardData,
 	__out PDWORD pcbChallengeData,
 	__in DWORD dwFlags)
 {
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetChallengeEx - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -4504,14 +4736,18 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 	int r;
 	BOOL DisplayPinpadUI = FALSE;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardAuthenticateEx\n");
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 2, "CardAuthenticateEx: PinId=%u, dwFlags=0x%08X, cbPinData=%u, Attempts %s\n",
-		PinId, dwFlags, cbPinData, pcAttemptsRemaining ? "YES" : "NO");
+	logprintf(pCardData, 2,
+		  "CardAuthenticateEx: PinId=%u, dwFlags=0x%08X, cbPinData=%lu, Attempts %s\n",
+		  (unsigned int)PinId, (unsigned int)dwFlags,
+		  (unsigned long)cbPinData, pcAttemptsRemaining ? "YES" : "NO");
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
@@ -4617,7 +4853,9 @@ DWORD WINAPI CardChangeAuthenticatorEx(__in PCARD_DATA pCardData,
 	struct sc_pkcs15_auth_info *auth_info;
 	BOOL DisplayPinpadUI = FALSE;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardChangeAuthenticatorEx\n");
 
 	if (!pCardData)
@@ -4640,8 +4878,12 @@ DWORD WINAPI CardChangeAuthenticatorEx(__in PCARD_DATA pCardData,
 	if (cRetryCount)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 2, "CardChangeAuthenticatorEx: AuthenticatingPinId=%u, dwFlags=0x%08X, cbAuthenticatingPinData=%u, TargetPinId=%u, cbTargetData=%u, Attempts %s\n",
-		dwAuthenticatingPinId, dwFlags, cbAuthenticatingPinData, dwTargetPinId, cbTargetData, pcAttemptsRemaining ? "YES" : "NO");
+	logprintf(pCardData, 2,
+		  "CardChangeAuthenticatorEx: AuthenticatingPinId=%u, dwFlags=0x%08X, cbAuthenticatingPinData=%lu, TargetPinId=%u, cbTargetData=%lu, Attempts %s\n",
+		  (unsigned int)dwAuthenticatingPinId, (unsigned int)dwFlags,
+		  (unsigned long)cbAuthenticatingPinData,
+		  (unsigned int)dwTargetPinId, (unsigned long)cbTargetData,
+		  pcAttemptsRemaining ? "YES" : "NO");
 
 
 	check_reader_status(pCardData);
@@ -4706,8 +4948,12 @@ DWORD WINAPI CardDeauthenticateEx(__in PCARD_DATA pCardData,
 	__in DWORD dwFlags)
 {
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardDeauthenticateEx PinId=%d dwFlags=0x%08X\n",PinId, dwFlags);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardDeauthenticateEx PinId=%u dwFlags=0x%08X\n",
+		  (unsigned int)PinId, (unsigned int)dwFlags);
 
 	return CardDeauthenticate(pCardData, wszCARD_USER_USER, 0);
 }
@@ -4723,14 +4969,18 @@ DWORD WINAPI CardGetContainerProperty(__in PCARD_DATA pCardData,
 	VENDOR_SPECIFIC *vs = NULL;
 	struct md_pkcs15_container *cont = NULL;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetContainerProperty\n");
 
 	check_reader_status(pCardData);
 
 	if (!pCardData) return SCARD_E_INVALID_PARAMETER;
-	logprintf(pCardData, 2, "CardGetContainerProperty bContainerIndex=%u, wszProperty=%S," \
-		"cbData=%u, dwFlags=0x%08X\n",bContainerIndex,NULLWSTR(wszProperty),cbData,dwFlags);
+	logprintf(pCardData, 2,
+		  "CardGetContainerProperty bContainerIndex=%u, wszProperty=%S, cbData=%lu, dwFlags=0x%08X\n",
+		  (unsigned int)bContainerIndex, NULLWSTR(wszProperty),
+		  (unsigned long)cbData, (unsigned int)dwFlags);
 	if (!wszProperty)
 		return SCARD_E_INVALID_PARAMETER;
 	if (dwFlags)
@@ -4745,7 +4995,8 @@ DWORD WINAPI CardGetContainerProperty(__in PCARD_DATA pCardData,
 	cont = &vs->p15_containers[bContainerIndex];
 
 	if (!cont->prkey_obj)   {
-		logprintf(pCardData, 7, "Container %i is empty\n", bContainerIndex);
+		logprintf(pCardData, 7, "Container %u is empty\n",
+			  (unsigned int)bContainerIndex);
 		return SCARD_E_NO_KEY_CONTAINER;
 	}
 
@@ -4767,7 +5018,8 @@ DWORD WINAPI CardGetContainerProperty(__in PCARD_DATA pCardData,
 		if (cbData < sizeof(*p))
 			return ERROR_INSUFFICIENT_BUFFER;
 		*p = ROLE_USER;
-		logprintf(pCardData, 2,"Return Pin id %u\n",*p);
+		logprintf(pCardData, 2, "Return Pin id %u\n",
+			  (unsigned int)*p);
 		return SCARD_S_SUCCESS;
 	}
 
@@ -4781,7 +5033,9 @@ DWORD WINAPI CardSetContainerProperty(__in PCARD_DATA pCardData,
 	__in DWORD cbDataLen,
 	__in DWORD dwFlags)
 {
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardSetContainerProperty - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -4797,8 +5051,13 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 	VENDOR_SPECIFIC *vs;
 	DWORD dwret;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 2, "CardGetProperty('%S',cbData=%u,dwFlags=%u) called\n", NULLWSTR(wszProperty),cbData,dwFlags);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 2,
+		  "CardGetProperty('%S',cbData=%lu,dwFlags=%lu) called\n",
+		  NULLWSTR(wszProperty), (unsigned long)cbData,
+		  (unsigned long)dwFlags);
 
 	if (!pCardData || !wszProperty)
 		return SCARD_E_INVALID_PARAMETER;
@@ -4920,7 +5179,9 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 		p->dwFlags = 0;
 		switch (dwFlags)   {
 			case ROLE_USER:
-				logprintf(pCardData, 2,"returning info on PIN ROLE_USER ( Auth ) [%u]\n",dwFlags);
+				logprintf(pCardData, 2,
+					  "returning info on PIN ROLE_USER ( Auth ) [%lu]\n",
+					  (unsigned long)dwFlags);
 				p->PinPurpose = DigitalSignaturePin;
 				p->PinCachePolicy.dwVersion = PIN_CACHE_POLICY_CURRENT_VERSION;
 				p->PinCachePolicy.dwPinCachePolicyInfo = 0;
@@ -4929,7 +5190,9 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 				p->dwUnblockPermission = CREATE_PIN_SET(ROLE_ADMIN);
 				break;
 			case ROLE_ADMIN:
-				logprintf(pCardData, 2,"returning info on PIN ROLE_ADMIN ( Unblock ) [%u]\n",dwFlags);
+				logprintf(pCardData, 2,
+					  "returning info on PIN ROLE_ADMIN ( Unblock ) [%lu]\n",
+					  (unsigned long)dwFlags);
 				p->PinPurpose = UnblockOnlyPin;
 				p->PinCachePolicy.dwVersion = PIN_CACHE_POLICY_CURRENT_VERSION;
 				p->PinCachePolicy.dwPinCachePolicyInfo = 0;
@@ -4938,7 +5201,9 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 				p->dwUnblockPermission = 0;
 				break;
 			default:
-				logprintf(pCardData, 0,"Invalid Pin number %u requested\n",dwFlags);
+				logprintf(pCardData, 0,
+					  "Invalid Pin number %lu requested\n",
+					  (unsigned long)dwFlags);
 				return SCARD_E_INVALID_PARAMETER;
 		}
 	}
@@ -5013,14 +5278,18 @@ DWORD WINAPI CardSetProperty(__in   PCARD_DATA pCardData,
 {
 	VENDOR_SPECIFIC *vs;
 
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardSetProperty\n");
 
 	if (!pCardData)
 		return SCARD_E_INVALID_PARAMETER;
 
-	logprintf(pCardData, 2, "CardSetProperty wszProperty=%S, pbData=%p, cbDataLen=%u, dwFlags=%u",\
-		NULLWSTR(wszProperty),pbData,cbDataLen,dwFlags);
+	logprintf(pCardData, 2,
+		  "CardSetProperty wszProperty=%S, pbData=%p, cbDataLen=%lu, dwFlags=%lu",
+		  NULLWSTR(wszProperty), pbData, (unsigned long)cbDataLen,
+		  (unsigned long)dwFlags);
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 
@@ -5113,7 +5382,9 @@ DWORD WINAPI CardImportSessionKey(
 	UNREFERENCED_PARAMETER(pbInput);
 	UNREFERENCED_PARAMETER(cbInput);
 	UNREFERENCED_PARAMETER(dwFlags);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardImportSessionKey - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5136,7 +5407,9 @@ DWORD WINAPI MDImportSessionKey(
 	UNREFERENCED_PARAMETER(phKey);
 	UNREFERENCED_PARAMETER(pbInput);
 	UNREFERENCED_PARAMETER(cbInput);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "MDImportSessionKey - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5164,7 +5437,9 @@ DWORD WINAPI MDEncryptData(
 	UNREFERENCED_PARAMETER(dwFlags);
 	UNREFERENCED_PARAMETER(ppEncryptedData);
 	UNREFERENCED_PARAMETER(pcEncryptedData);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "MDEncryptData - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5192,7 +5467,9 @@ DWORD WINAPI CardGetSharedKeyHandle(
 	UNREFERENCED_PARAMETER(ppbOutput);
 	UNREFERENCED_PARAMETER(pcbOutput);
 	UNREFERENCED_PARAMETER(phKey);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetSharedKeyHandle - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5207,7 +5484,9 @@ DWORD WINAPI CardDestroyKey(
 {
 	UNREFERENCED_PARAMETER(pCardData);
 	UNREFERENCED_PARAMETER(hKey);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardDestroyKey - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5231,7 +5510,9 @@ DWORD WINAPI CardGetAlgorithmProperty (
 	UNREFERENCED_PARAMETER(cbData);
 	UNREFERENCED_PARAMETER(pdwDataLen);
 	UNREFERENCED_PARAMETER(dwFlags);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetAlgorithmProperty - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5254,7 +5535,9 @@ DWORD WINAPI CardGetKeyProperty(
 	UNREFERENCED_PARAMETER(cbData);
 	UNREFERENCED_PARAMETER(pdwDataLen);
 	UNREFERENCED_PARAMETER(dwFlags);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardGetKeyProperty - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5276,7 +5559,9 @@ DWORD WINAPI CardSetKeyProperty(
 	UNREFERENCED_PARAMETER(pbInput);
 	UNREFERENCED_PARAMETER(cbInput);
 	UNREFERENCED_PARAMETER(dwFlags);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardSetKeyProperty - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5307,7 +5592,9 @@ DWORD WINAPI CardProcessEncryptedData(
 	UNREFERENCED_PARAMETER(cbOutput);
 	UNREFERENCED_PARAMETER(pdwOutputLen);
 	UNREFERENCED_PARAMETER(dwFlags);
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardProcessEncryptedData - unsupported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
 }
@@ -5387,22 +5674,30 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 		return (DWORD) ERROR_REVISION_MISMATCH;
 
 	suppliedVersion = pCardData->dwVersion;
-	
+
 	/* VENDOR SPECIFIC */
 	vs = pCardData->pvVendorSpecific = pCardData->pfnCspAlloc(sizeof(VENDOR_SPECIFIC));
 	memset(vs, 0, sizeof(VENDOR_SPECIFIC));
 
 	logprintf(pCardData, 1, "==================================================================\n");
-	logprintf(pCardData, 1, "\nP:%d T:%d pCardData:%p ",GetCurrentProcessId(), GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardAcquireContext, dwVersion=%u, name=%S,hScard=0x%08X, hSCardCtx=0x%08X\n",
-			pCardData->dwVersion, NULLWSTR(pCardData->pwszCardName),pCardData->hScard, pCardData->hSCardCtx);
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1,
+		  "CardAcquireContext, dwVersion=%lu, name=%S,hScard=0x%08X, hSCardCtx=0x%08X\n",
+		  (unsigned long)pCardData->dwVersion,
+		  NULLWSTR(pCardData->pwszCardName),
+		  (unsigned int)pCardData->hScard,
+		  (unsigned int)pCardData->hSCardCtx);
 
 	vs->hScard = pCardData->hScard;
 	vs->hSCardCtx = pCardData->hSCardCtx;
 
-	logprintf(pCardData, 2, "request version pCardData->dwVersion = %d\n", pCardData->dwVersion);
+	logprintf(pCardData, 2, "request version pCardData->dwVersion = %lu\n",
+		  (unsigned long)pCardData->dwVersion);
 	pCardData->dwVersion = min(pCardData->dwVersion, MD_CURRENT_VERSION_SUPPORTED);
-	logprintf(pCardData, 2, "pCardData->dwVersion = %d\n", pCardData->dwVersion);
+	logprintf(pCardData, 2, "pCardData->dwVersion = %lu\n",
+		  (unsigned long)pCardData->dwVersion);
 
 	dwret = md_create_context(pCardData, vs);
 	if (dwret != SCARD_S_SUCCESS) {
@@ -5454,7 +5749,9 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 	}
 
 	logprintf(pCardData, 1, "OpenSC init done.\n");
-	logprintf(pCardData, 1, "Supplied version %u - version used %u.\n", suppliedVersion, pCardData->dwVersion);
+	logprintf(pCardData, 1, "Supplied version %lu - version used %lu.\n",
+		  (unsigned long)suppliedVersion,
+		  (unsigned long)pCardData->dwVersion);
 
 	if (pCardData->dwVersion >= CARD_DATA_VERSION_FIVE) {
 		pCardData->pfnCardDeriveKey = CardDeriveKey;
@@ -5624,8 +5921,11 @@ BOOL APIENTRY DllMain( HINSTANCE hinstDLL,
 		break;
 	}
 
-	logprintf(NULL,8,"\n********** DllMain Module(handle:0x%p) '%s'; reason='%s'; Reserved=%p; P:%d; T:%d\n",
-			hinstDLL, name, reason, lpReserved, GetCurrentProcessId(), GetCurrentThreadId());
+	logprintf(NULL, 8,
+		  "\n********** DllMain Module(handle:0x%p) '%s'; reason='%s'; Reserved=%p; P:%lu; T:%lu\n",
+		  hinstDLL, name, reason, lpReserved,
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId());
 	switch (ul_reason_for_call)
 	{
 	case DLL_PROCESS_ATTACH:

--- a/src/minidriver/versioninfo-minidriver.rc.in
+++ b/src/minidriver/versioninfo-minidriver.rc.in
@@ -53,4 +53,8 @@ BEGIN
     LTEXT           "This window will be closed automatically after the PIN has been submitted on the PINPAD or if the PINPAD timeout occurs (in general 30 seconds).",IDC_STATIC,7,46,298,19
 END
 
+#ifndef __MINGW32__
 IDI_LOGO               ICON                    "..\\..\\win32\\OpenSC.ico"
+#else
+IDI_LOGO               ICON                    "../../win32/OpenSC.ico"
+#endif

--- a/src/pkcs11/debug.c
+++ b/src/pkcs11/debug.c
@@ -200,14 +200,14 @@ static void sc_pkcs11_print_attr(int level, const char *file, unsigned int line,
 
 	if (fm == NULL) {
 		sc_do_log(context, level,
-				file, line, function,
-				"%s: Attribute 0x%x = %s\n",
-				info, attr->type, value);
+			  file, line, function,
+			  "%s: Attribute 0x%lx = %s\n",
+			  info, attr->type, value);
 	} else {
 		sc_do_log(context, level,
-				file, line, function,
-				"%s: %s = %s\n",
-				info, fm->name, value);
+			  file, line, function,
+			  "%s: %s = %s\n",
+			  info, fm->name, value);
 	}
 }
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -289,7 +289,8 @@ pkcs15_bind(struct sc_pkcs11_card *p11card, struct sc_app_info *app_info)
 	if (!p11card->nmechanisms) {
 		ck_rv = register_mechanisms(p11card);
 		if (ck_rv != CKR_OK) {
-			sc_log(context, "cannot register mechanisms; CKR 0x%X", ck_rv);
+			sc_log(context, "cannot register mechanisms; CKR 0x%lX",
+			       ck_rv);
 			return ck_rv;
 		}
 	}
@@ -482,7 +483,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 
 	rv = slot_get_token(slotID, &slot);
 	if (rv != CKR_OK)   {
-		sc_log(context, "C_GetTokenInfo() get token: rv 0x%X", rv);
+		sc_log(context, "C_GetTokenInfo() get token: rv 0x%lX", rv);
 		goto out;
 	}
 
@@ -497,7 +498,9 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	/* User PIN flags are cleared before re-calculation */
 	slot->token_info.flags &= ~(CKF_USER_PIN_COUNT_LOW|CKF_USER_PIN_FINAL_TRY|CKF_USER_PIN_LOCKED);
 	auth = slot_data_auth(slot->fw_data);
-	sc_log(context, "C_GetTokenInfo() auth. object %p, token-info flags 0x%X", auth, slot->token_info.flags);
+	sc_log(context,
+	       "C_GetTokenInfo() auth. object %p, token-info flags 0x%lX", auth,
+	       slot->token_info.flags);
 	if (auth) {
 		pin_info = (struct sc_pkcs15_auth_info*) auth->data;
 
@@ -893,7 +896,8 @@ pkcs15_add_object(struct sc_pkcs11_slot *slot, struct pkcs15_any_object *obj,
 		*pHandle = handle;
 
 	list_append(&slot->objects, obj);
-	sc_log(context, "Slot:%X Setting object handle of 0x%lx to 0x%lx", slot->id, obj->base.handle, handle);
+	sc_log(context, "Slot:%lX Setting object handle of 0x%lx to 0x%lx",
+	       slot->id, obj->base.handle, handle);
 	obj->base.handle = handle;
 	obj->base.flags |= SC_PKCS11_OBJECT_SEEN;
 	obj->refcount++;
@@ -1828,7 +1832,8 @@ pkcs15_init_pin(struct sc_pkcs11_slot *slot, CK_CHAR_PTR pPin, CK_ULONG ulPinLen
 		return sc_to_cryptoki_error(rc, "C_InitPin");
 	}
 
-	sc_log(context, "Init PIN: pin %p:%d; unblock style %i", pPin, ulPinLen, sc_pkcs11_conf.pin_unblock_style);
+	sc_log(context, "Init PIN: pin %p:%lu; unblock style %i", pPin,
+	       ulPinLen, sc_pkcs11_conf.pin_unblock_style);
 
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[slot->fw_data_idx];
 	if (!fw_data)
@@ -2597,7 +2602,9 @@ get_X509_usage_privk(CK_ATTRIBUTE_PTR pTempl, CK_ULONG ulCount, unsigned long *x
 		if (typ == CKA_OPENSC_NON_REPUDIATION && *val)
 			*x509_usage |= SC_PKCS15INIT_X509_NON_REPUDIATION;
 		if (typ == CKA_VERIFY || typ == CKA_WRAP || typ == CKA_ENCRYPT) {
-			sc_log(context, "get_X509_usage_privk(): invalid typ = 0x%0x", typ);
+			sc_log(context,
+			       "get_X509_usage_privk(): invalid typ = 0x%0lx",
+			       typ);
 			return CKR_ATTRIBUTE_TYPE_INVALID;
 		}
 	}
@@ -2623,7 +2630,9 @@ get_X509_usage_pubk(CK_ATTRIBUTE_PTR pTempl, CK_ULONG ulCount, unsigned long *x5
 		if (typ == CKA_DERIVE && *val)
 			*x509_usage |= SC_PKCS15INIT_X509_KEY_AGREEMENT;
 		if (typ == CKA_SIGN || typ == CKA_UNWRAP || typ == CKA_DECRYPT) {
-			sc_log(context, "get_X509_usage_pubk(): invalid typ = 0x%0x", typ);
+			sc_log(context,
+			       "get_X509_usage_pubk(): invalid typ = 0x%0lx",
+			       typ);
 			return CKR_ATTRIBUTE_TYPE_INVALID;
 		}
 	}
@@ -2693,7 +2702,8 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 	char		priv_label[SC_PKCS15_MAX_LABEL_SIZE];
 	int		rc, rv = CKR_OK;
 
-	sc_log(context, "Keypair generation, mech = 0x%0x", pMechanism->mechanism);
+	sc_log(context, "Keypair generation, mech = 0x%0lx",
+	       pMechanism->mechanism);
 
 	if (pMechanism->mechanism != CKM_RSA_PKCS_KEY_PAIR_GEN
 			&& pMechanism->mechanism != CKM_GOSTR3410_KEY_PAIR_GEN
@@ -3511,7 +3521,8 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 	unsigned sign_flags = SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER
 			| SC_PKCS15_PRKEY_USAGE_NONREPUDIATION;
 
-	sc_log(context, "Initiating signing operation, mechanism 0x%x.",pMechanism->mechanism);
+	sc_log(context, "Initiating signing operation, mechanism 0x%lx.",
+	       pMechanism->mechanism);
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[session->slot->fw_data_idx];
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_Sign");
@@ -3564,7 +3575,7 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 		flags = SC_ALGORITHM_ECDSA_HASH_SHA1;
 		break;
 	default:
-		sc_log(context, "DEE - need EC for %d",pMechanism->mechanism);
+		sc_log(context, "DEE - need EC for %lu", pMechanism->mechanism);
 		return CKR_MECHANISM_INVALID;
 	}
 
@@ -3572,7 +3583,9 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 	if (rv < 0)
 		return sc_to_cryptoki_error(rv, "C_Sign");
 
-	sc_log(context, "Selected flags %X. Now computing signature for %d bytes. %d bytes reserved.", flags, ulDataLen, *pulDataLen);
+	sc_log(context,
+	       "Selected flags %X. Now computing signature for %lu bytes. %lu bytes reserved.",
+	       flags, ulDataLen, *pulDataLen);
 	rv = sc_pkcs15_compute_signature(fw_data->p15_card, prkey->prv_p15obj, flags,
 			pData, ulDataLen, pSignature, *pulDataLen);
 	if (rv < 0 && !sc_pkcs11_conf.lock_login && !prkey_has_path) {
@@ -3691,7 +3704,8 @@ pkcs15_prkey_derive(struct sc_pkcs11_session *session, void *obj,
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_DeriveKey");
 
-	sc_log(context, "derivation %p %p %p %p %d %p %d", session, obj, pMechanism, pParameters, ulParametersLen, pData, *pulDataLen);
+	sc_log(context, "derivation %p %p %p %p %lu %p %lu", session, obj,
+	       pMechanism, pParameters, ulParametersLen, pData, *pulDataLen);
 
 	/* See which of the alternative keys supports derivation */
 	while (prkey && !(prkey->prv_info->usage & SC_PKCS15_PRKEY_USAGE_DERIVE))
@@ -4086,7 +4100,9 @@ data_value_to_attr(CK_ATTRIBUTE_PTR attr, struct sc_pkcs15_data *data)
 	if (!attr || !data)
 		return CKR_ATTRIBUTE_VALUE_INVALID;
 
-	sc_log(context, "data_value_to_attr(): data(%p,len:%i)", data, data->data_len);
+	sc_log(context,
+	       "data_value_to_attr(): data(%p,len:%"SC_FORMAT_LEN_SIZE_T"u)",
+	       data, data->data_len);
 
 	check_attribute_buffer(attr, data->data_len);
 	memcpy(attr->pValue, data->data, data->data_len);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -878,6 +878,8 @@ pkcs15_add_object(struct sc_pkcs11_slot *slot, struct pkcs15_any_object *obj,
 {
 	unsigned int i;
 	struct pkcs15_fw_data *card_fw_data;
+	CK_OBJECT_HANDLE handle =
+		(CK_OBJECT_HANDLE)obj; /* cast pointer to long, will truncate on Win64 */
 
 	if (obj == NULL || slot == NULL)
 		return;
@@ -888,11 +890,11 @@ pkcs15_add_object(struct sc_pkcs11_slot *slot, struct pkcs15_any_object *obj,
 		return;
 
 	if (pHandle != NULL)
-		*pHandle = (CK_OBJECT_HANDLE)obj; /* cast pointer to long */
+		*pHandle = handle;
 
 	list_append(&slot->objects, obj);
-	sc_log(context, "Slot:%X Setting object handle of 0x%lx to 0x%lx", slot->id, obj->base.handle, (CK_OBJECT_HANDLE)obj);
-	obj->base.handle = (CK_OBJECT_HANDLE)obj; /* cast pointer to long */
+	sc_log(context, "Slot:%X Setting object handle of 0x%lx to 0x%lx", slot->id, obj->base.handle, handle);
+	obj->base.handle = handle;
 	obj->base.flags |= SC_PKCS11_OBJECT_SEEN;
 	obj->refcount++;
 

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -252,7 +252,8 @@ sc_pkcs11_sign_init(struct sc_pkcs11_session *session, CK_MECHANISM_PTR pMechani
 		LOG_FUNC_RETURN(context, CKR_ARGUMENTS_BAD);
 
 	/* See if we support this mechanism type */
-	sc_log(context, "mechanism 0x%X, key-type 0x%X", pMechanism->mechanism, key_type);
+	sc_log(context, "mechanism 0x%lX, key-type 0x%lX",
+	       pMechanism->mechanism, key_type);
 	mt = sc_pkcs11_find_mechanism(p11card, pMechanism->mechanism, CKF_SIGN);
 	if (mt == NULL)
 		LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -286,8 +286,8 @@ static CK_RV sc_pkcs11_openssl_md_final(sc_pkcs11_operation_t *op,
 	EVP_MD_CTX *md_ctx = DIGEST_CTX(op);
 
 	if (*pulDigestLen < (unsigned) EVP_MD_CTX_size(md_ctx)) {
-		sc_log(context, "Provided buffer too small: %ul < %d",
-			*pulDigestLen, EVP_MD_CTX_size(md_ctx));
+		sc_log(context, "Provided buffer too small: %lu < %d",
+		       *pulDigestLen, EVP_MD_CTX_size(md_ctx));
 		*pulDigestLen = EVP_MD_CTX_size(md_ctx);
 		return CKR_BUFFER_TOO_SMALL;
 	}

--- a/src/pkcs11/pkcs11-display.c
+++ b/src/pkcs11/pkcs11-display.c
@@ -18,6 +18,9 @@
  */
 
 #include "config.h"
+#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#include <inttypes.h>
+#endif
 #include <string.h>
 
 #ifdef ENABLE_OPENSSL
@@ -90,10 +93,18 @@ buf_spec(CK_VOID_PTR buf_addr, CK_ULONG buf_len)
 {
 	static char ret[64];
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1800
+	const size_t prwidth = sizeof(CK_VOID_PTR) * 2;
+
+	sprintf(ret, "%0*"PRIxPTR" / %lu", (int) prwidth, (uintptr_t) buf_addr,
+		buf_len);
+#else
 	if (sizeof(CK_VOID_PTR) == 4)
-		sprintf(ret, "%08lx / %ld", (unsigned long) buf_addr, (CK_LONG) buf_len);
+		sprintf(ret, "%08lx / %lu", (unsigned long) buf_addr, buf_len);
 	else
-		sprintf(ret, "%016lx / %ld", (unsigned long) buf_addr, (CK_LONG) buf_len);
+		sprintf(ret, "%016llx / %lu", (unsigned long long) buf_addr,
+			buf_len);
+#endif
 
 	return ret;
 }

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -423,14 +423,14 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 	}
 
 	if (pSlotList == NULL_PTR) {
-		sc_log(context, "was only a size inquiry (%d)\n", numMatches);
+		sc_log(context, "was only a size inquiry (%lu)\n", numMatches);
 		*pulCount = numMatches;
 		rv = CKR_OK;
 		goto out;
 	}
 
 	if (*pulCount < numMatches) {
-		sc_log(context, "buffer was too small (needed %d)\n", numMatches);
+		sc_log(context, "buffer was too small (needed %lu)\n", numMatches);
 		*pulCount = numMatches;
 		rv = CKR_BUFFER_TOO_SMALL;
 		goto out;
@@ -440,7 +440,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 	*pulCount = numMatches;
 	rv = CKR_OK;
 
-	sc_log(context, "returned %d slots\n", numMatches);
+	sc_log(context, "returned %lu slots\n", numMatches);
 
 out:
 	if (found != NULL) {
@@ -503,7 +503,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 	}
 
 	rv = slot_get_slot(slotID, &slot);
-	sc_log(context, "C_GetSlotInfo() get slot rv %i", rv);
+	sc_log(context, "C_GetSlotInfo() get slot rv %lu", rv);
 	if (rv == CKR_OK)   {
 		if (slot->reader == NULL)   {
 			rv = CKR_TOKEN_NOT_PRESENT;
@@ -513,7 +513,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 			if (now >= slot->slot_state_expires || now == 0) {
 				/* Update slot status */
 				rv = card_detect(slot->reader);
-				sc_log(context, "C_GetSlotInfo() card detect rv 0x%X", rv);
+				sc_log(context, "C_GetSlotInfo() card detect rv 0x%lX", rv);
 
 				if (rv == CKR_TOKEN_NOT_RECOGNIZED || rv == CKR_OK)
 					slot->slot_info.flags |= CKF_TOKEN_PRESENT;
@@ -530,7 +530,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 	if (rv == CKR_OK)
 		memcpy(pInfo, &slot->slot_info, sizeof(CK_SLOT_INFO));
 
-	sc_log(context, "C_GetSlotInfo() flags 0x%X", pInfo->flags);
+	sc_log(context, "C_GetSlotInfo() flags 0x%lX", pInfo->flags);
 	sc_log(context, "C_GetSlotInfo(0x%lx) = %s", slotID, lookup_enum( RV_T, rv));
 	sc_pkcs11_unlock();
 	return rv;

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -333,7 +333,7 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	if (rv != CKR_OK)
 		goto out;
 
-	sc_log(context, "C_FindObjectsInit(slot = %d)\n", session->slot->id);
+	sc_log(context, "C_FindObjectsInit(slot = %lu)\n", session->slot->id);
 	dump_template(SC_LOG_DEBUG_NORMAL, "C_FindObjectsInit()", pTemplate, ulCount);
 
 	rv = session_start_operation(session, SC_PKCS11_OPERATION_FIND,
@@ -362,8 +362,9 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 			if (object->ops->get_attribute(session, object, &private_attribute) != CKR_OK)
 			        continue;
 			if (is_private) {
-				sc_log(context, "Object %d/%d: Private object and not logged in.",
-					 slot->id, object->handle);
+				sc_log(context,
+				       "Object %lu/%lu: Private object and not logged in.",
+				       slot->id, object->handle);
 				continue;
 			}
 		}
@@ -373,20 +374,23 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 		for (j = 0; j < ulCount; j++) {
 			rv = object->ops->cmp_attribute(session, object, &pTemplate[j]);
 			if (rv == 0) {
-				sc_log(context, "Object %d/%d: Attribute 0x%x does NOT match.",
-					 slot->id, object->handle, pTemplate[j].type);
+				sc_log(context,
+				       "Object %lu/%lu: Attribute 0x%lx does NOT match.",
+				       slot->id, object->handle, pTemplate[j].type);
 				match = 0;
 				break;
 			}
 
 			if (context->debug >= 4) {
-				sc_log(context, "Object %d/%d: Attribute 0x%x matches.",
-					 slot->id, object->handle, pTemplate[j].type);
+				sc_log(context,
+				       "Object %lu/%lu: Attribute 0x%lx matches.",
+				       slot->id, object->handle, pTemplate[j].type);
 			}
 		}
 
 		if (match) {
-			sc_log(context, "Object %d/%d matches\n", slot->id, object->handle);
+			sc_log(context, "Object %lu/%lu matches\n", slot->id,
+			       object->handle);
 			/* Realloc handles - remove restriction on only 32 matching objects -dee */
 			if (operation->num_handles >= operation->allocated_handles) {
 				operation->allocated_handles += SC_PKCS11_FIND_INC_HANDLES;

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -273,7 +273,7 @@ CK_RV C_Login(CK_SESSION_HANDLE hSession,	/* the session's handle */
 		goto out;
 	}
 
-	sc_log(context, "C_Login(0x%lx, %d)", hSession, userType);
+	sc_log(context, "C_Login(0x%lx, %lu)", hSession, userType);
 
 	slot = session->slot;
 
@@ -295,7 +295,7 @@ CK_RV C_Login(CK_SESSION_HANDLE hSession,	/* the session's handle */
 		}
 	}
 	else {
-		sc_log(context, "C_Login() slot->login_user %li", slot->login_user);
+		sc_log(context, "C_Login() slot->login_user %i", slot->login_user);
 		if (slot->login_user >= 0) {
 			if ((CK_USER_TYPE) slot->login_user == userType)
 				rv = CKR_USER_ALREADY_LOGGED_IN;

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -310,14 +310,18 @@ again:
 				rv = CKR_OK;
 			}
 			if (rv != CKR_OK)   {
-				sc_log(context, "%s: cannot bind 'generic' token: rv 0x%X", reader->name, rv);
+				sc_log(context,
+				       "%s: cannot bind 'generic' token: rv 0x%lX",
+				       reader->name, rv);
 				return rv;
 			}
 
 			sc_log(context, "%s: Creating 'generic' token.", reader->name);
 			rv = frameworks[i]->create_tokens(p11card, app_generic);
 			if (rv != CKR_OK)   {
-				sc_log(context, "%s: create 'generic' token error 0x%X", reader->name, rv);
+				sc_log(context,
+				       "%s: create 'generic' token error 0x%lX",
+				       reader->name, rv);
 				return rv;
 			}
 		}
@@ -333,14 +337,17 @@ again:
 			sc_log(context, "%s: Binding %s token.", reader->name, app_name);
 			rv = frameworks[i]->bind(p11card, app_info);
 			if (rv != CKR_OK)   {
-				sc_log(context, "%s: bind %s token error Ox%X", reader->name, app_name, rv);
+				sc_log(context, "%s: bind %s token error Ox%lX",
+				       reader->name, app_name, rv);
 				continue;
 			}
 
 			sc_log(context, "%s: Creating %s token.", reader->name, app_name);
 			rv = frameworks[i]->create_tokens(p11card, app_info);
 			if (rv != CKR_OK)   {
-				sc_log(context, "%s: create %s token error 0x%X", reader->name, app_name, rv);
+				sc_log(context,
+				       "%s: create %s token error 0x%lX",
+				       reader->name, app_name, rv);
 				return rv;
 			}
 		}
@@ -490,7 +497,9 @@ CK_RV slot_find_changed(CK_SLOT_ID_PTR idp, int mask)
 	card_detect_all();
 	for (i=0; i<list_size(&virtual_slots); i++) {
 		sc_pkcs11_slot_t *slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
-		sc_log(context, "slot 0x%lx token: %d events: 0x%02X",slot->id, (slot->slot_info.flags & CKF_TOKEN_PRESENT), slot->events);
+		sc_log(context, "slot 0x%lx token: %lu events: 0x%02X",
+		       slot->id, (slot->slot_info.flags & CKF_TOKEN_PRESENT),
+		       slot->events);
 		if ((slot->events & SC_EVENT_CARD_INSERTED)
 				&& !(slot->slot_info.flags & CKF_TOKEN_PRESENT)) {
 			/* If a token has not been initialized, clear the inserted event */

--- a/src/pkcs15init/pkcs15-authentic.c
+++ b/src/pkcs15init/pkcs15-authentic.c
@@ -254,8 +254,9 @@ authentic_pkcs15_new_file(struct sc_profile *profile, struct sc_card *card,
 		file->path.count = -1;
 	}
 
-	sc_log(ctx, "file(size:%i,type:%i/%i,id:%04X), path(type:%X,'%s')",  file->size, file->type, file->ef_structure, file->id,
-			file->path.type, sc_print_path(&file->path));
+	sc_log(ctx, "file(size:%"SC_FORMAT_LEN_SIZE_T"u,type:%i/%i,id:%04X), path(type:%X,'%s')",
+	       file->size, file->type, file->ef_structure, file->id,
+	       file->path.type, sc_print_path(&file->path));
 	if (out)
 		*out = file;
 	else
@@ -525,8 +526,10 @@ authentic_pkcs15_create_key(struct sc_profile *profile, struct sc_pkcs15_card *p
 	int	 rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "create private key(keybits:%i,usage:%X,access:%X,ref:%X)", keybits,
-			key_info->usage, key_info->access_flags, key_info->key_reference);
+	sc_log(ctx,
+	       "create private key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,usage:%X,access:%X,ref:%X)",
+	       keybits, key_info->usage, key_info->access_flags,
+	       key_info->key_reference);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 256))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid RSA key size");
 
@@ -604,8 +607,10 @@ authentic_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15c
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "generate key(bits:%i,path:%s,AuthID:%s\n", keybits,
-			sc_print_path(&key_info->path), sc_pkcs15_print_id(&object->auth_id));
+	sc_log(ctx,
+	       "generate key(bits:%"SC_FORMAT_LEN_SIZE_T"u,path:%s,AuthID:%s\n",
+	       keybits, sc_print_path(&key_info->path),
+	       sc_pkcs15_print_id(&object->auth_id));
 
 	if (!object->content.value || object->content.len != sizeof(struct sc_authentic_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -669,8 +674,10 @@ authentic_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "Store IAS/ECC key(keybits:%i,AuthID:%s,path:%s)",
-			keybits, sc_pkcs15_print_id(&object->auth_id), sc_print_path(&key_info->path));
+	sc_log(ctx,
+	       "Store IAS/ECC key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,AuthID:%s,path:%s)",
+	       keybits, sc_pkcs15_print_id(&object->auth_id),
+	       sc_print_path(&key_info->path));
 
 	if (!object->content.value || object->content.len != sizeof(struct sc_authentic_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -716,7 +723,8 @@ authentic_pkcs15_delete_rsa_sdo (struct sc_profile *profile, struct sc_pkcs15_ca
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "delete SDO RSA key (ref:%i,size:%i)", key_info->key_reference, key_info->modulus_length);
+	sc_log(ctx, "delete SDO RSA key (ref:%i,size:%"SC_FORMAT_LEN_SIZE_T"u)",
+	       key_info->key_reference, key_info->modulus_length);
 
 	rv = authentic_pkcs15_new_file(profile, p15card->card, SC_PKCS15_TYPE_PRKEY_RSA, key_info->key_reference, &file);
 	LOG_TEST_GOTO_ERR(ctx, rv, "PRKEY_RSA instantiation file error");

--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -481,8 +481,9 @@ cardos_store_pin(sc_profile_t *profile, sc_card_t *card,
 	 * "no padding required". */
 	maxlen = MIN(profile->pin_maxlen, sizeof(pinpadded));
 	if (pin_len > maxlen) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "invalid pin length: %u (max %u)\n",
-		         pin_len, maxlen);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "invalid pin length: %"SC_FORMAT_LEN_SIZE_T"u (max %u)\n",
+			 pin_len, maxlen);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	memcpy(pinpadded, pin, pin_len);

--- a/src/pkcs15init/pkcs15-cflex.c
+++ b/src/pkcs15init/pkcs15-cflex.c
@@ -289,8 +289,9 @@ cflex_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_pkcs15_obj
 	case 1024: size = 326; break;
 	case 2048: size = 646; break;
 	default:
-		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "Unsupported key size %u\n",
-				key_info->modulus_length);
+		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL,
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 key_info->modulus_length);
 		r = SC_ERROR_INVALID_ARGUMENTS;
 		goto out;
 	}

--- a/src/pkcs15init/pkcs15-entersafe.c
+++ b/src/pkcs15init/pkcs15-entersafe.c
@@ -363,10 +363,10 @@ static int entersafe_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		 ( keybits > 2048 ) ||
 		 ( keybits % 0x20 ) )
 	{
-		sc_debug( card->ctx,
-				  SC_LOG_DEBUG_NORMAL,
-				  "Unsupported key size %u\n",
-				  keybits );
+		sc_debug(card->ctx,
+			 SC_LOG_DEBUG_NORMAL,
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -413,10 +413,10 @@ static int entersafe_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15ca
 		 ( keybits > 2048 ) ||
 		 ( keybits % 0x20 ) )
 	{
-		sc_debug( card->ctx,
-				  SC_LOG_DEBUG_NORMAL,
-				  "Unsupported key size %u\n",
-				  keybits );
+		sc_debug(card->ctx,
+			 SC_LOG_DEBUG_NORMAL,
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -371,7 +371,7 @@ cosm_new_file(struct sc_profile *profile, struct sc_card *card,
 	file->ef_structure = structure;
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		 "file size %i; ef type %i/%i; id %04X, path_len %i\n",
+		 "file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X, path_len %"SC_FORMAT_LEN_SIZE_T"u\n",
 		 file->size, file->type, file->ef_structure, file->id,
 		 file->path.len);
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "file path: %s",
@@ -410,7 +410,8 @@ static int epass2003_pkcs15_store_key(struct sc_profile *profile,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "index %i; id %s\n", idx,
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "index %"SC_FORMAT_LEN_SIZE_T"u; id %s\n", idx,
 		 sc_pkcs15_print_id(&key_info->id));
 	if (key->algorithm != SC_ALGORITHM_RSA
 	    || key->algorithm != SC_ALGORITHM_RSA)
@@ -439,11 +440,13 @@ static int epass2003_pkcs15_store_key(struct sc_profile *profile,
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r,
 		    "create key: failed to create key file");
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "index %i; keybits %i\n", idx,
-		 keybits);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "index %"SC_FORMAT_LEN_SIZE_T"u; keybits %"SC_FORMAT_LEN_SIZE_T"u\n",
+		 idx, keybits);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 0x20)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
-			 "Unsupported key size %u\n", keybits);
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -518,11 +521,13 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_NORMAL, r,
 		    "create key: failed to create key file");
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "index %i; keybits %i\n", idx,
-		 keybits);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "index %"SC_FORMAT_LEN_SIZE_T"u; keybits %"SC_FORMAT_LEN_SIZE_T"u\n",
+		 idx, keybits);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 0x20)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
-			 "Unsupported key size %u\n", keybits);
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 keybits);
 		r = SC_ERROR_INVALID_ARGUMENTS;
 		goto err;
 	}
@@ -555,7 +560,7 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	    + pukf->path.value[pukf->path.len - 1];
 
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		 "public key size %i; ef type %i/%i; id %04X; path: %s",
+		 "public key size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X; path: %s",
 		 pukf->size, pukf->type, pukf->ef_structure, pukf->id,
 		 sc_print_path(&pukf->path));
 

--- a/src/pkcs15init/pkcs15-gpk.c
+++ b/src/pkcs15init/pkcs15-gpk.c
@@ -518,8 +518,10 @@ gpk_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	sc_file_t	*keyfile;
 	int             r, n;
 
-	sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "path=%s, %d bits\n", sc_print_path(&key_info->path),
-			key_info->modulus_length);
+	sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "path=%s, %"SC_FORMAT_LEN_SIZE_T"u bits\n",
+		 sc_print_path(&key_info->path),
+		 key_info->modulus_length);
 
 	if (obj->type != SC_PKCS15_TYPE_PRKEY_RSA) {
 		sc_debug(p15card->card->ctx, SC_LOG_DEBUG_NORMAL, "GPK supports generating only RSA keys.");

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -241,7 +241,9 @@ iasecc_pkcs15_new_file(struct sc_profile *profile, struct sc_card *card,
 	file->path.value[file->path.len - 1] = file->id & 0xFF;
 	file->path.count = -1;
 
-	sc_log(ctx, "file size %i; ef type %i/%i; id %04X\n", file->size, file->type, file->ef_structure, file->id);
+	sc_log(ctx,
+	       "file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X\n",
+	       file->size, file->type, file->ef_structure, file->id);
 	sc_log(ctx, "path type %X; path '%s'", file->path.type, sc_print_path(&file->path));
 
 	if (out)
@@ -430,8 +432,8 @@ iasecc_sdo_set_key_acls_from_profile(struct sc_profile *profile, struct sc_card 
 	*(sdo->docp.acls_contact.value + 0) = amb;
 	memcpy(sdo->docp.acls_contact.value + 1, scb, cntr);
 
-	sc_log(ctx, "AMB: %X, CNTR %i, %x %x %x %x %x %x",
-			amb, cntr, scb[0], scb[1], scb[2], scb[3], scb[4], scb[5], scb[6]);
+	sc_log(ctx, "AMB: %X, CNTR %i, %x %x %x %x %x %x %x",
+	       amb, cntr, scb[0], scb[1], scb[2], scb[3], scb[4], scb[5], scb[6]);
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
@@ -914,8 +916,10 @@ iasecc_pkcs15_fix_private_key_attributes(struct sc_profile *profile, struct sc_p
 
 	sc_log(ctx, "SDO(class:%X,ref:%X,usage:%X)",
 			sdo_prvkey->sdo_class, sdo_prvkey->sdo_ref, sdo_prvkey->usage);
-	sc_log(ctx, "SDO ACLs(%i):%s", sdo_prvkey->docp.acls_contact.size,
-			sc_dump_hex(sdo_prvkey->docp.acls_contact.value, sdo_prvkey->docp.acls_contact.size));
+	sc_log(ctx, "SDO ACLs(%"SC_FORMAT_LEN_SIZE_T"u):%s",
+	       sdo_prvkey->docp.acls_contact.size,
+	       sc_dump_hex(sdo_prvkey->docp.acls_contact.value,
+			   sdo_prvkey->docp.acls_contact.size));
 	sc_log(ctx, "SDO AMB:%X, SCBS:%s", sdo_prvkey->docp.amb,
 			sc_dump_hex(sdo_prvkey->docp.scbs, IASECC_MAX_SCBS));
 
@@ -1052,10 +1056,13 @@ iasecc_pkcs15_create_key(struct sc_profile *profile, struct sc_pkcs15_card *p15c
 	int	 rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "create private key(keybits:%i,usage:%X,access:%X,ref:%X)",
-			keybits, key_info->usage, key_info->access_flags, key_info->key_reference);
+	sc_log(ctx,
+	       "create private key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,usage:%X,access:%X,ref:%X)",
+	       keybits, key_info->usage, key_info->access_flags,
+	       key_info->key_reference);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 256))   {
-		sc_log(ctx, "Unsupported key size %u", keybits);
+		sc_log(ctx, "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u",
+		       keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -1111,8 +1118,10 @@ iasecc_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15card
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "generate key(bits:%i,path:%s,AuthID:%s\n", keybits,
-			sc_print_path(&key_info->path), sc_pkcs15_print_id(&object->auth_id));
+	sc_log(ctx,
+	       "generate key(bits:%"SC_FORMAT_LEN_SIZE_T"u,path:%s,AuthID:%s\n",
+	       keybits, sc_print_path(&key_info->path),
+	       sc_pkcs15_print_id(&object->auth_id));
 
 	if (!object->content.value || object->content.len != sizeof(struct iasecc_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -1122,7 +1131,8 @@ iasecc_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15card
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "'Magic' control failed for SDO PrvKey");
 
 	if (keybits < 1024 || keybits > 2048 || (keybits%0x100))   {
-		sc_log(ctx, "Unsupported key size %u\n", keybits);
+		sc_log(ctx, "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+		       keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -1204,8 +1214,10 @@ iasecc_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p15ca
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "Store IAS/ECC key(keybits:%i,AuthID:%s,path:%s)",
-			keybits, sc_pkcs15_print_id(&object->auth_id), sc_print_path(&key_info->path));
+	sc_log(ctx,
+	       "Store IAS/ECC key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,AuthID:%s,path:%s)",
+	       keybits, sc_pkcs15_print_id(&object->auth_id),
+	       sc_print_path(&key_info->path));
 
 	if (!object->content.value || object->content.len != sizeof(struct iasecc_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -1216,8 +1228,10 @@ iasecc_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p15ca
 	if (sdo_prvkey->magic != SC_CARDCTL_IASECC_SDO_MAGIC)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "'Magic' control failed for SDO PrvKey");
 
-	sc_log(ctx, "key compulsory attr(size:%i,on_card:%i)",
-			sdo_prvkey->data.prv_key.compulsory.size, sdo_prvkey->data.prv_key.compulsory.on_card);
+	sc_log(ctx,
+	       "key compulsory attr(size:%"SC_FORMAT_LEN_SIZE_T"u,on_card:%i)",
+	       sdo_prvkey->data.prv_key.compulsory.size,
+	       sdo_prvkey->data.prv_key.compulsory.on_card);
 
 	rv = sc_profile_get_parent(profile, "private-key", &file);
 	LOG_TEST_RET(ctx, rv, "cannot instantiate parent DF of the private key");

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -1741,8 +1741,10 @@ sc_pkcs15init_store_certificate(struct sc_pkcs15_card *p15card,
 		cert_info->path = existing_path;
 	}
 
-	sc_log(ctx, "Store cert(%.*s,ID:%s,der(%p,%i))", (int) sizeof object->label, object->label,
-			sc_pkcs15_print_id(&cert_info->id), args->der_encoded.value, args->der_encoded.len);
+	sc_log(ctx, "Store cert(%.*s,ID:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
+	       (int) sizeof object->label, object->label,
+	       sc_pkcs15_print_id(&cert_info->id), args->der_encoded.value,
+	       args->der_encoded.len);
 
 	if (!profile->pkcs15.direct_certificates)
 		r = sc_pkcs15init_store_data(p15card, profile, object, &args->der_encoded, &cert_info->path);
@@ -2273,12 +2275,15 @@ prkey_bits(struct sc_pkcs15_card *p15card, struct sc_pkcs15_prkey *key)
 		return sc_pkcs15init_keybits(&key->u.dsa.q);
 	case SC_ALGORITHM_GOSTR3410:
 		if (sc_pkcs15init_keybits(&key->u.gostr3410.d) > SC_PKCS15_GOSTR3410_KEYSIZE) {
-			sc_log(ctx, "Unsupported key (keybits %u)", sc_pkcs15init_keybits(&key->u.gostr3410.d));
+			sc_log(ctx,
+			       "Unsupported key (keybits %"SC_FORMAT_LEN_SIZE_T"u)",
+			       sc_pkcs15init_keybits(&key->u.gostr3410.d));
 			return SC_ERROR_OBJECT_NOT_VALID;
 		}
 		return SC_PKCS15_GOSTR3410_KEYSIZE;
 	case SC_ALGORITHM_EC:
-		sc_log(ctx, "Private EC key length %u", key->u.ec.params.field_length);
+		sc_log(ctx, "Private EC key length %"SC_FORMAT_LEN_SIZE_T"u",
+		       key->u.ec.params.field_length);
 		if (key->u.ec.params.field_length == 0)   {
 			sc_log(ctx, "Invalid EC key length");
 			return SC_ERROR_OBJECT_NOT_VALID;
@@ -2597,7 +2602,8 @@ select_object_path(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	if (!name)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
-	sc_log(ctx, "key-domain.%s @%s (auth_id.len=%d)", name, sc_print_path(path), obj->auth_id.len);
+	sc_log(ctx, "key-domain.%s @%s (auth_id.len=%"SC_FORMAT_LEN_SIZE_T"u)",
+	       name, sc_print_path(path), obj->auth_id.len);
 
 	indx_id.len = 1;
 	for (indx = TEMPLATE_INSTANTIATE_MIN_INDEX; indx <= TEMPLATE_INSTANTIATE_MAX_INDEX; indx++)   {
@@ -3391,7 +3397,7 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 			LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 		reference = pin_id;
 		type = SC_AC_CHV;
-		sc_log(ctx, "Symbolic PIN resolved to PIN(type:CHV,reference:%i)", type, reference);
+		sc_log(ctx, "Symbolic PIN resolved to PIN(type:CHV,reference:%i)", reference);
 	}
 
 	if (path && path->len)   {
@@ -3414,7 +3420,10 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 	}
 
 	if (pin_obj)   {
-		sc_log(ctx, "PIN object '%.*s'; pin_obj->content.len:%i", (int) sizeof pin_obj->label, pin_obj->label, pin_obj->content.len);
+		sc_log(ctx,
+		       "PIN object '%.*s'; pin_obj->content.len:%"SC_FORMAT_LEN_SIZE_T"u",
+		       (int) sizeof pin_obj->label, pin_obj->label,
+		       pin_obj->content.len);
 		if (pin_obj->content.value && pin_obj->content.len)   {
 			if (pin_obj->content.len > sizeof(pinbuf))
 				LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "PIN buffer is too small");
@@ -3433,7 +3442,9 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 		if (callbacks.get_pin)   {
 			pinsize = sizeof(pinbuf);
 			r = callbacks.get_pin(profile, pin_id, &auth_info, label, pinbuf, &pinsize);
-			sc_log(ctx, "'get_pin' callback returned %i; pinsize:%i", r, pinsize);
+			sc_log(ctx,
+			       "'get_pin' callback returned %i; pinsize:%"SC_FORMAT_LEN_SIZE_T"u",
+			       r, pinsize);
 		}
 		break;
 	case SC_AC_SCB:
@@ -3667,8 +3678,10 @@ sc_pkcs15init_update_file(struct sc_profile *profile,
 	}
 
 	if (selected_file->size < datalen) {
-		sc_log(ctx, "File %s too small (require %u, have %u)",
-				sc_print_path(&file->path), datalen, selected_file->size);
+		sc_log(ctx,
+		       "File %s too small (require %u, have %"SC_FORMAT_LEN_SIZE_T"u)",
+		       sc_print_path(&file->path), datalen,
+		       selected_file->size);
 		sc_file_free(selected_file);
 		LOG_TEST_RET(ctx, SC_ERROR_FILE_TOO_SMALL, "Update file failed");
 	}
@@ -3896,11 +3909,15 @@ sc_pkcs15init_qualify_pin(struct sc_card *card, const char *pin_name,
 	pin_attrs = &auth_info->attrs.pin;
 
 	if (pin_len < pin_attrs->min_length) {
-		sc_log(ctx, "%s too short (min length %u)", pin_name, pin_attrs->min_length);
+		sc_log(ctx,
+		       "%s too short (min length %"SC_FORMAT_LEN_SIZE_T"u)",
+		       pin_name, pin_attrs->min_length);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_LENGTH);
 	}
 	if (pin_len > pin_attrs->max_length) {
-		sc_log(ctx, "%s too long (max length %u)", pin_name, pin_attrs->max_length);
+		sc_log(ctx,
+		       "%s too long (max length %"SC_FORMAT_LEN_SIZE_T"u)",
+		       pin_name, pin_attrs->max_length);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_LENGTH);
 	}
 

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -290,8 +290,10 @@ myeid_create_pin(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	int r;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "PIN('%s',ref:%i,flags:0x%X,pin_len:%d,puk_len:%d)\n",
-			pin_obj->label, auth_info->attrs.pin.reference, auth_info->attrs.pin.flags, pin_len, puk_len);
+	sc_log(ctx,
+	       "PIN('%s',ref:%i,flags:0x%X,pin_len:%"SC_FORMAT_LEN_SIZE_T"u,puk_len:%"SC_FORMAT_LEN_SIZE_T"u)\n",
+	       pin_obj->label, auth_info->attrs.pin.reference,
+	       auth_info->attrs.pin.flags, pin_len, puk_len);
 
 	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;
@@ -671,7 +673,10 @@ myeid_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		else if (object->type == SC_PKCS15_TYPE_PRKEY_EC) {
 			struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
 
-			sc_log(ctx, "curve '%s', len %i, oid '%s'", ecparams->named_curve, ecparams->field_length, sc_dump_oid(&(ecparams->id)));
+			sc_log(ctx,
+			       "curve '%s', len %"SC_FORMAT_LEN_SIZE_T"u, oid '%s'",
+			       ecparams->named_curve, ecparams->field_length,
+			       sc_dump_oid(&(ecparams->id)));
 			pubkey->algorithm = SC_ALGORITHM_EC;
 
 			r = sc_select_file(card, &file->path, NULL);

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -170,8 +170,9 @@ awp_new_file(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 				ifile->path.value[ifile->path.len-2] |= 0x01;
 			}
 
-			sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "info_file(id:%04X,size:%i,rlen:%i)",
-					ifile->id, ifile->size, ifile->record_length);
+			sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+				 "info_file(id:%04X,size:%"SC_FORMAT_LEN_SIZE_T"u,rlen:%i)",
+				 ifile->id, ifile->size, ifile->record_length);
 			*info_out = ifile;
 		}
 		else   {
@@ -180,7 +181,9 @@ awp_new_file(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	}
 
 	if (ofile)   {
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "obj file %04X; size %i; ", ofile->id, ofile->size);
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+			 "obj file %04X; size %"SC_FORMAT_LEN_SIZE_T"u; ",
+			 ofile->id, ofile->size);
 		if (obj_out)
 			*obj_out = ofile;
 		else
@@ -346,7 +349,9 @@ awp_update_container_entry (struct sc_pkcs15_card *p15card, struct sc_profile *p
 	unsigned char *buff = NULL;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "update container entry(type:%X,len:%i,count %i,rec %i,offs %i", type, file_id, rec, offs);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "update container entry(type:%X,id %i,rec %i,offs %i",
+		 type, file_id, rec, offs);
 	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "container file(file-id:%X,rlen:%i,rcount:%i)",
 			list_file->id, list_file->record_length, list_file->record_count);
 
@@ -724,7 +729,9 @@ awp_update_object_list(struct sc_pkcs15_card *p15card, struct sc_profile *profil
 		goto done;
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "ii %i, rv %i; %X; %i", ii, rv, file->id, file->size);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "ii %i, rv %i; %X; %"SC_FORMAT_LEN_SIZE_T"u",
+		 ii, rv, file->id, file->size);
 	*(buff + ii) = COSM_LIST_TAG;
 	*(buff + ii + 1) = (file->id >> 8) & 0xFF;
 	*(buff + ii + 2) = file->id & 0xFF;
@@ -775,12 +782,16 @@ awp_encode_key_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *obj
 
 	ki->label.value = (unsigned char *)strdup(obj->label);
 	ki->label.len = strlen(obj->label);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "cosm_encode_key_info() label(%i):%s",ki->label.len, ki->label.value);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "cosm_encode_key_info() label(%u):%s",
+		 ki->label.len, ki->label.value);
 
 	/*
 	 * Oberthur saves modulus value without tag and length.
 	 */
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "pubkey->modulus.len %i",pubkey->modulus.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "pubkey->modulus.len %"SC_FORMAT_LEN_SIZE_T"u",
+		 pubkey->modulus.len);
 	ki->modulus.value = malloc(pubkey->modulus.len);
 	if (!ki->modulus.value)   {
 		r = SC_ERROR_OUT_OF_MEMORY;
@@ -928,8 +939,10 @@ awp_encode_cert_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 
 	cert_info = (struct sc_pkcs15_cert_info *)obj->data;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Encode cert(%s,id:%s,der(%p,%i))", obj->label,
-			sc_pkcs15_print_id(&cert_info->id), obj->content.value, obj->content.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "Encode cert(%s,id:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
+		 obj->label, sc_pkcs15_print_id(&cert_info->id),
+		 obj->content.value, obj->content.len);
 	memset(&pubkey, 0, sizeof(pubkey));
 
 	ci->label.value = (unsigned char *)strdup(obj->label);
@@ -1095,8 +1108,10 @@ awp_encode_data_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 
 	data_info = (struct sc_pkcs15_data_info *)obj->data;
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Encode data(%s,id:%s,der(%p,%i))", obj->label,
-			sc_pkcs15_print_id(&data_info->id), obj->content.value, obj->content.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "Encode data(%s,id:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
+		 obj->label, sc_pkcs15_print_id(&data_info->id),
+		 obj->content.value, obj->content.len);
 
 	di->flags = 0x0000;
 
@@ -1370,7 +1385,8 @@ awp_update_df_create_cert(struct sc_pkcs15_card *p15card, struct sc_profile *pro
 	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "COSM new file error");
 
 	memset(&icert, 0, sizeof(icert));
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Cert Der(%p,%i)", der.value, der.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "Cert Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
 	rv = awp_encode_cert_info(p15card, obj, &icert);
 	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "'Create Cert' update DF failed: cannot encode info");
 
@@ -1456,7 +1472,8 @@ awp_update_df_create_prvkey(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_NORMAL, rv, "New private key info file error");
 
 	pubkey.algorithm = SC_ALGORITHM_RSA;
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "PrKey Der(%p,%i)", der.value, der.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "PrKey Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
 	rv = sc_pkcs15_decode_pubkey(ctx, &pubkey, der.value, der.len);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_NORMAL, rv, "AWP 'update private key' DF failed: decode public key error");
 
@@ -1508,7 +1525,8 @@ awp_update_df_create_pubkey(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_NORMAL, rv, "New public key info file error");
 
 	pubkey.algorithm = SC_ALGORITHM_RSA;
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "PrKey Der(%p,%i)", der.value, der.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "PrKey Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
 	rv = sc_pkcs15_decode_pubkey(ctx, &pubkey, der.value, der.len);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_NORMAL, rv, "AWP 'update public key' DF failed: decode public key error");
 
@@ -1555,7 +1573,8 @@ awp_update_df_create_data(struct sc_pkcs15_card *p15card, struct sc_profile *pro
 	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "COSM new file error");
 
 	memset(&idata, 0, sizeof(idata));
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Data Der(%p,%i)", der.value, der.len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "Data Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
 	rv = awp_encode_data_info(p15card, obj, &idata);
 	SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, rv, "'Create Data' update DF failed: cannot encode info");
 

--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -276,7 +276,9 @@ cosm_create_reference_data(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	};
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "pin lens %i/%i", pin_len,  puk_len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+		 "pin lens %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
+		 pin_len, puk_len);
 	if (!pin || pin_len>0x40)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	if (puk && !puk_len)
@@ -534,8 +536,9 @@ cosm_new_file(struct sc_profile *profile, struct sc_card *card,
 		file->ef_structure = structure;
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "cosm_new_file() file size %i; ef type %i/%i; id %04X",file->size,
-			file->type, file->ef_structure, file->id);
+	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+		 "cosm_new_file() file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X",
+		 file->size, file->type, file->ef_structure, file->id);
 	*out = file;
 
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);

--- a/src/pkcs15init/pkcs15-openpgp.c
+++ b/src/pkcs15init/pkcs15-openpgp.c
@@ -279,7 +279,9 @@ static int openpgp_store_data(struct sc_pkcs15_card *p15card, struct sc_profile 
 		r = sc_select_file(card, path, &file);
 		LOG_TEST_RET(card->ctx, r, "Cannot select cert file");
 		r = sc_pkcs15init_authenticate(profile, p15card, file, SC_AC_OP_UPDATE);
-		sc_log(card->ctx, "Data to write is %d long", content->len);
+		sc_log(card->ctx,
+		       "Data to write is %"SC_FORMAT_LEN_SIZE_T"u long",
+		       content->len);
 		if (r >= 0 && content->len)
 			r = sc_put_data(p15card->card, 0x7F21, (const unsigned char *) content->value, content->len);
 		break;

--- a/src/pkcs15init/pkcs15-rtecp.c
+++ b/src/pkcs15init/pkcs15-rtecp.c
@@ -321,7 +321,9 @@ static int rtecp_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 				&& key_info->modulus_length
 				!= SC_PKCS15_GOSTR3410_KEYSIZE))
 	{
-		sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "Unsupported key size %u\n", key_info->modulus_length);
+		sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
+			 key_info->modulus_length);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	if (obj->type == SC_PKCS15_TYPE_PRKEY_GOSTR3410)

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -486,8 +486,9 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 
 		keybits = ((raw_pubkey[0] * 256) + raw_pubkey[1]);  /* modulus bit length */
 		if (keybits != key_info->modulus_length)  {
-			sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "key-size from card[%i] does not match[%i]\n",
-					keybits, key_info->modulus_length);
+			sc_debug(ctx, SC_LOG_DEBUG_NORMAL,
+				 "key-size from card[%"SC_FORMAT_LEN_SIZE_T"u] does not match[%"SC_FORMAT_LEN_SIZE_T"u]\n",
+				 keybits, key_info->modulus_length);
 			SC_TEST_RET(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_PKCS15INIT, "Failed to generate key");
 		}
 		memcpy (pubkey->u.rsa.modulus.data, &raw_pubkey[2], pubkey->u.rsa.modulus.len);

--- a/src/smm/Makefile.am
+++ b/src/smm/Makefile.am
@@ -19,6 +19,6 @@ libsmm_local_la_SOURCES = smm-local.c sm-module.h \
 	sm-card-authentic.c sm-card-iasecc.c \
 	smm-local.exports
 libsmm_local_la_LIBADD = $(OPTIONAL_OPENSSL_LIBS) ../libopensc/libopensc.la
-libsmm_local_la_LDFLAGS = -version-info @OPENSC_LT_CURRENT@:@OPENSC_LT_REVISION@:@OPENSC_LT_AGE@
+libsmm_local_la_LDFLAGS = -no-undefined -version-info @OPENSC_LT_CURRENT@:@OPENSC_LT_REVISION@:@OPENSC_LT_AGE@
 
 # noinst_HEADERS = sm.h

--- a/src/smm/sm-card-authentic.c
+++ b/src/smm/sm-card-authentic.c
@@ -143,7 +143,8 @@ sm_authentic_get_apdus(struct sc_context *ctx, struct sm_info *sm_info,
 	if (!sm_info)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM get APDUs: rdata:%p, init_len:%i", rdata, init_len);
+	sc_log(ctx, "SM get APDUs: rdata:%p, init_len:%"SC_FORMAT_LEN_SIZE_T"u",
+	       rdata, init_len);
 	sc_log(ctx, "SM get APDUs: serial %s", sc_dump_hex(sm_info->serialnr.value, sm_info->serialnr.len));
 
 	if (init_data)   {

--- a/src/smm/sm-card-iasecc.c
+++ b/src/smm/sm-card-iasecc.c
@@ -67,7 +67,9 @@ sm_iasecc_get_apdu_read_binary(struct sc_context *ctx, struct sm_info *sm_info, 
         if (!rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM get 'READ BINARY' APDUs: offset:%i,size:%i", cmd_data->offs, cmd_data->count);
+	sc_log(ctx,
+	       "SM get 'READ BINARY' APDUs: offset:%"SC_FORMAT_LEN_SIZE_T"u,size:%"SC_FORMAT_LEN_SIZE_T"u",
+	       cmd_data->offs, cmd_data->count);
 	offs = cmd_data->offs;
 	while (cmd_data->count > data_offs)   {
 		int sz = (cmd_data->count - data_offs) > SM_MAX_DATA_SIZE ? SM_MAX_DATA_SIZE : (cmd_data->count - data_offs);
@@ -111,7 +113,9 @@ sm_iasecc_get_apdu_update_binary(struct sc_context *ctx, struct sm_info *sm_info
         if (!rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM get 'UPDATE BINARY' APDUs: offset:%i,size:%i", cmd_data->offs, cmd_data->count);
+	sc_log(ctx,
+	       "SM get 'UPDATE BINARY' APDUs: offset:%"SC_FORMAT_LEN_SIZE_T"u,size:%"SC_FORMAT_LEN_SIZE_T"u",
+	       cmd_data->offs, cmd_data->count);
 	offs = cmd_data->offs;
 	while (data_offs < cmd_data->count)   {
 		int sz = (cmd_data->count - data_offs) > SM_MAX_DATA_SIZE ? SM_MAX_DATA_SIZE : (cmd_data->count - data_offs);
@@ -157,7 +161,9 @@ sm_iasecc_get_apdu_create_file(struct sc_context *ctx, struct sm_info *sm_info, 
 	if (!cmd_data || !cmd_data->data || !rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM get 'CREATE FILE' APDU: FCP(%i) %s", cmd_data->size, sc_dump_hex(cmd_data->data,cmd_data->size));
+	sc_log(ctx,
+	       "SM get 'CREATE FILE' APDU: FCP(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+	       cmd_data->size, sc_dump_hex(cmd_data->data,cmd_data->size));
 
  	rv = rdata->alloc(rdata, &rapdu);
 	LOG_TEST_RET(ctx, rv, "SM get 'UPDATE BINARY' APDUs: cannot allocate remote APDU");
@@ -231,9 +237,9 @@ sm_iasecc_get_apdu_verify_pin(struct sc_context *ctx, struct sm_info *sm_info, s
 	if (!pin_data || !rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM get 'VERIFY PIN' APDU: ", pin_data->pin_reference);
+	sc_log(ctx, "SM get 'VERIFY PIN' APDU: %u", pin_data->pin_reference);
 
- 	rv = rdata->alloc(rdata, &rapdu);
+	rv = rdata->alloc(rdata, &rapdu);
 	LOG_TEST_RET(ctx, rv, "SM get 'VERIFY PIN' APDUs: cannot allocate remote APDU");
 
 	rapdu->apdu.cse = SC_APDU_CASE_3_SHORT;
@@ -505,7 +511,8 @@ sm_iasecc_get_apdus(struct sc_context *ctx, struct sm_info *sm_info,
 	if (!sm_info)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx, "SM IAS/ECC get APDUs: init_len:%i", init_len);
+	sc_log(ctx, "SM IAS/ECC get APDUs: init_len:%"SC_FORMAT_LEN_SIZE_T"u",
+	       init_len);
 	sc_log(ctx, "SM IAS/ECC get APDUs: rdata:%p", rdata);
 	sc_log(ctx, "SM IAS/ECC get APDUs: serial %s", sc_dump_hex(sm_info->serialnr.value, sm_info->serialnr.len));
 
@@ -579,7 +586,9 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 
 	LOG_FUNC_CALLED(ctx);
 
-	sc_log(ctx, "IAS/ECC decode answer() rdata length %i, out length %i", rdata->length, out_len);
+	sc_log(ctx,
+	       "IAS/ECC decode answer() rdata length %i, out length %"SC_FORMAT_LEN_SIZE_T"u",
+	       rdata->length, out_len);
         for (rapdu = rdata->data; rapdu; rapdu = rapdu->next)   {
                 unsigned char *decrypted;
                 size_t decrypted_len;
@@ -590,7 +599,9 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 		unsigned char ticket[8];
 		size_t ticket_len = sizeof(ticket);
 
-		sc_log(ctx, "IAS/ECC decode response(%i) %s", rapdu->apdu.resplen, sc_dump_hex(rapdu->apdu.resp, rapdu->apdu.resplen));
+		sc_log(ctx,
+		       "IAS/ECC decode response(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+		       rapdu->apdu.resplen, sc_dump_hex(rapdu->apdu.resp, rapdu->apdu.resplen));
 
 		sc_copy_asn1_entry(c_asn1_iasecc_sm_data_object, asn1_iasecc_sm_data_object);
 		sc_format_asn1_entry(asn1_iasecc_sm_data_object + 0, resp_data, &resp_len, 0);
@@ -614,7 +625,10 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 					&decrypted, &decrypted_len);
 			LOG_TEST_RET(ctx, rv, "IAS/ECC decode answer(s): cannot decrypt card answer data");
 
-			sc_log(ctx, "IAS/ECC decrypted data(%i) %s", decrypted_len, sc_dump_hex(decrypted, decrypted_len));
+			sc_log(ctx,
+			       "IAS/ECC decrypted data(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+			       decrypted_len,
+			       sc_dump_hex(decrypted, decrypted_len));
 			while(*(decrypted + decrypted_len - 1) == 0x00)
 			       decrypted_len--;
 			if (*(decrypted + decrypted_len - 1) != 0x80)
@@ -628,7 +642,9 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 				memcpy(out + offs, decrypted, decrypted_len);
 
 				offs += decrypted_len;
-				sc_log(ctx, "IAS/ECC decode card answer(s): out_len/offs %i/%i", out_len, offs);
+				sc_log(ctx,
+				       "IAS/ECC decode card answer(s): out_len/offs %"SC_FORMAT_LEN_SIZE_T"u/%i",
+				       out_len, offs);
 			}
 
 			free(decrypted);

--- a/src/smm/sm-card-iasecc.c
+++ b/src/smm/sm-card-iasecc.c
@@ -22,6 +22,7 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -185,7 +186,7 @@ sm_iasecc_get_apdu_create_file(struct sc_context *ctx, struct sm_info *sm_info, 
 static int
 sm_iasecc_get_apdu_delete_file(struct sc_context *ctx, struct sm_info *sm_info, struct sc_remote_data *rdata)
 {
-	unsigned int file_id = (unsigned int)(long)sm_info->cmd_data;
+	unsigned int file_id = (unsigned int)(uintptr_t)sm_info->cmd_data;
 	struct sc_remote_apdu *rapdu = NULL;
 	int rv;
 

--- a/src/smm/sm-cwa14890.c
+++ b/src/smm/sm-cwa14890.c
@@ -147,7 +147,9 @@ sm_cwa_decode_authentication_data(struct sc_context *ctx, struct sm_cwa_keyset *
 	rv = sm_decrypt_des_cbc3(ctx, keyset->enc, session_data->mdata, session_data->mdata_len, &decrypted, &decrypted_len);
 	LOG_TEST_RET(ctx, rv, "sm_ecc_decode_auth_data() DES CBC3 decrypt error");
 
-	sc_log(ctx, "sm_ecc_decode_auth_data() decrypted(%i) %s", decrypted_len, sc_dump_hex(decrypted, decrypted_len));
+	sc_log(ctx,
+	       "sm_ecc_decode_auth_data() decrypted(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+	       decrypted_len, sc_dump_hex(decrypted, decrypted_len));
 
 	if (memcmp(decrypted, session_data->icc.rnd, 8)) {
 		free(decrypted);
@@ -278,14 +280,16 @@ sm_cwa_initialize(struct sc_context *ctx, struct sm_info *sm_info, struct sc_rem
 	rv = sm_encrypt_des_cbc3(ctx, cwa_keyset->enc, buf, offs, &encrypted, &encrypted_len, 1);
 	LOG_TEST_RET(ctx, rv, "_encrypt_des_cbc3() failed");
 
-	sc_log(ctx, "ENCed(%i) %s", encrypted_len, sc_dump_hex(encrypted, encrypted_len));
+	sc_log(ctx, "ENCed(%"SC_FORMAT_LEN_SIZE_T"u) %s", encrypted_len,
+	       sc_dump_hex(encrypted, encrypted_len));
 
 	memcpy(buf, encrypted, encrypted_len);
 	offs = encrypted_len;
 
 	rv = sm_cwa_get_mac(ctx, cwa_keyset->mac, &icv, buf, offs, &cblock, 1);
 	LOG_TEST_RET(ctx, rv, "sm_ecc_get_mac() failed");
-	sc_log(ctx, "MACed(%i) %s", sizeof(cblock), sc_dump_hex(cblock, sizeof(cblock)));
+	sc_log(ctx, "MACed(%"SC_FORMAT_LEN_SIZE_T"u) %s", sizeof(cblock),
+	       sc_dump_hex(cblock, sizeof(cblock)));
 
 	apdu->cse = SC_APDU_CASE_4_SHORT;
 	apdu->cla = 0x00;
@@ -315,14 +319,17 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "securize APDU (cla:%X,ins:%X,p1:%X,p2:%X,data(%i):%p)",
-			apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen, apdu->data);
+	sc_log(ctx,
+	       "securize APDU (cla:%X,ins:%X,p1:%X,p2:%X,data(%"SC_FORMAT_LEN_SIZE_T"u):%p)",
+	       apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen,
+	       apdu->data);
 
 	sm_incr_ssc(session_data->ssc, sizeof(session_data->ssc));
 
 	rv = sm_encrypt_des_cbc3(ctx, session_data->session_enc, apdu->data, apdu->datalen, &encrypted, &encrypted_len, 0);
 	LOG_TEST_RET(ctx, rv, "securize APDU: DES CBC3 encryption failed");
-	sc_log(ctx, "encrypted data (len:%i, %s)", encrypted_len, sc_dump_hex(encrypted, encrypted_len));
+	sc_log(ctx, "encrypted data (len:%"SC_FORMAT_LEN_SIZE_T"u, %s)",
+	       encrypted_len, sc_dump_hex(encrypted, encrypted_len));
 
 	offs = 0;
 	if (apdu->ins & 0x01)   {
@@ -341,7 +348,8 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	memcpy(edfb_data + offs, encrypted, encrypted_len);
 	offs += encrypted_len;
 	edfb_len = offs;
-	sc_log(ctx, "securize APDU: EDFB(len:%i,%sà", edfb_len, sc_dump_hex(edfb_data, edfb_len));
+	sc_log(ctx, "securize APDU: EDFB(len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
+	       edfb_len, sc_dump_hex(edfb_data, edfb_len));
 
 	free(encrypted);
 	encrypted = NULL;
@@ -368,7 +376,8 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	/* } */
 
 	mac_len = offs;
-	sc_log(ctx, "securize APDU: MAC data(len:%i,%s)", mac_len, sc_dump_hex(mac_data, mac_len));
+	sc_log(ctx, "securize APDU: MAC data(len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
+	       mac_len, sc_dump_hex(mac_data, mac_len));
 
 	memset(icv, 0, sizeof(icv));
 	rv = sm_cwa_get_mac(ctx, session_data->session_mac, &icv, mac_data, mac_len, &cblock, 0);
@@ -391,7 +400,8 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	sbuf[offs++] = 8;
 	memcpy(sbuf + offs, cblock, 8);
 	offs += 8;
-	sc_log(ctx, "securize APDU: SM data(len:%i,%s)", offs, sc_dump_hex(sbuf, offs));
+	sc_log(ctx, "securize APDU: SM data(len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
+	       offs, sc_dump_hex(sbuf, offs));
 
 	if (offs > sizeof(rapdu->sbuf))
 		LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "securize APDU: buffer too small for encrypted data");

--- a/src/smm/sm-global-platform.c
+++ b/src/smm/sm-global-platform.c
@@ -321,7 +321,9 @@ sm_gp_encrypt_command_data(struct sc_context *ctx, unsigned char *session_key,
 	if (!out || !out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "SM GP encrypt command data error");
 
-	sc_log(ctx, "SM GP encrypt command data(len:%i,%p)", in_len, in);
+	sc_log(ctx,
+	       "SM GP encrypt command data(len:%"SC_FORMAT_LEN_SIZE_T"u,%p)",
+	       in_len, in);
 	if (in==NULL || in_len==0)   {
 		*out = NULL;
 		*out_len = 0;
@@ -363,9 +365,10 @@ sm_gp_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info,
 	LOG_FUNC_CALLED(ctx);
 
 	apdu_data = (unsigned char *)apdu->data;
-	sc_log(ctx, "SM GP securize APDU(cse:%X,cla:%X,ins:%X,data(len:%i,%p),lc:%i,GP level:%X,GP index:%X",
-				apdu->cse, apdu->cla, apdu->ins, apdu->datalen, apdu->data,
-				apdu->lc, gp_level, gp_index);
+	sc_log(ctx,
+	       "SM GP securize APDU(cse:%X,cla:%X,ins:%X,data(len:%"SC_FORMAT_LEN_SIZE_T"u,%p),lc:%"SC_FORMAT_LEN_SIZE_T"u,GP level:%X,GP index:%X",
+	       apdu->cse, apdu->cla, apdu->ins, apdu->datalen, apdu->data,
+	       apdu->lc, gp_level, gp_index);
 
 	if (gp_level == 0 || (apdu->cla & 0x04))
 		return 0;
@@ -384,7 +387,9 @@ sm_gp_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info,
 		if (encrypted_len + 8 > SC_MAX_APDU_BUFFER_SIZE)
 			LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "SM GP securize APDU: not enough place for encrypted data");
 
-		sc_log(ctx, "SM GP securize APDU: encrypted length %i", encrypted_len);
+		sc_log(ctx,
+		       "SM GP securize APDU: encrypted length %"SC_FORMAT_LEN_SIZE_T"u",
+		       encrypted_len);
 	}
 	else   {
 		LOG_TEST_RET(ctx, SC_ERROR_SM_INVALID_LEVEL, "SM GP securize APDU: invalid SM level");

--- a/src/smm/smm-local.c
+++ b/src/smm/smm-local.c
@@ -87,7 +87,8 @@ sm_gp_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 
-	sc_log(ctx, "SM type:%X, KMC(%i) %s", sm_info->sm_type, hex_len, sc_dump_hex(hex, hex_len));
+	sc_log(ctx, "SM type:%X, KMC(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+	       sm_info->sm_type, hex_len, sc_dump_hex(hex, hex_len));
 	if (hex_len != 16 && hex_len != 48 )
 		return SC_ERROR_INVALID_DATA;
 
@@ -135,7 +136,8 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_SM_KEYSET_NOT_FOUND;
 	}
 
-	sc_log(ctx, "keyset::enc(%i) %s", strlen(value), value);
+	sc_log(ctx, "keyset::enc(%"SC_FORMAT_LEN_SIZE_T"u) %s", strlen(value),
+	       value);
 	if (strlen(value) == 16)   {
 		memcpy(cwa_keyset->enc, value, 16);
 	}
@@ -147,7 +149,8 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 
-		sc_log(ctx, "ENC(%i) %s", hex_len, sc_dump_hex(hex, hex_len));
+		sc_log(ctx, "ENC(%"SC_FORMAT_LEN_SIZE_T"u) %s", hex_len,
+		       sc_dump_hex(hex, hex_len));
 		if (hex_len != 16)
 			return SC_ERROR_INVALID_DATA;
 
@@ -167,7 +170,8 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_SM_KEYSET_NOT_FOUND;
 	}
 
-	sc_log(ctx, "keyset::mac(%i) %s", strlen(value), value);
+	sc_log(ctx, "keyset::mac(%"SC_FORMAT_LEN_SIZE_T"u) %s", strlen(value),
+	       value);
 	if (strlen(value) == 16)   {
 		memcpy(cwa_keyset->mac, value, 16);
 	}
@@ -179,7 +183,8 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 
-		sc_log(ctx, "MAC(%i) %s", hex_len, sc_dump_hex(hex, hex_len));
+		sc_log(ctx, "MAC(%"SC_FORMAT_LEN_SIZE_T"u) %s", hex_len,
+		       sc_dump_hex(hex, hex_len));
 		if (hex_len != 16)
 			return SC_ERROR_INVALID_DATA;
 
@@ -203,7 +208,9 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 	}
 
 	if (hex_len != sizeof(cwa_session->ifd.sn))   {
-		sc_log(ctx, "SM get 'ifd_serial': invalid IFD serial length: %i", hex_len);
+		sc_log(ctx,
+		       "SM get 'ifd_serial': invalid IFD serial length: %"SC_FORMAT_LEN_SIZE_T"u",
+		       hex_len);
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 
@@ -313,7 +320,8 @@ finalize(struct sc_context *ctx, struct sm_info *sm_info, struct sc_remote_data 
 	int rv = SC_ERROR_INTERNAL;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "SM finalize: out buffer(%i) %p", out_len, out);
+	sc_log(ctx, "SM finalize: out buffer(%"SC_FORMAT_LEN_SIZE_T"u) %p",
+	       out_len, out);
 	if (!sm_info || !rdata)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -396,8 +396,8 @@ static int cardos_sm4h(const unsigned char *in, size_t inlen, unsigned char
 	unsigned int i,j;
 
 	if (keylen != 16) {
-		printf("key has wrong size, need 16 bytes, got %zd. aborting.\n",
-			keylen);
+		printf("key has wrong size, need 16 bytes, got %"SC_FORMAT_LEN_SIZE_T"d. aborting.\n",
+		       keylen);
 		return 0;
 	}
 
@@ -593,7 +593,8 @@ static int cardos_format(const char *opt_startkey)
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
+		       apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -914,7 +915,8 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
+		       apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -999,7 +1001,8 @@ change_startkey:
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
+		       apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -385,12 +385,7 @@ static int print_info(sc_card_t *card) {
 				if (r < 0) {
 					printf("      unable to read the file: %s\n", sc_strerror(r));
 				} else {
-#ifdef _WIN32
-					// visual studio doesn't support %zu
-					printf("      Size: %Iu\n", size);
-#else
-					printf("      Size: %zu\n", size);
-#endif
+					printf("      Size: %"SC_FORMAT_LEN_SIZE_T"u\n", size);
 				}
 				printf("\n");
 				if (strcmp(records[i].directory, "mscp") == 0 && strcmp(records[i].filename, "cmapfile") == 0 ) {

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -365,7 +365,8 @@ static int do_userinfo(sc_card_t *card)
 			return EXIT_FAILURE;
 		}
 		if (r != (signed)count) {
-			fprintf(stderr, "%s: expecting %zd, got only %d bytes\n", openpgp_data[i].ef, count, r);
+			fprintf(stderr, "%s: expecting %"SC_FORMAT_LEN_SIZE_T"d, got only %d bytes\n",
+				openpgp_data[i].ef, count, r);
 			return EXIT_FAILURE;
 		}
 

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -654,7 +654,7 @@ int main(int argc, char **argv)
 		#ifndef _WIN32
 		execv(exec_program, largv);
 		#else
-		_execv(exec_program, largv);
+		_execv(exec_program, (const char * const*)largv);
 		#endif
 		/* we should not get here */
 		perror("execv()");

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -530,7 +530,8 @@ static int list_data_objects(void)
 					return 1;
 				}
 				sc_pkcs15_free_data_object(data_object);
-				printf("  Size:%5lu", (unsigned long) cinfo->data.len);
+				printf("  Size:%5"SC_FORMAT_LEN_SIZE_T"u",
+				       cinfo->data.len);
 			} else {
 				printf("  AuthID:%-3s", sc_pkcs15_print_id(&objs[i]->auth_id));
 			}

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -656,8 +656,9 @@ int main(int argc, char *argv[])
 
 			file->path = path;
 
-			printf("File key creation %s, size %zd.\n", file->path.value,
-				file->size);
+			printf("File key creation %s, size %"SC_FORMAT_LEN_SIZE_T"d.\n",
+			       file->path.value,
+			       file->size);
 
 			r = sc_create_file(card, file);
 			if(r) goto out;
@@ -672,7 +673,7 @@ int main(int argc, char *argv[])
 			}
 		}
 
-		printf("Private key length is %zd\n", lg);
+		printf("Private key length is %"SC_FORMAT_LEN_SIZE_T"d\n", lg);
 
 		printf("Write private key.\n");
 		r = sc_update_binary(card,0,pdata,lg,0);
@@ -696,7 +697,7 @@ int main(int argc, char *argv[])
 		r = sc_pkcs15_encode_pubkey(ctx, &key, &pdata, &lg);
 		if(r) goto out;
 
-		printf("Public key length %zd\n", lg);
+		printf("Public key length %"SC_FORMAT_LEN_SIZE_T"d\n", lg);
 
 		sc_format_path("3F000002", &path);
 		r = sc_select_file(card, &path, NULL);

--- a/win32/Makefile.am
+++ b/win32/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST = ltrc.inc Makefile.mak Make.rules.mak \
 		versioninfo.rc.in winconfig.h.in OpenSC.iss.in OpenSC.wxs.in versioninfo-customactions.rc.in
 dist_noinst_HEADERS = versioninfo.rc winconfig.h OpenSC.iss OpenSC.wxs license.rtf OpenSC.ico dlgbmp.bmp bannrbmp.bmp
 
-if ENABLE_MINIDRIVER
+if ENABLE_MINIDRIVER_SETUP_CUSTOMACTION
 lib_LTLIBRARIES = customactions@LIBRARY_BITNESS@.la
 
 AM_CPPFLAGS = -I$(top_srcdir)


### PR DESCRIPTION
This pull request contains uncontroversial commits from PR #850 as suggested by @frankmorgner .

Specifically, it excludes the following commits:
* b83a806a8386ab ("Add multiple PINs support to minidriver"),
* db5e03cd6e74bf ("Provide notification about and handle card resets by other contexts"),
* f2df771049af1a ("Keep track of card resets by other contexts in minidriver").

Other than pulling out these commits and rebasing on top of current master there are also two
additional changes from last version in PR #850:
* sc-hsm PIN-PUK association added as explained by Frank,
* minidriver now links statically against libopensc as requested in #850.
