### PR TITLE
MyEID - T0 protocol fail for derive operation

### DIFF
--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1005,7 +1005,7 @@ int myeid_ecdh_derive(struct sc_card *card, const u8* pubkey, size_t pubkey_len,
 	memcpy(&sbuf[4 + ext_len_bytes], pubkey, pubkey_len);
 
 	apdu.lc = pubkey_len + 4 + ext_len_bytes;
-	apdu.le = 0;
+	apdu.le = pubkey_len / 2;
 	apdu.datalen = apdu.lc;
 	apdu.data = sbuf;
 


### PR DESCRIPTION
apdu.le  must be set minimally to shared key length (pubkey_len / 2),
otherwise sc_get_response() does not read derived shared key from card.