### PR TITLE
Refactored sc_get_challenge

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1661,40 +1661,27 @@ authentic_get_serialnr(struct sc_card *card, struct sc_serial_number *serial)
 }
 
 
-/* 'GET CHALLENGE' returns always 24 bytes */
 static int
 authentic_get_challenge(struct sc_card *card, unsigned char *rnd, size_t len)
 {
-	struct sc_context *ctx = card->ctx;
-	struct sc_apdu apdu;
+	/* 'GET CHALLENGE' returns always 24 bytes */
 	unsigned char rbuf[0x18];
-	int rv, nn;
+	size_t out_len;
+	int r;
 
-	LOG_FUNC_CALLED(ctx);
-	if (!rnd && len)
-		return SC_ERROR_INVALID_ARGUMENTS;
+	LOG_FUNC_CALLED(card->ctx);
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x84, 0x00, 0x00);
-	apdu.resp = rbuf;
-	apdu.resplen = sizeof(rbuf);
-	apdu.le = sizeof(rbuf);
+	r = iso_ops->get_challenge(card, rnd, sizeof rbuf);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE cmd failed");
 
-	while (len > 0) {
-		rv = sc_transmit_apdu(card, &apdu);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, rv, "APDU transmit failed");
-		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		LOG_TEST_RET(ctx, rv, "PIN cmd failed");
-
-		if (apdu.resplen != sizeof(rbuf))
-			return sc_check_sw(card, apdu.sw1, apdu.sw2);
-
-		nn = len > apdu.resplen ? apdu.resplen : len;
-		memcpy(rnd, apdu.resp, nn);
-		len -= nn;
-		rnd += nn;
+	if (len < (size_t) r) {
+		out_len = len;
+	} else {
+		out_len = (size_t) r;
 	}
+	memcpy(rnd, rbuf, out_len);
 
-	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+	LOG_FUNC_RETURN(card->ctx, out_len);
 }
 
 

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1609,40 +1609,17 @@ static int coolkey_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 
 static int coolkey_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 {
-	size_t rbuflen = 0;
-	int r;
+	LOG_FUNC_CALLED(card->ctx);
 
-	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	if (len > COOLKEY_MAX_CHUNK_SIZE)
+		len = COOLKEY_MAX_CHUNK_SIZE;
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
-		 "challenge len=%"SC_FORMAT_LEN_SIZE_T"u", len);
+	LOG_TEST_RET(card->ctx,
+			coolkey_apdu_io(card, COOLKEY_CLASS, COOLKEY_INS_GET_RANDOM, 0, 0,
+				NULL, 0, &rnd, &len,  NULL, 0),
+			"Could not get challenge");
 
-	r = sc_lock(card);
-	if (r != SC_SUCCESS)
-		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
-
-	for(; len >= COOLKEY_MAX_CHUNK_SIZE; len -= COOLKEY_MAX_CHUNK_SIZE,
-										rnd += COOLKEY_MAX_CHUNK_SIZE) {
-		rbuflen = COOLKEY_MAX_CHUNK_SIZE;
-		r = coolkey_apdu_io(card, COOLKEY_CLASS, COOLKEY_INS_GET_RANDOM,
-			0, 0, NULL, 0, &rnd, &rbuflen,  NULL, 0);
-		if (r != COOLKEY_MAX_CHUNK_SIZE) {
-			len = 0;
-			break;
-		}
-	}
-	if (len) {
-		r = coolkey_apdu_io(card, COOLKEY_CLASS, COOLKEY_INS_GET_RANDOM,
-			0, 0, NULL, 0, &rnd, &len, NULL, 0);
-	}
-	sc_unlock(card);
-
-	if (r > 0) {
-		r= SC_SUCCESS;
-	}
-
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
-
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, (int) len);
 }
 
 static int coolkey_set_security_env(sc_card_t *card, const sc_security_env_t *env, int se_num)

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2573,34 +2573,26 @@ get_external_key_retries(struct sc_card *card, unsigned char kid, unsigned char 
 	return r;
 }
 
