### PR TITLE
EAC: Clearify naming of functions and data

### DIFF
--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -586,6 +586,10 @@ static int npa_standard_pin_cmd(struct sc_card *card,
 	return r;
 }
 
+#ifdef ENABLE_OPENSSL
+#include <openssl/evp/evp.h>
+#endif
+
 int
 npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 		int ask_for_secret, const char *new, size_t new_len)

--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -587,7 +587,7 @@ static int npa_standard_pin_cmd(struct sc_card *card,
 }
 
 #ifdef ENABLE_OPENSSL
-#include <openssl/evp/evp.h>
+#include <openssl/evp.h>
 #endif
 
 int

--- a/src/libopensc/card-npa.h
+++ b/src/libopensc/card-npa.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+#include "sm/sm-eac.h"
+
 const unsigned char esign_chat[] = {
 	0x7F, 0x4C, 0x0E,
 		0x06, 0x09, 0x04, 0x00, 0x7F, 0x00, 0x07, 0x03, 0x01, 0x02, 0x03,
@@ -32,6 +34,43 @@ const unsigned char esign_chat[] = {
 };
 
 const unsigned char df_esign_aid[]  = { 0xa0, 0x00, 0x00, 0x01, 0x67, 0x45, 0x53, 0x49, 0x47, 0x4e};
+
+/** 
+ * @brief Sends a reset retry counter APDU
+ *
+ * According to TR-03110 the reset retry counter APDU is used to set a new PIN
+ * or to reset the retry counter of the PIN. The standard requires this
+ * operation to be authorized either by an established PACE channel or by the
+ * effective authorization of the terminal's certificate.
+ * 
+ * @param[in] card
+ * @param[in] pin_id         Type of secret (usually PIN or CAN). You may use <tt>enum s_type</tt> from \c <openssl/pace.h>.
+ * @param[in] ask_for_secret whether to ask the user for the secret (\c 1) or not (\c 0)
+ * @param[in] new            (optional) new secret
+ * @param[in] new_len        (optional) length of \a new
+ * 
+ * @return \c SC_SUCCESS or error code if an error occurred
+ */
+int npa_reset_retry_counter(sc_card_t *card,
+		enum s_type pin_id, int ask_for_secret,
+		const char *new, size_t new_len);
+
+/** 
+ * @brief Send APDU to unblock the PIN
+ *
+ * @param[in] card
+ */
+#define npa_unblock_pin(card) \
+	npa_reset_retry_counter(card, PACE_PIN, 0, NULL, 0)
+/**
+ * @brief Send APDU to set a new PIN
+ *
+ * @param[in] card
+ * @param[in] newp           (optional) new PIN
+ * @param[in] newplen        (optional) length of \a new
+ */
+#define npa_change_pin(card, newp, newplen) \
+	npa_reset_retry_counter(card, PACE_PIN, 1, newp, newplen)
 
 #ifdef  __cplusplus
 }

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -350,14 +350,14 @@ _sc_card_add_ec_alg
 _sc_card_add_rsa_alg
 _sc_match_atr
 _sc_log
-npa_secret_name
+eac_secret_name
 get_pace_capabilities
 perform_pace
 perform_terminal_authentication
 perform_chip_authentication
-npa_default_flags
+eac_default_flags
+eac_pace_get_tries_left
 npa_reset_retry_counter
-npa_pace_get_tries_left
 escape_pace_input_to_buf
 escape_buf_to_pace_input
 escape_pace_output_to_buf

--- a/src/libopensc/reader-tr03119.c
+++ b/src/libopensc/reader-tr03119.c
@@ -1,7 +1,7 @@
 /*
  * reader-escape.c: implementation related to escape commands with pseudo APDUs
  *
- * Copyright (C) 2013-2015  Frank Morgner
+ * Copyright (C) 2013-2018  Frank Morgner
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -43,20 +43,31 @@
 #include <endian.h>
 #endif
 
-static const u8 escape_cla                          = 0xff;
-static const u8 escape_ins                          = 0x9a;
+int get_pace_capabilities(u8 *bitmap)
+{
+	if (!bitmap)
+		return SC_ERROR_INVALID_ARGUMENTS;
 
-static const u8 escape_p1_PIN                       = 0x04;
-static const u8 escape_p2_GetReaderPACECapabilities = 0x01;
-static const u8 escape_p2_EstablishPACEChannel      = 0x02;
-/*static const u8 escape_p2_DestroyPACEChannel        = 0x03;*/
-static const u8 escape_p2_PC_to_RDR_Secure          = 0x10;
+	/* BitMap */
+	*bitmap = EAC_BITMAP_PACE|EAC_BITMAP_EID|EAC_BITMAP_ESIGN;
 
