### PR TITLE
Reselect PKI-Applets after card reset

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -272,8 +272,9 @@ app default {
 		# can be specified as strings:
 		#
 		# rng - On-board random number source
+		# keep_alive - Request the card driver to send a "keep alive" command before each transaction to make sure that the required applet is still selected.
 		#
-		# flags = "rng", "0x80000000";
+		# flags = "rng", "keep_alive", "0x80000000";
 
 		# Enable pkcs11 initialization.
 		# Default: no
@@ -373,11 +374,30 @@ app default {
 		# notify_pin_bad_text = "bad text";
 	# }
 
-	# PIV cards need an entry similar to this one:
-	# card_atr 3B:7D:96:00:00:80:31:80:65:B0:83:11:00:AC:83:00:90:00 {
-		# name = "PIV-II";
-		# driver = "piv";
-	# }
+	# Yubikey is known to have the PIV applet and the OpenPGP applet. OpenSC
+	# can handle both to access keys and certificates, but only one at a time.
+	card_atr 3b:f8:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:34:d4 {
+		name = "Yubikey 4";
+		# Select the PKI applet to use ("PIV-II" or "openpgp")
+		driver = "PIV-II";
+		# Recover from other applications accessing a different applet
+		flags = "keep_alive";
+	}
+	card_atr 3b:fc:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:4e:45:4f:72:33:e1 {
+		name = "Yubikey Neo";
+		# Select the PKI applet to use ("PIV-II" or "openpgp")
+		driver = "PIV-II";
+		# Recover from other applications accessing a different applet
+		flags = "keep_alive";
+	}
+	card_atr 3b:8c:80:01:59:75:62:69:6b:65:79:4e:45:4f:72:33:58 {
+		atrmask = "FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:00:00";
+		name = "Yubikey Neo";
+		# Select the PKI applet to use ("PIV-II" or "openpgp")
+		driver = "PIV-II";
+		# Recover from other applications accessing a different applet
+		flags = "keep_alive";
+	}
 
 	# Micardo driver sometimes only play together with T=0
 	# In theory only the 'cold' ATR should be specified, as T=0 will

--- a/src/libopensc/card-asepcos.c
+++ b/src/libopensc/card-asepcos.c
@@ -1026,6 +1026,20 @@ static int asepcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *pdata,
 	return r;
 }
 
+static int asepcos_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0 && card->type == SC_CARD_TYPE_ASEPCOS_JAVA) {
+		/* in case of a Java card try to select the ASEPCOS applet */
+		r = asepcos_select_asepcos_applet(card);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 static struct sc_card_driver * sc_get_driver(void)
 {
 	if (iso_ops == NULL)
@@ -1042,6 +1056,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	asepcos_ops.list_files        = asepcos_list_files;
 	asepcos_ops.card_ctl          = asepcos_card_ctl;
 	asepcos_ops.pin_cmd           = asepcos_pin_cmd;
+	asepcos_ops.card_reader_lock_obtained = asepcos_card_reader_lock_obtained;
 
 	return &asepcos_drv;
 }

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -491,7 +491,6 @@ authentic_init(struct sc_card *card)
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
-
 static int
 authentic_erase_binary(struct sc_card *card, unsigned int offs, size_t count, unsigned long flags)
 {
@@ -2115,6 +2114,21 @@ authentic_finish(struct sc_card *card)
 }
 
 
+static int authentic_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0
+			&& card->type == SC_CARD_TYPE_OBERTHUR_AUTHENTIC_3_2) {
+		r = authentic_select_aid(card, aid_AuthentIC_3_2, sizeof(aid_AuthentIC_3_2), NULL, NULL);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
+
 /* SM related */
 #ifdef ENABLE_SM
 static int
@@ -2367,6 +2381,7 @@ sc_get_driver(void)
 	authentic_ops.card_ctl = authentic_card_ctl;
 	authentic_ops.process_fci = authentic_process_fci;
 	authentic_ops.pin_cmd = authentic_pin_cmd;
+	authentic_ops.card_reader_lock_obtained = authentic_card_reader_lock_obtained;
 
 	return &authentic_drv;
 }

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -2287,6 +2287,7 @@ static int coolkey_init(sc_card_t *card)
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_SUCCESS);
 }
 
+
 static int
 coolkey_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 {
@@ -2342,6 +2343,7 @@ coolkey_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	return r;
 }
 
