### PR TITLE
CAC issues

### DIFF
--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1106,6 +1106,7 @@ static int cac_select_file_by_type(sc_card_t *card, const sc_path_t *in_path, sc
 		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 		if (apdu.sw1 == 0x6A && apdu.sw2 == 0x86)   {
 			apdu.p2 = 0x00;
+			apdu.resplen = sizeof(buf);
 			if (sc_transmit_apdu(card, &apdu) == SC_SUCCESS)
 				r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 		}

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -607,16 +607,15 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		if (r == SC_ERROR_INS_NOT_SUPPORTED) {
 			/* The CACv1 instruction is not recognized. Try with CACv2 */
 			card->type = SC_CARD_TYPE_CAC_II;
-			goto cac2;
-		}
-		if (r < 0)
+		} else if (r < 0)
 			goto done;
+	}
 
+	if ((card->type == SC_CARD_TYPE_CAC_I) && (priv->object_type == CAC_OBJECT_TYPE_CERT)) {
 		r = cac_cac1_get_cert_tag(card, val_len, &tl, &tl_len);
 		if (r < 0)
 			goto done;
 	} else {
-cac2:
 		r = cac_read_file(card, CAC_FILE_TAG, &tl, &tl_len);
 		if (r < 0)  {
 			goto done;

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -390,9 +390,7 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 		goto err;
 	}
 
-	if (apdu.sw1 == 0x61) {
-		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	}
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Card returned error ");

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -604,6 +604,11 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		/* SPICE smart card emulator only presents CAC-1 cards with the old CAC-1 interface as
 		 * certs. If we are a cac 1 card, use the old interface */
 		r = cac_cac1_get_certificate(card, &val, &val_len);
+		if (r == SC_ERROR_INS_NOT_SUPPORTED) {
+			/* The CACv1 instruction is not recognized. Try with CACv2 */
+			card->type = SC_CARD_TYPE_CAC_II;
+			goto cac2;
+		}
 		if (r < 0)
 			goto done;
 
@@ -611,6 +616,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		if (r < 0)
 			goto done;
 	} else {
+cac2:
 		r = cac_read_file(card, CAC_FILE_TAG, &tl, &tl_len);
 		if (r < 0)  {
 			goto done;


### PR DESCRIPTION
These commits resolve the following issues in CAC driver:
 * Wrong re-transmit of APDU (does not show specific problem, but was emitting bogus errors)
 * Infinite loop when reading CAC certificate (because of missing SW check)
    https://bugzilla.redhat.com/show_bug.cgi?id=1473335
 * Unable to read ALT token (very corner-case)
    https://bugzilla.redhat.com/show_bug.cgi?id=1473418
    This one is not elegant (improvements welcome)
    I am able to read this cards certificate, but not do any operations (the card looks like it does not understand VERIFY PIN instructions).

##### Checklist

- [X] Tested with the following card: Various CAC cards
	- [X] tested PKCS#11
