### PR TITLE
PC/SC: don't reset the card on disconnection

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -84,8 +84,8 @@ app default {
 		#
 		# What to do when disconnecting from a card (SCardDisconnect)
 		# Valid values: leave, reset, unpower.
-		# Default: reset
-		# disconnect_action = unpower;
+		# Default: leave
+		# disconnect_action = reset;
 		#
 		# What to do at the end of a transaction (SCardEndTransaction)
 		# Valid values: leave, reset, unpower.

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -781,7 +781,7 @@ static int pcsc_init(sc_context_t *ctx)
 		gpriv->connect_exclusive =
 			scconf_get_bool(conf_block, "connect_exclusive", gpriv->connect_exclusive);
 		gpriv->disconnect_action =
-			pcsc_reset_action(scconf_get_str(conf_block, "disconnect_action", "reset"));
+			pcsc_reset_action(scconf_get_str(conf_block, "disconnect_action", "leave"));
 		gpriv->transaction_end_action =
 			pcsc_reset_action(scconf_get_str(conf_block, "transaction_end_action", "leave"));
 		gpriv->reconnect_action =


### PR DESCRIPTION
Windows/macOS (minidriver/tokend) handle the authentication status and
perform an explicit logout on shutdown. PKCS#11 standard requires a
session for logging into the card; when closing the session we perform
an explicit logout. Hence, the authentication status should be reset
even if not performing a reset on disconnect.

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
