### PR TITLE
Avoid GCC 7 warnings with -Werror

### DIFF
--- a/src/libopensc/card-incrypto34.c
+++ b/src/libopensc/card-incrypto34.c
@@ -357,7 +357,7 @@ static int incrypto34_create_file(sc_card_t *card, sc_file_t *file)
 				 * generation. */
 			case SC_FILE_EF_LINEAR_VARIABLE_TLV:
 				type[1] = 0xff;
-				/* FALLTHROUGH */
+				/* fall through */
 			default:
 				type[0] |= file->ef_structure & 7;
 				break;

--- a/src/libopensc/card-incrypto34.c
+++ b/src/libopensc/card-incrypto34.c
@@ -357,6 +357,7 @@ static int incrypto34_create_file(sc_card_t *card, sc_file_t *file)
 				 * generation. */
 			case SC_FILE_EF_LINEAR_VARIABLE_TLV:
 				type[1] = 0xff;
+				/* FALLTHROUGH */
 			default:
 				type[0] |= file->ef_structure & 7;
 				break;

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -926,7 +926,7 @@ static int rutoken_get_do_info(sc_card_t *card, sc_DO_INFO_t * pInfo)
 			break;
 		case select_next:
 			apdu.p2 = 0x02;
-			/* FALLTHROUGH */
+			/* fall through */
 		case select_by_id:
 			data[0] = pInfo->DoId;
 			apdu.data = data;

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -925,7 +925,8 @@ static int rutoken_get_do_info(sc_card_t *card, sc_DO_INFO_t * pInfo)
 			apdu.cse = SC_APDU_CASE_2_SHORT;
 			break;
 		case select_next:
-			apdu.p2  = 0x02;
+			apdu.p2 = 0x02;
+			/* FALLTHROUGH */
 		case select_by_id:
 			data[0] = pInfo->DoId;
 			apdu.data = data;

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -978,7 +978,7 @@ static int westcos_card_ctl(sc_card_t * card, unsigned long cmd, void *ptr)
 		data.pin1.data = priv_data->default_key.key_value;
 		return sc_pin_cmd(card, &data, NULL);
 	case SC_CARDCTL_WESTCOS_CHANGE_KEY:
