### PR TITLE
opensc-notify: register a desktop menu entry

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,37 +459,26 @@ case "${host}" in
 			have_notify="yes"
 		;;
 	*)
-			AC_PATH_PROG([GDBUS], [gdbus], [not found])
-			if test "${GDBUS}" = "not found"; then
-				have_notify="no"
-				have_gdbus="no"
-			else
-				have_notify="yes"
-				have_gdbus="yes"
-			fi
-
-			if test "${have_notify}" = "no"; then
-				PKG_CHECK_MODULES( [GIO2], [gio-2.0],
-								  [ have_notify="yes"
-									have_gio2="yes" ],
-								  [ have_notify="no"
-									have_gio2="no" ])
-				saved_CFLAGS="${CFLAGS}"
-				CFLAGS="${CFLAGS} ${GIO2_CFLAGS}"
-				AC_CHECK_HEADERS(gio/gio.h, [],
-								 [ AC_MSG_WARN([glib2 headers not found])
-								   have_notify="no"
-								   have_gio2="no" ])
-				CFLAGS="${saved_CFLAGS}"
-				saved_LIBS="$LIBS"
-				LIBS="$LIBS  ${GIO2_LIBS}"
-				AC_MSG_CHECKING([for g_application_send_notification])
-				AC_TRY_LINK_FUNC(g_application_send_notification, [ AC_MSG_RESULT([yes]) ],
-								 [ AC_MSG_WARN([Cannot link against glib2])
-								   have_notify="no"
-								   have_gio2="no"  ])
-				LIBS="$saved_LIBS"
-			fi
+			PKG_CHECK_MODULES( [GIO2], [gio-2.0],
+							  [ have_notify="yes"
+								have_gio2="yes" ],
+							  [ have_notify="no"
+								have_gio2="no" ])
+			saved_CFLAGS="${CFLAGS}"
+			CFLAGS="${CFLAGS} ${GIO2_CFLAGS}"
+			AC_CHECK_HEADERS(gio/gio.h, [],
+							 [ AC_MSG_WARN([glib2 headers not found])
+							   have_notify="no"
+							   have_gio2="no" ])
+			CFLAGS="${saved_CFLAGS}"
+			saved_LIBS="$LIBS"
+			LIBS="$LIBS  ${GIO2_LIBS}"
+			AC_MSG_CHECKING([for g_application_send_notification])
+			AC_TRY_LINK_FUNC(g_application_send_notification, [ AC_MSG_RESULT([yes]) ],
+							 [ AC_MSG_WARN([Cannot link against glib2])
+							   have_notify="no"
+							   have_gio2="no"  ])
+			LIBS="$saved_LIBS"
 		;;
 esac
 
@@ -509,9 +498,6 @@ esac
 if test "${enable_notify}" = "yes"; then
 	if test "${have_notify}" = "yes"; then
 		AC_DEFINE([ENABLE_NOTIFY], [1], [Use notification libraries and header files])
-		if test "${have_gdbus}" = "yes"; then
-			AC_DEFINE_UNQUOTED([GDBUS], ["${GDBUS}"], [Path to gdbus])
-		fi
 		if test "${have_gio2}" = "yes"; then
 			AC_DEFINE([ENABLE_GIO2], [1], [Use glib2 libraries and header files])
 			OPTIONAL_NOTIFY_CFLAGS="${GIO2_CFLAGS}"
@@ -1117,7 +1103,6 @@ OPENCT_CFLAGS:           ${OPENCT_CFLAGS}
 OPENCT_LIBS:             ${OPENCT_LIBS}
 PCSC_CFLAGS:             ${PCSC_CFLAGS}
 CRYPTOTOKENKIT_CFLAGS:   ${CRYPTOTOKENKIT_CFLAGS}
-GDBUS:                   ${GDBUS}
 GIO2_CFLAGS:             ${GIO2_CFLAGS}
 GIO2_LIBS:               ${GIO2_LIBS}
 

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -35,6 +35,7 @@
 #endif /* PKCS11_THREAD_LOCKING */
 
 #include "sc-pkcs11.h"
+#include "ui/notify.h"
 
 #ifndef MODULE_APP_NAME
 #define MODULE_APP_NAME "opensc-pkcs11"
@@ -237,6 +238,8 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs)
 		return CKR_CRYPTOKI_ALREADY_INITIALIZED;
 	}
 
+	sc_notify_init();
+
 	rv = sc_pkcs11_init_lock((CK_C_INITIALIZE_ARGS_PTR) pInitArgs);
 	if (rv != CKR_OK)
 		goto out;
@@ -299,6 +302,8 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
 
 	if (pReserved != NULL_PTR)
 		return CKR_ARGUMENTS_BAD;
+
+	sc_notify_close();
 
 	if (context == NULL)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -7,6 +7,7 @@ VDFORMAT=GZIP
 endif
 
 do_subst = $(SED) \
