### PR TITLE
Make CardOS 5.3 working with OpenSC

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -237,7 +237,8 @@ static int cardos_init(sc_card_t *card)
 		_sc_card_add_rsa_alg(card, 2048, flags, 0);
 	}
 
-	if (card->type >= SC_CARD_TYPE_CARDOS_V5_0) {
+	if (card->type == SC_CARD_TYPE_CARDOS_V5_0
+		|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
 		/* Starting with CardOS 5, the card supports PIN query commands */
 		card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO;
 	}

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -59,7 +59,7 @@ static struct sc_atr_table cardos_atrs[] = {
 	/* CardOS v5.0 */
 	{ "3b:d2:18:00:81:31:fe:58:c9:01:14", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	/* CardOS v5.3 */
-	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
+	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_3, 0, NULL},
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 
@@ -83,6 +83,8 @@ static int cardos_match_card(sc_card_t *card)
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_4)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_V5_0)
+		return 1;
+	if (card->type == SC_CARD_TYPE_CARDOS_V5_3)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_2) {
 		int rv;
@@ -195,7 +197,8 @@ static int cardos_init(sc_card_t *card)
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_2B
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_2C
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_4
-		|| card->type == SC_CARD_TYPE_CARDOS_V5_0) {
+		|| card->type == SC_CARD_TYPE_CARDOS_V5_0
+		|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
 		rsa_2048 = 1;
 		card->caps |= SC_CARD_CAP_APDU_EXT;
 	}
@@ -230,7 +233,7 @@ static int cardos_init(sc_card_t *card)
 		_sc_card_add_rsa_alg(card, 2048, flags, 0);
 	}
 
-	if (card->type == SC_CARD_TYPE_CARDOS_V5_0) {
+	if (card->type >= SC_CARD_TYPE_CARDOS_V5_0) {
 		/* Starting with CardOS 5, the card supports PIN query commands */
 		card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO;
 	}
@@ -249,7 +252,7 @@ static const struct sc_card_error cardos_errors[] = {
 { 0x6f82, SC_ERROR_CARD_CMD_FAILED,	"not enough memory in xram"}, 
 { 0x6f84, SC_ERROR_CARD_CMD_FAILED,	"general protection fault"}, 
 
-/* the card doesn't now thic combination of ins+cla+p1+p2 */
+/* the card doesn't now this combination of ins+cla+p1+p2 */
 /* i.e. command will never work */
 { 0x6881, SC_ERROR_NO_CARD_SUPPORT,	"logical channel not supported"}, 
 { 0x6a86, SC_ERROR_INCORRECT_PARAMETERS,"p1/p2 invalid"}, 
@@ -781,6 +784,8 @@ cardos_set_security_env(sc_card_t *card,
 	if (card->type == SC_CARD_TYPE_CARDOS_CIE_V1) {
 		cardos_restore_security_env(card, 0x30);
 		apdu.p1 = 0xF1;
+	} else if (card->type == SC_CARD_TYPE_CARDOS_V5_3) {
+		apdu.p1 = 0x41;
 	} else {
 		apdu.p1 = 0x01;
 	}
@@ -1235,7 +1240,8 @@ cardos_logout(sc_card_t *card)
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_2C
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_3
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_4
-			|| card->type == SC_CARD_TYPE_CARDOS_V5_0) {
+			|| card->type == SC_CARD_TYPE_CARDOS_V5_0
+			|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
 		sc_apdu_t apdu;
 		int       r;
 		sc_path_t path;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -177,11 +177,13 @@ static int cardos_init(sc_card_t *card)
 	card->cla = 0x00;
 
 	/* Set up algorithm info. */
-	flags = SC_ALGORITHM_NEED_USAGE
-		| SC_ALGORITHM_RSA_RAW
+	flags = SC_ALGORITHM_RSA_RAW
 		| SC_ALGORITHM_RSA_HASH_NONE
 		| SC_ALGORITHM_ONBOARD_KEY_GEN
 		;
+	if (card->type != SC_CARD_TYPE_CARDOS_V5_3)
+		flags |= SC_ALGORITHM_NEED_USAGE;
+
 	_sc_card_add_rsa_alg(card,  512, flags, 0);
 	_sc_card_add_rsa_alg(card,  768, flags, 0);
 	_sc_card_add_rsa_alg(card, 1024, flags, 0);
@@ -252,7 +254,7 @@ static const struct sc_card_error cardos_errors[] = {
 { 0x6f82, SC_ERROR_CARD_CMD_FAILED,	"not enough memory in xram"}, 
 { 0x6f84, SC_ERROR_CARD_CMD_FAILED,	"general protection fault"}, 
 
-/* the card doesn't now this combination of ins+cla+p1+p2 */
+/* the card doesn't know this combination of ins+cla+p1+p2 */
 /* i.e. command will never work */
 { 0x6881, SC_ERROR_NO_CARD_SUPPORT,	"logical channel not supported"}, 
 { 0x6a86, SC_ERROR_INCORRECT_PARAMETERS,"p1/p2 invalid"}, 

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -177,12 +177,14 @@ static int cardos_init(sc_card_t *card)
 	card->cla = 0x00;
 
 	/* Set up algorithm info. */
-	flags = SC_ALGORITHM_RSA_RAW
-		| SC_ALGORITHM_RSA_HASH_NONE
+	flags = SC_ALGORITHM_RSA_HASH_NONE
 		| SC_ALGORITHM_ONBOARD_KEY_GEN
 		;
 	if (card->type != SC_CARD_TYPE_CARDOS_V5_3)
-		flags |= SC_ALGORITHM_NEED_USAGE;
+		flags |= SC_ALGORITHM_RSA_RAW
+			| SC_ALGORITHM_NEED_USAGE;
+	else
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
 
 	_sc_card_add_rsa_alg(card,  512, flags, 0);
 	_sc_card_add_rsa_alg(card,  768, flags, 0);

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -47,6 +47,7 @@ enum {
 	SC_CARD_TYPE_CARDOS_CIE_V1, /* Italian CIE (eID) v1 */
 	SC_CARD_TYPE_CARDOS_M4_4,
 	SC_CARD_TYPE_CARDOS_V5_0,
+	SC_CARD_TYPE_CARDOS_V5_3,
 
 	/* flex/cyberflex drivers */
 	SC_CARD_TYPE_FLEX_BASE = 2000,


### PR DESCRIPTION
These commits make signatures and encryption with RSA mechanisms working with CardOS 5.3 cards. 

The changes are isolated for the this specific version (based on ATR) so it will not affect any previous cards. But it can be that the older cards (CardOS 5.0) can work with the same attributes and therefore I would be glad for some testing and feedback before merging this change from other people who contributed to the earlier versions of CardOS driver. Especially @szikora @mtausig who touched the driver in recent years in context of CardOS 5.0 (but anyone else comments and testing would be appreciated).

Basic test case that can be used to verify functionality is attached in the following gist (`RSA_X_509` will not work for CardOS 5.3 and this PR):
https://gist.github.com/Jakuje/5a993d2b2d8a9cac35203599e49e6831