-		if (1) {
+		{
 			int lrc;
 			u8 temp[7];
 			sc_changekey_t *ck = (sc_changekey_t *) ptr;

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -473,8 +473,10 @@ static int get_name_from_EF_DatiPersonali(unsigned char *EFdata,
 	if (fields[f_first_name].len + fields[f_last_name].len + 1 >= name_len)
 		return -1;
 
-	snprintf(name, name_len, "%s %s",
-		fields[f_first_name].value, fields[f_last_name].value);
+	/* the lengths are already checked that they will fit in buffer */
+	snprintf(name, name_len, "%.*s %.*s",
+		fields[f_first_name].len, fields[f_first_name].value,
+		fields[f_last_name].len, fields[f_last_name].value);
 	return 0;
 }
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1072,7 +1072,7 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 		else   {
 			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0) {
 				int ti_len = MIN(strlen(p15card->tokeninfo->label),
-					sizeof(label) - strlen(auth->label) - 3);
+					sizeof(label) - strlen(auth->label) - 4);
 				snprintf(label, sizeof(label), "%.*s (%.*s)",
 					(int) strlen(auth->label), auth->label,
 					ti_len, p15card->tokeninfo->label);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1043,7 +1043,7 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 {
 	struct pkcs15_slot_data *fw_data;
 	struct sc_pkcs15_auth_info *pin_info = NULL;
-	char label[64];
+	char label[(sizeof auth->label) + 10];
 
 	sc_log(context, "Called");
 	pkcs15_init_token_info(p15card, &slot->token_info);
@@ -1070,13 +1070,11 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 			pin_info = NULL;
 		}
 		else   {
-			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0) {
-				int ti_len = MIN(strlen(p15card->tokeninfo->label),
-					sizeof(label) - strlen(auth->label) - 4);
-				snprintf(label, sizeof(label), "%.*s (%.*s)",
-					(int) strlen(auth->label), auth->label,
-					ti_len, p15card->tokeninfo->label);
-			} else
+			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0)
+				snprintf(label, sizeof(label), "%.*s (%s)",
+					(int) sizeof(auth->label), auth->label,
+					p15card->tokeninfo->label);
+			else
 				/* The PIN label is empty or says just non-useful "PIN" */
 				snprintf(label, sizeof(label), "%s", p15card->tokeninfo->label);
 			slot->token_info.flags |= CKF_LOGIN_REQUIRED;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1070,9 +1070,13 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 			pin_info = NULL;
 		}
 		else   {
-			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0)
-				snprintf(label, sizeof(label), "%.*s (%s)", (int) sizeof auth->label, auth->label, p15card->tokeninfo->label);
-			else
+			if (auth->label[0] && strncmp(auth->label, "PIN", 4) != 0) {
+				int ti_len = MIN(strlen(p15card->tokeninfo->label),
+					sizeof(label) - strlen(auth->label) - 3);
+				snprintf(label, sizeof(label), "%.*s (%.*s)",
+					(int) strlen(auth->label), auth->label,
+					ti_len, p15card->tokeninfo->label);
+			} else
 				/* The PIN label is empty or says just non-useful "PIN" */
 				snprintf(label, sizeof(label), "%s", p15card->tokeninfo->label);
 			slot->token_info.flags |= CKF_LOGIN_REQUIRED;

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -335,7 +335,8 @@ iasecc_file_convert_acls(struct sc_context *ctx, struct sc_profile *profile, str
 		if (acl)   {
 			switch (acl->method)   {
 			case SC_AC_IDA:
-				LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "'IDA' not actually supported");
+				sc_log(ctx, "'IDA' not actually supported");
+				return SC_ERROR_NOT_SUPPORTED;
 			case SC_AC_SCB:
 				if ((acl->key_ref & IASECC_SCB_METHOD_MASK) == IASECC_SCB_METHOD_USER_AUTH)   {
 					acl->method = SC_AC_SEN;

--- a/src/sm/sm-common.c
+++ b/src/sm/sm-common.c
@@ -62,12 +62,19 @@
 			l1=l2=0; \
 			switch (n) { \
 			case 8: l2 =((DES_LONG)(*(--(c))))<<24L; \
+				/* FALLTHROUGH */ \
 			case 7: l2|=((DES_LONG)(*(--(c))))<<16L; \
+				/* FALLTHROUGH */ \
 			case 6: l2|=((DES_LONG)(*(--(c))))<< 8L; \
+				/* FALLTHROUGH */ \
 			case 5: l2|=((DES_LONG)(*(--(c))));	 \
+				/* FALLTHROUGH */ \
 			case 4: l1 =((DES_LONG)(*(--(c))))<<24L; \
+				/* FALLTHROUGH */ \
 			case 3: l1|=((DES_LONG)(*(--(c))))<<16L; \
+				/* FALLTHROUGH */ \
 			case 2: l1|=((DES_LONG)(*(--(c))))<< 8L; \
+				/* FALLTHROUGH */ \
 			case 1: l1|=((DES_LONG)(*(--(c))));	 \
 				} \
 			}

--- a/src/sm/sm-common.c
+++ b/src/sm/sm-common.c
@@ -62,19 +62,19 @@
 			l1=l2=0; \
 			switch (n) { \
 			case 8: l2 =((DES_LONG)(*(--(c))))<<24L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 7: l2|=((DES_LONG)(*(--(c))))<<16L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 6: l2|=((DES_LONG)(*(--(c))))<< 8L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 5: l2|=((DES_LONG)(*(--(c))));	 \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 4: l1 =((DES_LONG)(*(--(c))))<<24L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 3: l1|=((DES_LONG)(*(--(c))))<<16L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 2: l1|=((DES_LONG)(*(--(c))))<< 8L; \
-				/* FALLTHROUGH */ \
+				/* fall through */ \
 			case 1: l1|=((DES_LONG)(*(--(c))));	 \
 				} \
 			}

--- a/src/tests/pintest.c
+++ b/src/tests/pintest.c
@@ -66,7 +66,7 @@ static int ask_and_verify_pin(struct sc_pkcs15_object *pin_obj)
 	}
 
 	snprintf(prompt, sizeof(prompt), "Please enter PIN code [%.*s]: ",
-		(int) MIN(sizeof(prompt) - 26, strlen(pin_obj->label)),
+		(int) MIN(sizeof(prompt) - 27, strlen(pin_obj->label)),
 		pin_obj->label);
 	pass = (u8 *) getpass(prompt);
 

--- a/src/tests/pintest.c
+++ b/src/tests/pintest.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #endif
 
+#include "libopensc/internal.h"
 #include "libopensc/opensc.h"
 #include "libopensc/pkcs15.h"
 #include "common/compat_getpass.h"
@@ -64,7 +65,9 @@ static int ask_and_verify_pin(struct sc_pkcs15_object *pin_obj)
 		return 0;
 	}
 
