### PR TITLE
clang-analyzer and pkcs11-tool issues

### DIFF
--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -75,8 +75,9 @@ C_LoadModule(const char *mspec, CK_FUNCTION_LIST_PTR_PTR funcs)
 		return (void *) mod;
 	else {
 		fprintf(stderr, "C_GetFunctionList failed %lx", rv);
-		C_UnloadModule((void *) mod);
-		return NULL;
+		rv = C_UnloadModule((void *) mod);
+		if (rv == CKR_OK)
+			mod = NULL; /* already freed */
 	}
 failed:
 	free(mod);

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -665,7 +665,6 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		cert_len = 0;
 		cert_ptr = NULL;
 		cert_type = 0;
-		tl_head_len = 2;
 		for (tl_ptr = tl, val_ptr=val; tl_len >= 2;
 				val_len -= len, val_ptr += len, tl_len -= tl_head_len) {
 			tl_start = tl_ptr;
@@ -943,7 +942,7 @@ static int cac_rsa_op(sc_card_t *card,
 	if (rbuflen != 0) {
 		int n = MIN(rbuflen, outplen);
 		memcpy(outp,rbuf, n);
-		outp += n;
+		/*outp += n;     unused */ 
 		outplen -= n;
 	}
 	free(rbuf);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2020,6 +2020,7 @@ pgp_update_pubkey_blob(sc_card_t *card, u8* modulus, size_t modulus_len,
 	pubkey.u.rsa.exponent.len  = exponent_len >> 3;
 
 	r = sc_pkcs15_encode_pubkey(card->ctx, &pubkey, &data, &len);
+	LOG_TEST_RET(card->ctx, r, "Cannot encode pubkey.");
 
 	sc_log(card->ctx, "Update blob content.");
 	r = pgp_set_blob(pk_blob, data, len);

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1489,7 +1489,7 @@ static int sc_hsm_init(struct sc_card *card)
 	size_t expanded_len = PATH_MAX;
 #endif
 	int flags,ext_flags;
-	sc_file_t *file;
+	sc_file_t *file = NULL;
 	sc_path_t path;
 	sc_hsm_private_data_t *priv = card->drv_data;
 
@@ -1530,7 +1530,7 @@ static int sc_hsm_init(struct sc_card *card)
 
 	sc_path_set(&path, SC_PATH_TYPE_DF_NAME, sc_hsm_aid.value, sc_hsm_aid.len, 0, 0);
 	if (sc_hsm_select_file_ex(card, &path, 0, &file) == SC_SUCCESS
-			&& file->prop_attr && file->prop_attr_len >= 5) {
+			&& file && file->prop_attr && file->prop_attr_len >= 5) {
 		static char card_name[SC_MAX_APDU_BUFFER_SIZE];
 		u8 type = file->prop_attr[2];
 		u8 major = file->prop_attr[3];

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -257,6 +257,8 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 
 	/* set other objects */
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_CAC_INIT_GET_GENERIC_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not initiate generic objects.");
+
 	for (i = 0; i < count; i++) {
 		struct sc_pkcs15_data_info obj_info;
 		struct sc_pkcs15_object    obj_obj;
@@ -273,6 +275,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
 	}
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_CAC_FINAL_GET_GENERIC_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not finalize generic objects.");
 
 	/*
 	 * certs, pubkeys and priv keys are related and we assume
@@ -282,6 +285,8 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 	 */
 	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "CAC adding certs, pub and priv keys...");
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_CAC_INIT_GET_CERT_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not initiate cert objects.");
+
 	for (i = 0; i < count; i++) {
 		struct sc_pkcs15_data_info obj_info;
 		struct sc_pkcs15_cert_info cert_info;
@@ -294,6 +299,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		sc_pkcs15_cert_t *cert_out = NULL;
 
 		r = (card->ops->card_ctl)(card, SC_CARDCTL_CAC_GET_NEXT_CERT_OBJECT, &obj_info);
+		LOG_TEST_RET(card->ctx, r, "Can not get next object");
 
 		memset(&cert_info, 0, sizeof(cert_info));
 		memset(&pubkey_info, 0, sizeof(pubkey_info));
@@ -421,6 +427,7 @@ fail:
 
 	}
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_CAC_FINAL_GET_CERT_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not finalize cert objects.");
 
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
 }

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -539,6 +539,8 @@ static int sc_pkcs15emu_coolkey_init(sc_pkcs15_card_t *p15card)
 
 	/* set other objects */
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_COOLKEY_INIT_GET_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not initiate objects.");
+
 	for (i = 0; i < count; i++) {
 		struct sc_cardctl_coolkey_object     coolkey_obj;
 		struct sc_pkcs15_object    obj_obj;
@@ -676,6 +678,7 @@ fail:
 
 	}
 	r = (card->ops->card_ctl)(card, SC_CARDCTL_COOLKEY_FINAL_GET_OBJECTS, &count);
+	LOG_TEST_RET(card->ctx, r, "Can not finalize objects.");
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1098,8 +1098,10 @@ sc_pkcs15_dup_pubkey(struct sc_context *ctx, struct sc_pkcs15_pubkey *key, struc
 		rv = sc_asn1_encode_algorithm_id(ctx, &alg, &alglen,key->alg_id, 0);
 		if (rv == SC_SUCCESS) {
 			pubkey->alg_id = (struct sc_algorithm_id *)calloc(1, sizeof(struct sc_algorithm_id));
-			if (pubkey->alg_id == NULL)
+			if (pubkey->alg_id == NULL) {
+				free(pubkey);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+			}
 			rv = sc_asn1_decode_algorithm_id(ctx, alg, alglen, pubkey->alg_id, 0);
 			free(alg);
 		}
@@ -1389,8 +1391,10 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 		}
 
 		pubkey->u.ec.ecpointQ.value = malloc(pk.len);
-		if (pubkey->u.ec.ecpointQ.value == NULL)
-			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+		if (pubkey->u.ec.ecpointQ.value == NULL) {
+			r = SC_ERROR_OUT_OF_MEMORY;
+			LOG_TEST_GOTO_ERR(ctx, r, "failed to malloc() memory");
+		}
 		memcpy(pubkey->u.ec.ecpointQ.value, pk.value, pk.len);
 		pubkey->u.ec.ecpointQ.len = pk.len;
 	}

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -718,7 +718,7 @@ __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 	} else if (!(pubkey->emulated && (fw_data->p15_card->flags & SC_PKCS15_CARD_FLAG_EMULATED))) {
 		sc_pkcs15_free_pubkey(p15_key);
 	}
