### PR TITLE
sc_pkcs15_read_der_file fails when used with piv to read pubkey from file

### DIFF
--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1263,7 +1263,11 @@ sc_pkcs15_read_der_file(sc_context_t *ctx, char * filename,
 	len = r;
 
 	body = tagbuf;
-	r = sc_asn1_read_tag(&body, len, &cla_out, &tag_out, &bodylen);
+	/*
+	 * We are only getting the tag, without the rest of the data
+	 * don't test that the tag and data is lenn theg the len 
+	 */
+	r = sc_asn1_read_tag(&body, 0xffff, &cla_out, &tag_out, &bodylen);
 	if (r != SC_SUCCESS)
 		goto out;
 


### PR DESCRIPTION
I would like this to make it in 0.17.0. As stated below, it looks like only the piv code would be effected by this change. 

sc_pkcs15_read_der_file reads 16 bytes to get the tag. It then calls
  sc_asn1_read_tag(&body, len, &cla_out, &tag_out, &bodylen);
with len = 16 passed into sc_asn1_read_tag as buflen.

sc_asn1_read_tag parses the tag then checks to make sure the data
does overflow the size left.

At this point len = the size of the data  for the tag, which in most cases
is greater the 16.
  if (len > left)
    return SC_ERROR_INVALID_ASN1_OBJECT;

This causes sc_pkcs15_read_der_file to fail.

The change replaces the call with:
  sc_asn1_read_tag(&body, 0xffff, &cla_out, &tag_out, &bodylen);
Thus the if above does not fail.

The PIV code  used sc_asn1_read_tag  with 0xffff to get the size of
an object so to can allocate a buffer then read the full object.

As far as I can tell the only place this ie ever used (and used to work)
in from pkcs15-piv.c  when there is key on the card but no certificate.
and is used when trying to sign a certificate request to get the public key.

 Changes to be committed:
	modified:   pkcs15-pubkey.c