-	sprintf(prompt, "Please enter PIN code [%.*s]: ", (int) sizeof pin_obj->label, pin_obj->label);
+	snprintf(prompt, sizeof(prompt), "Please enter PIN code [%.*s]: ",
+		(int) MIN(sizeof(prompt) - 26, strlen(pin_obj->label)),
+		pin_obj->label);
 	pass = (u8 *) getpass(prompt);
 
 	if (SC_SUCCESS != sc_lock(card))

--- a/src/tests/pintest.c
+++ b/src/tests/pintest.c
@@ -57,7 +57,7 @@ static int ask_and_verify_pin(struct sc_pkcs15_object *pin_obj)
 {
 	struct sc_pkcs15_auth_info *pin_info = (struct sc_pkcs15_auth_info *) pin_obj->data;
 	int i = 0;
-	char prompt[80];
+	char prompt[(sizeof pin_obj->label) + 30];
 	u8 *pass;
 
 	if (pin_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN) {
@@ -66,8 +66,7 @@ static int ask_and_verify_pin(struct sc_pkcs15_object *pin_obj)
 	}
 
 	snprintf(prompt, sizeof(prompt), "Please enter PIN code [%.*s]: ",
-		(int) MIN(sizeof(prompt) - 27, strlen(pin_obj->label)),
-		pin_obj->label);
+		(int) sizeof pin_obj->label, pin_obj->label);
 	pass = (u8 *) getpass(prompt);
 
 	if (SC_SUCCESS != sc_lock(card))

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1908,7 +1908,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			break;
 		default: 
 			oaep_params.hashAlg = CKM_SHA_1;
-			/* FALLTHROUGH */
+			/* fall through */
 		case CKM_SHA_1:
 			oaep_params.mgf = CKG_MGF1_SHA1;
 			break;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1908,7 +1908,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			break;
 		default: 
 			oaep_params.hashAlg = CKM_SHA_1;
-			/* fallthrough to SHA-1 default */
+			/* FALLTHROUGH */
 		case CKM_SHA_1:
 			oaep_params.mgf = CKG_MGF1_SHA1;
 			break;

--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -34,6 +34,7 @@
 #endif
 
 #include "common/compat_getpass.h"
+#include "libopensc/internal.h"
 #include "libopensc/opensc.h"
 #include "libopensc/pkcs15.h"
 #include "libopensc/asn1.h"
@@ -143,7 +144,8 @@ static char * get_pin(struct sc_pkcs15_object *obj)
 			return strdup(opt_pincode);
 	}
 
