### PR TITLE
Make OpenSC PKCS#11 Vendor Defined attributes, mechanisms etc unique

### DIFF
--- a/src/pkcs11/pkcs11-opensc.h
+++ b/src/pkcs11/pkcs11-opensc.h
@@ -3,12 +3,21 @@
 
 /* OpenSC specific extensions */
 /*
+ * define OpenSC specific Vendor Defined  extensions
+ * to make unique OpenSC  flags, attribures, mechanisms, etc.
+ * 
+ * Netscape used NSSCK_VENDOR_NSS 0x4E534350 "NSCP"
+ */
+
+#define SC_VENDOR_DEFINED 0x4F534300  /* OSC */
+
+/*
  * In PKCS#11 there is no CKA_ attribute dedicated to the NON-REPUDIATION flag.
  * We need this flag in PKCS#15/libopensc to make dinstinction between
  * 'signature' and 'qualified signature' key slots.
  */
-#define CKA_OPENSC_NON_REPUDIATION      (CKA_VENDOR_DEFINED | 1UL)
+#define CKA_OPENSC_NON_REPUDIATION      (CKA_VENDOR_DEFINED | SC_VENDOR_DEFINED | 1UL)
 
-#define CKA_SPKI			(CKA_VENDOR_DEFINED | 2UL)
+#define CKA_SPKI			(CKA_VENDOR_DEFINED | SC_VENDOR_DEFINED | 2UL)
 
 #endif


### PR DESCRIPTION
This will help when p11-kit is used and will allow for additional
CK*_* things to be defined that have a much better chance of being
unique.

OR in "OSC" to any CK*_VENDOR_DEFINED thing.
with #define SC_VENDOR_DEFINED 0x4F534300  /* OSC */

This follows Netscapes convention of doing the same but
using: #define NSSCK_VENDOR_NSS 0x4E534350 /* NSCP */

The current 2 defines  CKA_* are for internal attributes.

 On branch OSC_VENDOR_DEFINED
 Changes to be committed:
	modified:   pkcs11-opensc.h

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


	- [ X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
