### PR TITLE
Fix CKA_DERIVE bug in pkcs11-tool.c 

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3369,7 +3369,7 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 		printf("%sunwrap", sepa);
 		sepa = ", ";
 	}
-	if ((!pub || sec) && getDERIVE(sess, obj)) {
+	if (getDERIVE(sess, obj)) {
 		printf("%sderive", sepa);
 		sepa = ", ";
 	}


### PR DESCRIPTION
This bug prevented it from displaying CKA_DERIV key usage for EC public keys. Thanks to @dengert for finding the bug and proposing this fix.

I've tested it on MacOS El Capitan and Sierra. Output of `pkcs11-tool -O -l` is correct now (assuming #1032 is applied, as without #1032 OpenSC simply cannot retrieve certificates, at least on Mac).

Request review and merge. Since it's a one-liner, it shouldn't take too long.