### PR TITLE
GetTokenInfo does not release the acquired lock and its return value is not properly checked in pkcs11-tool

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -487,12 +487,16 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 		goto out;
 	}
 
-	if (slot->p11card == NULL)
-		return CKR_TOKEN_NOT_PRESENT;
+	if (slot->p11card == NULL) {
+		rv = CKR_TOKEN_NOT_PRESENT;
+		goto out;
+	}
 
 	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
-	if (!fw_data)
-		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetTokenInfo");
+	if (!fw_data) {
+		rv = sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_GetTokenInfo");
+		goto out;
+	}
 	p15card = fw_data->p15_card;
 
 	/* User PIN flags are cleared before re-calculation */

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1105,6 +1105,9 @@ static void show_token(CK_SLOT_ID slot)
 	if (rv == CKR_TOKEN_NOT_RECOGNIZED) {
 		printf("  (token not recognized)\n");
 		return;
+	} else if (rv != CKR_OK) {
+		printf("C_GetTokenInfo() failed: rv = %s\n", CKR2Str(rv));
+		return;
 	}
 	if (!(info.flags & CKF_TOKEN_INITIALIZED) && (!verbose)) {
 		printf("  token state:   uninitialized\n");


### PR DESCRIPTION
`C_GetTokenInfo()` does not release the acquired lock and its return value is not properly checked in `pkcs11-tool`. This makes NSS `modutil` choke because it is using a global lock for PKCS#11 operations.

This is result of testing with Athena ASEPCOS cards, which behaves somehow somehow weird with uninitialized card:
```
5: C_GetSlotInfo
2017-04-12 11:19:41.825
[in] slotID = 0x0
[out] pInfo: 
      slotDescription:        'OMNIKEY AG CardMan 3021 00 00   '
                              '                                '
      manufacturerID:         'OMNIKEY AG                      '
      hardwareVersion:         3.2
      firmwareVersion:         0.0
      flags:                   7
        CKF_TOKEN_PRESENT                
        CKF_REMOVABLE_DEVICE             
        CKF_HW_SLOT                      
Returned:  0 CKR_OK

6: C_GetTokenInfo
2017-04-12 11:19:41.920
[in] slotID = 0x0
Returned:  224 CKR_TOKEN_NOT_PRESENT
```

Longer write up in the following bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1376090

The following investigation would be to find out why the `CKF_TOKEN_PRESENT` flag is present when the card detection failed. There is the whole log:

https://gist.github.com/Jakuje/64dc7df1d8e11d74c8d756aa20a6b5fd