-	sprintf(buf, "Enter PIN [%.*s]: ", (int) sizeof obj->label, obj->label);
+	snprintf(buf, sizeof(buf), "Enter PIN [%.*s]: ",
+		(int) MIN(strlen(obj->label), sizeof(buf)-14), obj->label);
 	while (1) {
 		pincode = getpass(buf);
 		if (strlen(pincode) == 0)

--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -130,7 +130,7 @@ static char *readpin_stdin(void)
 
 static char * get_pin(struct sc_pkcs15_object *obj)
 {
-	char buf[80];
+	char buf[(sizeof obj->label) + 20];
 	char *pincode;
 	struct sc_pkcs15_auth_info *pinfo = (struct sc_pkcs15_auth_info *) obj->data;
 
@@ -145,7 +145,7 @@ static char * get_pin(struct sc_pkcs15_object *obj)
 	}
 
 	snprintf(buf, sizeof(buf), "Enter PIN [%.*s]: ",
-		(int) MIN(strlen(obj->label), sizeof(buf) - 15), obj->label);
+		(int) sizeof obj->label, obj->label);
 	while (1) {
 		pincode = getpass(buf);
 		if (strlen(pincode) == 0)

--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -145,7 +145,7 @@ static char * get_pin(struct sc_pkcs15_object *obj)
 	}
 
 	snprintf(buf, sizeof(buf), "Enter PIN [%.*s]: ",
-		(int) MIN(strlen(obj->label), sizeof(buf)-14), obj->label);
+		(int) MIN(strlen(obj->label), sizeof(buf) - 15), obj->label);
 	while (1) {
 		pincode = getpass(buf);
 		if (strlen(pincode) == 0)

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2794,7 +2794,7 @@ handle_option(const struct option *opt)
 		break;
 	case OPT_USE_PINPAD_DEPRECATED:
 		fprintf(stderr, "'--no-prompt' is deprecated , use '--use-pinpad' instead.\n");
-		/* FALLTHROUGH */
+		/* fall through */
 	case OPT_USE_PINPAD:
 		opt_use_pinpad = 1;
 		break;
@@ -2891,7 +2891,7 @@ parse_commandline(int argc, char **argv)
 		switch (o->has_arg) {
 		case optional_argument:
 			*sp++ = ':';
-			/* FALLTHROUGH */
+			/* fall through */
 		case required_argument:
 			*sp++ = ':';
 		case no_argument:
@@ -3146,7 +3146,7 @@ static int verify_pin(struct sc_pkcs15_card *p15card, char *auth_id_str)
 
 		if (pin_obj->label[0])
 			snprintf(pin_label, sizeof(pin_label), "User PIN [%.*s]",
-				(int) MIN(sizeof(pin_label)-11, strlen(pin_obj->label)),
+				(int) MIN(sizeof(pin_label) - 12, strlen(pin_obj->label)),
 				pin_obj->label);
 		else
 			snprintf(pin_label, sizeof(pin_label), "User PIN");

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -3091,7 +3091,7 @@ int get_pin(sc_ui_hints_t *hints, char **out)
 static int verify_pin(struct sc_pkcs15_card *p15card, char *auth_id_str)
 {
 	struct sc_pkcs15_object	*pin_obj = NULL;
-	char pin_label[64];
+	char pin_label[(sizeof pin_obj->label) + 20];
 	char *pin = NULL;
 	int r;
 
@@ -3146,8 +3146,7 @@ static int verify_pin(struct sc_pkcs15_card *p15card, char *auth_id_str)
 
 		if (pin_obj->label[0])
 			snprintf(pin_label, sizeof(pin_label), "User PIN [%.*s]",
-				(int) MIN(sizeof(pin_label) - 12, strlen(pin_obj->label)),
-				pin_obj->label);
+				(int) sizeof pin_obj->label, pin_obj->label);
 		else
 			snprintf(pin_label, sizeof(pin_label), "User PIN");
                 memset(&hints, 0, sizeof(hints));

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -61,6 +61,7 @@
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L */
 
 #include "common/compat_strlcpy.h"
+#include "libopensc/internal.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/pkcs15.h"
 #include "libopensc/log.h"
@@ -2793,6 +2794,7 @@ handle_option(const struct option *opt)
 		break;
 	case OPT_USE_PINPAD_DEPRECATED:
 		fprintf(stderr, "'--no-prompt' is deprecated , use '--use-pinpad' instead.\n");
+		/* FALLTHROUGH */
 	case OPT_USE_PINPAD:
 		opt_use_pinpad = 1;
 		break;
@@ -2889,6 +2891,7 @@ parse_commandline(int argc, char **argv)
 		switch (o->has_arg) {
 		case optional_argument:
 			*sp++ = ':';
+			/* FALLTHROUGH */
 		case required_argument:
 			*sp++ = ':';
 		case no_argument:
@@ -3142,7 +3145,9 @@ static int verify_pin(struct sc_pkcs15_card *p15card, char *auth_id_str)
 			return SC_ERROR_OBJECT_NOT_FOUND;
 
 		if (pin_obj->label[0])
-			snprintf(pin_label, sizeof(pin_label), "User PIN [%s]", pin_obj->label);
+			snprintf(pin_label, sizeof(pin_label), "User PIN [%.*s]",
+				(int) MIN(sizeof(pin_label)-11, strlen(pin_obj->label)),
+				pin_obj->label);
 		else
 			snprintf(pin_label, sizeof(pin_label), "User PIN");
                 memset(&hints, 0, sizeof(hints));


### PR DESCRIPTION
The PR #1178 from @frankmorgner introduced treating all warnings as errors. But my GCC7 on current Fedora 26 has some more checks that needed to be addressed to make it build for me. I am not completely convinced that all the changes I made are correct/better so I would be glad for review/comments/improvements if some of the parts can be done better or if I misunderstood some of the unclear cases.

```
-Werror=implicit-fallthrough=
	libopensc/card-incrypto34.c
		not sure if this is a bug or intention
	libopensc/card-rutoken.c
		most probably intention
	libopensc/card-westcos.c
		remove bogus if so the compile is not confused
		I will fill a separate bug to gcc probably
	pkcs15init/pkcs15-iasecc.c
		Simplify the log and avoid compiler confusion
	sm/sm-common.c
		explicit fallthrough
	tools/pkcs11-tool.c
		use explicit fallthrough comment
	tools/pkcs15-init.c
		The fallthrough is obvious here

-Werror=format-truncation=
	libopensc/pkcs15-itacns.c
		use explicit string lengths
	pkcs11/framework-pkcs15.c
		calculate the truncation
	tests/pintest.c
		avoid sprintf
	tools/pkcs15-crypt.c
		avoid sprintf
	tools/pkcs15-init.c
		calculate the truncation
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Tested with the following card: PIV, CAC
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