-	static int 
-epass2003_get_challenge(sc_card_t *card, u8 *rnd, size_t count)
+static int 
+epass2003_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 {
-	sc_apdu_t apdu;
 	u8 rbuf[16];
-	size_t n;
-	int ret = SC_SUCCESS; /* if count == 0 */
+	size_t out_len;
+	int r;
 
-	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x84, 0x00, 0x00);
-	apdu.le = sizeof(rbuf);
-	apdu.resp = rbuf;
-	apdu.resplen = sizeof(rbuf);
+	LOG_FUNC_CALLED(card->ctx);
 
-	while (count > 0)
-	{
-		ret = sc_transmit_apdu(card, &apdu);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "APDU transmit failed");
-		ret = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "Get challenge failed");
-		if (apdu.resplen != sizeof(rbuf))
-			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN);
-		n = count < sizeof(rbuf) ? count : sizeof(rbuf);
-		memcpy(rnd, rbuf, n);
-		count -= n;
-		rnd += n;
+	r = iso_ops->get_challenge(card, rnd, sizeof rbuf);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE cmd failed");
+
+	if (len < (size_t) r) {
+		out_len = len;
+	} else {
+		out_len = (size_t) r;
 	}
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, ret);
+	memcpy(rnd, rbuf, out_len);
+
+	LOG_FUNC_RETURN(card->ctx, (int) out_len);
 }
 
 

