### PR TITLE
[AuthentIC v3] Correctly handle APDUs with more than 256 bytes

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -807,46 +807,6 @@ authentic_select_file(struct sc_card *card, const struct sc_path *path,
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
-
-static int
-authentic_apdus_allocate(struct sc_apdu **head, struct sc_apdu **new)
-{
-	struct sc_apdu *allocated_apdu = NULL, *tmp_apdu = NULL;
-
-	if (!head)
-		return SC_ERROR_INVALID_ARGUMENTS;
-
-	allocated_apdu = calloc(1, sizeof(struct sc_apdu));
-	if (!allocated_apdu)
-		return SC_ERROR_OUT_OF_MEMORY;
-
-	if (*head == NULL)
-		*head = allocated_apdu;
-
-	if (new)
-		*new = allocated_apdu;
-
-	tmp_apdu = *head;
-	while(tmp_apdu->next)
-		tmp_apdu = tmp_apdu->next;
-
-	tmp_apdu->next = allocated_apdu;
-
-	return 0;
-}
-
-
-static void
-authentic_apdus_free(struct sc_apdu *apdu)
-{
-	while(apdu)   {
-		struct sc_apdu *tmp_apdu = apdu->next;
-		free(apdu);
-		apdu = tmp_apdu;
-	}
-}
-
-
 static int
 authentic_read_binary(struct sc_card *card, unsigned int idx,
 		unsigned char *buf, size_t count, unsigned long flags)
@@ -888,8 +848,7 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	if (!rv)
-		rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
+	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
 	if (!rv)
 		count = ret_count;
 
@@ -905,7 +864,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 		const unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_context *ctx = card->ctx;
-	struct sc_apdu *apdus = NULL, *cur_apdu = NULL;
+	struct sc_apdu *apdu = NULL;
 	size_t sz, rest;
 	int rv;
 
@@ -914,37 +873,35 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
 	       idx, count, card->max_send_size);
 
-	/* see comments for authentic_read_binary() */
-	sc_log(ctx, "reader flags 0x%lX", card->reader->flags);
-	if (count > 255 && !(card->reader->flags & SC_READER_HAS_WAITING_AREA))
-		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid size of the data to read");
+	apdu = calloc(1, sizeof(struct sc_apdu));
+	if(!apdu)
+		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
 
 	rest = count;
 	while(rest)   {
-		if (authentic_apdus_allocate(&apdus, &cur_apdu))
-			LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
-
 		sz = rest > 255 ? 255 : rest;
-		sc_format_apdu(card, cur_apdu, SC_APDU_CASE_3_SHORT, 0xD0, (idx >> 8) & 0x7F, idx & 0xFF);
-		cur_apdu->lc = sz;
-		cur_apdu->datalen = sz;
-		cur_apdu->data = buf + count - rest;
+		sc_format_apdu(card, apdu, SC_APDU_CASE_3_SHORT, 0xD0, (idx >> 8) & 0x7F, idx & 0xFF);
+		apdu->lc = sz;
+		apdu->datalen = sz;
+		apdu->data = buf + count - rest;
+
+		rv = sc_transmit_apdu(card, apdu);
+		if(rv)
+			break;
 
 		idx += sz;
 		rest -= sz;
 	}
 
-	if (!apdus)
+	if (rv)
 	{
 		LOG_TEST_RET(ctx, SC_ERROR_INTERNAL, "authentic_write_binary() failed");
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	rv = sc_transmit_apdu(card, apdus);
-	if (!rv)
-		rv = sc_check_sw(card, apdus->sw1, apdus->sw2);
+	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
 
-	authentic_apdus_free(apdus);
+	free(apdu);
 
 	LOG_TEST_RET(ctx, rv, "authentic_write_binary() failed");
 	LOG_FUNC_RETURN(ctx, count);
@@ -956,7 +913,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 		const unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_context *ctx = card->ctx;
-	struct sc_apdu *apdus = NULL, *cur_apdu = NULL;
+	struct sc_apdu *apdu = NULL;
 	size_t sz, rest;
 	int rv;
 
@@ -965,37 +922,35 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
 	       idx, count, card->max_send_size);
 
