### PR TITLE
pkcs11-tool testsuite improvements

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4321,13 +4321,13 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		break;
 	case CKM_RSA_X_509:
 		dataLen = modLenBytes;
+		pseudo_randomize(data, dataLen);
 		break;
 	default:
 		dataLen = sizeof(data);	/* let's hope it's OK */
+		pseudo_randomize(data, dataLen);
 		break;
 	}
-
-	pseudo_randomize(data, dataLen);
 
 	if (firstMechType == CKM_RSA_X_509) {
 		/* make sure our data is smaller than the modulus */

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4847,7 +4847,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		return 0;
 
 	if (EVP_PKEY_size(pkey) > (int)sizeof(encrypted)) {
-		fprintf(stderr, "Ciphertext buffer too small\n");
+		printf("Ciphertext buffer too small\n");
 		EVP_PKEY_free(pkey);
 		return 0;
 	}
@@ -4858,14 +4858,14 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 #endif
 	EVP_PKEY_free(pkey);
 	if (((int) encrypted_len) <= 0) {
-		fprintf(stderr, "Encryption failed, returning\n");
+		printf("Encryption failed, returning\n");
 		return 0;
 	}
 
 	mech.mechanism = mech_type;
 	rv = p11->C_DecryptInit(session, &mech, privKeyObject);
-	if (rv == CKR_MECHANISM_INVALID) {
-		fprintf(stderr, "Mechanism not supported\n");
+	if (rv == CKR_MECHANISM_INVALID || rv == CKR_MECHANISM_PARAM_INVALID) {
+		printf("Mechanism not supported\n");
 		return 0;
 	}
 	if (rv != CKR_OK)


### PR DESCRIPTION
The randomization should not happen for the `RSA_PKCS` mechanism, since the data is already filled with ASN1 encoded DigestInfo + SHA1 hash.

The second commit improves handling of decryption testcases to get reasonable reports in single stream (not writing first part of line to stdout and the second to stderr) and avoids hard-failures with OAEP mechanisms (`CKR_MECHANISM_PARAM_INVALID`).

##### Checklist
- [X] Tested with the following card: YubiHSM2 with its own PKCS#11 module
	- [X] tested PKCS#11