-	if (object->pub_data) {
+	if (object && object->pub_data) {
 		if ((object->pub_data->alg_id)&&(object->pub_data->algorithm == SC_ALGORITHM_GOSTR3410))
 			object->pub_data->alg_id->params = &((object->pub_data->u).gostr3410.params);
 	}
@@ -734,7 +734,7 @@ static int
 __pkcs15_create_prkey_object(struct pkcs15_fw_data *fw_data,
 	struct sc_pkcs15_object *prkey, struct pkcs15_any_object **prkey_object)
 {
-	struct pkcs15_prkey_object *object;
+	struct pkcs15_prkey_object *object = NULL;
 	int rv;
 
 	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &object,
@@ -1821,7 +1821,7 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 
 		if (p15card)   {
 			sc_log(context, "pkcs15init erase card");
-			rc = sc_pkcs15init_erase_card(p15card, profile, NULL);
+			sc_pkcs15init_erase_card(p15card, profile, NULL);
 
 			sc_log(context, "pkcs15init unbind");
 			sc_pkcs15init_unbind(profile);
@@ -2253,11 +2253,11 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 
 	    key_obj->flags = 2; /* TODO not sure what these mean */
 
-	    skey_info = calloc(1, sizeof(sc_pkcs15_skey_info_t));
+		skey_info = calloc(1, sizeof(sc_pkcs15_skey_info_t));
 		if (skey_info == NULL) {
 			rv = CKR_HOST_MEMORY;
 			goto out;
-	    }
+		}
 	    key_obj->data = skey_info;
 	    skey_info->usage = args.usage;
 	    skey_info->native = 0; /* card can not use this */
@@ -2266,7 +2266,7 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 	    skey_info->data.value = args.key.data;
 	    skey_info->data.len = args.key.data_len;
 	    skey_info->value_len = args.value_len; /* callers prefered length */
-
+	    args.key.data = NULL;
 	}
 	else {
 #if 1
@@ -2290,6 +2290,7 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 	rv = CKR_OK;
 
 out:
+	free(args.key.data); /* if allocated */
 	free(key_obj);
 	return rv;
 }
@@ -2335,7 +2336,6 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 			return CKR_ATTRIBUTE_VALUE_INVALID;
 	}
 
