### PR TITLE
Improved key file creation with MyEID card to allow creating private keys under specific PINs. A fix to sc_pkcs15_verify_pin when called with empty pin data.

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -293,15 +293,31 @@ sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *pi
 		const unsigned char *pincode, size_t pinlen)
 {
 	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 	int r;
 
 	LOG_FUNC_CALLED(ctx);
 
-	r = _validate_pin(p15card, (struct sc_pkcs15_auth_info *)pin_obj->data, pinlen);
+	/*
+	 * if pin cache is disabled, we can get here with no PIN data.
+	 * in this case, to avoid error or unnecessary pin prompting on pinpad,
+	 * check if the PIN has been already verified and the access condition
+	 * is still open on card.
+	 */
+	if (pinlen == 0) {
+	    r = sc_pkcs15_get_pin_info(p15card, pin_obj);
+
+	    if (r == SC_SUCCESS && auth_info->logged_in == SC_PIN_STATE_LOGGED_IN)
+		LOG_FUNC_RETURN(ctx, r);
+	}
+
+	r = _validate_pin(p15card, auth_info, pinlen);
+
 	if (r)
 		LOG_FUNC_RETURN(ctx, r);
 
 	r = _sc_pkcs15_verify_pin(p15card, pin_obj, pincode, pinlen);
+
 	if (r == SC_SUCCESS)
 		sc_pkcs15_pincache_add(p15card, pin_obj, pincode, pinlen);
 


### PR DESCRIPTION
The changes have been tested with a MyEID card. Myeid_create_key has been tested by creating a card with four pins. A key was generated under pin 1 and another key under pin 4. After creation, verified that the correct security attributes were set into both keys.

The change in pkcs15-pin.c was made to fix a problem, which appears when creating objects using C_CreateObject, when pin caching is disabed. With a normal smart card reader, C_CreateObject would fail, because sc_pkcs15_verify_pin was called with empty PIN data, even if C_Login had been called and the required pin had been verified. With a pinpad reader, the user was prompted for pin multiple times. The code has been updated to check the pin verification state if this is possible, and return success if the access condition is already open. 