--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -1211,17 +1211,17 @@ isoApplet_compute_signature(struct sc_card *card,
 static int
 isoApplet_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 {
-	struct sc_context *ctx = card->ctx;
 	int r;
 
-	LOG_FUNC_CALLED(ctx);
+	LOG_FUNC_CALLED(card->ctx);
 
-	if(card->caps & SC_CARD_CAP_RNG)   {
+	if(card->caps & SC_CARD_CAP_RNG) {
 		r = iso_ops->get_challenge(card, rnd, len);
 	} else   {
 		r = SC_ERROR_NOT_SUPPORTED;
 	}
-	LOG_FUNC_RETURN(ctx, r);
+
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 static int isoApplet_card_reader_lock_obtained(sc_card_t *card, int was_reset)

--- a/src/libopensc/card-muscle.c
+++ b/src/libopensc/card-muscle.c
@@ -775,8 +775,12 @@ static int muscle_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 {
 	if (len == 0)
 		return SC_SUCCESS;
-	else
-		return msc_get_challenge(card, len, 0, NULL, rnd);
+	else {
+		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL,
+				msc_get_challenge(card, len, 0, NULL, rnd),
+				"GET CHALLENGE cmd failed");
+		return (int) len;
+	}
 }
 
 static int muscle_check_sw(sc_card_t * card, unsigned int sw1, unsigned int sw2) {

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1222,16 +1222,17 @@ pgp_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 static int
 pgp_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 {
-	struct pgp_priv_data *priv = DRVDATA(card);
+	struct pgp_priv_data *priv;
 
 	LOG_FUNC_CALLED(card->ctx);
 
+	priv = DRVDATA(card);
 	if (0 == (priv->ext_caps & EXT_CAP_GET_CHALLENGE)) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 	}
 
 	if (priv->max_challenge_size > 0 && len > priv->max_challenge_size) {
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_WRONG_LENGTH);
+		len = priv->max_challenge_size;
 	}
 
 	LOG_FUNC_RETURN(card->ctx, iso_ops->get_challenge(card, rnd, len));

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -1133,33 +1133,25 @@ static int rutoken_compute_signature(struct sc_card *card,
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, ret);
 }
 
-static int rutoken_get_challenge(sc_card_t *card, u8 *rnd, size_t count)
+static int rutoken_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 {
-	sc_apdu_t apdu;
-	u8 rbuf[32];
-	size_t n;
-	int ret = SC_SUCCESS; /* if count == 0 */
+	unsigned char rbuf[32];
+	size_t out_len;
+	int r;
 
-	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x84, 0x00, 0x00);
-	apdu.le = sizeof(rbuf);
-	apdu.resp = rbuf;
-	apdu.resplen = sizeof(rbuf);
+	LOG_FUNC_CALLED(card->ctx);
 
-	while (count > 0)
-	{
-		ret = sc_transmit_apdu(card, &apdu);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "APDU transmit failed");
-		ret = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, ret, "Get challenge failed");
-		if (apdu.resplen != sizeof(rbuf))
-			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_UNKNOWN);
-		n = count < sizeof(rbuf) ? count : sizeof(rbuf);
-		memcpy(rnd, rbuf, n);
-		count -= n;
-		rnd += n;
+	r = iso_ops->get_challenge(card, rnd, sizeof rbuf);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE cmd failed");
+
+	if (len < (size_t) r) {
+		out_len = len;
+	} else {
+		out_len = (size_t) r;
 	}
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, ret);
+	memcpy(rnd, rbuf, out_len);
+
+	LOG_FUNC_RETURN(card->ctx, out_len);
 }
 
 static int rutoken_get_serial(sc_card_t *card, sc_serial_number_t *serial)

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -225,6 +225,19 @@ static int sc_hsm_select_file(sc_card_t *card,
 
 
 
+static int sc_hsm_get_challenge(struct sc_card *card, unsigned char *rnd, size_t len)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	if (len > 1024) {
+		len = 1024;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, iso_ops->get_challenge(card, rnd, len));
+}
+
+
+
 static int sc_hsm_match_card(struct sc_card *card)
 {
 	sc_path_t path;
@@ -1703,6 +1716,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	sc_hsm_ops                   = *iso_drv->ops;
 	sc_hsm_ops.match_card        = sc_hsm_match_card;
 	sc_hsm_ops.select_file       = sc_hsm_select_file;
+	sc_hsm_ops.get_challenge     = sc_hsm_get_challenge;
 	sc_hsm_ops.read_binary       = sc_hsm_read_binary;
 	sc_hsm_ops.update_binary     = sc_hsm_update_binary;
 	sc_hsm_ops.list_files        = sc_hsm_list_files;

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -792,6 +792,17 @@ static int starcos_select_file(sc_card_t *card,
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
 }
 
+static int starcos_get_challenge(struct sc_card *card, unsigned char *rnd, size_t len)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	if (len > 8) {
+		len = 8;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, iso_ops->get_challenge(card, rnd, len));
+}
+
 #define STARCOS_AC_ALWAYS	0x9f
 #define STARCOS_AC_NEVER	0x5f
 #define STARCOS_PINID2STATE(a)	((((a) & 0x0f) == 0x01) ? ((a) & 0x0f) : (0x0f - ((0x0f & (a)) >> 1)))
@@ -1848,6 +1859,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	starcos_ops.init   = starcos_init;
 	starcos_ops.finish = starcos_finish;
 	starcos_ops.select_file = starcos_select_file;