-	rv = CKR_OK;
 	while (ulCount--) {
 		CK_ATTRIBUTE_PTR attr = pTemplate++;
 		sc_pkcs15_bignum_t *bn = NULL;
@@ -2429,7 +2429,6 @@ pkcs15_create_certificate(struct sc_pkcs11_slot *slot,
 	if (cert_type != CKC_X_509)
 		return CKR_ATTRIBUTE_VALUE_INVALID;
 
-	rv = CKR_OK;
 	while (ulCount--) {
 		CK_ATTRIBUTE_PTR attr = pTemplate++;
 
@@ -2438,7 +2437,7 @@ pkcs15_create_certificate(struct sc_pkcs11_slot *slot,
 		case CKA_CLASS:
 			break;
 		case CKA_PRIVATE:
-			rv = attr_extract(attr, &bValue, NULL);
+			attr_extract(attr, &bValue, NULL);
 			if (bValue) {
 				rv = CKR_TEMPLATE_INCONSISTENT;
 				goto out;
@@ -2505,7 +2504,6 @@ pkcs15_create_data(struct sc_pkcs11_slot *slot, struct sc_profile *profile,
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_CreateObject");
 
-	rv = CKR_OK;
 	while (ulCount--) {
 		CK_ATTRIBUTE_PTR attr = pTemplate++;
 
@@ -2514,7 +2512,7 @@ pkcs15_create_data(struct sc_pkcs11_slot *slot, struct sc_profile *profile,
 		case CKA_CLASS:
 			break;
 		case CKA_PRIVATE:
-			rv = attr_extract(attr, &bValue, NULL);
+			attr_extract(attr, &bValue, NULL);
 			if (bValue) {
 				pin = slot_data_auth_info(slot->fw_data);
 				if (pin == NULL) {

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1059,8 +1059,10 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 	info->hash_mech = hash_mech;
 
 	new_type = sc_pkcs11_new_fw_mechanism(mech, &mech_info, sign_type->key_type, info, free_info);
-
-	if (!new_type)
+	if (!new_type) {
+		free(info);
 		return CKR_HOST_MEMORY;
+	}
+
 	return sc_pkcs11_register_mechanism(p11card, new_type);
 }

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -230,8 +230,6 @@ CK_RV card_detect(sc_reader_t *reader)
 	unsigned int i;
 	int j;
 
-	rv = CKR_OK;
-
 	sc_log(context, "%s: Detecting smart card", reader->name);
 	/* Check if someone inserted a card */
 again:

--- a/src/pkcs15init/pkcs15-cflex.c
+++ b/src/pkcs15init/pkcs15-cflex.c
@@ -296,9 +296,9 @@ cflex_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_pkcs15_obj
 		goto out;
 	}
 
-	if (prkf->size < size)
+	if (prkf && prkf->size < size)
 		prkf->size = size;
-	if (pukf->size < size + 4)
+	if (pukf && pukf->size < size + 4)
 		pukf->size = size + 4;
 
 	/* Now create the files */
@@ -385,7 +385,7 @@ cflex_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 {
 	sc_pkcs15_prkey_info_t *key_info = (sc_pkcs15_prkey_info_t *) obj->data;
 	sc_card_t *card = p15card->card;
-	sc_file_t	*prkf, *pukf;
+	sc_file_t	*prkf = NULL, *pukf = NULL;
 	unsigned char	keybuf[1024];
 	size_t		size;
 	int		r;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2193,7 +2193,6 @@ static void	parse_certificate(struct x509cert_info *cert,
 	cert->issuer_len = n;
 
 	/* check length first */
-	n = 0;
 	n = i2d_ASN1_INTEGER(X509_get_serialNumber(x), NULL);
 	if (n < 0)
 		util_fatal("OpenSSL error while encoding serial number");
@@ -3542,6 +3541,9 @@ get_mechanisms(CK_SLOT_ID slot, CK_MECHANISM_TYPE_PTR *pList, CK_FLAGS flags)
 	CK_RV		rv;
 
 	rv = p11->C_GetMechanismList(slot, *pList, &ulCount);
+	if (rv != CKR_OK)
+		p11_fatal("C_GetMechanismList", rv);
+
 	*pList = calloc(ulCount, sizeof(**pList));
 	if (*pList == NULL)
 		util_fatal("calloc failed: %m");
@@ -5193,6 +5195,7 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 		p11_fatal("C_SignInit", rv);
 	if (getALWAYS_AUTHENTICATE(session, priv_key))
 		login(session,CKU_CONTEXT_SPECIFIC);
+
 	rv = p11->C_Sign(session, data, data_len, sig, &sig_len);
 	if (rv != CKR_OK)
 		p11_fatal("C_Sign", rv);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4433,7 +4433,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 			modLenBytes, i);
 	}
 
-	/* 4rd test: the other signature keys */
+	/* 4th test: the other signature keys */
 
 	for (i = 0; mechTypes[i] != 0xffffff; i++)
 		if (mechTypes[i] == firstMechType)
@@ -4446,16 +4446,6 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		label = getLABEL(sess, privKeyObject, NULL);
 		modLenBits = get_private_key_length(sess, privKeyObject);
 		modLenBytes = (modLenBits + 7) / 8;
-
-		/* Fill in data[0] and dataLens[0] */
-		dataLen = modLenBytes;
-		data[0] = 0x00;
-		data[1] = 0x01;
-		memset(data + 2, 0xFF, dataLen - 3 - dataLens[1]);
-		data[dataLen - 36] = 0x00;
-		memcpy(data + (dataLen - dataLens[1]), datas[1], dataLens[1]);
-		datas[0] = data;
-		dataLens[0] = dataLen;
 
 		printf("  testing key %d (%u bits%s%s) with 1 signature mechanism",
 				(int) (j-1),
@@ -4480,6 +4470,16 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		else   {
 			printf("\n");
 		}
+
+		/* Fill in data[0] and dataLens[0] */
+		dataLen = modLenBytes;
+		data[0] = 0x00;
+		data[1] = 0x01;
+		memset(data + 2, 0xFF, dataLen - 3 - dataLens[1]);
+		data[dataLen - 36] = 0x00;
+		memcpy(data + (dataLen - dataLens[1]), datas[1], dataLens[1]);
+		datas[0] = data;
+		dataLens[0] = dataLen;
 
 		errors += sign_verify_openssl(sess, &ck_mech, privKeyObject,
 			datas[i], dataLens[i], verifyData, sizeof(verifyData),

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -2061,8 +2061,6 @@ int main(int argc, char * const argv[])
 
 	assert(sizeof(option_help)/sizeof(char *)==sizeof(options)/sizeof(struct option));
 
-	c = OPT_PUK;
-
 	while (1) {
 		c = getopt_long(argc, argv, "r:cuko:sva:LR:CwDTU", options, &long_optind);
 		if (c == -1)


### PR DESCRIPTION
I was playing with `clang-analyzer` and identified some of the (non-significant) issues. Most missing checks for return values, unused assignments and so on.
Additionally, this pull request contains the commit fixing the `pkcs11-tool` issue reported in #1055.