### PR TITLE
Dnie better wrapping/unwrapping of the secure apdus

### DIFF
--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -913,15 +913,5 @@ void dnie_format_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	}
 }
 
-void dnie_free_apdu_buffers(sc_apdu_t *apdu,
-				unsigned char * resp, size_t resplen)
-{
-	if (apdu->resp != resp) {
-		free(apdu->resp);
-		apdu->resp = resp;
-		apdu->resplen = resplen;
-	}
-}
-
 #endif				/* HAVE_OPENSSL */
 /* _ end of cwa-dnie.c - */

--- a/src/libopensc/cwa-dnie.h
+++ b/src/libopensc/cwa-dnie.h
@@ -75,9 +75,6 @@ void dnie_format_apdu(sc_card_t *card, sc_apdu_t *apdu,
                        unsigned char * resp, size_t resplen,
                        const unsigned char * data, size_t datalen);
 
-void dnie_free_apdu_buffers(sc_apdu_t *apdu,
-                               unsigned char * resp, size_t resplen);
-
 #endif
 
 #endif


### PR DESCRIPTION
Once the pull #975 is committed this is the second part that can be added to the DNIe. As I said in the previous issues/pulls the DNIe driver could be improved if the _sc_transmit_apdu_ was called normally. This pull contains the following improvements:

* Now it is possible not to force all the apdus to be SC_APDU_CASE_4_SHORT. The wrapping transforms the apdu into a CASE_4 and allocates the buffer for the response if necessary.
* Not the _dnie_free_apdu_buffers_ can be integrated inside _dnie_sm_free_wrapped_apdu_ and avoid the need to call (and remember to call) this method. Now the clean part manages the response if created (if a response buffer was allocated in the previous point this part frees it).
* The _dnie_free_apdu_buffers_ now is not necessary (common _get_sm_apdu_ and _free_sm_apdu_ now handle everything safely).
* The previous calls that were modified to be CASE_4 have been transformed back to CASE_3 (the _get_sm_apdu_ method do the transformation now).
* Finally the _cwa_hexdump_ (which generates warnings in valgrind) has been changed to _sc_hex_dump_.

No memory problems detected with valgrind and my tester runs smoothly with the changes (both versions of DNIe). This modification can be seen as the second part of the previous unification to opensc secure messaging (I didn't want to do it before being sure the previous part was integrated).

With this pull the only thing I have in mind that can improve the DNIe driver is transforming the signature key in version 3.0 to always authenticate. But for the moment that part cannot be done. So I have no more pending changes.