### PR TITLE
Coverity fixes

### DIFF
--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -472,7 +472,7 @@ static int cac_cac1_get_certificate(sc_card_t *card, u8 **out_buf, size_t *out_l
 	size_t left = 0;
 	size_t len, next_len;
 	sc_apdu_t apdu;
-	int r;
+	int r = SC_SUCCESS;
 
 
 	/* get the size */
@@ -681,12 +681,12 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 			r = sc_decompress_alloc(&priv->cache_buf, &priv->cache_buf_len,
 				cert_ptr, cert_len, COMPRESSION_AUTO);
 #else
-			sc_log(card->ctx, "PIV compression not supported, no zlib");
+			sc_log(card->ctx, "CAC compression not supported, no zlib");
 			r = SC_ERROR_NOT_SUPPORTED;
 #endif
 			if (r)
 				goto done;
-		} else {
+		} else if (cert_len > 0) {
 			priv->cache_buf = malloc(cert_len);
 			if (priv->cache_buf == NULL) {
 				r = SC_ERROR_OUT_OF_MEMORY;
@@ -694,6 +694,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 			}
 			priv->cache_buf_len = cert_len;
 			memcpy(priv->cache_buf, cert_ptr, cert_len);
+		} else {
+			sc_log(card->ctx, "Can't read zero-length certificate");
+			goto done;
 		}
 		break;
 	default:

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1377,7 +1377,7 @@ coolkey_fill_object(sc_card_t *card, sc_cardctl_coolkey_object_t *obj)
 {
 	int r;
 	size_t buf_len = obj->length;
-	u8 *new_obj_data = malloc(buf_len);
+	u8 *new_obj_data = NULL;
 	sc_cardctl_coolkey_object_t *obj_entry;
 	coolkey_private_data_t * priv = COOLKEY_DATA(card);
 
@@ -1421,7 +1421,7 @@ coolkey_find_attribute(sc_card_t *card, sc_cardctl_coolkey_attribute_t *attribut
 	const u8 *obj = attribute->object->data;
 	const u8 *attr = NULL;
 	size_t buf_len = attribute->object->length;
-	coolkey_object_header_t *object_head = (coolkey_object_header_t *)obj;
+	coolkey_object_header_t *object_head;
 	int attribute_count,i;
 	attribute->attribute_data_type = SC_CARDCTL_COOLKEY_ATTR_TYPE_STRING;
 	attribute->attribute_length = 0;
@@ -1442,6 +1442,7 @@ coolkey_find_attribute(sc_card_t *card, sc_cardctl_coolkey_attribute_t *attribut
 	if (buf_len <= sizeof(coolkey_v0_object_header_t)) {
 		return SC_ERROR_CORRUPTED_DATA;
 	}
+	object_head = (coolkey_object_header_t *)obj;
 	object_record_type = object_head->record_type;
 	/* make sure it's a type we recognize */
 	if ((object_record_type != COOLKEY_V1_OBJECT) && (object_record_type != COOLKEY_V0_OBJECT)) {
@@ -2198,6 +2199,8 @@ static int coolkey_initialize(sc_card_t *card)
 			continue;
 		}
 		r = coolkey_add_object(priv, object_id, NULL, object_len, 0);
+		if (r != SC_SUCCESS)
+			sc_log(card->ctx, "coolkey_add_object() returned %d", r);
 
 	}
 	if (r != SC_ERROR_FILE_END_REACHED) {

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -487,7 +487,7 @@ static int entersafe_select_fid(sc_card_t *card,
 								sc_file_t **file_out)
 {
 	int r;
-	sc_file_t *file=0;
+	sc_file_t *file = NULL;
 	sc_path_t path;
 
 	memset(&path, 0, sizeof(sc_path_t));

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -669,6 +669,7 @@ static int gids_get_crypto_identifier_from_key_ref(sc_card_t *card, const unsign
 	if (index >= recordsnum) {
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 	}
+	*cryptoidentifier = 0x00; /* initialize to zero */
 	if (records[index].wKeyExchangeKeySizeBits == 1024 || records[index].wSigKeySizeBits == 1024) {
 		*cryptoidentifier = GIDS_RSA_1024_IDENTIFIER;
 		return SC_SUCCESS;
@@ -879,12 +880,16 @@ static int gids_read_public_key (struct sc_card *card , unsigned int algorithm,
 	if (keydata != NULL) {
 		rsa_key.modulus.data = (u8*) keydata;
 		rsa_key.modulus.len = len;
+	} else {
+		rsa_key.modulus.len = 0;
 	}
 
 	keydata = sc_asn1_find_tag(card->ctx, keytemplate, tlen, GIDS_PUBKEY_TAG_EXPONENT, &len);
 	if (keydata != NULL) {
 		rsa_key.exponent.data = (u8*) keydata;
 		rsa_key.exponent.len = len;
+	} else {
+		rsa_key.exponent.len = 0;
 	}
 
 	if (rsa_key.exponent.len && rsa_key.modulus.len) {
@@ -1460,7 +1465,7 @@ static int gids_import_key(sc_card_t *card, sc_pkcs15_object_t *object, sc_pkcs1
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_NORMAL, r, "unable to put the private key - key greater than 2048 bits ?");
 	r = SC_SUCCESS;
 err:
-	sc_mem_clear(buffer, sizeof(buffer));
+	sc_mem_clear(buffer, buflen);
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -394,6 +394,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 			sc_log(ctx, "  type: %s", type);
 			sc_log(ctx, "  EF structure: %d", byte & 0x07);
 			sc_log(ctx, "  tag 0x82: 0x%02x", byte);
+			/* FIXME: check return value? */
 			sc_file_set_type_attr(file, &byte, 1);
 		}
 	}

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -667,6 +667,8 @@ static int sc_pkcs15emu_coolkey_init(sc_pkcs15_card_t *p15card)
 		}
 
 		r = sc_pkcs15emu_object_add(p15card, obj_type, &obj_obj, obj_info);
+		if (r != SC_SUCCESS)
+			sc_log(card->ctx, "sc_pkcs15emu_object_add() returned %d", r);
 fail:
 		if (key) { sc_pkcs15_free_pubkey(key); }
 

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -710,7 +710,7 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		struct sc_pkcs15_cert_info cert_info;
 		struct sc_pkcs15_object    cert_obj;
 		sc_pkcs15_der_t   cert_der;
-		sc_pkcs15_cert_t *cert_out;
+		sc_pkcs15_cert_t *cert_out = NULL;
 		
 		ckis[i].cert_found = 0;
 		ckis[i].key_alg = -1;
@@ -761,6 +761,8 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
 		if (r < 0 || cert_out->key == NULL) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Failed to read/parse the certificate r=%d",r);
+			if (cert_out != NULL)
+				sc_pkcs15_free_certificate(cert_out);
 			continue;
 		}
 		/* 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -460,6 +460,7 @@ static int sc_pkcs15emu_sc_hsm_get_ec_public_key(struct sc_context *ctx, sc_cvc_
 	memcpy(pubkey->u.ec.params.der.value, ecp->der.value, ecp->der.len);
 	pubkey->u.ec.params.der.len = ecp->der.len;
 
+	/* FIXME: check return value? */
 	sc_pkcs15_fix_ec_parameters(ctx, &pubkey->u.ec.params);
 
 	return SC_SUCCESS;
@@ -627,11 +628,8 @@ static int sc_pkcs15emu_sc_hsm_add_prkd(sc_pkcs15_card_t * p15card, u8 keyid) {
 
 	len = sizeof efbin;
 	r = read_file(p15card, fid, efbin, &len);
-	LOG_TEST_RET(card->ctx, r, "Could not read EF");
 
-	if (r < 0) {
-		return SC_SUCCESS;
-	}
+	LOG_TEST_RET(card->ctx, r, "Could not read EF");
 
 	if (efbin[0] == 0x67) {		/* Decode CSR and create public key object */
 		sc_pkcs15emu_sc_hsm_add_pubkey(p15card, efbin, len, key_info, prkd.label);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -574,8 +574,11 @@ __pkcs15_create_cert_object(struct pkcs15_fw_data *fw_data, struct sc_pkcs15_obj
 	/* Certificate object */
 	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &object,
 			cert, &pkcs15_cert_ops, sizeof(struct pkcs15_cert_object));
-	if (rv < 0)
+	if (rv < 0) {
+		if (p15_cert != NULL)
+			sc_pkcs15_free_certificate(p15_cert);
 		return rv;
+	}
 
 	object->cert_info = p15_info;
 	object->cert_data = p15_cert;
@@ -646,6 +649,8 @@ __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 		object->pub_data = p15_key;
 		if (p15_key && object->pub_info->modulus_length == 0 && p15_key->algorithm == SC_ALGORITHM_RSA)
 			object->pub_info->modulus_length = 8 * p15_key->u.rsa.modulus.len;
+	} else if (pubkey->emulated && (fw_data->p15_card->flags & SC_PKCS15_CARD_FLAG_EMULATED)) {
+		sc_pkcs15_free_pubkey(p15_key);
 	}
 
 	if (pubkey_object != NULL)

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -760,7 +760,7 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 	struct sc_pkcs15_object	*pin_obj = NULL;
 	struct sc_app_info	*app;
 	struct sc_file		*df = profile->df_info->file;
-	int			r;
+	int			r = SC_SUCCESS;
 
 	LOG_FUNC_CALLED(ctx);
 	p15card->card = card;

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -512,10 +512,10 @@ myeid_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 				keybits = key_info->field_length;
 			else
 				key_info->field_length = keybits;
-			break;
-			
+
 			if (sc_card_find_ec_alg(p15card->card, keybits, &prkey->u.ec.params.id) == NULL)
 				LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Unsupported algorithm or key size");			
+			break;
 		default:
 			LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Store key failed: Unsupported key type");
 			break;

--- a/src/scconf/scconf.c
+++ b/src/scconf/scconf.c
@@ -411,6 +411,8 @@ char *scconf_list_strdup(const scconf_list * list, const char *filler)
 	if (filler) {
 		len += scconf_list_array_length(list) * (strlen(filler) + 1);
 	}
+	if (len == 0)
+		return NULL;
 	buf = malloc(len);
 	if (!buf) {
 		return NULL;

--- a/src/tests/p15dump.c
+++ b/src/tests/p15dump.c
@@ -30,8 +30,7 @@ static int dump_objects(const char *what, int type)
 		printf("failed.\n");
 		fprintf(stderr, "Error enumerating %s: %s\n",
 			what, sc_strerror(count));
-		if (SC_SUCCESS != sc_unlock(card))
-			return 1;
+		sc_unlock(card);
 		return 1;
 	}
 	if (count == 0) {

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -277,7 +277,7 @@ static int changeAdminKey(sc_card_t* card, const char *so_pin, const char* new_k
 
 	if (new_key == NULL) {
 		printf("Enter new admin key (48 hexadecimal characters) : ");
-		util_getpass(&_so_pin, NULL, stdin);
+		util_getpass(&_new_key, NULL, stdin);
 		printf("\n");
 	} else {
 		_new_key = (char *)new_key;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1318,8 +1318,10 @@ do_store_data_object(struct sc_profile *profile)
 		args.der_encoded.value = data;
 		args.der_encoded.len = datalen;
 		r = sc_lock(p15card->card);
-		if (r < 0)
+		if (r < 0) {
+			free(data);
 			return r;
+		}
 		r = sc_pkcs15init_store_data_object(p15card, profile, &args, NULL);
 		sc_unlock(p15card->card);
 	}

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -794,15 +794,18 @@ static int read_public_key(void)
 
 	if (r == SC_ERROR_OBJECT_NOT_FOUND) {
 		fprintf(stderr, "Public key with ID '%s' not found.\n", opt_pubkey);
-		return 2;
+		r = 2;
+		goto out;
 	}
 	if (r < 0) {
 		fprintf(stderr, "Public key enumeration failed: %s\n", sc_strerror(r));
-		return 1;
+		r = 1;
+		goto out;
 	}
 	if (!pubkey) {
 		fprintf(stderr, "Public key not available\n");
-		return 1;
+		r = 1;
+		goto out;
 	}
 
 	r = sc_pkcs15_encode_pubkey_as_spki(ctx, pubkey, &pem_key.value, &pem_key.len);
@@ -814,6 +817,7 @@ static int read_public_key(void)
 		free(pem_key.value);
 	}
 
+out:
 	if (cert)
 		sc_pkcs15_free_certificate(cert);
 	else if (pubkey)
@@ -2098,6 +2102,7 @@ int main(int argc, char * const argv[])
 			break;
 		case OPT_USE_PINPAD_DEPRECATED:
 			fprintf(stderr, "'--no-prompt' is deprecated , use '--use-pinpad' instead.\n");
+			/* fallthrough */
 		case OPT_USE_PINPAD:
 			opt_use_pinpad = 1;
 			break;

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -697,6 +697,7 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 		memset(inbuf, 0, sizeof(inbuf));
 		if (fgets(inbuf, sizeof(inbuf), stdin) == NULL) {
 			fprintf(stderr, "Input aborted\n");
+			free(shares);
 			return -1;
 		}
 		p = (sp->x);
@@ -706,6 +707,7 @@ static int recreate_password_from_shares(char **pwd, int *pwdlen, int num_of_pas
 		memset(inbuf, 0, sizeof(inbuf));
 		if (fgets(inbuf, sizeof(inbuf), stdin) == NULL) {
 			fprintf(stderr, "Input aborted\n");
+			free(shares);
 			return -1;
 		}
 		binlen = 64;

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -91,8 +91,6 @@ static int finalize = 0;
 static int install_pin = 0;
 static int overwrite = 0;
 
-static const char *pin = NULL;
-static const char *puk = NULL;
 static char *cert = NULL;
 
 static int keylen = 0;
@@ -260,7 +258,7 @@ static int unlock_pin(sc_card_t *card,
 	}
 	else
 	{
-		if(pin == NULL || puk == NULL)
+		if(pin_value == NULL || puk_value == NULL)
 		{
 			return SC_ERROR_INVALID_ARGUMENTS;
 		}
@@ -372,6 +370,8 @@ int main(int argc, char *argv[])
 	RSA	*rsa = NULL;
 	BIGNUM	*bn = NULL;
 	BIO	*mem = NULL;
+	static const char *pin = NULL;
+	static const char *puk = NULL;
 
 	while (1)
 	{


### PR DESCRIPTION
card-cac.c
 * CLANG_WARNING: The left operand of '<' is a garbage value
card-coolkey.c
 * CLANG_WARNING: overwriting variable
 * CPPCHECK_WARNING: memory leak / overwrite variable
 * CLANG_WARNING: null pointer dereference
 * UNUSED_VALUE: unused return value
card-gids.c
 * CLANG_WARNING: Branch condition evaluates to a garbage value
 * SIZEOF_MISMATCH: suspicious_sizeof
card-myeid.c
 * RESOURCE_LEAK: Variable "buf" going out of scope leaks the storage it points to.
 * CLANG_WARNING: overwriting variable
 * (rewrite not to confuse coverity)
pkcs15-cac.c
 * RESOURCE_LEAK: Variable "cert_out" going out of scope leaks the storage it points to.
pkcs15-coolkey.c
 * UNUSED_VALUE: unused return value
pkcs15-piv.c
 * RESOURCE_LEAK: Variable "cert_out" going out of scope leaks the storage it points to.
pkcs15-sc-hsm.c
 * DEADCODE
pkcs11/framework-pkcs15.c
 * RESOURCE_LEAK: Variable "p15_cert" going out of scope leaks the storage it points to.
pkcs15init/pkcs15-lib.c
 * CLANG_WARNING: Assigned value is garbage or undefined
pkcs15init/pkcs15-myeid.c
 * UNREACHABLE: Probably wrong placement of code block
tests/p15dump.c
 * IDENTICAL_BRANCHES
pkcs15-init.c
 * CLANG_WARNING: Potential leak of memory pointed to by 'args.der_encoded.value'
pkcs15-tool.c
 * RESOURCE_LEAK: Variable "cert" going out of scope leaks the storage it points to.
 * MISSING_BREAK: The above case falls through to this one.
sc-hsm-tool.c
 * CLANG_WARNING: Potential leak of memory pointed to by 'sp'
westcos-tool.c
 * FORWARD_NULL: Passing null pointer "pin" to "unlock_pin", which dereferences it.
 * (rewrite not to confuse coverity)
card-cac.c
* Avoid malloc with 0 argument
gids-tool.c
* FORWARD_NULL -- copy&paste error
scconf.c
* CLANG_WARNING: Call to 'malloc' has an allocation size of 0 bytes