### PR TITLE
CardOS 5.0 support improvement

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -789,7 +789,7 @@ cardos_set_security_env(sc_card_t *card,
 	if (card->type == SC_CARD_TYPE_CARDOS_CIE_V1) {
 		cardos_restore_security_env(card, 0x30);
 		apdu.p1 = 0xF1;
-	} else if (card->type == SC_CARD_TYPE_CARDOS_V5_3) {
+	} else if (card->type == SC_CARD_TYPE_CARDOS_V5_0 || card->type == SC_CARD_TYPE_CARDOS_V5_3) {
 		apdu.p1 = 0x41;
 	} else {
 		apdu.p1 = 0x01;


### PR DESCRIPTION
I saw that OpenSC 0.17-rc1 became available in Debian sid, so I attempted to test it against my CardOS 5.0 card. I noticed that `pkcs11-tool -t -l` failed the same way it did in April before I applied the relevant part of an additional change by @Jakuje on top of #1003 .

If this gets into the 0.17 release, I can quit using my own patched builds of OpenSC :)
The fact that the 0.17 release is close is why I made a minimal change to use P1 = 0x41 selectively on CardOS 5.0, instead of the more invasive code simplification (unifying CardOS 5.0 and 5.3 support) from https://github.com/Jakuje/OpenSC/commit/7356ee75a848456c871ab99267b1e49616fe2100 .