-static const u8 escape_p1_IFD                       = 0x01;
-static const u8 escape_p2_vendor                    = 0x01;
-/*static const u8 escape_p2_product                   = 0x03;*/
-static const u8 escape_p2_version_firmware          = 0x06;
-/*static const u8 escape_p2_version_driver            = 0x07;*/
+	return SC_SUCCESS;
+}
+
+const u8 escape_cla                          = 0xff;
+const u8 escape_ins                          = 0x9a;
+
+const u8 escape_p1_PIN                       = 0x04;
+const u8 escape_p2_GetReaderPACECapabilities = 0x01;
+const u8 escape_p2_EstablishPACEChannel      = 0x02;
+/*const u8 escape_p2_DestroyPACEChannel        = 0x03;*/
+const u8 escape_p2_PC_to_RDR_Secure          = 0x10;
+
+const u8 escape_p1_IFD                       = 0x01;
+const u8 escape_p2_vendor                    = 0x01;
+/*const u8 escape_p2_product                   = 0x03;*/
+const u8 escape_p2_version_firmware          = 0x06;
+/*const u8 escape_p2_version_driver            = 0x07;*/
 
 struct sc_asn1_entry g_boolean[] = {
 	{ "boolean",
@@ -79,7 +90,7 @@ struct sc_asn1_entry g_numeric_string_as_octet_string[] = {
 	{ NULL , 0 , 0 , 0 , NULL , NULL }
 };
 
-static const struct sc_asn1_entry g_EstablishPACEChannelInput_data[] = {
+const struct sc_asn1_entry g_EstablishPACEChannelInput_data[] = {
 	{ "passwordID",
 		/* use an OCTET STRING to avoid a conversion to int */
 		SC_ASN1_STRUCT, SC_ASN1_CTX|0x01|SC_ASN1_CONS, 0, NULL, NULL },
@@ -94,7 +105,7 @@ static const struct sc_asn1_entry g_EstablishPACEChannelInput_data[] = {
 		SC_ASN1_STRUCT, SC_ASN1_CTX|0x05|SC_ASN1_CONS, SC_ASN1_OPTIONAL|SC_ASN1_ALLOC, NULL, NULL },
 	{ NULL , 0 , 0 , 0 , NULL , NULL }
 };
-static const struct sc_asn1_entry g_EstablishPACEChannelOutput_data[] = {
+const struct sc_asn1_entry g_EstablishPACEChannelOutput_data[] = {
 	{ "errorCode",
 		SC_ASN1_STRUCT, SC_ASN1_CTX|0x01|SC_ASN1_CONS, 0, NULL, NULL },
 	{ "statusMSESetAT",
@@ -109,7 +120,7 @@ static const struct sc_asn1_entry g_EstablishPACEChannelOutput_data[] = {
 		SC_ASN1_STRUCT, SC_ASN1_CTX|0x06|SC_ASN1_CONS, SC_ASN1_OPTIONAL|SC_ASN1_ALLOC, NULL, NULL },
 	{ NULL , 0 , 0 , 0 , NULL , NULL }
 };
-static const struct sc_asn1_entry g_EstablishPACEChannel[] = {
+const struct sc_asn1_entry g_EstablishPACEChannel[] = {
 	{ "EstablishPACEChannel",
 		SC_ASN1_STRUCT, SC_ASN1_TAG_SEQUENCE|SC_ASN1_CONS, 0, NULL, NULL },
 	{ NULL , 0 , 0 , 0 , NULL , NULL }

--- a/src/libopensc/reader-tr03119.h
+++ b/src/libopensc/reader-tr03119.h
@@ -1,7 +1,7 @@
 /*
  * reader-tr03119.h: interface related to escape commands with pseudo APDUs
  *
- * Copyright (C) 2013-2015  Frank Morgner
+ * Copyright (C) 2013-2018  Frank Morgner
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,60 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @brief NPA capabilities (TR-03119): PACE */
+#define EAC_BITMAP_PACE  0x40
+/** @brief NPA capabilities (TR-03119): EPA: eID */
+#define EAC_BITMAP_EID   0x20
+/** @brief NPA capabilities (TR-03119): EPA: eSign */
+#define EAC_BITMAP_ESIGN 0x10
+
+/** 
+ * @brief Get the PACE capabilities
+ * 
+ * @param[in,out] bitmap where to store capabilities bitmap
+ * @note Since this code offers no support for terminal certificate, the bitmap is always \c PACE_BITMAP_PACE|PACE_BITMAP_EID
+ * 
+ * @return \c SC_SUCCESS or error code if an error occurred
+ */
+int get_pace_capabilities(u8 *bitmap);
+
+/** @brief NPA result (TR-03119): Kein Fehler */
+#define EAC_SUCCESS                            0x00000000
+/** @brief NPA result (TR-03119): Längen im Input sind inkonsistent */
+#define EAC_ERROR_LENGTH_INCONSISTENT          0xD0000001
+/** @brief NPA result (TR-03119): Unerwartete Daten im Input */
+#define EAC_ERROR_UNEXPECTED_DATA              0xD0000002
+/** @brief NPA result (TR-03119): Unerwartete Kombination von Daten im Input */
+#define EAC_ERROR_UNEXPECTED_DATA_COMBINATION  0xD0000003
+/** @brief NPA result (TR-03119): Die Karte unterstützt das PACE – Verfahren nicht.  (Unerwartete Struktur in Antwortdaten der Karte) */
+#define EAC_ERROR_CARD_NOT_SUPPORTED           0xE0000001
+/** @brief NPA result (TR-03119): Der Kartenleser unterstützt den angeforderten bzw. den ermittelten Algorithmus nicht.  */
+#define EAC_ERROR_ALGORITH_NOT_SUPPORTED       0xE0000002
+/** @brief NPA result (TR-03119): Der Kartenleser kennt die PIN – ID nicht. */
+#define EAC_ERROR_PINID_NOT_SUPPORTED          0xE0000003
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf Select EF_CardAccess (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_SELECT_EF_CARDACCESS         0xF0000000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf Read Binary (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_READ_BINARY                  0xF0010000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf MSE: Set AT (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_MSE_SET_AT                   0xF0020000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 1 (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_GENERAL_AUTHENTICATE_1       0xF0030000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 2 (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_GENERAL_AUTHENTICATE_2       0xF0040000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 3 (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_GENERAL_AUTHENTICATE_3       0xF0050000
+/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 4 (needs to be OR-ed with SW1|SW2) */
+#define EAC_ERROR_GENERAL_AUTHENTICATE_4       0xF0060000
+/** @brief NPA result (TR-03119): Kommunikationsabbruch mit Karte. */
+#define EAC_ERROR_COMMUNICATION                0xF0100001
+/** @brief NPA result (TR-03119): Keine Karte im Feld. */
+#define EAC_ERROR_NO_CARD                      0xF0100002
+/** @brief NPA result (TR-03119): Benutzerabbruch. */
+#define EAC_ERROR_ABORTED                      0xF0200001
+/** @brief NPA result (TR-03119): Benutzer – Timeout */
+#define EAC_ERROR_TIMEOUT                      0xF0200002
 
 void sc_detect_escape_cmds(sc_reader_t *reader);
 

--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2015 Frank Morgner
+ * Copyright (C) 2011-2018 Frank Morgner
  *
  * This file is part of OpenSC.
  *
@@ -34,7 +34,7 @@
 #include <openssl/evp.h>
 #endif
 
-char npa_default_flags = 0;
+char eac_default_flags = 0;
 #define ISO_MSE 0x22
 
 #if defined(ENABLE_OPENPACE)
@@ -70,46 +70,46 @@ IMPLEMENT_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
  * MSE:Set AT
  */
 
-typedef struct npa_mse_cd_st {
+typedef struct {
 	ASN1_OBJECT *cryptographic_mechanism_reference;
 	ASN1_OCTET_STRING *key_reference1;
 	ASN1_OCTET_STRING *key_reference2;
 	ASN1_OCTET_STRING *eph_pub_key;
 	ASN1_AUXILIARY_DATA *auxiliary_data;
 	CVC_CHAT *chat;
-} NPA_MSE_C;
+} EAC_MSE_C;
 /* Note that we can not use ASN1_AUXILIARY_DATA for the auxiliary_data element
  * here. Due to limitations of OpenSSL it is not possible to *encode* an
  * optional item template (such as auxiliary_data) in an other item template
  * (such as ASN1_AUXILIARY_DATA). However, we can do
  *
- * NPA_MSE_C->auxiliary_data = d2i_ASN1_AUXILIARY_DATA(...)
+ * EAC_MSE_C->auxiliary_data = d2i_ASN1_AUXILIARY_DATA(...)
  *
  * because they both use the same underlying struct.
  *
  * See also openssl/crypto/asn1/tasn_dec.c:183
  */
-ASN1_SEQUENCE(NPA_MSE_C) = {
+ASN1_SEQUENCE(EAC_MSE_C) = {
 	/* 0x80
 	 * Cryptographic mechanism reference */
-	ASN1_IMP_OPT(NPA_MSE_C, cryptographic_mechanism_reference, ASN1_OBJECT, 0),
+	ASN1_IMP_OPT(EAC_MSE_C, cryptographic_mechanism_reference, ASN1_OBJECT, 0),
 	/* 0x83
 	 * Reference of a public key / secret key */
-	ASN1_IMP_OPT(NPA_MSE_C, key_reference1, ASN1_OCTET_STRING, 3),
+	ASN1_IMP_OPT(EAC_MSE_C, key_reference1, ASN1_OCTET_STRING, 3),
 	/* 0x84
 	 * Reference of a private key / Reference for computing a session key */
-	ASN1_IMP_OPT(NPA_MSE_C, key_reference2, ASN1_OCTET_STRING, 4),
+	ASN1_IMP_OPT(EAC_MSE_C, key_reference2, ASN1_OCTET_STRING, 4),
 	/* 0x91
 	 * Ephemeral Public Key */
-	ASN1_IMP_OPT(NPA_MSE_C, eph_pub_key, ASN1_OCTET_STRING, 0x11),
+	ASN1_IMP_OPT(EAC_MSE_C, eph_pub_key, ASN1_OCTET_STRING, 0x11),
 	/* 0x67
 	 * Auxiliary authenticated data. See note above. */
-	ASN1_APP_IMP_SEQUENCE_OF_OPT(NPA_MSE_C, auxiliary_data, CVC_DISCRETIONARY_DATA_TEMPLATE, 7),
+	ASN1_APP_IMP_SEQUENCE_OF_OPT(EAC_MSE_C, auxiliary_data, CVC_DISCRETIONARY_DATA_TEMPLATE, 7),
 	/* Certificate Holder Authorization Template */
-	ASN1_OPT(NPA_MSE_C, chat, CVC_CHAT),
-} ASN1_SEQUENCE_END(NPA_MSE_C)
-DECLARE_ASN1_FUNCTIONS(NPA_MSE_C)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_MSE_C)
+	ASN1_OPT(EAC_MSE_C, chat, CVC_CHAT),
+} ASN1_SEQUENCE_END(EAC_MSE_C)
+DECLARE_ASN1_FUNCTIONS(EAC_MSE_C)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_MSE_C)
 
 
 /*
@@ -117,78 +117,78 @@ IMPLEMENT_ASN1_FUNCTIONS(NPA_MSE_C)
  */
 
 /* Protocol Command Data */
-typedef struct npa_gen_auth_pace_cd_st {
+typedef struct {
 	ASN1_OCTET_STRING *mapping_data;
 	ASN1_OCTET_STRING *eph_pub_key;
 	ASN1_OCTET_STRING *auth_token;
-} NPA_GEN_AUTH_PACE_C_BODY;
-ASN1_SEQUENCE(NPA_GEN_AUTH_PACE_C_BODY) = {
+} EAC_GEN_AUTH_PACE_C_BODY;
+ASN1_SEQUENCE(EAC_GEN_AUTH_PACE_C_BODY) = {
 	/* 0x81
 	 * Mapping Data */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_C_BODY, mapping_data, ASN1_OCTET_STRING, 1),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_C_BODY, mapping_data, ASN1_OCTET_STRING, 1),
 	/* 0x83
 	 * Ephemeral Public Key */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_C_BODY, eph_pub_key, ASN1_OCTET_STRING, 3),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_C_BODY, eph_pub_key, ASN1_OCTET_STRING, 3),
 	/* 0x85
 	 * Authentication Token */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_C_BODY, auth_token, ASN1_OCTET_STRING, 5),
-} ASN1_SEQUENCE_END(NPA_GEN_AUTH_PACE_C_BODY)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_C_BODY)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_C_BODY)
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_C_BODY, auth_token, ASN1_OCTET_STRING, 5),
+} ASN1_SEQUENCE_END(EAC_GEN_AUTH_PACE_C_BODY)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_C_BODY)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_C_BODY)
 
-typedef NPA_GEN_AUTH_PACE_C_BODY NPA_GEN_AUTH_PACE_C;
+typedef EAC_GEN_AUTH_PACE_C_BODY EAC_GEN_AUTH_PACE_C;
 /* 0x7C
  * Dynamic Authentication Data */
-ASN1_ITEM_TEMPLATE(NPA_GEN_AUTH_PACE_C) =
+ASN1_ITEM_TEMPLATE(EAC_GEN_AUTH_PACE_C) =
 	ASN1_EX_TEMPLATE_TYPE(
 			ASN1_TFLG_IMPTAG|ASN1_TFLG_APPLICATION,
-			0x1c, NPA_GEN_AUTH_PACE_C, NPA_GEN_AUTH_PACE_C_BODY)
-ASN1_ITEM_TEMPLATE_END(NPA_GEN_AUTH_PACE_C)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_C)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_C)
+			0x1c, EAC_GEN_AUTH_PACE_C, EAC_GEN_AUTH_PACE_C_BODY)
+ASN1_ITEM_TEMPLATE_END(EAC_GEN_AUTH_PACE_C)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_C)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_C)
 
 /* Protocol Response Data */
-typedef struct npa_gen_auth_pace_rapdu_body_st {
+typedef struct {
 	ASN1_OCTET_STRING *enc_nonce;
 	ASN1_OCTET_STRING *mapping_data;
 	ASN1_OCTET_STRING *eph_pub_key;
 	ASN1_OCTET_STRING *auth_token;
 	ASN1_OCTET_STRING *cur_car;
 	ASN1_OCTET_STRING *prev_car;
-} NPA_GEN_AUTH_PACE_R_BODY;
-ASN1_SEQUENCE(NPA_GEN_AUTH_PACE_R_BODY) = {
+} EAC_GEN_AUTH_PACE_R_BODY;
+ASN1_SEQUENCE(EAC_GEN_AUTH_PACE_R_BODY) = {
 	/* 0x80
 	 * Encrypted Nonce */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, enc_nonce, ASN1_OCTET_STRING, 0),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, enc_nonce, ASN1_OCTET_STRING, 0),
 	/* 0x82
 	 * Mapping Data */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, mapping_data, ASN1_OCTET_STRING, 2),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, mapping_data, ASN1_OCTET_STRING, 2),
 	/* 0x84
 	 * Ephemeral Public Key */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, eph_pub_key, ASN1_OCTET_STRING, 4),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, eph_pub_key, ASN1_OCTET_STRING, 4),
 	/* 0x86
 	 * Authentication Token */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, auth_token, ASN1_OCTET_STRING, 6),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, auth_token, ASN1_OCTET_STRING, 6),
 	/* 0x87
 	 * Most recent Certification Authority Reference */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, cur_car, ASN1_OCTET_STRING, 7),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, cur_car, ASN1_OCTET_STRING, 7),
 	/* 0x88
 	 * Previous Certification Authority Reference */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_PACE_R_BODY, prev_car, ASN1_OCTET_STRING, 8),
-} ASN1_SEQUENCE_END(NPA_GEN_AUTH_PACE_R_BODY)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_R_BODY)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_R_BODY)
+	ASN1_IMP_OPT(EAC_GEN_AUTH_PACE_R_BODY, prev_car, ASN1_OCTET_STRING, 8),
+} ASN1_SEQUENCE_END(EAC_GEN_AUTH_PACE_R_BODY)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_R_BODY)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_R_BODY)
 
-typedef NPA_GEN_AUTH_PACE_R_BODY NPA_GEN_AUTH_PACE_R;
+typedef EAC_GEN_AUTH_PACE_R_BODY EAC_GEN_AUTH_PACE_R;
 /* 0x7C
  * Dynamic Authentication Data */