+	starcos_ops.get_challenge = starcos_get_challenge;
 	starcos_ops.check_sw    = starcos_check_sw;
 	starcos_ops.create_file = starcos_create_file;
 	starcos_ops.delete_file = NULL;

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -1291,7 +1291,7 @@ int cwa_create_secure_channel(sc_card_t * card,
 
 	/* get challenge: retrieve 8 random bytes from card */
 	sc_log(ctx, "Step 8.4.1.11: Prepare External Auth: Get Challenge");
-	res = card->ops->get_challenge(card, sm->icc.rnd, sizeof(sm->icc.rnd));
+	res = sc_get_challenge(card, sm->icc.rnd, sizeof(sm->icc.rnd));
 	if (res != SC_SUCCESS) {
 		msg = "Get Challenge failed";
 		goto csc_end;

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -260,31 +260,6 @@ iasecc_sm_se_mutual_authentication(struct sc_card *card, unsigned se_num)
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
-
-
-static int
-iasecc_sm_get_challenge(struct sc_card *card, unsigned char *out, size_t len)
-{
-	struct sc_context *ctx = card->ctx;
-	struct sc_apdu apdu;
-	unsigned char rbuf[SC_MAX_APDU_BUFFER_SIZE];
-	int rv;
-
-	sc_log(ctx, "SM get challenge: length %"SC_FORMAT_LEN_SIZE_T"u", len);
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x84, 0, 0);
-	apdu.le = len;
-	apdu.resplen = len;
-	apdu.resp = rbuf;
-
-	rv = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(ctx, rv, "APDU transmit failed");
-	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	LOG_TEST_RET(ctx, rv, "Command failed");
-
-	memcpy(out, rbuf, apdu.resplen);
-
-	LOG_FUNC_RETURN(ctx, apdu.resplen);
-}
 #endif
 
 
@@ -309,7 +284,7 @@ iasecc_sm_initialize(struct sc_card *card, unsigned se_num, unsigned cmd)
 	rv = iasecc_sm_se_mutual_authentication(card, se_num);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_initialize() MUTUAL AUTHENTICATION failed");
 
-	rv = iasecc_sm_get_challenge(card, cwa_session->card_challenge, SM_SMALL_CHALLENGE_LEN);
+	rv = sc_get_challenge(card, cwa_session->card_challenge, SM_SMALL_CHALLENGE_LEN);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_initialize() GET CHALLENGE failed");
 
 	sc_remote_data_init(&rdata);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -621,12 +621,6 @@ iso7816_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 	int r;
 	struct sc_apdu apdu;
 
-	if (len == 0)
-		return SC_SUCCESS;
-
-	if (!rnd)
-		return SC_ERROR_INVALID_ARGUMENTS;
-
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0x84, 0x00, 0x00);
 	apdu.le = len;
 	apdu.resp = rnd;
@@ -635,14 +629,14 @@ iso7816_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 
-	if (apdu.resplen != len) {
-		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		if (r == SC_SUCCESS) {
-			r = SC_ERROR_WRONG_LENGTH;
-		}
-	}
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE failed");
 
-	return r;
+	if (len < apdu.resplen) {
+		return (int) len;
+	}
+   
+	return (int) apdu.resplen;
 }
 
 

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3665,7 +3665,7 @@ DWORD WINAPI CardGetChallenge(__in PCARD_DATA pCardData,
 	}
 
 	rv = sc_get_challenge(vs->p15card->card, *ppbChallengeData, 8);
-	if (rv)   {
+	if (rv < 0) {
 		logprintf(pCardData, 1, "Get challenge failed: %s\n", sc_strerror(rv));
 		pCardData->pfnCspFree(*ppbChallengeData);
 		*ppbChallengeData = NULL;

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1609,7 +1609,8 @@ static int do_random(int argc, char **argv)
 
 	count = atoi(argv[0]);
 	if (count < 0 || (size_t) count > sizeof buffer) {
-		printf("Number must be in range 0..256\n");
+		printf("Number must be in range 0..%"SC_FORMAT_LEN_SIZE_T"u\n",
+			   	sizeof buffer);
 		return -1;
 	}
 


### PR DESCRIPTION
Let sc_get_challenge() do sc_lock() and loop through the card driver's get_challenge() until enough bytes were collected. The card driver's get_challenge() now returns the number of bytes collected (less or equal than requested) or an error code.

- Allow more code re-use.
- PIV driver now uses ASN.1 parser for reading the random bytes
- SC-HSM now has a maximum for the challenge

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Tested with the following card: OpenPGP 3.3, SC-HSM 2.4, CardOS 4.3B
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
