### PR TITLE
Minidriver improvements from #850

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1484,7 +1484,7 @@ static int sc_hsm_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 
 static int sc_hsm_init(struct sc_card *card)
 {
-#ifdef _WIN32
+#if defined(ENABLE_OPENPACE) && defined(_WIN32)
 	char expanded_val[PATH_MAX];
 	size_t expanded_len = PATH_MAX;
 #endif

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1211,6 +1211,7 @@ _get_auth_object_by_name(struct sc_pkcs15_card *p15card, char *name)
 	struct sc_pkcs15_object *out = NULL;
 	int rv = SC_ERROR_OBJECT_NOT_FOUND;
 
+	/* please keep me in sync with md_get_pin_by_role() in minidriver */
 	if (!strcmp(name, "UserPIN"))   {
 		/* Try to get 'global' PIN; if no, get the 'local' one */
 		rv = sc_pkcs15_find_pin_by_flags(p15card, SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL,


### PR DESCRIPTION
This pull requests contains minidriver improvements from #850, without card reset handling.

Specifically it contains two commits:
* Multiple PINs support in minidriver (practically the old commit from #850 ported on top of the current master),

* Minidriver card reinitialization cleanup, making sure that functions in card reinitialization path leave minidriver context in a consistent state if some error happens during their execution.
It is mostly a cleanup part of "Keep track of card resets by other contexts in minidriver"
(without the actual reset handling code introduced by that commit), simplified.

There is also a third, one-line commit fixing a compiler warning in sc-hsm.
This commit is not related to minidriver, I have added it here to not create a separate pull request for such a tiny change.

There is more information about each change in an individual commit message.
