### PR TITLE
Skip correctly two bytes after reading 2b size

### DIFF
--- a/src/libopensc/simpletlv.c
+++ b/src/libopensc/simpletlv.c
@@ -90,8 +90,9 @@ sc_simpletlv_read_tag(u8 **buf, size_t buflen, u8 *tag_out, size_t *taglen)
 			*taglen = 0;
 			return SC_ERROR_INVALID_ARGUMENTS;
 		}
+		/* skip two bytes (the size) */
 		len = lebytes2ushort(p);
-		p++;
+		p+=2;
 	}
 	*taglen = len;
 	*buf = p;


### PR DESCRIPTION
The SimpleTLV function used in CAC driver did not properly parse multi-byte lengths and therefore failing with CAC cards having some bigger field (currently ignored) before certificate data in TL file.

This might not be complete fix yet so do not hurry with merging, but it is clearly a bug that needs to get fixed. 

##### Checklist
- [X] Tested with the following card: CAC
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend