### PR TITLE
 md: protect MD entry points with CriticalSection

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3593,6 +3593,8 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 		}
 	}
 
+	free(pubkey_der.value);
+
 	logprintf(pCardData, 7, "returns container(idx:%u) info",
 		  (unsigned int)bContainerIndex);
 	return SCARD_S_SUCCESS;


### PR DESCRIPTION
`CardDeleteContext` may be called at any time, interrupting any ongoing operation with the same `PCARD_DATA`. This leads to a race condition when `CardDeleteContext` deletes, for example, the `sc_context_t` which the interrupted call still wants to access. We have seen and fixed this problem in #973 specifically for the PIN entry process, however, it also applies to all other calls to the md.

The new implementation removes the need for global data in the md.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Tested with the following card: sc-hsm, cardos
	- [x] tested Windows Minidriver