### PR TITLE
Inform card driver of  C_Login(CKU_CONTEXT_SPECIFIC)

### DIFF
--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -237,6 +237,7 @@ sc_pkcs15_search_objects
 sc_pkcs15_unbind
 sc_pkcs15_unblock_pin
 sc_pkcs15_verify_pin
+sc_pkcs15_verify_pin_context_specific
 sc_pkcs15_get_pin_info
 sc_pkcs15_verify_pin_with_session_pin
 sc_pkcs15emu_add_data_object

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -519,6 +519,13 @@ typedef struct sc_card {
 	struct sc_version version;
 
 	void *mutex;
+	/* 
+	 * Inform card driver of a context specific login.
+	 * Card driver can take action or ignore.  
+	 * set to 1 by framework_pkcs11
+	 * set to 0 by card driver when a crypto operation is done. 
+	 */
+	int sc_card_context_specific_login;
 #ifdef ENABLE_SM
 	struct sm_context sm_ctx;
 #endif

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -459,6 +459,25 @@ out:
 	LOG_FUNC_RETURN(ctx, r);
 }
 
+/*
+ * Verify pin and tell card driver concect_specific_login is being started
+ */
+
+
+int sc_pkcs15_verify_pin_context_specific(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *pin_obj,
+		const unsigned char *pincode, size_t pinlen)
+{
+	struct sc_card * card = p15card->card;
+	struct sc_context *ctx = card->ctx;
+	int r;
+
+	LOG_FUNC_CALLED(ctx);
+	card->sc_card_context_specific_login = 1;
+	r = sc_pkcs15_verify_pin(p15card, pin_obj, pincode, pinlen);
+	if (r != SC_SUCCESS)
+		card->sc_card_context_specific_login =  0;
+	LOG_FUNC_RETURN(ctx, r);
+}
 
 
 /*

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -768,6 +768,9 @@ int sc_pkcs15_find_skey_by_id(struct sc_pkcs15_card *card,
 int sc_pkcs15_verify_pin(struct sc_pkcs15_card *card,
 			 struct sc_pkcs15_object *pin_obj,
 			 const u8 *pincode, size_t pinlen);
+int sc_pkcs15_verify_pin_context_specific(struct sc_pkcs15_card *card,
+			 struct sc_pkcs15_object *pin_obj,
+			 const u8 *pincode, size_t pinlen);
 int sc_pkcs15_verify_pin_with_session_pin(struct sc_pkcs15_card *p15card,
 			 struct sc_pkcs15_object *pin_obj,
 			 const unsigned char *pincode, size_t pinlen,

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1591,7 +1591,11 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 		}
 	}
 
-	rc = sc_pkcs15_verify_pin(p15card, auth_object, pPin, ulPinLen);
+	if (userType  == CKU_CONTEXT_SPECIFIC)
+		rc = sc_pkcs15_verify_pin_context_specific(p15card, auth_object, pPin, ulPinLen);
+	else
+		rc = sc_pkcs15_verify_pin(p15card, auth_object, pPin, ulPinLen);
+
 	sc_log(context, "PKCS15 verify PIN returned %d", rc);
 
 	if (rc != SC_SUCCESS)


### PR DESCRIPTION
A fix for issue https://github.com/OpenSC/OpenSC/issues/1071


framework-pkcs15.c sets card->sc_card_context_specific_login
if C_Login(CKU_CONTEXT_SPECIFIC)  is done.

Card drivers can ignore or use and reset this information.

card-piv.c will use this to not send VERIFY Lc=0  command to the card till
a crypto operation is done. NIST 800 SIGN key is "Always Authenticate"
and enforced on card which requires VERIFY PIN  immediately before
the crypto  operation using this key.

Thunderbird and other applications that call C_GetSessionInfo  between
C_Login and C_Sign were causing OpenSC to test status of the card i
using VERIFY Lc=0 which card treated this as a violation of the
"Always Authenticate".

 Changes to be committed:
	modified:   card-piv.c
	modified:   opensc.h
	modified:   ../pkcs11/framework-pkcs15.c