+
 static int
 coolkey_logout(sc_card_t *card)
 {
@@ -2356,6 +2358,20 @@ coolkey_logout(sc_card_t *card)
 	memset(priv->nonce, 0, sizeof(priv->nonce));
 	priv->nonce_valid = 0;
 	return SC_SUCCESS;
+}
+
+
+static int coolkey_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0) {
+		r = coolkey_select_applet(card);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 static struct sc_card_operations coolkey_ops;
@@ -2388,6 +2404,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	coolkey_ops.check_sw = coolkey_check_sw;
 	coolkey_ops.pin_cmd = coolkey_pin_cmd;
 	coolkey_ops.logout = coolkey_logout;
+	coolkey_ops.card_reader_lock_obtained = coolkey_card_reader_lock_obtained;
 
 	return &coolkey_drv;
 }

--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -566,6 +566,20 @@ static int gemsafe_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	return r;
 }
 
+static int gemsafe_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+	gemsafe_exdata *exdata = (gemsafe_exdata *)card->drv_data;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0 && exdata) {
+		r = gp_select_applet(card, exdata->aid, exdata->aid_len);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 static struct sc_card_driver *sc_get_driver(void)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
@@ -585,6 +599,7 @@ static struct sc_card_driver *sc_get_driver(void)
 	gemsafe_ops.get_challenge 		 = gemsafe_get_challenge;
 	gemsafe_ops.process_fci	= gemsafe_process_fci;
 	gemsafe_ops.pin_cmd		 = iso_ops->pin_cmd;
+	gemsafe_ops.card_reader_lock_obtained = gemsafe_card_reader_lock_obtained;
 
 	return &gemsafe_drv;
 }

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -2047,12 +2047,26 @@ static int gids_card_ctl(sc_card_t * card, unsigned long cmd, void *ptr)
 	}
 }
 
+static int gids_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0) {
+		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+		size_t resplen = sizeof(rbuf);
+		r = gids_select_aid(card, gids_aid.value, gids_aid.len, rbuf, &resplen);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 static struct sc_card_driver *sc_get_driver(void)
 {
 
 	if (iso_ops == NULL)
 		iso_ops = sc_get_iso7816_driver()->ops;
-
 
 	gids_ops.match_card = gids_match_card;
 	gids_ops.init = gids_init;
@@ -2088,6 +2102,8 @@ static struct sc_card_driver *sc_get_driver(void)
 	gids_ops.put_data = NULL;
 	gids_ops.delete_record = NULL;
 	gids_ops.read_public_key = gids_read_public_key;
+	gids_ops.card_reader_lock_obtained = gids_card_reader_lock_obtained;
+
 	return &gids_drv;
 }
 

--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -1224,6 +1224,21 @@ isoApplet_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 	LOG_FUNC_RETURN(ctx, r);
 }
 
