### PR TITLE
Do not call list_init() twice (amend 6bfb39454)

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -264,7 +264,6 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs)
 	list_attributes_seeker(&sessions, session_list_seeker);
 
 	/* List of slots */
-	list_init(&virtual_slots);
 	if (0 != list_init(&virtual_slots)) {
 		rv = CKR_HOST_MEMORY;
 		goto out;


### PR DESCRIPTION
During rework of error handling of memory allocation (#1020), there was left `list_init()` twice. It was jumping on me in valgrind for awful long time, but it took me some time to understand what was going on.

This commit removes the double-init and should make memory footprint clean.