### PR TITLE
pkcs11-tool: fixed RSA-X-509 corner case test

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4257,6 +4257,11 @@ static int test_signature(CK_SESSION_HANDLE sess)
 
 	pseudo_randomize(data, dataLen);
 
+	if (firstMechType == CKM_RSA_X_509) {
+		/* make sure our data is smaller than the modulus */
+		data[0] = 0x00;
+	}
+
 	ck_mech.mechanism = firstMechType;
 	rv = p11->C_SignInit(sess, &ck_mech, privKeyObject);
 	/* mechanism not implemented, don't test */


### PR DESCRIPTION
For testing RSA-X-509, we are generating random bytes for signing. It
may happen that the modulus is smaller than the random number
generated, which triggers an error in the card. With this change, we
are setting the most significant byte to 0x00 to assure the random
number is smaller than the modulus.