### PR TITLE
Properly parse TokenInfo of PKCS#15 cards (CardOS 5 with ECC)

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -171,7 +171,7 @@ static int cardos_init(sc_card_t *card)
 	sc_apdu_t apdu;
 	u8 rbuf[2];
 
-	card->name = "CardOS M4";
+	card->name = "Atos CardOS";
 	card->cla = 0x00;
 
 	/* Set up algorithm info. */

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -59,6 +59,7 @@ static struct sc_atr_table cardos_atrs[] = {
 	/* CardOS v5.0 */
 	{ "3b:d2:18:00:81:31:fe:58:c9:01:14", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	/* CardOS v5.3 */
+	{ "3b:d2:18:00:81:31:fe:58:c9:02:17", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	{ "3b:d2:18:00:81:31:fe:58:c9:03:16", NULL, NULL, SC_CARD_TYPE_CARDOS_V5_0, 0, NULL},
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -163,6 +163,7 @@ extern "C" {
 struct sc_supported_algo_info {
 	unsigned int reference;
 	unsigned int mechanism;
+	struct sc_object_id *parameters; /* OID for ECC, NULL for RSA */
 	unsigned int operations;
 	struct sc_object_id algo_id;
 	unsigned int algo_ref;

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -188,6 +188,9 @@ static int cardos_info(void)
 		printf(" (that's CardOS M4.4)\n");
 	} else if (apdu.resp[0] == 0xc9 && apdu.resp[1] == 0x01) {
 		printf(" (that's CardOS V5.0)\n");
+	} else if (apdu.resp[0] == 0xc9 &&
+			(apdu.resp[1] == 0x02 || apdu.resp[1] == 0x03)) {
+		printf(" (that's CardOS V5.3)\n");
 	} else {
 		printf(" (unknown Version)\n");
 	}


### PR DESCRIPTION
Fixes #1134 

The parsing now looks successful and driver continues to work with new cards. The parsed `parameters` value is ignored at this moment. Though, I would appreciate a review it if makes sense and I didn't miss anything.

I also took the opportunity to rename the driver from CardOS M4 (not M4 only anymore) to Atos. It confused me before few times.

##### Checklist
- [X] Tested with the following card: cardos (my CardOS 5.3, @bigon's CardOS 5.3 cards)
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
