### PR TITLE
Simplify differences between CardOS 5 versions and unbreak 5.3 signatures

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -175,14 +175,12 @@ static int cardos_init(sc_card_t *card)
 	card->cla = 0x00;
 
 	/* Set up algorithm info. */
-	flags = SC_ALGORITHM_RSA_HASH_NONE
+	flags = SC_ALGORITHM_RSA_RAW
+		| SC_ALGORITHM_RSA_HASH_NONE
 		| SC_ALGORITHM_ONBOARD_KEY_GEN
 		;
 	if (card->type != SC_CARD_TYPE_CARDOS_V5_0)
-		flags |= SC_ALGORITHM_RSA_RAW
-			| SC_ALGORITHM_NEED_USAGE;
-	else
-		flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+		flags |= SC_ALGORITHM_NEED_USAGE;
 
 	_sc_card_add_rsa_alg(card,  512, flags, 0);
 	_sc_card_add_rsa_alg(card,  768, flags, 0);
@@ -925,8 +923,9 @@ cardos_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
 	}
 
 	/* check if any operation was selected */
-	if(do_rsa_sig == 0 && do_rsa_pure_sig == 0)  {
-		/* no operation selected. we just have to try both, for the lack of any better reasoning */
+	if (do_rsa_sig == 0 && do_rsa_pure_sig == 0) {
+		/* no operation selected. we just have to try both,
+		 * for the lack of any better reasoning */
 		sc_log(ctx, "I was unable to determine, whether this key can be used with RSA_SIG or RSA_PURE_SIG. I will just try both.");
 		do_rsa_sig = 1;
 		do_rsa_pure_sig = 1;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -59,7 +59,7 @@ static struct sc_atr_table cardos_atrs[] = {
 	/* CardOS v5.0 */
 	{ "3b:d2:18:00:81:31:fe:58:c9:01:14", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	/* CardOS v5.3 */
-	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_3, 0, NULL},
+	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 
@@ -83,8 +83,6 @@ static int cardos_match_card(sc_card_t *card)
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_4)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_V5_0)
-		return 1;
-	if (card->type == SC_CARD_TYPE_CARDOS_V5_3)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_2) {
 		int rv;
@@ -180,7 +178,7 @@ static int cardos_init(sc_card_t *card)
 	flags = SC_ALGORITHM_RSA_HASH_NONE
 		| SC_ALGORITHM_ONBOARD_KEY_GEN
 		;
-	if (card->type != SC_CARD_TYPE_CARDOS_V5_3)
+	if (card->type != SC_CARD_TYPE_CARDOS_V5_0)
 		flags |= SC_ALGORITHM_RSA_RAW
 			| SC_ALGORITHM_NEED_USAGE;
 	else
@@ -201,8 +199,7 @@ static int cardos_init(sc_card_t *card)
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_2B
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_2C
 		|| card->type == SC_CARD_TYPE_CARDOS_M4_4
-		|| card->type == SC_CARD_TYPE_CARDOS_V5_0
-		|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
+		|| card->type == SC_CARD_TYPE_CARDOS_V5_0) {
 		rsa_2048 = 1;
 		card->caps |= SC_CARD_CAP_APDU_EXT;
 	}
@@ -237,8 +234,7 @@ static int cardos_init(sc_card_t *card)
 		_sc_card_add_rsa_alg(card, 2048, flags, 0);
 	}
 
-	if (card->type == SC_CARD_TYPE_CARDOS_V5_0
-		|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
+	if (card->type == SC_CARD_TYPE_CARDOS_V5_0) {
 		/* Starting with CardOS 5, the card supports PIN query commands */
 		card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO;
 	}
@@ -789,10 +785,8 @@ cardos_set_security_env(sc_card_t *card,
 	if (card->type == SC_CARD_TYPE_CARDOS_CIE_V1) {
 		cardos_restore_security_env(card, 0x30);
 		apdu.p1 = 0xF1;
-	} else if (card->type == SC_CARD_TYPE_CARDOS_V5_3) {
-		apdu.p1 = 0x41;
 	} else {
-		apdu.p1 = 0x01;
+		apdu.p1 = 0x41;
 	}
 	switch (env->operation) {
 	case SC_SEC_OPERATION_DECIPHER:
@@ -1249,8 +1243,7 @@ cardos_logout(sc_card_t *card)
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_2C
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_3
 		   	|| card->type == SC_CARD_TYPE_CARDOS_M4_4
-			|| card->type == SC_CARD_TYPE_CARDOS_V5_0
-			|| card->type == SC_CARD_TYPE_CARDOS_V5_3) {
+			|| card->type == SC_CARD_TYPE_CARDOS_V5_0) {
 		sc_apdu_t apdu;
 		int       r;
 		sc_path_t path;

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -47,7 +47,6 @@ enum {
 	SC_CARD_TYPE_CARDOS_CIE_V1, /* Italian CIE (eID) v1 */
 	SC_CARD_TYPE_CARDOS_M4_4,
 	SC_CARD_TYPE_CARDOS_V5_0,
-	SC_CARD_TYPE_CARDOS_V5_3,
 
 	/* flex/cyberflex drivers */
 	SC_CARD_TYPE_FLEX_BASE = 2000,


### PR DESCRIPTION
This is an alternative approach to the #1079, which resolves the same problem (and I somehow forgot to fill the PR earlier), but also unbreaks the signatures too as stated in #1055.

On the other hand, it "breaks" back the mechanisms advertised by CardOS cards by adding `RSA_X_509` to the list which, in fact, is not supported by the card operations.

I would appreciate ideas how to improve this situation sooner or later. Currently, this fact is making the tests in `pkcs11-tool` failing, because the `RSA_X_509` signatures do not work.