-	/* see comments for authentic_read_binary() */
-	sc_log(ctx, "reader flags 0x%lX", card->reader->flags);
-	if (count > 255 && !(card->reader->flags & SC_READER_HAS_WAITING_AREA))
-		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid size of the data to read");
+	apdu = calloc(1, sizeof(struct sc_apdu));
+	if(!apdu)
+		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
 
 	rest = count;
 	while(rest)   {
-		if (authentic_apdus_allocate(&apdus, &cur_apdu))
-			LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
-
 		sz = rest > 255 ? 255 : rest;
-		sc_format_apdu(card, cur_apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
-		cur_apdu->lc = sz;
-		cur_apdu->datalen = sz;
-		cur_apdu->data = buf + count - rest;
+		sc_format_apdu(card, apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
+		apdu->lc = sz;
+		apdu->datalen = sz;
+		apdu->data = buf + count - rest;
+
+		rv = sc_transmit_apdu(card, apdu);
+		if(rv)
+			break;
 
 		idx += sz;
 		rest -= sz;
 	}
 
-	if (!apdus)
+	if (rv)
 	{
 		LOG_TEST_RET(ctx, SC_ERROR_INTERNAL, "authentic_update_binary() failed");
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	rv = sc_transmit_apdu(card, apdus);
-	if (!rv)
-		rv = sc_check_sw(card, apdus->sw1, apdus->sw2);
+	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
 
-	authentic_apdus_free(apdus);
+	free(apdu);
 
 	LOG_TEST_RET(ctx, rv, "authentic_update_binary() failed");
 	LOG_FUNC_RETURN(ctx, count);

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -812,7 +812,7 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 		unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_context *ctx = card->ctx;
-	struct sc_apdu *apdu = NULL;
+	struct sc_apdu apdu;
 	size_t sz, rest, ret_count = 0;
 	int rv;
 
@@ -821,21 +821,17 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_recv_size:%"SC_FORMAT_LEN_SIZE_T"u",
 	       idx, count, card->max_recv_size);
 
-	apdu = calloc(1, sizeof(struct sc_apdu));
-	if(!apdu)
-		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
-
 	rest = count;
 	while(rest)   {
 		sz = rest > 256 ? 256 : rest;
-		sc_format_apdu(card, apdu, SC_APDU_CASE_2_SHORT, 0xB0, (idx >> 8) & 0x7F, idx & 0xFF);
-		apdu->le = sz;
-		apdu->resplen = sz;
-		apdu->resp = (buf + ret_count);
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xB0, (idx >> 8) & 0x7F, idx & 0xFF);
+		apdu.le = sz;
+		apdu.resplen = sz;
+		apdu.resp = (buf + ret_count);
 
-		rv = sc_transmit_apdu(card, apdu);
+		rv = sc_transmit_apdu(card, &apdu);
 		if(!rv)
-			ret_count += apdu->resplen;
+			ret_count += apdu.resplen;
 		else
 			break;
 
@@ -848,12 +844,10 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	if (!rv)
 		count = ret_count;
 
-	free(apdu);
-	
 	LOG_TEST_RET(ctx, rv, "authentic_read_binary() failed");
 	LOG_FUNC_RETURN(ctx, count);
 }
@@ -864,7 +858,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 		const unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_context *ctx = card->ctx;
-	struct sc_apdu *apdu = NULL;
+	struct sc_apdu apdu;
 	size_t sz, rest;
 	int rv;
 
@@ -873,19 +867,15 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
 	       idx, count, card->max_send_size);
 
-	apdu = calloc(1, sizeof(struct sc_apdu));
-	if(!apdu)
-		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
-
 	rest = count;
 	while(rest)   {
 		sz = rest > 255 ? 255 : rest;
-		sc_format_apdu(card, apdu, SC_APDU_CASE_3_SHORT, 0xD0, (idx >> 8) & 0x7F, idx & 0xFF);
-		apdu->lc = sz;
-		apdu->datalen = sz;
-		apdu->data = buf + count - rest;
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xD0, (idx >> 8) & 0x7F, idx & 0xFF);
+		apdu.lc = sz;
+		apdu.datalen = sz;
+		apdu.data = buf + count - rest;
 
-		rv = sc_transmit_apdu(card, apdu);
+		rv = sc_transmit_apdu(card, &apdu);
 		if(rv)
 			break;
 
@@ -899,9 +889,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
-
-	free(apdu);
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 
 	LOG_TEST_RET(ctx, rv, "authentic_write_binary() failed");
 	LOG_FUNC_RETURN(ctx, count);
@@ -913,7 +901,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 		const unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_context *ctx = card->ctx;
-	struct sc_apdu *apdu = NULL;
+	struct sc_apdu apdu;
 	size_t sz, rest;
 	int rv;
 
@@ -922,19 +910,15 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
 	       idx, count, card->max_send_size);
 
-	apdu = calloc(1, sizeof(struct sc_apdu));
-	if(!apdu)
-		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "cannot allocate APDU");
-
 	rest = count;
 	while(rest)   {
 		sz = rest > 255 ? 255 : rest;
-		sc_format_apdu(card, apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
-		apdu->lc = sz;
-		apdu->datalen = sz;
-		apdu->data = buf + count - rest;
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xD6, (idx >> 8) & 0x7F, idx & 0xFF);
+		apdu.lc = sz;
+		apdu.datalen = sz;
+		apdu.data = buf + count - rest;
 
-		rv = sc_transmit_apdu(card, apdu);
+		rv = sc_transmit_apdu(card, &apdu);
 		if(rv)
 			break;
 
@@ -948,9 +932,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 		LOG_FUNC_RETURN(ctx, count);
 	}
 
-	rv = sc_check_sw(card, apdu->sw1, apdu->sw2);
-
-	free(apdu);
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 
 	LOG_TEST_RET(ctx, rv, "authentic_update_binary() failed");
 	LOG_FUNC_RETURN(ctx, count);


### PR DESCRIPTION
Multiple sc_transmit_apdu calls are made when more than 256 bytes (read) or 255 bytes (write and update) are requested.
This fixes #1147.
<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] Tested with the following card: Oberthur AuthentIC 3.2.2
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [x] tested macOS Tokend
