### PR TITLE
0.17.0-rc1 pkcs11-tool minimal fix for CKA_ALWAYS_AUTHENTICATE

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4851,6 +4851,8 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		p11_fatal("C_DecryptInit", rv);
 
 	data_len = encrypted_len;
+	if (getALWAYS_AUTHENTICATE(session, privKeyObject))
+		login(session,CKU_CONTEXT_SPECIFIC);
 	rv = p11->C_Decrypt(session, encrypted, encrypted_len, data, &data_len);
 	if (rv != CKR_OK)
 		p11_fatal("C_Decrypt", rv);


### PR DESCRIPTION
An additional check for CKA_ALWAYS_AUTHENTICATE is need to get pkcs11-tool
to complete when using a PIV card.

There are many more calls to crypto functions which need this test:
    if (getALWAYS_AUTHENTICATE(session, key))
         login(session,CKU_CONTEXT_SPECIFIC);

This commit only addresses the PIV cards use of CKA_ALWAYS_AUTHENTICATE
It is needed for both pin_caching = false; and pin_caching =  true;

 On branch tag-0.17.0-rc1
 Changes to be committed:
	modified:   pkcs11-tool.c

A complete solution would require adding many other similar pieces of code, as well as moving code.  That could be left to the next release. 


