### PR TITLE
documentation for ignore_private_certificate parameter.

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -782,6 +782,11 @@ app tokend {
 		# Default: 300
 		#
 		# score = 10;
+
+		# Tokend ignore to read PIN protected certificate that is set SC_PKCS15_CO_FLAG_PRIVATE flag.
+		# Default: true
+		#
+		# ignore_private_certificate = false;
 	}
 }
 


### PR DESCRIPTION
ref: OpenSC/OpenSC.tokend#32