+static int isoApplet_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0) {
+		size_t rlen = SC_MAX_APDU_BUFFER_SIZE;
+		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+		r = isoApplet_select_applet(card, isoApplet_aid, ISOAPPLET_AID_LEN, rbuf, &rlen);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 static struct sc_card_driver *sc_get_driver(void)
 {
 	sc_card_driver_t *iso_drv = sc_get_iso7816_driver();
@@ -1246,6 +1261,7 @@ static struct sc_card_driver *sc_get_driver(void)
 	isoApplet_ops.set_security_env = isoApplet_set_security_env;
 	isoApplet_ops.compute_signature = isoApplet_compute_signature;
 	isoApplet_ops.get_challenge = isoApplet_get_challenge;
+	isoApplet_ops.card_reader_lock_obtained = isoApplet_card_reader_lock_obtained;
 
 	/* unsupported functions */
 	isoApplet_ops.write_binary = NULL;

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -362,6 +362,19 @@ jpki_compute_signature(sc_card_t * card,
 	LOG_FUNC_RETURN(card->ctx, apdu.resplen);
 }
 
+static int jpki_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0) {
+		r = jpki_select_ap(card);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 static struct sc_card_driver *
 sc_get_driver(void)
 {
@@ -376,6 +389,7 @@ sc_get_driver(void)
 	jpki_ops.pin_cmd = jpki_pin_cmd;
 	jpki_ops.set_security_env = jpki_set_security_env;
 	jpki_ops.compute_signature = jpki_compute_signature;
+	jpki_ops.card_reader_lock_obtained = jpki_card_reader_lock_obtained;
 
 	return &jpki_drv;
 }

--- a/src/libopensc/card-muscle.c
+++ b/src/libopensc/card-muscle.c
@@ -810,6 +810,21 @@ static int muscle_check_sw(sc_card_t * card, unsigned int sw1, unsigned int sw2)
 	return iso_ops->check_sw(card, sw1, sw2);
 }
 
+static int muscle_card_reader_lock_obtained(sc_card_t *card, int was_reset)
+{
+	int r = SC_SUCCESS;
+
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (was_reset > 0) {
+		if (msc_select_applet(card, muscleAppletId, sizeof muscleAppletId) != 1) {
+			r = SC_ERROR_INVALID_CARD;
+		}
+	}
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
 
 static struct sc_card_driver * sc_get_driver(void)
 {
@@ -837,6 +852,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	muscle_ops.select_file = muscle_select_file;
 	muscle_ops.delete_file = muscle_delete_file;
 	muscle_ops.list_files = muscle_list_files;
+	muscle_ops.card_reader_lock_obtained = muscle_card_reader_lock_obtained;
 
 	return &muscle_drv;
 }

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -388,7 +388,7 @@ static const struct piv_object piv_objects[] = {
 static struct sc_card_operations piv_ops;
 
 static struct sc_card_driver piv_drv = {
-	"PIV-II  for multiple cards",
+	"Personal Identity Verification Card",
 	"PIV-II",
 	&piv_ops,
 	NULL, 0, NULL
@@ -3030,7 +3030,7 @@ static int piv_init(sc_card_t *card)
 	       card->max_send_size, card->max_recv_size, card->type);
 	card->cla = 0x00;
 	if(card->name == NULL)
-		card->name = "PIV-II card";
+		card->name = card->driver->name;
 
 	/*
 	 * Set card_issues based on card type either set by piv_match_card or by opensc.conf

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2333,7 +2333,7 @@ static int piv_validate_general_authentication(sc_card_t *card,
 
 	u8 sbuf[4096]; /* needs work. for 3072 keys, needs 384+10 or so */
 	u8 *rbuf = NULL;
-	size_t rbuflen = 0;
+	size_t rbuflen;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -631,6 +631,8 @@ static int load_card_atrs(sc_context_t *ctx)
 
 				if (!strcmp(list->data, "rng"))
 					flags = SC_CARD_FLAG_RNG;
+				else if (!strcmp(list->data, "keep_alive"))
+					flags = SC_CARD_FLAG_KEEP_ALIVE;
 				else if (sscanf(list->data, "%x", &flags) != 1)
 					flags = 0;
 

--- a/src/libopensc/dir.c
+++ b/src/libopensc/dir.c
@@ -259,10 +259,8 @@ void sc_free_apps(sc_card_t *card)
 	int	i;
 
 	for (i = 0; i < card->app_count; i++) {
-		if (card->app[i]->label)
-			free(card->app[i]->label);
-		if (card->app[i]->ddo.value)
-			free(card->app[i]->ddo.value);
+		free(card->app[i]->label);
+		free(card->app[i]->ddo.value);
 		free(card->app[i]);
 	}
 	card->app_count = -1;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -453,6 +453,7 @@ struct sc_reader_operations {
 
 /* Hint SC_CARD_CAP_RNG */
 #define SC_CARD_FLAG_RNG		0x00000002
+#define SC_CARD_FLAG_KEEP_ALIVE	0x00000004
 
 /*
  * Card capabilities

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -790,15 +790,12 @@ sc_pkcs15_free_tokeninfo(struct sc_pkcs15_tokeninfo *tokeninfo)
 void
 sc_pkcs15_free_app(struct sc_pkcs15_card *p15card)
 {
-	if (!p15card || !p15card->app)
-		return;
-
-	if (p15card->app->label)
+	if (p15card && p15card->app) {
 		free(p15card->app->label);
-	if (p15card->app->ddo.value)
 		free(p15card->app->ddo.value);
-	free(p15card->app);
-	p15card->app = NULL;
+		free(p15card->app);
+		p15card->app = NULL;
+	}
 }
 
 


### PR DESCRIPTION
PKI-Applets may not be active if the card has been reset or unpowered.
The SELECT command used to activate the applet, is identical to the one
used during card matching or initialization.

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] Tested with the following card: Yubikey 4 (OpenPGP)
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
