### PR TITLE
PKCS#11 does not define a CKA_VALUE for public keys and is missused

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3998,8 +3998,13 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 			unsigned char *value = NULL;
 			size_t len;
 
-			if (sc_pkcs15_encode_pubkey(context, pubkey->pub_data, &value, &len))
-				return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetAttributeValue");
+			if (attr->type != CKA_SPKI) {
+				if (sc_pkcs15_encode_pubkey(context, pubkey->pub_data, &value, &len))
+					return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetAttributeValue");
+				} else {
+					if (sc_pkcs15_encode_pubkey_as_spki(context, pubkey->pub_data, &value, &len))
+					return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetAttributeValue");
+				}
 
 			if (attr->pValue == NULL_PTR) {
 				attr->ulValueLen = len;
@@ -4016,7 +4021,7 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 
 			free(value);
 		}
-		else if (pubkey->base.p15_object && pubkey->base.p15_object->content.value && pubkey->base.p15_object->content.len)   {
+		else if (attr->type != CKA_SPKI && pubkey->base.p15_object && pubkey->base.p15_object->content.value && pubkey->base.p15_object->content.len)   {
 			check_attribute_buffer(attr, pubkey->base.p15_object->content.len);
 			memcpy(attr->pValue, pubkey->base.p15_object->content.value, pubkey->base.p15_object->content.len);
 		}

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3873,6 +3873,7 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 		case CKA_MODULUS:
 		case CKA_MODULUS_BITS:
 		case CKA_VALUE:
+		case CKA_SPKI:
 		case CKA_PUBLIC_EXPONENT:
 		case CKA_EC_PARAMS:
 		case CKA_EC_POINT:
@@ -3975,9 +3976,17 @@ pkcs15_pubkey_get_attribute(struct sc_pkcs11_session *session, void *object, CK_
 		return get_modulus_bits(pubkey->pub_data, attr);
 	case CKA_PUBLIC_EXPONENT:
 		return get_public_exponent(pubkey->pub_data, attr);
+	/* 
+	 * PKCS#11 does not define a CKA_VALUE for a CKO_PUBLIC_KEY.
+	 * OpenSC does, but it is not consistent it what it returns
+	 * Internally to do verify, with OpenSSL, we need a SPKI that
+	 * can be converted into a EVP_KEY with d2i_PUBKEY
+	 * CKA_SPKI is defined internally as a CKA_VENDOR_DFINED attribute.
+	 */
 	case CKA_VALUE:
+	case CKA_SPKI:
 
-		if (pubkey->pub_info && pubkey->pub_info->direct.raw.value && pubkey->pub_info->direct.raw.len)   {
+		if (attr->type != CKA_SPKI && pubkey->pub_info && pubkey->pub_info->direct.raw.value && pubkey->pub_info->direct.raw.len)   {
 			check_attribute_buffer(attr, pubkey->pub_info->direct.raw.len);
 			memcpy(attr->pValue, pubkey->pub_info->direct.raw.value, pubkey->pub_info->direct.raw.len);
 		}

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -686,7 +686,7 @@ sc_pkcs11_verify_final(sc_pkcs11_operation_t *operation,
 {
 	struct signature_data *data;
 	struct sc_pkcs11_object *key;
-	unsigned char *pubkey_value;
+	unsigned char *pubkey_value = NULL;
 	CK_KEY_TYPE key_type;
 	CK_BYTE params[9 /* GOST_PARAMS_OID_SIZE */] = { 0 };
 	CK_ATTRIBUTE attr = {CKA_VALUE, NULL, 0};
@@ -700,6 +700,14 @@ sc_pkcs11_verify_final(sc_pkcs11_operation_t *operation,
 		return CKR_ARGUMENTS_BAD;
 
 	key = data->key;
+	rv = key->ops->get_attribute(operation->session, key, &attr_key_type);
+	if (rv != CKR_OK)
+		return rv;
+
+	if (key_type != CKK_GOSTR3410)
+		attr.type = CKA_SPKI;
+		
+
 	rv = key->ops->get_attribute(operation->session, key, &attr);
 	if (rv != CKR_OK)
 		return rv;
@@ -709,8 +717,7 @@ sc_pkcs11_verify_final(sc_pkcs11_operation_t *operation,
 	if (rv != CKR_OK)
 		goto done;
 
-	rv = key->ops->get_attribute(operation->session, key, &attr_key_type);
-	if (rv == CKR_OK && key_type == CKK_GOSTR3410) {
+	if (key_type == CKK_GOSTR3410) {
 		rv = key->ops->get_attribute(operation->session, key, &attr_key_params);
 		if (rv != CKR_OK)
 			goto done;

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -405,7 +405,9 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 {
 	int res;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	EVP_PKEY *pkey;
+	EVP_PKEY *pkey = NULL;
+	const unsigned char *pubkey_tmp;
+	int is_spki = 0;
 
 	if (mech == CKM_GOSTR3410)
 	{
@@ -419,7 +421,38 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 #endif
 	}
 
-	pkey = d2i_PublicKey(EVP_PKEY_RSA, NULL, &pubkey, pubkey_len);
+	/*
+	 * PKCS#11 does not define CKA_VALUE for public keys, and different cards
+	 * return either the raw or spki versions as defined in PKCS#15
+	 * And we need to support more then just RSA.
+	 * We can use d2i_PUBKEY which works for SPKI and any key type. 
+	 */
+	pubkey_tmp = pubkey; /* pass in so pubkey pointer is not modified */
+	/* SPKI ASN.1 starts with SEQUENCE, SEQUENCE, OBJECT IDENTIFIER */
+	if (*pubkey_tmp++ == 0x30) {
+		if (*pubkey_tmp & 0x80)
+			pubkey_tmp += *pubkey_tmp & 0x7F;
+
+		pubkey_tmp++;
+		if (*pubkey_tmp++ == 0x30) {
+			if (*pubkey_tmp & 0x80)
+				pubkey_tmp += *pubkey_tmp & 0x7F;
+
+			pubkey_tmp += 1;
+			if (*pubkey_tmp == 0x06)
+				is_spki = 1;
+		}
+	}
+
+	pubkey_tmp = pubkey; /* pass in so pubkey pointer is not modified */
+
+	if (is_spki) {
+		pkey = d2i_PUBKEY(NULL, &pubkey_tmp, pubkey_len);
+	}else {
+		/* Assume it is RSA */
+		/* TODO support others  but GOST is done above, and EC always uses SPKI */
+		pkey = d2i_PublicKey(EVP_PKEY_RSA, NULL, &pubkey_tmp, pubkey_len);
+	}
 	if (pkey == NULL)
 		return CKR_GENERAL_ERROR;
 
@@ -449,6 +482,7 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 		 case CKM_RSA_X_509:
 		 	pad = RSA_NO_PADDING;
 		 	break;
+		/* TODO support more then RSA */
 		 default:
 			EVP_PKEY_free(pkey);
 		 	return CKR_ARGUMENTS_BAD;

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -406,8 +406,7 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 	int res;
 	CK_RV rv = CKR_GENERAL_ERROR;
 	EVP_PKEY *pkey = NULL;
-	const unsigned char *pubkey_tmp;
-	int is_spki = 0;
+	const unsigned char *pubkey_tmp = NULL;
 
 	if (mech == CKM_GOSTR3410)
 	{
@@ -428,31 +427,8 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, int pubkey_len,
 	 * We can use d2i_PUBKEY which works for SPKI and any key type. 
 	 */
 	pubkey_tmp = pubkey; /* pass in so pubkey pointer is not modified */
-	/* SPKI ASN.1 starts with SEQUENCE, SEQUENCE, OBJECT IDENTIFIER */
-	if (*pubkey_tmp++ == 0x30) {
-		if (*pubkey_tmp & 0x80)
-			pubkey_tmp += *pubkey_tmp & 0x7F;
 
-		pubkey_tmp++;
-		if (*pubkey_tmp++ == 0x30) {
-			if (*pubkey_tmp & 0x80)
-				pubkey_tmp += *pubkey_tmp & 0x7F;
-
-			pubkey_tmp += 1;
-			if (*pubkey_tmp == 0x06)
-				is_spki = 1;
-		}
-	}
-
-	pubkey_tmp = pubkey; /* pass in so pubkey pointer is not modified */
-
-	if (is_spki) {
-		pkey = d2i_PUBKEY(NULL, &pubkey_tmp, pubkey_len);
-	}else {
-		/* Assume it is RSA */
-		/* TODO support others  but GOST is done above, and EC always uses SPKI */
-		pkey = d2i_PublicKey(EVP_PKEY_RSA, NULL, &pubkey_tmp, pubkey_len);
-	}
+	pkey = d2i_PUBKEY(NULL, &pubkey_tmp, pubkey_len);
 	if (pkey == NULL)
 		return CKR_GENERAL_ERROR;
 

--- a/src/pkcs11/pkcs11-opensc.h
+++ b/src/pkcs11/pkcs11-opensc.h
@@ -9,4 +9,6 @@
  */
 #define CKA_OPENSC_NON_REPUDIATION      (CKA_VENDOR_DEFINED | 1UL)
 
+#define CKA_SPKI			(CKA_VENDOR_DEFINED | 2UL)
+
 #endif


### PR DESCRIPTION
This is a replacement for #991. It tests if the CKA_VALUE is a spki before calling d2i_PUBKEY. The previous pull request referred to "**direct**" and "spki", but should have used "**raw**" and "spki"  

OpenSC openssl.c in sc_pkcs11_verify_data assumes that it can
retieve the CKA_VALUE for a public key object, and expect it to
be usable as RSA.

But internally sc_pkcs15_pubkey can have a "raw" or "spki"
version of the public key as defined by PKCS#15.  Card drivers
or pkcs15-<card> routines may store either the "raw" or "spki"
versions. A get attribute request for CKA_VALUE for a public key
will return either the raw, spki or will derived rsa verison of the
pubkey.

This commit will test if the CKA_VALUE is a spki and use d2i_PUBKEY
which takes a spki version and returns an EVP_KEY. If it not an spki
the current method, d21_PublicKey(EVP_PKEY_RSA,...) is used which
only works for RSA.

The problem was found while testing pkcs11-tool -t -l  where
the  verify tests would fail with a CKR_GENERAL_ERROR because
the card driver stored the public key as a spki.

On branch verify-pubkey-as-spki-2
 Changes to be committed:
	modified:   src/pkcs11/openssl.c

Date:      Fri Apr 07 07:50:00 2017 -0600