-ASN1_ITEM_TEMPLATE(NPA_GEN_AUTH_PACE_R) =
+ASN1_ITEM_TEMPLATE(EAC_GEN_AUTH_PACE_R) =
 	ASN1_EX_TEMPLATE_TYPE(
 			ASN1_TFLG_IMPTAG|ASN1_TFLG_APPLICATION,
-			0x1c, NPA_GEN_AUTH_PACE_R, NPA_GEN_AUTH_PACE_R_BODY)
-ASN1_ITEM_TEMPLATE_END(NPA_GEN_AUTH_PACE_R)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_R)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_R)
+			0x1c, EAC_GEN_AUTH_PACE_R, EAC_GEN_AUTH_PACE_R_BODY)
+ASN1_ITEM_TEMPLATE_END(EAC_GEN_AUTH_PACE_R)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_R)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_PACE_R)
 
 
 /*
@@ -196,61 +196,61 @@ IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_PACE_R)
  */
 
 /* Protocol Command Data */
-typedef struct npa_gen_auth_ca_cd_st {
+typedef struct eac_gen_auth_ca_cd_st {
 	ASN1_OCTET_STRING *eph_pub_key;
-} NPA_GEN_AUTH_CA_C_BODY;
-ASN1_SEQUENCE(NPA_GEN_AUTH_CA_C_BODY) = {
+} EAC_GEN_AUTH_CA_C_BODY;
+ASN1_SEQUENCE(EAC_GEN_AUTH_CA_C_BODY) = {
 	/* 0x80
 	 * Ephemeral Public Key */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_CA_C_BODY, eph_pub_key, ASN1_OCTET_STRING, 0),
-} ASN1_SEQUENCE_END(NPA_GEN_AUTH_CA_C_BODY)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_C_BODY)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_C_BODY)
+	ASN1_IMP_OPT(EAC_GEN_AUTH_CA_C_BODY, eph_pub_key, ASN1_OCTET_STRING, 0),
+} ASN1_SEQUENCE_END(EAC_GEN_AUTH_CA_C_BODY)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_C_BODY)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_C_BODY)
 
-typedef NPA_GEN_AUTH_CA_C_BODY NPA_GEN_AUTH_CA_C;
+typedef EAC_GEN_AUTH_CA_C_BODY EAC_GEN_AUTH_CA_C;
 /* 0x7C
  * Dynamic Authentication Data */
-ASN1_ITEM_TEMPLATE(NPA_GEN_AUTH_CA_C) =
+ASN1_ITEM_TEMPLATE(EAC_GEN_AUTH_CA_C) =
 	ASN1_EX_TEMPLATE_TYPE(
 			ASN1_TFLG_IMPTAG|ASN1_TFLG_APPLICATION,
-			0x1c, NPA_GEN_AUTH_CA_C, NPA_GEN_AUTH_CA_C_BODY)
-ASN1_ITEM_TEMPLATE_END(NPA_GEN_AUTH_CA_C)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_C)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_C)
+			0x1c, EAC_GEN_AUTH_CA_C, EAC_GEN_AUTH_CA_C_BODY)
+ASN1_ITEM_TEMPLATE_END(EAC_GEN_AUTH_CA_C)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_C)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_C)
 
 /* Protocol Response Data */
-typedef struct npa_gen_auth_ca_rapdu_body_st {
+typedef struct eac_gen_auth_ca_rapdu_body_st {
 	ASN1_OCTET_STRING *nonce;
 	ASN1_OCTET_STRING *auth_token;
-} NPA_GEN_AUTH_CA_R_BODY;
-ASN1_SEQUENCE(NPA_GEN_AUTH_CA_R_BODY) = {
+} EAC_GEN_AUTH_CA_R_BODY;
+ASN1_SEQUENCE(EAC_GEN_AUTH_CA_R_BODY) = {
 	/* 0x81
 	 * Nonce */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_CA_R_BODY, nonce, ASN1_OCTET_STRING, 1),
+	ASN1_IMP_OPT(EAC_GEN_AUTH_CA_R_BODY, nonce, ASN1_OCTET_STRING, 1),
 	/* 0x82
 	 * Authentication Token */
-	ASN1_IMP_OPT(NPA_GEN_AUTH_CA_R_BODY, auth_token, ASN1_OCTET_STRING, 2),
-} ASN1_SEQUENCE_END(NPA_GEN_AUTH_CA_R_BODY)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_R_BODY)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_R_BODY)
+	ASN1_IMP_OPT(EAC_GEN_AUTH_CA_R_BODY, auth_token, ASN1_OCTET_STRING, 2),
+} ASN1_SEQUENCE_END(EAC_GEN_AUTH_CA_R_BODY)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_R_BODY)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_R_BODY)
 
-typedef NPA_GEN_AUTH_CA_R_BODY NPA_GEN_AUTH_CA_R;
+typedef EAC_GEN_AUTH_CA_R_BODY EAC_GEN_AUTH_CA_R;
 /* 0x7C
  * Dynamic Authentication Data */
-ASN1_ITEM_TEMPLATE(NPA_GEN_AUTH_CA_R) =
+ASN1_ITEM_TEMPLATE(EAC_GEN_AUTH_CA_R) =
 	ASN1_EX_TEMPLATE_TYPE(
 			ASN1_TFLG_IMPTAG|ASN1_TFLG_APPLICATION,
-			0x1c, NPA_GEN_AUTH_CA_R, NPA_GEN_AUTH_CA_R_BODY)
-ASN1_ITEM_TEMPLATE_END(NPA_GEN_AUTH_CA_R)
-DECLARE_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_R)
-IMPLEMENT_ASN1_FUNCTIONS(NPA_GEN_AUTH_CA_R)
+			0x1c, EAC_GEN_AUTH_CA_R, EAC_GEN_AUTH_CA_R_BODY)
+ASN1_ITEM_TEMPLATE_END(EAC_GEN_AUTH_CA_R)
+DECLARE_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_R)
+IMPLEMENT_ASN1_FUNCTIONS(EAC_GEN_AUTH_CA_R)
 
 
 
 #define maxresp SC_MAX_APDU_BUFFER_SIZE - 2
 
 /** @brief NPA secure messaging context */