+	   -e 's,[@]bindir[@],$(bindir),g' \
 	   -e 's,[@]CVCDIR[@],$(CVCDIR),g' \
 	   -e 's,[@]PACKAGE[@],$(PACKAGE),g' \
 	   -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
@@ -24,7 +25,7 @@ OPENSC_NOTIFY_BUILT_SOURCES = opensc-notify-cmdline.h opensc-notify-cmdline.c
 OPENSC_ASN1_BUILT_SOURCES = opensc-asn1-cmdline.h opensc-asn1-cmdline.c
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in $(srcdir)/versioninfo-tools.rc $(srcdir)/versioninfo-opensc-notify.rc
-EXTRA_DIST = Makefile.mak versioninfo-tools.rc.in versioninfo-opensc-notify.rc.in npa-tool.ggo.in npa-tool.1 opensc-notify.ggo.in egk-tool.ggo.in egk-tool.1 opensc-asn1.ggo.in opensc-asn1.1
+EXTRA_DIST = Makefile.mak versioninfo-tools.rc.in versioninfo-opensc-notify.rc.in npa-tool.ggo.in npa-tool.1 opensc-notify.ggo.in egk-tool.ggo.in egk-tool.1 opensc-asn1.ggo.in opensc-asn1.1 org.opensc-project.opensc-notify.desktop.in
 
 noinst_HEADERS = util.h fread_to_eof.h
 noinst_PROGRAMS = sceac-example
@@ -208,6 +209,12 @@ sc_hsm_tool_SOURCES += versioninfo-tools.rc
 gids_tool_SOURCES += versioninfo-tools.rc
 opensc_notify_SOURCES += versioninfo-opensc-notify.rc
 endif
+
+applicationsdir = $(datadir)/applications
+applications_DATA = org.opensc-project.opensc-notify.desktop
+
+org.opensc-project.opensc-notify.desktop: org.opensc-project.opensc-notify.desktop
+	$(do_subst) < $(abs_srcdir)/org.opensc-project.opensc-notify.desktop.in > $@
 
 clean-local:
 	rm -f $(abs_builddir)/npa-tool.ggo $(abs_builddir)/opensc-notify.ggo

--- a/src/tools/org.opensc-project.opensc-notify.desktop.in
+++ b/src/tools/org.opensc-project.opensc-notify.desktop.in
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=OpenSC Notify
+Type=Application
+Comment=Monitor smart card events to send notifications.
+Exec=@bindir@/opensc-notify
+Icon=preferences-system-notifications
+Categories=Security;System;

--- a/src/tools/util.c
+++ b/src/tools/util.c
@@ -30,6 +30,7 @@
 #endif
 #include <ctype.h>
 #include "util.h"
+#include "ui/notify.h"
 
 int
 is_string_valid_atr(const char *atr_str)
@@ -53,6 +54,8 @@ util_connect_card_ex(sc_context_t *ctx, sc_card_t **cardp,
 	struct sc_reader *reader = NULL, *found = NULL;
 	struct sc_card *card = NULL;
 	int r;
+
+	sc_notify_init();
 
 	if (do_wait) {
 		unsigned int event;
@@ -354,6 +357,9 @@ util_fatal(const char *fmt, ...)
 	vfprintf(stderr, fmt, ap);
 	fprintf(stderr, "\nAborting.\n");
 	va_end(ap);
+
+	sc_notify_close();
+
 	exit(1);
 }
 

--- a/src/ui/notify.c
+++ b/src/ui/notify.c
@@ -398,28 +398,30 @@ static void notify_gio(struct sc_context *ctx,
 		const char *title, const char *text, const char *icon,
 		const char *group)
 {
-	GIcon *gicon = NULL;
-	GNotification *notification = g_notification_new (title);
-	if (!notification) {
-		return;
-	}
-
-	if (text) {
-		g_notification_set_body (notification, text);
-	}
-	if (icon) {
-		gicon = g_themed_icon_new (icon);
-		if (gicon) {
-			g_notification_set_icon (notification, gicon);
+	if (application) {
+		GIcon *gicon = NULL;
+		GNotification *notification = g_notification_new (title);
+		if (!notification) {
+			return;
 		}
-	}
 
-	g_application_send_notification(application, group, notification);
+		if (text) {
+			g_notification_set_body (notification, text);
+		}
+		if (icon) {
+			gicon = g_themed_icon_new (icon);
+			if (gicon) {
+				g_notification_set_icon (notification, gicon);
+			}
+		}
 
-	if (gicon) {
-		g_object_unref(gicon);
+		g_application_send_notification(application, group, notification);
+
+		if (gicon) {
+			g_object_unref(gicon);
+		}
+		g_object_unref(notification);
 	}
-	g_object_unref(notification);
 }
 
 #else


### PR DESCRIPTION
- fixes showing notifications in gnome-shell via gio2
- removes gdbus interface for notifications
- fixes #1186

##### Checklist

- [x] Tested with the following card: sc-hsm
	- [x] tested PKCS#11