### PR TITLE
PIV detection of AID using Discovery Object before doing select AID - Partial Fix #1243

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3048,7 +3048,7 @@ static int piv_init(sc_card_t *card)
 			apdu.le = apdu.resplen;
 			r = sc_transmit_apdu(card, &apdu);
 			priv->neo_version = (neo_version_buf[0]<<16) | (neo_version_buf[1] <<8) | neo_version_buf[2];
-			sc_log(card->ctx, "NEO card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->neo_version);
+			sc_log(card->ctx, "Yubico card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->neo_version);
 			break;
 	}
 
@@ -3066,16 +3066,18 @@ static int piv_init(sc_card_t *card)
 		case SC_CARD_TYPE_PIV_II_NEO:
 			priv->card_issues = CI_NO_EC384
 				| CI_VERIFY_630X
-				| CI_VERIFY_LC0_FAIL
 				| CI_OTHER_AID_LOSE_STATE
 				| CI_LEAKS_FILE_NOT_FOUND
 				| CI_NFC_EXPOSE_TOO_MUCH;
+			if (priv->neo_version  < 0x00040302)
+				priv->card_issues |= CI_VERIFY_LC0_FAIL;
 			break;
 
 		case SC_CARD_TYPE_PIV_II_YUBIKEY4:
-			priv->card_issues = CI_VERIFY_LC0_FAIL
-				| CI_OTHER_AID_LOSE_STATE
+			priv->card_issues =  CI_OTHER_AID_LOSE_STATE
 				| CI_LEAKS_FILE_NOT_FOUND;
+			if (priv->neo_version  < 0x00040302)
+				priv->card_issues |= CI_VERIFY_LC0_FAIL;
 			break;
 
 		case SC_CARD_TYPE_PIV_II_HIST:
@@ -3085,6 +3087,7 @@ static int piv_init(sc_card_t *card)
 		case SC_CARD_TYPE_PIV_II_GENERIC:
 			priv->card_issues = CI_VERIFY_LC0_FAIL
 				| CI_OTHER_AID_LOSE_STATE;
+			/* TODO may need more research */
 			break;
 
 		default:

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -213,6 +213,7 @@ static struct piv_aid piv_aids[] = {
 							/* will also test after first PIN verify if protected object can be used instead */
 #define CI_CANT_USE_GETDATA_FOR_STATE	    0x00000008U /* No object to test verification inplace of VERIFY Lc=0 */
 #define CI_LEAKS_FILE_NOT_FOUND		    0x00000010U /* GET DATA of empty object returns 6A 82 even if PIN not verified */
+#define CI_DISCOVERY_USELESS		    0x00000020U /* Discovery can not be used to query active AID */
 
 #define CI_OTHER_AID_LOSE_STATE		    0x00000100U /* Other drivers match routines may reset our security state and lose AID!!! */
 #define CI_NFC_EXPOSE_TOO_MUCH		    0x00000200U /* PIN, crypto and objects exposed over NFS in violation of 800-73-3 */
@@ -2662,7 +2663,6 @@ err:
 }
 
 
-/* Do not use the cache value but read every time */
 static int piv_find_discovery(sc_card_t *card)
 {
 	int r = 0;
@@ -2957,7 +2957,7 @@ piv_finish(sc_card_t *card)
 
 static int piv_match_card(sc_card_t *card)
 {
-	int i, k;
+	int i, i7e, k;
 	size_t j;
 	u8 *p, *pe;
 	sc_file_t aidfile;
@@ -3058,7 +3058,7 @@ static int piv_match_card(sc_card_t *card)
 	 * We may get interference on some cards by other drivers trying SELECT_AID before
 	 * we get to see if PIV application is still active.
 	 * putting PIV driver first might help. 
-	 * TODO could be cached too
+	 * This may fail if the wrong AID is active
 	 */
 	i = piv_find_discovery(card);
 
@@ -3066,6 +3066,22 @@ static int piv_match_card(sc_card_t *card)
 		/* Detect by selecting applet */
 		i = piv_find_aid(card, &aidfile);
 	}
+
+	if (i >= 0) {
+		/*
+		 * We now know PIV AID is active, test DISCOVERY object 
+		 * Some CAC cards with PIV don't support DISCOVERY and return 
+		 * SC_ERROR_INCORRECT_PARAMETERS. Any error other then 
+		 * SC_ERROR_FILE_NOT_FOUND means we cannot use discovery 
+		 * to test for active AID.
+		 */
+		i7e = piv_find_discovery(card);
+		if (i7e != 0 && i7e !=  SC_ERROR_FILE_NOT_FOUND) {
+			priv->card_issues |= CI_DISCOVERY_USELESS;
+			priv->obj_cache[PIV_OBJ_DISCOVERY].flags |= PIV_OBJ_CACHE_NOT_PRESENT;
+		}
+	}
+
 
 	if (i < 0) {
 		piv_finish(card);
@@ -3083,7 +3099,7 @@ static int piv_match_card(sc_card_t *card)
 
 static int piv_init(sc_card_t *card)
 {
-	int r;
+	int r = 0;
 	piv_private_data_t * priv = PIV_DATA(card);
 	sc_apdu_t apdu;
 	unsigned long flags;
@@ -3136,7 +3152,7 @@ static int piv_init(sc_card_t *card)
 
 	switch(card->type) {
 		case SC_CARD_TYPE_PIV_II_NEO:
-			priv->card_issues = CI_NO_EC384
+			priv->card_issues |= CI_NO_EC384
 				| CI_VERIFY_630X
 				| CI_OTHER_AID_LOSE_STATE
 				| CI_LEAKS_FILE_NOT_FOUND
@@ -3146,18 +3162,18 @@ static int piv_init(sc_card_t *card)
 			break;
 
 		case SC_CARD_TYPE_PIV_II_YUBIKEY4:
-			priv->card_issues =  CI_OTHER_AID_LOSE_STATE
+			priv->card_issues |=  CI_OTHER_AID_LOSE_STATE
 				| CI_LEAKS_FILE_NOT_FOUND;
 			if (priv->neo_version  < 0x00040302)
 				priv->card_issues |= CI_VERIFY_LC0_FAIL;
 			break;
 
 		case SC_CARD_TYPE_PIV_II_HIST:
-			priv->card_issues = 0;
+			priv->card_issues |= 0;
 			break;
 
 		case SC_CARD_TYPE_PIV_II_GENERIC:
-			priv->card_issues = CI_VERIFY_LC0_FAIL
+			priv->card_issues |= CI_VERIFY_LC0_FAIL
 				| CI_OTHER_AID_LOSE_STATE;
 			/* TODO may need more research */
 			break;
@@ -3196,12 +3212,13 @@ static int piv_init(sc_card_t *card)
 	 * 800-73-3 cards may have a history object and/or a discovery object
 	 * We want to process them now as this has information on what
 	 * keys and certs the card has and how the pin might be used.
+	 * If they fail, ignore it there are optional and introdced in
+	 * NIST 800-73-3 and NIST 800-73-2 so some older cards may 
+	 * not handle the requets. 
 	 */
 	piv_process_history(card);
 
-	r = piv_process_discovery(card);
-	if (r > 0)
-		r = 0;
+	piv_process_discovery(card);
 
 	priv->pstate=PIV_STATE_NORMAL;
 	sc_unlock(card) ; /* obtained in piv_match */
@@ -3477,7 +3494,6 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 	int r = 0;
 	u8 temp[256];
 	size_t templen = sizeof(temp);
-	struct sc_pin_cmd_data data;
 	piv_private_data_t * priv = PIV_DATA(card); /* may be null */
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
@@ -3494,7 +3510,14 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 
 	/* first see if AID is active AID by reading discovery object '7E' */
 	/* If not try selecting AID */
-	r = piv_find_discovery(card);
+
+	/* but if x card does not support DISCOVERY object we can not use it */
+	if (priv->card_issues & CI_DISCOVERY_USELESS) {
+	    r =  SC_ERROR_NO_CARD_SUPPORT;
+	} else {
+	    r = piv_find_discovery(card);
+	}
+
 	if (r < 0)
 		r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, temp, &templen);
 
@@ -3504,15 +3527,7 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 	if (was_reset > 0)
 		priv->logged_in =  SC_PIN_STATE_UNKNOWN;
 
-	/* See if VERIFY Lc=empty will tell us the state */
-	memset(&data, 0, sizeof(data));
-	data.cmd = SC_PIN_CMD_GET_INFO;
-	data.pin_type = SC_AC_CHV;
-	data.pin_reference =  priv->pin_preference;
-	/* will try our best to see if logged_in or not */
-	r = piv_pin_cmd(card, &data, NULL);
-
-	r = 0; /* ignore return from piv_pin_cmd */
+	r = 0;
 
 err:
 	LOG_FUNC_RETURN(card->ctx, r);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1017,6 +1017,7 @@ iso7816_build_pin_apdu(struct sc_card *card, struct sc_apdu *apdu,
 	case SC_AC_CHV:
 		/* fall through */
 	case SC_AC_SESSION:
+	case SC_AC_CONTEXT_SPECIFIC:
 		break;
 	default:
 		return SC_ERROR_INVALID_ARGUMENTS;

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -90,6 +90,11 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DNIE_USER:
 		case SC_CARD_TYPE_DNIE_TERMINATED:
 		case SC_CARD_TYPE_IASECC_GEMALTO:
+		case SC_CARD_TYPE_PIV_II_GENERIC:
+		case SC_CARD_TYPE_PIV_II_HIST:
+		case SC_CARD_TYPE_PIV_II_NEO:
+		case SC_CARD_TYPE_PIV_II_YUBIKEY4:
+
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -149,6 +149,7 @@ struct sc_crt {
 #define SC_AC_SCB                       0x00000040 /* IAS/ECC SCB byte. */
 #define SC_AC_IDA                       0x00000080 /* PKCS#15 authentication ID */
 #define SC_AC_SESSION			0x00000100 /* Session PIN */
+#define SC_AC_CONTEXT_SPECIFIC		0x00000200 /* Context specific login */
 
 #define SC_AC_UNKNOWN			0xFFFFFFFE
 #define SC_AC_NEVER			0xFFFFFFFF

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1617,7 +1617,16 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 		}
 	}
 
-	rc = sc_pkcs15_verify_pin(p15card, auth_object, pPin, ulPinLen);
+	if (userType  == CKU_CONTEXT_SPECIFIC && pin_info) {
+		int auth_meth_saved = pin_info->auth_method;
+
+		sc_log(context, "Setting SC_AC_CONTEXT_SPECIFIC");
+		pin_info->auth_method = SC_AC_CONTEXT_SPECIFIC;
+		rc = sc_pkcs15_verify_pin(p15card, auth_object, pPin, ulPinLen);
+		pin_info->auth_method = auth_meth_saved;
+	} else
+		rc = sc_pkcs15_verify_pin(p15card, auth_object, pPin, ulPinLen);
+
 	sc_log(context, "PKCS15 verify PIN returned %d", rc);
 
 	if (rc != SC_SUCCESS)


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] Tested with the following cards: Yubikey 4 and PIV cards 
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
