### PR TITLE
Fix sc_pkcs15_get_bitstring_extension endianness

### DIFF
--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -139,7 +139,7 @@ cac_alg_flags_from_algorithm(int algorithm)
 
 /* map a cert usage and algorithm to public and private key usages */
 static int
-cac_map_usage(unsigned long long cert_usage, int algorithm, unsigned int *pub_usage_ptr, unsigned int *pr_usage_ptr, int allow_nonrepudiation)
+cac_map_usage(unsigned int cert_usage, int algorithm, unsigned int *pub_usage_ptr, unsigned int *pr_usage_ptr, int allow_nonrepudiation)
 {
 	unsigned int pub_usage = 0, pr_usage = 0;
 	unsigned int alg_flags = cac_alg_flags_from_algorithm(algorithm);
@@ -184,7 +184,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 	};
 	/* oid for key usage */
 	static const struct sc_object_id usage_type = {{ 2, 5, 29, 15, -1 }};
-	unsigned long long usage;
+	unsigned int usage;
 
 
 	/*
@@ -401,7 +401,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 			usage = 0xd9ULL; /* basic default usage */
 		}
 		cac_map_usage(usage, cert_out->key->algorithm, &pubkey_info.usage, &prkey_info.usage, 1);
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,  "cert %s: cert_usage=0x%llx, pub_usage=0x%x priv_usage=0x%x\n",
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,  "cert %s: cert_usage=0x%x, pub_usage=0x%x priv_usage=0x%x\n",
 				sc_dump_hex(cert_info.id.value, cert_info.id.len),
 				 usage, pubkey_info.usage, prkey_info.usage);
 		if (cert_out->key->algorithm != SC_ALGORITHM_RSA) {

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -310,13 +310,13 @@ sc_pkcs15_get_extension(struct sc_context *ctx, struct sc_pkcs15_cert *cert,
 int
 sc_pkcs15_get_bitstring_extension(struct sc_context *ctx,
 	struct sc_pkcs15_cert *cert, const struct sc_object_id *type,
-	unsigned long long *value, int *is_critical)
+	unsigned int *value, int *is_critical)
 {
 	int r;
 	u8 *bit_string = NULL;
 	size_t bit_string_len=0, val_len = sizeof(*value);
 	struct sc_asn1_entry asn1_bit_string[] = {
-		{ "bitString", SC_ASN1_BIT_STRING, SC_ASN1_TAG_BIT_STRING, 0, value, &val_len },
+		{ "bitString", SC_ASN1_BIT_FIELD, SC_ASN1_TAG_BIT_STRING, 0, value, &val_len },
 		{ NULL, 0, 0, 0, NULL, NULL }
 	};
 

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -104,7 +104,7 @@ typedef struct common_key_info_st {
 	int pubkey_from_file;
 	int key_alg;
 	unsigned int pubkey_len;
-	unsigned long long cert_keyUsage; /* x509 key usage as defined in certificate */
+	unsigned int cert_keyUsage; /* x509 key usage as defined in certificate */
 	int cert_keyUsage_present; /* 1 if keyUsage found in certificate */
 	int pub_usage;
 	int priv_usage;
@@ -773,13 +773,11 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 
 		if (follows_nist_fascn == 0) {
 			struct sc_object_id keyUsage_oid={{2,5,29,15,-1}};
-			unsigned long long *value;
 			int r = 0;
 
-			value = &ckis[i].cert_keyUsage;
 			r = sc_pkcs15_get_bitstring_extension(card->ctx, cert_out,
 				&keyUsage_oid,
-				value, NULL);
+				&ckis[i].cert_keyUsage, NULL);
 			if ( r >= 0)
 				ckis[i].cert_keyUsage_present = 1;
 				/* TODO if no key usage, we could set all uses */

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -738,7 +738,7 @@ int sc_pkcs15_get_extension(struct sc_context *ctx,
 int sc_pkcs15_get_bitstring_extension(struct sc_context *ctx,
                                       struct sc_pkcs15_cert *cert,
                                       const struct sc_object_id *type,
-                                      unsigned long long *value,
+                                      unsigned int *value,
                                       int *is_critical);
 /* sc_pkcs15_create_cdf:  Creates a new certificate DF on a card pointed
  * by <card>.  Information about the file, such as the file ID, is read


### PR DESCRIPTION
Like asn1's decode_bit_field.  However, because we're decoding an
`unsigned long long` here, not an `unsigned int`, we can't just
change the decoder to SC_ASN1_BIT_FIELD.

##### Checklist
- [x] Tested with the following card: YubiKey 4
	- [x] tested PKCS#11

Tested on ar71xx MIPS box.