### PR TITLE
jpki: add disable_sign_cert parameter

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -783,6 +783,11 @@ app tokend {
 		#
 		# score = 10;
 	}
+
+	# workaround for PIN protected certificate issue #1097
+	card_driver jpki {
+		disable_sign_cert = true;
+	}
 }
 
 # Used by OpenSC minidriver on Windows only

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -82,7 +82,10 @@ jpki_finish(sc_card_t * card)
 	struct jpki_private_data *drvdata = JPKI_DRVDATA(card);
 
 	LOG_FUNC_CALLED(card->ctx);
-
+	if (drvdata->mf) {
+		free(drvdata->mf);
+		drvdata->mf = NULL;
+	}
 	if (drvdata) {
 		free(drvdata);
 		card->drv_data = NULL;

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -97,6 +97,9 @@ jpki_init(struct sc_card *card)
 	sc_file_t *mf;
 	int flags;
 
+	scconf_block **blocks, *blk;
+	int i;
+
 	LOG_FUNC_CALLED(card->ctx);
 
 	drvdata = malloc(sizeof (struct jpki_private_data));
@@ -132,6 +135,23 @@ jpki_init(struct sc_card *card)
 	flags = SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_PAD_PKCS1;
 	_sc_card_add_rsa_alg(card, 2048, flags, 0);
 
+	for (i = 0; card->ctx->conf_blocks[i]; i++) {
+		blocks = scconf_find_blocks(card->ctx->conf,
+					    card->ctx->conf_blocks[i],
+					    "card_driver", "jpki");
+		if (!blocks) {
+			continue;
+		}
+		blk = blocks[0];
+		free(blocks);
+		if (blk == NULL) {
+			continue;
+		}
+		drvdata->disable_sign_cert = scconf_get_bool(blk, "disable_sign_cert", 0);
+		if (drvdata->disable_sign_cert) {
+			sc_log(card->ctx, "disabled sign cert");
+		}
+	}
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 

--- a/src/libopensc/jpki.h
+++ b/src/libopensc/jpki.h
@@ -39,6 +39,7 @@ struct jpki_private_data {
 	sc_file_t *mf;
 	int selected;
 	int logged_in;
+	int disable_sign_cert;
 };
 
 int jpki_select_ap(struct sc_card *card);

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -207,6 +207,43 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		if (rc < 0)
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 	}
+
+	/* add public keys */
+	for (i = 0; i < 2; i++) {
+		static int pubkey_id[2] = { 1, 2 };
+		static const char *jpki_pubkey_names[2] = {
+			"User Authentication Public Key",
+			"Digital Signature Public Key"
+		};
+		struct sc_pkcs15_pubkey_info pubkey_info;
+		struct sc_pkcs15_object pubkey_obj;
+		static char const *jpki_pubkey_paths[2] = {
+			"000A",
+			"0001"
+		};
+
+		if (drvdata->disable_sign_cert) {
+			if (i == 1) {
+				continue;
+			}
+		}
+
+		memset(&pubkey_info, 0, sizeof (pubkey_info));
+		memset(&pubkey_obj, 0, sizeof (pubkey_obj));
+
+		strlcpy(pubkey_obj.label, jpki_pubkey_names[i], sizeof (pubkey_obj.label));
+		pubkey_info.id.len = 1;
+		pubkey_info.id.value[0] = pubkey_id[i];
+		pubkey_info.native = 1;
+		pubkey_info.key_reference = i + 1;
+
+		sc_format_path(jpki_pubkey_paths[i], &pubkey_info.path);
+		pubkey_info.path.type = SC_PATH_TYPE_FILE_ID;
+
+		rc = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
+		if (rc < 0)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+	}
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -177,7 +177,7 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 			"User Authentication Key",
 			"Digital Signature Key"
 		};
-
+		static int prkey_user_consent[2] = { 0, 1 };
 		struct sc_pkcs15_prkey_info prkey_info;
 		struct sc_pkcs15_object prkey_obj;
 
@@ -200,7 +200,7 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		strlcpy(prkey_obj.label, prkey_name[i], sizeof (prkey_obj.label));
 		prkey_obj.auth_id.len = 1;
 		prkey_obj.auth_id.value[0] = prkey_pin[i];
-		prkey_obj.user_consent = 0;
+		prkey_obj.user_consent = prkey_user_consent[i];
 		prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
 
 		rc = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -81,6 +81,12 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		static int jpki_cert_authority[4] = {0, 0, 1, 1};
 		struct sc_pkcs15_cert_info cert_info;
 		struct sc_pkcs15_object cert_obj;
+
+		if (drvdata->disable_sign_cert) {
+			if (i == 1 || i == 3) {
+				continue;
+			}
+		}
 		memset(&cert_info, 0, sizeof(cert_info));
 		memset(&cert_obj, 0, sizeof(cert_obj));
 
@@ -122,6 +128,13 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		struct sc_pkcs15_auth_info pin_info;
 		struct sc_pkcs15_object pin_obj;
 		struct sc_pin_cmd_data pin_cmd_data;
+
+		if (drvdata->disable_sign_cert) {
+			if (i == 1) {
+				continue;
+			}
+		}
+
 		memset(&pin_info, 0, sizeof (pin_info));
 		memset(&pin_obj, 0, sizeof (pin_obj));
 		memset(&pin_cmd_data, 0, sizeof(pin_cmd_data));
@@ -167,6 +180,12 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 
 		struct sc_pkcs15_prkey_info prkey_info;
 		struct sc_pkcs15_object prkey_obj;
+
+		if (drvdata->disable_sign_cert) {
+			if (i == 1) {
+				continue;
+			}
+		}
 
 		memset(&prkey_info, 0, sizeof (prkey_info));
 		memset(&prkey_obj, 0, sizeof (prkey_obj));


### PR DESCRIPTION
JPKI card has two certificates I've described here: #959
- Certificate for authentication: it's able to read any time.
- Certificate for signature: it's protected by PIN

I just realized that PIN protected certificate will cause harm on sevral browsers, so I added a parameter to disable this.
@frankmorgner  Could you merge the patch before 0.17 release? It's only effect to JPKI card driver.

Setting example:
~~~
    card_driver jpki {
        disable_sign_cert = true
    }
~~~
Thank you.