### PR TITLE
Fix #1076

### DIFF
--- a/src/libopensc/card-sc-hsm.h
+++ b/src/libopensc/card-sc-hsm.h
@@ -89,7 +89,7 @@ struct sc_cvc {
 
 	int modulusSize;					// Size of RSA modulus in bits
 
-	char chr[17];						// Certificate holder reference
+	char chr[21];						// Certificate holder reference
 
 	u8 *signature;						// Certificate signature or request self-signed signature
 	size_t signatureLen;

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -956,7 +956,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 		r = sc_pin_cmd(card, &pindata, NULL);
 	}
 
-	if (r != SC_ERROR_DATA_OBJECT_NOT_FOUND)
+	if ((r != SC_ERROR_DATA_OBJECT_NOT_FOUND) && (r != SC_ERROR_INCORRECT_PARAMETERS))
 		card->caps |= SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH;
 
 


### PR DESCRIPTION
This also fixes a bug with certain SmartCard-HSMs that were produced with a CHR longer than the allowed 16 characters.