-struct npa_sm_ctx {
+struct eac_sm_ctx {
 	/** @brief EAC context */
 	EAC_CTX *ctx;
 	/** @brief Certificate Description given on initialization of PACE */
@@ -270,32 +270,32 @@ extern BUF_MEM *BUF_MEM_create(size_t len);
 extern BUF_MEM *BUF_MEM_create_init(const void *buf, size_t len);
 
 
-static int npa_sm_encrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_encrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *data, size_t datalen, u8 **enc);
-static int npa_sm_decrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_decrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *enc, size_t enclen, u8 **data);
-static int npa_sm_authenticate(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_authenticate(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *data, size_t datalen, u8 **outdata);
-static int npa_sm_verify_authentication(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_verify_authentication(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *mac, size_t maclen,
 		const u8 *macdata, size_t macdatalen);
-static int npa_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *apdu);
-static int npa_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *sm_apdu);
-static int npa_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
+static int eac_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *apdu);
-static void npa_sm_clear_free(const struct iso_sm_ctx *ctx);
+static void eac_sm_clear_free(const struct iso_sm_ctx *ctx);
 
 
 
 
-static struct npa_sm_ctx *
-npa_sm_ctx_create(EAC_CTX *ctx, const unsigned char *certificate_description,
+static struct eac_sm_ctx *
+eac_sm_ctx_create(EAC_CTX *ctx, const unsigned char *certificate_description,
 		size_t certificate_description_length,
 		const unsigned char *id_icc, size_t id_icc_length)
 {
-	struct npa_sm_ctx *out = malloc(sizeof *out);
+	struct eac_sm_ctx *out = malloc(sizeof *out);
 	if (!out)
 		goto err;
 
@@ -320,10 +320,10 @@ npa_sm_ctx_create(EAC_CTX *ctx, const unsigned char *certificate_description,
 	out->eph_pub_key = NULL;
 	out->auxiliary_data = NULL;
 
-	out->flags = npa_default_flags;
-	if (out->flags & NPA_FLAG_DISABLE_CHECK_TA)
+	out->flags = eac_default_flags;
+	if (out->flags & EAC_FLAG_DISABLE_CHECK_TA)
 		TA_disable_checks(out->ctx);
-	if (out->flags & NPA_FLAG_DISABLE_CHECK_CA)
+	if (out->flags & EAC_FLAG_DISABLE_CHECK_CA)
 		CA_disable_passive_authentication(out->ctx);
 
 	return out;
@@ -334,7 +334,7 @@ err:
 }
 
 static int
-npa_sm_start(sc_card_t *card, EAC_CTX *eac_ctx,
+eac_sm_start(sc_card_t *card, EAC_CTX *eac_ctx,
 		const unsigned char *certificate_description,
 		size_t certificate_description_length,
 		const unsigned char *id_icc, size_t id_icc_length)
@@ -353,7 +353,7 @@ npa_sm_start(sc_card_t *card, EAC_CTX *eac_ctx,
 		goto err;
 	}
 
-	sctx->priv_data = npa_sm_ctx_create(eac_ctx,
+	sctx->priv_data = eac_sm_ctx_create(eac_ctx,
 			certificate_description, certificate_description_length,
 			id_icc, id_icc_length);
 	if (!sctx->priv_data) {
@@ -361,14 +361,14 @@ npa_sm_start(sc_card_t *card, EAC_CTX *eac_ctx,
 		goto err;
 	}
 
-	sctx->authenticate = npa_sm_authenticate;
-	sctx->encrypt = npa_sm_encrypt;
-	sctx->decrypt = npa_sm_decrypt;
-	sctx->verify_authentication = npa_sm_verify_authentication;
-	sctx->pre_transmit = npa_sm_pre_transmit;
-	sctx->post_transmit = npa_sm_post_transmit;
-	sctx->finish = npa_sm_finish;
-	sctx->clear_free = npa_sm_clear_free;
+	sctx->authenticate = eac_sm_authenticate;
+	sctx->encrypt = eac_sm_encrypt;
+	sctx->decrypt = eac_sm_decrypt;
+	sctx->verify_authentication = eac_sm_verify_authentication;
+	sctx->pre_transmit = eac_sm_pre_transmit;
+	sctx->post_transmit = eac_sm_post_transmit;
+	sctx->finish = eac_sm_finish;
+	sctx->clear_free = eac_sm_clear_free;
 	sctx->padding_indicator = SM_ISO_PADDING;
 	sctx->block_length = EVP_CIPHER_block_size(eac_ctx->key_ctx->cipher);
 
@@ -394,7 +394,7 @@ static int format_mse_cdata(struct sc_context *ctx, int protocol,
 		const unsigned char *auxiliary_data, size_t auxiliary_data_len,
 		const CVC_CHAT *chat, unsigned char **cdata)
 {
-	NPA_MSE_C *data = NULL;
+	EAC_MSE_C *data = NULL;
 	unsigned char *data_sequence = NULL;
 	const unsigned char *data_no_sequence;
 	unsigned char *p;
@@ -406,7 +406,7 @@ static int format_mse_cdata(struct sc_context *ctx, int protocol,
 		goto err;
 	}
 
-	data = NPA_MSE_C_new();
+	data = EAC_MSE_C_new();
 	if (!data) {
 		ssl_error(ctx);
 		r = SC_ERROR_INTERNAL;
@@ -467,7 +467,7 @@ static int format_mse_cdata(struct sc_context *ctx, int protocol,
 	data->chat = (CVC_CHAT *) chat;
 
 
-	length = i2d_NPA_MSE_C(data, &data_sequence);
+	length = i2d_EAC_MSE_C(data, &data_sequence);
 	data_no_sequence = data_sequence;
 	if (length < 0
 			|| (0x80 & ASN1_get_object(&data_no_sequence, &length, &tag, &class, length))) {
@@ -496,14 +496,14 @@ err:
 	if (data) {
 		/* do not free the functions parameter chat */
 		data->chat = NULL;
-		NPA_MSE_C_free(data);
+		EAC_MSE_C_free(data);
 	}
 	OPENSSL_free(data_sequence);
 
 	return r;
 }
 
-static int npa_mse(sc_card_t *card,
+static int eac_mse(sc_card_t *card,
 		unsigned char p1, unsigned char p2, int protocol,
 		const unsigned char *key_reference1, size_t key_reference1_len,
 		const unsigned char *key_reference2, size_t key_reference2_len,
@@ -555,26 +555,26 @@ err:
 	return r;
 }
 
-static int npa_mse_set_at(sc_card_t *card, unsigned char p1, int protocol,
+static int eac_mse_set_at(sc_card_t *card, unsigned char p1, int protocol,
 		const unsigned char *key_reference1, size_t key_reference1_len,
 		const unsigned char *key_reference2, size_t key_reference2_len,
 		const unsigned char *eph_pub_key, size_t eph_pub_key_len,
 		const unsigned char *auxiliary_data, size_t auxiliary_data_len,
 		const CVC_CHAT *chat, u8 *sw1, u8 *sw2)
 {
-	return npa_mse(card, p1, 0xA4, protocol, key_reference1,
+	return eac_mse(card, p1, 0xA4, protocol, key_reference1,
 			key_reference1_len, key_reference2, key_reference2_len,
 			eph_pub_key, eph_pub_key_len, auxiliary_data, auxiliary_data_len,
 			chat, sw1, sw2);
 }
 
-static int npa_mse_set_at_pace(sc_card_t *card, int protocol,
+static int eac_mse_set_at_pace(sc_card_t *card, int protocol,
 		enum s_type secret_key, const CVC_CHAT *chat, u8 *sw1, u8 *sw2)
 {
 	int r, tries;
 	unsigned char key = secret_key;
    
-	r = npa_mse_set_at(card, 0xC1, protocol, &key, sizeof key, NULL,
+	r = eac_mse_set_at(card, 0xC1, protocol, &key, sizeof key, NULL,
 			0, NULL, 0, NULL, 0, chat, sw1, sw2);
 	if (0 > r)
 		goto err;
@@ -585,7 +585,7 @@ static int npa_mse_set_at_pace(sc_card_t *card, int protocol,
 			if (tries <= 1) {
 				/* this is only a warning... */
 				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Remaining tries: %d (%s must be %s)\n",
-						tries, npa_secret_name(secret_key),
+						tries, eac_secret_name(secret_key),
 						tries ? "resumed" : "unblocked");
 			}
 			r = SC_SUCCESS;
@@ -608,12 +608,12 @@ err:
 
 #define ISO_GENERAL_AUTHENTICATE 0x86
 #define ISO_COMMAND_CHAINING 0x10
-static int npa_gen_auth_1_encrypted_nonce(sc_card_t *card,
+static int eac_gen_auth_1_encrypted_nonce(sc_card_t *card,
 		u8 **enc_nonce, size_t *enc_nonce_len)
 {
 	sc_apdu_t apdu;
-	NPA_GEN_AUTH_PACE_C *c_data = NULL;
-	NPA_GEN_AUTH_PACE_R *r_data = NULL;
+	EAC_GEN_AUTH_PACE_C *c_data = NULL;
+	EAC_GEN_AUTH_PACE_R *r_data = NULL;
 	unsigned char *d = NULL, *p;
 	int r, l;
 	unsigned char resp[maxresp];
@@ -622,12 +622,12 @@ static int npa_gen_auth_1_encrypted_nonce(sc_card_t *card,
 			0x00, 0x00);
 	apdu.cla = ISO_COMMAND_CHAINING;
 
-	c_data = NPA_GEN_AUTH_PACE_C_new();
+	c_data = EAC_GEN_AUTH_PACE_C_new();
 	if (!c_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
 	}
-	r = i2d_NPA_GEN_AUTH_PACE_C(c_data, &d);
+	r = i2d_EAC_GEN_AUTH_PACE_C(c_data, &d);
 	if (r < 0) {
 		ssl_error(card->ctx);
 		r = SC_ERROR_INTERNAL;
@@ -651,7 +651,7 @@ static int npa_gen_auth_1_encrypted_nonce(sc_card_t *card,
 
 	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "General authenticate (Encrypted Nonce) response data", apdu.resp, apdu.resplen);
 
-	if (!d2i_NPA_GEN_AUTH_PACE_R(&r_data,
+	if (!d2i_EAC_GEN_AUTH_PACE_R(&r_data,
 				(const unsigned char **) &apdu.resp, apdu.resplen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse general authenticate response data.");
 		ssl_error(card->ctx);
@@ -684,20 +684,20 @@ static int npa_gen_auth_1_encrypted_nonce(sc_card_t *card,
 
 err:
 	if (c_data)
-		NPA_GEN_AUTH_PACE_C_free(c_data);
+		EAC_GEN_AUTH_PACE_C_free(c_data);
 	OPENSSL_free(d);
 	if (r_data)
-		NPA_GEN_AUTH_PACE_R_free(r_data);
+		EAC_GEN_AUTH_PACE_R_free(r_data);
 
 	return r;
 }
-static int npa_gen_auth_2_map_nonce(sc_card_t *card,
+static int eac_gen_auth_2_map_nonce(sc_card_t *card,
 		const u8 *in, size_t in_len,
 		u8 **map_data_out, size_t *map_data_out_len)
 {
 	sc_apdu_t apdu;
-	NPA_GEN_AUTH_PACE_C *c_data = NULL;
-	NPA_GEN_AUTH_PACE_R *r_data = NULL;
+	EAC_GEN_AUTH_PACE_C *c_data = NULL;
+	EAC_GEN_AUTH_PACE_R *r_data = NULL;
 	unsigned char *d = NULL, *p;
 	int r, l;
 	unsigned char resp[maxresp];
@@ -706,7 +706,7 @@ static int npa_gen_auth_2_map_nonce(sc_card_t *card,
 			0x00, 0x00);
 	apdu.cla = ISO_COMMAND_CHAINING;
 
-	c_data = NPA_GEN_AUTH_PACE_C_new();
+	c_data = EAC_GEN_AUTH_PACE_C_new();
 	if (!c_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
@@ -719,7 +719,7 @@ static int npa_gen_auth_2_map_nonce(sc_card_t *card,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = i2d_NPA_GEN_AUTH_PACE_C(c_data, &d);
+	r = i2d_EAC_GEN_AUTH_PACE_C(c_data, &d);
 	if (r < 0) {
 		ssl_error(card->ctx);
 		r = SC_ERROR_INTERNAL;
@@ -743,7 +743,7 @@ static int npa_gen_auth_2_map_nonce(sc_card_t *card,
 
 	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "General authenticate (Map Nonce) response data", apdu.resp, apdu.resplen);
 
-	if (!d2i_NPA_GEN_AUTH_PACE_R(&r_data,
+	if (!d2i_EAC_GEN_AUTH_PACE_R(&r_data,
 				(const unsigned char **) &apdu.resp, apdu.resplen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse general authenticate response data.");
 		ssl_error(card->ctx);
@@ -776,20 +776,20 @@ static int npa_gen_auth_2_map_nonce(sc_card_t *card,
 
 err:
 	if (c_data)
-		NPA_GEN_AUTH_PACE_C_free(c_data);
+		EAC_GEN_AUTH_PACE_C_free(c_data);
 	OPENSSL_free(d);
 	if (r_data)
-		NPA_GEN_AUTH_PACE_R_free(r_data);
+		EAC_GEN_AUTH_PACE_R_free(r_data);
 
 	return r;
 }
-static int npa_gen_auth_3_perform_key_agreement(sc_card_t *card,
+static int eac_gen_auth_3_perform_key_agreement(sc_card_t *card,
 		const u8 *in, size_t in_len,
 		u8 **eph_pub_key_out, size_t *eph_pub_key_out_len)
 {
 	sc_apdu_t apdu;
-	NPA_GEN_AUTH_PACE_C *c_data = NULL;
-	NPA_GEN_AUTH_PACE_R *r_data = NULL;
+	EAC_GEN_AUTH_PACE_C *c_data = NULL;
+	EAC_GEN_AUTH_PACE_R *r_data = NULL;
 	unsigned char *d = NULL, *p;
 	int r, l;
 	unsigned char resp[maxresp];
@@ -798,7 +798,7 @@ static int npa_gen_auth_3_perform_key_agreement(sc_card_t *card,
 			0x00, 0x00);
 	apdu.cla = ISO_COMMAND_CHAINING;
 
-	c_data = NPA_GEN_AUTH_PACE_C_new();
+	c_data = EAC_GEN_AUTH_PACE_C_new();
 	if (!c_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
@@ -811,7 +811,7 @@ static int npa_gen_auth_3_perform_key_agreement(sc_card_t *card,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = i2d_NPA_GEN_AUTH_PACE_C(c_data, &d);
+	r = i2d_EAC_GEN_AUTH_PACE_C(c_data, &d);
 	if (r < 0) {
 		ssl_error(card->ctx);
 		r = SC_ERROR_INTERNAL;
@@ -835,7 +835,7 @@ static int npa_gen_auth_3_perform_key_agreement(sc_card_t *card,
 
 	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "General authenticate (Perform Key Agreement) response data", apdu.resp, apdu.resplen);
 
-	if (!d2i_NPA_GEN_AUTH_PACE_R(&r_data,
+	if (!d2i_EAC_GEN_AUTH_PACE_R(&r_data,
 				(const unsigned char **) &apdu.resp, apdu.resplen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse general authenticate response data.");
 		ssl_error(card->ctx);
@@ -868,22 +868,22 @@ static int npa_gen_auth_3_perform_key_agreement(sc_card_t *card,
 
 err:
 	if (c_data)
-		NPA_GEN_AUTH_PACE_C_free(c_data);
+		EAC_GEN_AUTH_PACE_C_free(c_data);
 	OPENSSL_free(d);
 	if (r_data)
-		NPA_GEN_AUTH_PACE_R_free(r_data);
+		EAC_GEN_AUTH_PACE_R_free(r_data);
 
 	return r;
 }
-static int npa_gen_auth_4_mutual_authentication(sc_card_t *card,
+static int eac_gen_auth_4_mutual_authentication(sc_card_t *card,
 		const u8 *in, size_t in_len,
 		u8 **auth_token_out, size_t *auth_token_out_len,
 		u8 **recent_car, size_t *recent_car_len,
 		u8 **prev_car, size_t *prev_car_len)
 {
 	sc_apdu_t apdu;
-	NPA_GEN_AUTH_PACE_C *c_data = NULL;
-	NPA_GEN_AUTH_PACE_R *r_data = NULL;
+	EAC_GEN_AUTH_PACE_C *c_data = NULL;
+	EAC_GEN_AUTH_PACE_R *r_data = NULL;
 	unsigned char *d = NULL, *p;
 	int r, l;
 	unsigned char resp[maxresp];
@@ -891,7 +891,7 @@ static int npa_gen_auth_4_mutual_authentication(sc_card_t *card,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, ISO_GENERAL_AUTHENTICATE,
 			0x00, 0x00);
 
-	c_data = NPA_GEN_AUTH_PACE_C_new();
+	c_data = EAC_GEN_AUTH_PACE_C_new();
 	if (!c_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
@@ -904,7 +904,7 @@ static int npa_gen_auth_4_mutual_authentication(sc_card_t *card,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = i2d_NPA_GEN_AUTH_PACE_C(c_data, &d);
+	r = i2d_EAC_GEN_AUTH_PACE_C(c_data, &d);
 	if (r < 0) {
 		ssl_error(card->ctx);
 		r = SC_ERROR_INTERNAL;
@@ -928,7 +928,7 @@ static int npa_gen_auth_4_mutual_authentication(sc_card_t *card,
 
 	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "General authenticate (Perform Key Agreement) response data", apdu.resp, apdu.resplen);
 
-	if (!d2i_NPA_GEN_AUTH_PACE_R(&r_data,
+	if (!d2i_EAC_GEN_AUTH_PACE_R(&r_data,
 				(const unsigned char **) &apdu.resp, apdu.resplen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse general authenticate response data.");
 		ssl_error(card->ctx);
@@ -985,10 +985,10 @@ static int npa_gen_auth_4_mutual_authentication(sc_card_t *card,
 
 err:
 	if (c_data)
-		NPA_GEN_AUTH_PACE_C_free(c_data);
+		EAC_GEN_AUTH_PACE_C_free(c_data);
 	OPENSSL_free(d);
 	if (r_data)
-		NPA_GEN_AUTH_PACE_R_free(r_data);
+		EAC_GEN_AUTH_PACE_R_free(r_data);
 
 	return r;
 }
@@ -999,27 +999,27 @@ get_psec(sc_card_t *card, const char *pin, size_t length_pin, enum s_type pin_id
 	char *p = NULL;
 	PACE_SEC *r;
 	/* Flawfinder: ignore */
-	char buf[MAX_MRZ_LEN > 32 ? MAX_MRZ_LEN : 32];
+	char buf[EAC_MAX_MRZ_LEN > 32 ? EAC_MAX_MRZ_LEN : 32];
 
 	if (!length_pin || !pin) {
 		if (0 > snprintf(buf, sizeof buf, "Please enter your %s: ",
-					npa_secret_name(pin_id))) {
+					eac_secret_name(pin_id))) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not create password prompt.\n");
 			return NULL;
 		}
-		p = malloc(MAX_MRZ_LEN+1);
+		p = malloc(EAC_MAX_MRZ_LEN+1);
 		if (!p) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Not enough memory for %s.\n",
-					npa_secret_name(pin_id));
+					eac_secret_name(pin_id));
 			return NULL;
 		}
-		if (0 > EVP_read_pw_string_min(p, 0, MAX_MRZ_LEN, buf, 0)) {
+		if (0 > EVP_read_pw_string_min(p, 0, EAC_MAX_MRZ_LEN, buf, 0)) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not read %s.\n",
-					npa_secret_name(pin_id));
+					eac_secret_name(pin_id));
 			return NULL;
 		}
 		length_pin = strlen(p);
-		if (length_pin > MAX_MRZ_LEN) {
+		if (length_pin > EAC_MAX_MRZ_LEN) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "MRZ too long");
 			return NULL;
 		}
@@ -1181,7 +1181,7 @@ int perform_pace(sc_card_t *card,
 
 		eac_ctx->tr_version = tr_version;
 
-		r = npa_mse_set_at_pace(card, eac_ctx->pace_ctx->protocol,
+		r = eac_mse_set_at_pace(card, eac_ctx->pace_ctx->protocol,
 				pace_input.pin_id, chat, &pace_output->mse_set_at_sw1,
 				&pace_output->mse_set_at_sw2);
 		if (r < 0) {
@@ -1196,7 +1196,7 @@ int perform_pace(sc_card_t *card,
 			r = SC_ERROR_OUT_OF_MEMORY;
 			goto err;
 		}
-		r = npa_gen_auth_1_encrypted_nonce(card, (u8 **) &enc_nonce->data,
+		r = eac_gen_auth_1_encrypted_nonce(card, (u8 **) &enc_nonce->data,
 				&enc_nonce->length);
 		if (r < 0) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not get encrypted nonce from card "
@@ -1230,7 +1230,7 @@ int perform_pace(sc_card_t *card,
 			r = SC_ERROR_INTERNAL;
 			goto err;
 		}
-		r = npa_gen_auth_2_map_nonce(card, (u8 *) mdata->data, mdata->length,
+		r = eac_gen_auth_2_map_nonce(card, (u8 *) mdata->data, mdata->length,
 				(u8 **) &mdata_opp->data, &mdata_opp->length);
 		if (r < 0) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not exchange mapping data with card "
@@ -1256,7 +1256,7 @@ int perform_pace(sc_card_t *card,
 			r = SC_ERROR_INTERNAL;
 			goto err;
 		}
-		r = npa_gen_auth_3_perform_key_agreement(card, (u8 *) pub->data, pub->length,
+		r = eac_gen_auth_3_perform_key_agreement(card, (u8 *) pub->data, pub->length,
 				(u8 **) &pub_opp->data, &pub_opp->length);
 		if (r < 0) {
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not exchange ephemeral public key with card "
@@ -1283,7 +1283,7 @@ int perform_pace(sc_card_t *card,
 			r = SC_ERROR_INTERNAL;
 			goto err;
 		}
-		r = npa_gen_auth_4_mutual_authentication(card, (u8 *) token->data, token->length,
+		r = eac_gen_auth_4_mutual_authentication(card, (u8 *) token->data, token->length,
 				(u8 **) &token_opp->data, &token_opp->length,
 				&pace_output->recent_car, &pace_output->recent_car_length,
 				&pace_output->previous_car, &pace_output->previous_car_length);
@@ -1344,7 +1344,7 @@ int perform_pace(sc_card_t *card,
 		sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "ID PCD", pace_output->id_pcd,
 				pace_output->id_pcd_length);
 
-		r = npa_sm_start(card, eac_ctx, pace_input.certificate_description,
+		r = eac_sm_start(card, eac_ctx, pace_input.certificate_description,
 				pace_input.certificate_description_length, pace_output->id_icc,
 				pace_output->id_icc_length);
 	}
@@ -1382,24 +1382,24 @@ err:
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
 }
 
-static int npa_mse_set_at_ta(sc_card_t *card, int protocol,
+static int eac_mse_set_at_ta(sc_card_t *card, int protocol,
 		const unsigned char *chr, size_t chr_len,
 		const unsigned char *eph_pub_key, size_t eph_pub_key_len,
 		const unsigned char *auxiliary_data, size_t auxiliary_data_len)
 {
-	return npa_mse_set_at(card, 0x81, protocol, chr, chr_len, NULL, 0,
+	return eac_mse_set_at(card, 0x81, protocol, chr, chr_len, NULL, 0,
 			eph_pub_key, eph_pub_key_len, auxiliary_data, auxiliary_data_len,
 			NULL, NULL, NULL);
 }
 
-static int npa_mse_set_dst(sc_card_t *card,
+static int eac_mse_set_dst(sc_card_t *card,
 		const unsigned char *chr, size_t chr_len)
 {
-	return npa_mse(card, 0x81, 0xb6, 0, chr, chr_len, NULL, 0, NULL, 0, NULL,
+	return eac_mse(card, 0x81, 0xb6, 0, chr, chr_len, NULL, 0, NULL, 0, NULL,
 			0, NULL, NULL, NULL);
 }
 
-static int npa_get_challenge(sc_card_t *card,
+static int eac_get_challenge(sc_card_t *card,
 		unsigned char *challenge, size_t len)
 {
 	sc_apdu_t apdu;
@@ -1425,7 +1425,7 @@ err:
 	return r;
 }
 
-static int npa_verify(sc_card_t *card,
+static int eac_verify(sc_card_t *card,
 		const unsigned char *cert, size_t cert_len)
 {
 	sc_apdu_t apdu;
@@ -1461,7 +1461,7 @@ err:
 	return r;
 }
 
-static int npa_external_authenticate(sc_card_t *card,
+static int eac_external_authenticate(sc_card_t *card,
 		unsigned char *signature, size_t signature_len)
 {
 	int r;
@@ -1501,7 +1501,7 @@ int perform_terminal_authentication(sc_card_t *card,
 	CVC_CERT *cvc_cert = NULL;
 	BUF_MEM *nonce = NULL, *signature = NULL;
 	struct iso_sm_ctx *isosmctx = NULL;
-	struct npa_sm_ctx *eacsmctx = NULL;
+	struct eac_sm_ctx *eacsmctx = NULL;
 	unsigned char *ef_cardaccess = NULL;
 	EAC_CTX *eac_ctx = NULL;
 
@@ -1544,7 +1544,7 @@ int perform_terminal_authentication(sc_card_t *card,
 			goto err;
 		}
 
-		isosmctx->priv_data = npa_sm_ctx_create(eac_ctx, NULL, 0, NULL, 0);
+		isosmctx->priv_data = eac_sm_ctx_create(eac_ctx, NULL, 0, NULL, 0);
 		if (!isosmctx->priv_data) {
 			r = SC_ERROR_INTERNAL;
 			goto err;
@@ -1566,7 +1566,7 @@ int perform_terminal_authentication(sc_card_t *card,
 		}
 		cert = *certs;
 
-		r = npa_mse_set_dst(card,
+		r = eac_mse_set_dst(card,
 				cvc_cert->body->certificate_authority_reference->data,
 				cvc_cert->body->certificate_authority_reference->length);
 		if (r < 0) {
@@ -1575,7 +1575,7 @@ int perform_terminal_authentication(sc_card_t *card,
 			goto err;
 		}
 
-		r = npa_verify(card, cert, cert_len);
+		r = eac_verify(card, cert, cert_len);
 		if (r < 0)
 			goto err;
 
@@ -1603,7 +1603,7 @@ int perform_terminal_authentication(sc_card_t *card,
 	}
 
 
-	r = npa_mse_set_at_ta(card, eacsmctx->ctx->ta_ctx->protocol,
+	r = eac_mse_set_at_ta(card, eacsmctx->ctx->ta_ctx->protocol,
 			cvc_cert->body->certificate_holder_reference->data,
 			cvc_cert->body->certificate_holder_reference->length,
 			(unsigned char *) eacsmctx->eph_pub_key->data, eacsmctx->eph_pub_key->length,
@@ -1620,7 +1620,7 @@ int perform_terminal_authentication(sc_card_t *card,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = npa_get_challenge(card, (unsigned char *) nonce->data, nonce->length);
+	r = eac_get_challenge(card, (unsigned char *) nonce->data, nonce->length);
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not get nonce for TA.");
 		goto err;
@@ -1644,7 +1644,7 @@ int perform_terminal_authentication(sc_card_t *card,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = npa_external_authenticate(card, (unsigned char *) signature->data,
+	r = eac_external_authenticate(card, (unsigned char *) signature->data,
 			signature->length);
 
 err:
@@ -1661,18 +1661,18 @@ err:
 		return r;
 }
 
-static int npa_mse_set_at_ca(sc_card_t *card, int protocol)
+static int eac_mse_set_at_ca(sc_card_t *card, int protocol)
 {
-	return npa_mse_set_at(card, 0x41, protocol, NULL, 0, NULL, 0, NULL, 0,
+	return eac_mse_set_at(card, 0x41, protocol, NULL, 0, NULL, 0, NULL, 0,
 			NULL, 0, NULL, NULL, NULL);
 }
 
-static int npa_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
+static int eac_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
 		BUF_MEM **nonce, BUF_MEM **token)
 {
 	sc_apdu_t apdu;
-	NPA_GEN_AUTH_CA_C *c_data = NULL;
-	NPA_GEN_AUTH_CA_R *r_data = NULL;
+	EAC_GEN_AUTH_CA_C *c_data = NULL;
+	EAC_GEN_AUTH_CA_R *r_data = NULL;
 	unsigned char *d = NULL;
 	int r;
 	unsigned char resp[maxresp];
@@ -1680,7 +1680,7 @@ static int npa_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, ISO_GENERAL_AUTHENTICATE,
 			0, 0);
 
-	c_data = NPA_GEN_AUTH_CA_C_new();
+	c_data = EAC_GEN_AUTH_CA_C_new();
 	if (!c_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
@@ -1694,7 +1694,7 @@ static int npa_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = i2d_NPA_GEN_AUTH_CA_C(c_data, &d);
+	r = i2d_EAC_GEN_AUTH_CA_C(c_data, &d);
 	if (r < 0) {
 		ssl_error(card->ctx);
 		r = SC_ERROR_INTERNAL;
@@ -1718,7 +1718,7 @@ static int npa_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
 
 	sc_debug_hex(card->ctx, SC_LOG_DEBUG_NORMAL, "General authenticate (Perform Key Agreement) response data", apdu.resp, apdu.resplen);
 
-	if (!d2i_NPA_GEN_AUTH_CA_R(&r_data,
+	if (!d2i_EAC_GEN_AUTH_CA_R(&r_data,
 				(const unsigned char **) &apdu.resp, apdu.resplen)) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse general authenticate response data.");
 		ssl_error(card->ctx);
@@ -1748,9 +1748,9 @@ static int npa_gen_auth_ca(sc_card_t *card, const BUF_MEM *eph_pub_key,
 
 err:
 	if (c_data)
-		NPA_GEN_AUTH_CA_C_free(c_data);
+		EAC_GEN_AUTH_CA_C_free(c_data);
 	if (r_data)
-		NPA_GEN_AUTH_CA_R_free(r_data);
+		EAC_GEN_AUTH_CA_R_free(r_data);
 	OPENSSL_free(d);
 
 	return r;
@@ -1768,7 +1768,7 @@ int perform_chip_authentication(sc_card_t *card,
 	int r;
 	BUF_MEM *picc_pubkey = NULL;
 	struct iso_sm_ctx *isosmctx;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card || !ef_cardsecurity || !ef_cardsecurity_len) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -1832,7 +1832,7 @@ int perform_chip_authentication_ex(sc_card_t *card, void *eac_ctx,
 	}
 
 
-	r = npa_mse_set_at_ca(card, ctx->ca_ctx->protocol);
+	r = eac_mse_set_at_ca(card, ctx->ca_ctx->protocol);
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not select protocol proberties "
 				"(MSE: Set AT failed).");
@@ -1847,7 +1847,7 @@ int perform_chip_authentication_ex(sc_card_t *card, void *eac_ctx,
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	r = npa_gen_auth_ca(card, eph_pub_key, &nonce, &token);
+	r = eac_gen_auth_ca(card, eph_pub_key, &nonce, &token);
 	if (r < 0) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "(General Authenticate failed).");
 		goto err;
@@ -1879,7 +1879,7 @@ int perform_chip_authentication_ex(sc_card_t *card, void *eac_ctx,
 	}
 
 	if (card->sm_ctx.sm_mode != SM_MODE_TRANSMIT) {
-		r = npa_sm_start(card, ctx, NULL, 0, NULL, 0);
+		r = eac_sm_start(card, ctx, NULL, 0, NULL, 0);
 	}
 
 err:
@@ -1895,7 +1895,7 @@ err:
 }
 
 static int
-increment_ssc(struct npa_sm_ctx *eacsmctx)
+increment_ssc(struct eac_sm_ctx *eacsmctx)
 {
 	if (!eacsmctx)
 		return SC_ERROR_INVALID_ARGUMENTS;
@@ -1907,13 +1907,13 @@ increment_ssc(struct npa_sm_ctx *eacsmctx)
 }
 
 static int
-npa_sm_encrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_encrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *data, size_t datalen, u8 **enc)
 {
 	BUF_MEM *encbuf = NULL, *databuf = NULL;
 	u8 *p = NULL;
 	int r;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card || !ctx || !enc || !ctx->priv_data) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -1949,13 +1949,13 @@ err:
 }
 
 static int
-npa_sm_decrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_decrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *enc, size_t enclen, u8 **data)
 {
 	BUF_MEM *encbuf = NULL, *databuf = NULL;
 	u8 *p = NULL;
 	int r;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card || !ctx || !enc || !ctx->priv_data || !data) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -1991,13 +1991,13 @@ err:
 }
 
 static int
-npa_sm_authenticate(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_authenticate(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *data, size_t datalen, u8 **macdata)
 {
 	BUF_MEM *inbuf = NULL, *macbuf = NULL;
 	u8 *p = NULL;
 	int r;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card || !ctx || !ctx->priv_data || !macdata) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -2040,13 +2040,13 @@ err:
 }
 
 static int
-npa_sm_verify_authentication(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_verify_authentication(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		const u8 *mac, size_t maclen,
 		const u8 *macdata, size_t macdatalen)
 {
 	int r;
 	BUF_MEM *inbuf = NULL, *my_mac = NULL;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card || !ctx || !ctx->priv_data) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -2115,7 +2115,7 @@ add_tag(unsigned char **asn1new, int constructed, int tag,
 	return newlen;
 }
 static int
-npa_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *apdu)
 {
 	int r;
@@ -2124,9 +2124,9 @@ npa_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 	int len;
 	BUF_MEM *signature = NULL;
 	unsigned char *sequence = NULL;
-	NPA_MSE_C *msesetat = NULL;
+	EAC_MSE_C *msesetat = NULL;
 	const unsigned char *p;
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 
 	if (!card)
 	   return SC_ERROR_INVALID_ARGUMENTS;
@@ -2136,7 +2136,7 @@ npa_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 	}
 	eacsmctx = ctx->priv_data;
 
-	if (!(eacsmctx->flags & NPA_FLAG_DISABLE_CHECK_ALL)) {
+	if (!(eacsmctx->flags & EAC_FLAG_DISABLE_CHECK_ALL)) {
 		if (apdu->ins == 0x2a && apdu->p1 == 0x00 && apdu->p2 == 0xbe) {
 			/* PSO:Verify Certificate
 			 * check certificate description to match given certificate */
@@ -2210,7 +2210,7 @@ npa_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 
 			len = add_tag(&sequence, 1, V_ASN1_SEQUENCE, V_ASN1_UNIVERSAL, apdu->data, apdu->datalen);
 			p = sequence;
-			if (len < 0 || !d2i_NPA_MSE_C(&msesetat, &p, len)) {
+			if (len < 0 || !d2i_EAC_MSE_C(&msesetat, &p, len)) {
 				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not parse MSE:Set AT.");
 				ssl_error(card->ctx);
 				r = SC_ERROR_INTERNAL;
@@ -2306,13 +2306,13 @@ err:
 	if (sequence)
 		OPENSSL_free(sequence);
 	if (msesetat)
-		NPA_MSE_C_free(msesetat);
+		EAC_MSE_C_free(msesetat);
 
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, r);
 }
 
 static int
-npa_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *sm_apdu)
 {
 	SC_FUNC_RETURN(card->ctx,  SC_LOG_DEBUG_NORMAL,
@@ -2320,10 +2320,10 @@ npa_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx,
 }
 
 static int
-npa_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
+eac_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
 		sc_apdu_t *apdu)
 {
-	struct npa_sm_ctx *eacsmctx;
+	struct eac_sm_ctx *eacsmctx;
 	if (!card)
 	   return SC_ERROR_INVALID_ARGUMENTS;
 	if(!ctx || !ctx->priv_data || !apdu)
@@ -2331,7 +2331,7 @@ npa_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
 				SC_ERROR_INVALID_ARGUMENTS);
 	eacsmctx = ctx->priv_data;
 
-	if (!(eacsmctx->flags & NPA_FLAG_DISABLE_CHECK_ALL)) {
+	if (!(eacsmctx->flags & EAC_FLAG_DISABLE_CHECK_ALL)) {
 		if (apdu->sw1 == 0x90 && apdu->sw2 == 0x00) {
 			if (apdu->ins == 0x84 && apdu->p1 == 0x00 && apdu->p2 == 0x00
 					&& apdu->le == 8 && apdu->resplen == 8) {
@@ -2359,10 +2359,10 @@ npa_sm_finish(sc_card_t *card, const struct iso_sm_ctx *ctx,
 }
 
 static void
-npa_sm_clear_free(const struct iso_sm_ctx *ctx)
+eac_sm_clear_free(const struct iso_sm_ctx *ctx)
 {
 	if (ctx) {
-		struct npa_sm_ctx *eacsmctx = ctx->priv_data;
+		struct eac_sm_ctx *eacsmctx = ctx->priv_data;
 		EAC_CTX_clear_free(eacsmctx->ctx);
 		if (eacsmctx->certificate_description)
 			BUF_MEM_free(eacsmctx->certificate_description);
@@ -2423,7 +2423,7 @@ static const char *PIN_name = "eID PIN";
 static const char *PUK_name = "PUK";
 static const char *CAN_name = "CAN";
 static const char *UNDEF_name = "UNDEF";
-const char *npa_secret_name(enum s_type pin_id) {
+const char *eac_secret_name(enum s_type pin_id) {
 	switch (pin_id) {
 		case PACE_MRZ:
 			return MRZ_name;
@@ -2438,76 +2438,7 @@ const char *npa_secret_name(enum s_type pin_id) {
 	}
 }
 
-int
-npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
-		int ask_for_secret, const char *new, size_t new_len)
-{
-	sc_apdu_t apdu;
-	char *p = NULL;
-	int r;
-
-	if (ask_for_secret && (!new || !new_len)) {
-		if (!(SC_READER_CAP_PIN_PAD & card->reader->capabilities)) {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-			p = malloc(MAX_PIN_LEN+1);
-			if (!p) {
-				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Not enough memory for new PIN.\n");
-				return SC_ERROR_OUT_OF_MEMORY;
-			}
-			if (0 > EVP_read_pw_string_min(p,
-						MIN_PIN_LEN, MAX_PIN_LEN+1,
-						"Please enter your new PIN: ", 0)) {
-				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not read new PIN.\n");
-				free(p);
-				return SC_ERROR_INTERNAL;
-			}
-			new_len = strlen(p);
-			if (new_len > MAX_PIN_LEN)
-				return SC_ERROR_INVALID_PIN_LENGTH;
-			new = p;
-#else
-			return SC_ERROR_NOT_SUPPORTED;
-#endif
-		}
-	}
-
-	sc_format_apdu(card, &apdu, 0, 0x2C, 0, pin_id);
-	apdu.data = (u8 *) new;
-	apdu.datalen = new_len;
-	apdu.lc = apdu.datalen;
-
-	if (new_len || ask_for_secret) {
-		apdu.p1 = 0x02;
-		apdu.cse = SC_APDU_CASE_3_SHORT;
-	} else {
-		apdu.p1 = 0x03;
-		apdu.cse = SC_APDU_CASE_1;
-	}
-
-	if (ask_for_secret && !new_len) {
-		struct sc_pin_cmd_data data;
-		data.apdu = &apdu;
-		data.cmd = SC_PIN_CMD_CHANGE;
-		data.flags = SC_PIN_CMD_IMPLICIT_CHANGE;
-		data.pin2.encoding = SC_PIN_ENCODING_ASCII;
-		data.pin2.length_offset = 0;
-		data.pin2.offset = 5;
-		data.pin2.max_length = MAX_PIN_LEN;
-		data.pin2.min_length = MIN_PIN_LEN;
-		data.pin2.pad_length = 0;
-		r = card->reader->ops->perform_verify(card->reader, &data);
-	} else
-		r = sc_transmit_apdu(card, &apdu);
-
-	if (p) {
-		sc_mem_clear(p, new_len);
-		free(p);
-	}
-
-	return r;
-}
-
-int npa_pace_get_tries_left(sc_card_t *card,
+int eac_pace_get_tries_left(sc_card_t *card,
 		enum s_type pin_id, int *tries_left)
 {
 	int r;
@@ -2515,7 +2446,7 @@ int npa_pace_get_tries_left(sc_card_t *card,
 
 	if (tries_left) {
 #if defined(ENABLE_OPENPACE) && defined(ENABLE_SM)
-		r = npa_mse_set_at_pace(card, 0, pin_id, 0, &sw1, &sw2);
+		r = eac_mse_set_at_pace(card, 0, pin_id, 0, &sw1, &sw2);
 #else
 		sc_apdu_t apdu;
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, ISO_MSE, 0xC1, 0xA4);
@@ -2534,15 +2465,4 @@ int npa_pace_get_tries_left(sc_card_t *card,
 	}
 
 	return r;
-}
-
-int get_pace_capabilities(u8 *bitmap)
-{
-	if (!bitmap)
-		return SC_ERROR_INVALID_ARGUMENTS;
-
-	/* BitMap */
-	*bitmap = NPA_BITMAP_PACE|NPA_BITMAP_EID|NPA_BITMAP_ESIGN;
-
-	return SC_SUCCESS;
 }

--- a/src/sm/sm-eac.h
+++ b/src/sm/sm-eac.h
@@ -38,6 +38,10 @@ extern "C" {
 #include <eac/eac.h>
 #include <eac/pace.h>
 
+/** @brief ASN.1 type for authenticated auxiliary data for terminal authentication */
+typedef STACK_OF(CVC_DISCRETIONARY_DATA_TEMPLATE) ASN1_AUXILIARY_DATA;
+DECLARE_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
+
 #else
 /** @brief Type of the secret */
 enum s_type {
@@ -157,10 +161,6 @@ int perform_terminal_authentication(sc_card_t *card,
 		const unsigned char **certs, const size_t *certs_lens,
 		const unsigned char *privkey, size_t privkey_len,
 		const unsigned char *auxiliary_data, size_t auxiliary_data_len);
-
-/** @brief ASN.1 type for authenticated auxiliary data for terminal authentication */
-typedef STACK_OF(CVC_DISCRETIONARY_DATA_TEMPLATE) ASN1_AUXILIARY_DATA;
-DECLARE_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
 
 /**
  * @brief Establish secure messaging using Chip Authentication version 2

--- a/src/sm/sm-eac.h
+++ b/src/sm/sm-eac.h
@@ -19,7 +19,7 @@
  */
 /**
  * @file
- * @defgroup npa Interface to German identity card (neuer Personalausweis, nPA)
+ * @defgroup eac Interface to Extended Access Control
  * @{
  */
 #ifndef _SC_EAC_H
@@ -37,10 +37,6 @@ extern "C" {
 #include <eac/cv_cert.h>
 #include <eac/eac.h>
 #include <eac/pace.h>
-
-/** @brief ASN.1 type for authenticated auxiliary data for terminal authentication */
-typedef STACK_OF(CVC_DISCRETIONARY_DATA_TEMPLATE) ASN1_AUXILIARY_DATA;
-DECLARE_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
 
 #else
 /** @brief Type of the secret */
@@ -80,50 +76,6 @@ enum eac_tr_version {
 };
 #endif
 
-/** @brief NPA capabilities (TR-03119): PACE */
-#define NPA_BITMAP_PACE  0x40
-/** @brief NPA capabilities (TR-03119): EPA: eID */
-#define NPA_BITMAP_EID   0x20
-/** @brief NPA capabilities (TR-03119): EPA: eSign */
-#define NPA_BITMAP_ESIGN 0x10
-
-/** @brief NPA result (TR-03119): Kein Fehler */
-#define NPA_SUCCESS                            0x00000000
-/** @brief NPA result (TR-03119): Längen im Input sind inkonsistent */
-#define NPA_ERROR_LENGTH_INCONSISTENT          0xD0000001
-/** @brief NPA result (TR-03119): Unerwartete Daten im Input */
-#define NPA_ERROR_UNEXPECTED_DATA              0xD0000002
-/** @brief NPA result (TR-03119): Unerwartete Kombination von Daten im Input */
-#define NPA_ERROR_UNEXPECTED_DATA_COMBINATION  0xD0000003
-/** @brief NPA result (TR-03119): Die Karte unterstützt das PACE – Verfahren nicht.  (Unerwartete Struktur in Antwortdaten der Karte) */
-#define NPA_ERROR_CARD_NOT_SUPPORTED           0xE0000001
-/** @brief NPA result (TR-03119): Der Kartenleser unterstützt den angeforderten bzw. den ermittelten Algorithmus nicht.  */
-#define NPA_ERROR_ALGORITH_NOT_SUPPORTED       0xE0000002
-/** @brief NPA result (TR-03119): Der Kartenleser kennt die PIN – ID nicht. */
-#define NPA_ERROR_PINID_NOT_SUPPORTED          0xE0000003
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf Select EF_CardAccess (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_SELECT_EF_CARDACCESS         0xF0000000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf Read Binary (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_READ_BINARY                  0xF0010000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf MSE: Set AT (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_MSE_SET_AT                   0xF0020000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 1 (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_GENERAL_AUTHENTICATE_1       0xF0030000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 2 (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_GENERAL_AUTHENTICATE_2       0xF0040000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 3 (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_GENERAL_AUTHENTICATE_3       0xF0050000
-/** @brief NPA result (TR-03119): Negative Antwort der Karte auf General Authenticate Step 4 (needs to be OR-ed with SW1|SW2) */
-#define NPA_ERROR_GENERAL_AUTHENTICATE_4       0xF0060000
-/** @brief NPA result (TR-03119): Kommunikationsabbruch mit Karte. */
-#define NPA_ERROR_COMMUNICATION                0xF0100001
-/** @brief NPA result (TR-03119): Keine Karte im Feld. */
-#define NPA_ERROR_NO_CARD                      0xF0100002
-/** @brief NPA result (TR-03119): Benutzerabbruch. */
-#define NPA_ERROR_ABORTED                      0xF0200001
-/** @brief NPA result (TR-03119): Benutzer – Timeout */
-#define NPA_ERROR_TIMEOUT                      0xF0200002
-
 /** @brief File identifier of EF.CardAccess */
 #define  FID_EF_CARDACCESS   0x011C
 /** @brief Short file identifier of EF.CardAccess */
@@ -134,17 +86,17 @@ enum eac_tr_version {
 #define SFID_EF_CARDSECURITY 0x1D
 
 /** @brief Maximum length of PIN */
-#define MAX_PIN_LEN       6
+#define EAC_MAX_PIN_LEN       6
 /** @brief Minimum length of PIN */
-#define MIN_PIN_LEN       6
+#define EAC_MIN_PIN_LEN       6
 /** @brief Length of CAN */
-#define CAN_LEN       6
+#define EAC_CAN_LEN       6
 /** @brief Minimum length of MRZ */
-#define MAX_MRZ_LEN       128
+#define EAC_MAX_MRZ_LEN       128
 /** @brief Number of retries for PIN */
-#define MAX_PIN_TRIES     3
+#define EAC_MAX_PIN_TRIES     3
 /** @brief Usage counter of PIN in suspended state */
-#define UC_PIN_SUSPENDED  1
+#define EAC_UC_PIN_SUSPENDED  1
 
 
 /**
@@ -154,18 +106,7 @@ enum eac_tr_version {
  *
  * @return Printable string containing the name
  */
-const char *npa_secret_name(enum s_type pin_id);
-
-
-/** 
- * @brief Get the PACE capabilities
- * 
- * @param[in,out] bitmap where to store capabilities bitmap
- * @note Since this code offers no support for terminal certificate, the bitmap is always \c PACE_BITMAP_PACE|PACE_BITMAP_EID
- * 
- * @return \c SC_SUCCESS or error code if an error occurred
- */
-int get_pace_capabilities(u8 *bitmap);
+const char *eac_secret_name(enum s_type pin_id);
 
 /** 
  * @brief Establish secure messaging using PACE
@@ -217,6 +158,10 @@ int perform_terminal_authentication(sc_card_t *card,
 		const unsigned char *privkey, size_t privkey_len,
 		const unsigned char *auxiliary_data, size_t auxiliary_data_len);
 
+/** @brief ASN.1 type for authenticated auxiliary data for terminal authentication */
+typedef STACK_OF(CVC_DISCRETIONARY_DATA_TEMPLATE) ASN1_AUXILIARY_DATA;
+DECLARE_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
+
 /**
  * @brief Establish secure messaging using Chip Authentication version 2
  *
@@ -233,25 +178,8 @@ int perform_chip_authentication(sc_card_t *card,
 int perform_chip_authentication_ex(sc_card_t *card, void *eacsmctx,
 		unsigned char *picc_pubkey, size_t picc_pubkey_len);
 
-/** 
- * @brief Sends a reset retry counter APDU
- *
- * According to TR-03110 the reset retry counter APDU is used to set a new PIN
- * or to reset the retry counter of the PIN. The standard requires this
- * operation to be authorized either by an established PACE channel or by the
- * effective authorization of the terminal's certificate.
- * 
- * @param[in] card
- * @param[in] pin_id         Type of secret (usually PIN or CAN). You may use <tt>enum s_type</tt> from \c <openssl/pace.h>.
- * @param[in] ask_for_secret whether to ask the user for the secret (\c 1) or not (\c 0)
- * @param[in] new            (optional) new secret
- * @param[in] new_len        (optional) length of \a new
- * 
- * @return \c SC_SUCCESS or error code if an error occurred
- */
-int npa_reset_retry_counter(sc_card_t *card,
-		enum s_type pin_id, int ask_for_secret,
-		const char *new, size_t new_len);
+/** @brief Disable all sanity checks done by OpenSC */
+#define EAC_FLAG_DISABLE_CHECK_ALL 1
 
 /** 
  * @brief Sends an MSE:Set AT to determine the number of remaining tries
@@ -262,34 +190,16 @@ int npa_reset_retry_counter(sc_card_t *card,
  * 
  * @return \c SC_SUCCESS or error code if an error occurred
  */
-int npa_pace_get_tries_left(sc_card_t *card,
+int eac_pace_get_tries_left(sc_card_t *card,
 		enum s_type pin_id, int *tries_left);
-/** 
- * @brief Send APDU to unblock the PIN
- *
- * @param[in] card
- */
-#define npa_unblock_pin(card) \
-	npa_reset_retry_counter(card, PACE_PIN, 0, NULL, 0)
-/**
- * @brief Send APDU to set a new PIN
- *
- * @param[in] card
- * @param[in] newp           (optional) new PIN
- * @param[in] newplen        (optional) length of \a new
- */
-#define npa_change_pin(card, newp, newplen) \
-	npa_reset_retry_counter(card, PACE_PIN, 1, newp, newplen)
 
-/** @brief Disable all sanity checks done by libnpa */
-#define NPA_FLAG_DISABLE_CHECK_ALL 1
 /** @brief Disable checking validity period of CV certificates */
-#define NPA_FLAG_DISABLE_CHECK_TA 2
+#define EAC_FLAG_DISABLE_CHECK_TA 2
 /** @brief Disable checking passive authentication during CA */
-#define NPA_FLAG_DISABLE_CHECK_CA 4
+#define EAC_FLAG_DISABLE_CHECK_CA 4
 
-/** @brief Use \c npa_default_flags to disable checks for EAC/SM */
-extern char npa_default_flags;
+/** @brief Use \c eac_default_flags to disable checks for EAC/SM */
+extern char eac_default_flags;
 
 #ifdef  __cplusplus
 }

--- a/src/tools/npa-tool.c
+++ b/src/tools/npa-tool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2012 Frank Morgner <frankmorgner@gmail.com>
+ * Copyright (C) 2010-2018 Frank Morgner <frankmorgner@gmail.com>
  *
  * This file is part of OpenSC.
  *
@@ -30,6 +30,7 @@
 #include <libopensc/log.h>
 #include <libopensc/opensc.h>
 #include <libopensc/sm.h>
+#include <libopensc/card-npa.h>
 #include <sm/sm-eac.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -419,11 +420,11 @@ main (int argc, char **argv)
 	if (cmdline.tr_03110v201_flag)
 		tr_version = EAC_TR_VERSION_2_01;
 	if (cmdline.disable_all_checks_flag)
-		npa_default_flags |= NPA_FLAG_DISABLE_CHECK_ALL;
+		eac_default_flags |= EAC_FLAG_DISABLE_CHECK_ALL;
 	if (cmdline.disable_ta_checks_flag)
-		npa_default_flags |= NPA_FLAG_DISABLE_CHECK_TA;
+		eac_default_flags |= EAC_FLAG_DISABLE_CHECK_TA;
 	if (cmdline.disable_ca_checks_flag)
-		npa_default_flags |= NPA_FLAG_DISABLE_CHECK_CA;
+		eac_default_flags |= EAC_FLAG_DISABLE_CHECK_CA;
 
 
 	r = initialize(cmdline.reader_arg, cmdline.verbose_given, &ctx, &reader);
@@ -457,12 +458,12 @@ main (int argc, char **argv)
 			if (pin) {
 				if (sscanf(pin, "%llu", &secret) != 1) {
 					fprintf(stderr, "%s is not an unsigned long long.\n",
-							npa_secret_name(pace_input.pin_id));
+							eac_secret_name(pace_input.pin_id));
 					exit(2);
 				}
 				if (strlen(pin) > pace_input.pin_length) {
 					fprintf(stderr, "%s too big, only %u digits allowed.\n",
-							npa_secret_name(pace_input.pin_id),
+							eac_secret_name(pace_input.pin_id),
 							(unsigned int) pace_input.pin_length);
 					exit(2);
 				}
@@ -474,12 +475,12 @@ main (int argc, char **argv)
 			if (can) {
 				if (sscanf(can, "%llu", &secret) != 1) {
 					fprintf(stderr, "%s is not an unsigned long long.\n",
-							npa_secret_name(pace_input.pin_id));
+							eac_secret_name(pace_input.pin_id));
 					exit(2);
 				}
 				if (strlen(can) > pace_input.pin_length) {
 					fprintf(stderr, "%s too big, only %u digits allowed.\n",
-							npa_secret_name(pace_input.pin_id),
+							eac_secret_name(pace_input.pin_id),
 							(unsigned int) pace_input.pin_length);
 					exit(2);
 				}
@@ -491,12 +492,12 @@ main (int argc, char **argv)
 			if (puk) {
 				if (sscanf(puk, "%llu", &secret) != 1) {
 					fprintf(stderr, "%s is not an unsigned long long.\n",
-							npa_secret_name(pace_input.pin_id));
+							eac_secret_name(pace_input.pin_id));
 					exit(2);
 				}
 				if (strlen(puk) > pace_input.pin_length) {
 					fprintf(stderr, "%s too big, only %u digits allowed.\n",
-							npa_secret_name(pace_input.pin_id),
+							eac_secret_name(pace_input.pin_id),
 							(unsigned int) pace_input.pin_length);
 					exit(2);
 				}
@@ -515,7 +516,7 @@ main (int argc, char **argv)
 			gettimeofday(&tv, NULL);
 			printf("%u,%06u: Trying %s=%s\n",
 					(unsigned int) tv.tv_sec, (unsigned int) tv.tv_usec,
-					npa_secret_name(pace_input.pin_id), pace_input.pin);
+					eac_secret_name(pace_input.pin_id), pace_input.pin);
 
 			r = perform_pace(card, pace_input, &pace_output, tr_version);
 
@@ -526,12 +527,12 @@ main (int argc, char **argv)
 		if (0 > r) {
 			printf("%u,%06u: Tried breaking %s without success.\n",
 					(unsigned int) tv.tv_sec, (unsigned int) tv.tv_usec,
-					npa_secret_name(pace_input.pin_id));
+					eac_secret_name(pace_input.pin_id));
 			goto err;
 		} else {
 			printf("%u,%06u: Tried breaking %s with success (=%s).\n",
 					(unsigned int) tv.tv_sec, (unsigned int) tv.tv_usec,
-					npa_secret_name(pace_input.pin_id),
+					eac_secret_name(pace_input.pin_id),
 					pace_input.pin);
 		}
 	}
@@ -750,7 +751,7 @@ main (int argc, char **argv)
 		if (r < 0)
 			goto err;
 		printf("Established PACE channel with %s.\n",
-				npa_secret_name(pace_input.pin_id));
+				eac_secret_name(pace_input.pin_id));
 
 nopace:
 		if (cmdline.cv_certificate_given || cmdline.private_key_given) {

--- a/src/tools/sceac-example.c
+++ b/src/tools/sceac-example.c
@@ -30,6 +30,7 @@
 #include "libopensc/sm.h"
 #include "sm/sm-iso.h"
 #include "sm/sm-eac.h"
+#include "libopensc/card-npa.h"
 #include <string.h>
 
 static const char *newpin = NULL;


### PR DESCRIPTION
Use names that are specific to EAC, not the German ID card (nPA),
because Protocol and Commands are defined by BSI TR-03110 and ICAO.
Functions that are nPA specific are moved to card-npa.h.

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
