### PR TITLE
Use cardholder name in the PIN prompt (PIV)

### DIFF
--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -359,7 +359,7 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 	};
 
 	static const pindata pins[] = {
-		{ "01", "PIV Card Holder pin", "", 0x80,
+		{ "01", "PIN", "", 0x80,
 		  /* label, flag  and ref will change if using global pin */
 		  SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
 		  8, 4, 8, 
@@ -932,7 +932,7 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 			pin_info.attrs.pin.reference = pin_ref;
 			pin_info.attrs.pin.flags &= ~SC_PKCS15_PIN_FLAG_LOCAL;
 			label = "Global PIN";
-		} 
+		}
 sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 		strncpy(pin_obj.label, label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 		pin_obj.flags = pins[i].obj_flags;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1024,6 +1024,7 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 	struct sc_pkcs15_auth_info *pin_info = NULL;
 	char label[64];
 
+	sc_log(context, "Called");
 	pkcs15_init_token_info(p15card, &slot->token_info);
 	slot->token_info.flags |= CKF_TOKEN_INITIALIZED;
 	if (auth != NULL)
@@ -1048,9 +1049,10 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 			pin_info = NULL;
 		}
 		else   {
-			if (auth->label[0])
+			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0)
 				snprintf(label, sizeof(label), "%.*s (%s)", (int) sizeof auth->label, auth->label, p15card->tokeninfo->label);
 			else
+				/* The PIN label is empty or says just non-useful "PIN" */
 				snprintf(label, sizeof(label), "%s", p15card->tokeninfo->label);
 			slot->token_info.flags |= CKF_LOGIN_REQUIRED;
 		}


### PR DESCRIPTION
The current PIN prompt for PIV cards is not very informative. It says either of the following:
```
token label        : PIV Card Holder pin (PIV_II)
token label        : Global PIN (PIV_II)
```
It answers the simple question if the user should use Global or Application PIN, but it does not say what card is that. Based on the report in RH bugzilla [1] and further discussion on mailing list [2] I decided to make two changes, hopefully to better:

 * Use shorter name for the `PIV Card Holder pin`, such as `App PIN` to make some space for the actual cardholder name (I was considering `Application PIN`, but it would not fit most of the names next to that). The name is abbreviation from `PIV Card Application PIN` referenced in the NIST documentation [3]
 * Replace the `PIV_II` string with the cardholder name (it is usually not important for users to hear that it is PIV card), if there is CN in the first (assuming AUTH) certificate read from the card.

The current prompt for the NIST test cards look like this:
```
token label        : App PIN (Test Cardholder X)
token label        : Global PIN (Test Cardholder VII)
```
This is also simple way for the end-application to fast recognize that the same/different card was inserted (as used in GNOME).

The code is mostly copied from CAC driver, which already does the same.

Yubikey PIV applets work the same way and report what is written in the certificate. In my case, I have some `bar` certificate:
```
token label        : App PIN (bar)
```

Suggestions for better naming or other improvements are welcomed.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1449740
[2] https://sourceforge.net/p/opensc/mailman/message/35898117/
[3] http://csrc.nist.gov/groups/SNS/piv/documents/test-piv-card-data-specifications.pdf

##### Checklist
- [X] Tested with the following card: PIV-II card (NIST test cards, Yubikey NEO)
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend