### PR TITLE
Removed unused configuration options

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -21,15 +21,6 @@ app default {
 	#
 	# debug_file = @DEBUG_FILE@
 
-	# Reopen debug file at the every debug message.
-	#
-	# For Windows it's forced to 'true'. The reason is that
-	#   in Windows file handles can not be shared between DLL-s,
-	#   each DLL has a separate file handle table.
-	#
-	# Default: false
-	# reopen_debug_file = true;
-
 	# PKCS#15 initialization / personalization
 	# profiles directory for pkcs15-init.
 	# Default: @PROFILE_DIR_DEFAULT@

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -27,7 +27,7 @@ app default {
 	#
 	# profile_dir = @PROFILE_DIR@;
 
-	# Dsiable pop-ups of built-in GUI
+	# Disable pop-ups of built-in GUI
 	#
 	# Default: false
 	# disable_popups = true;
@@ -169,15 +169,6 @@ app default {
 		#st_certificate = ZZSTTERM00001.cvcert;
 		#st_key = ZZSTTERM00001.pkcs8;
 	}
-
-	# Force using specific card driver
-	#
-	# If this option is present, OpenSC will use the supplied
-	# driver with all inserted cards.
-	#
-	# Default: autodetect
-	#
-	# force_card_driver = customcos;
 
 	# Configuration block for DNIe
 	#

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -1081,14 +1081,6 @@ app opensc-pkcs11 {
 		# Default: false
 		# create_puk_slot = true;
 
-		# Report as 'zero' the CKA_ID attribute of CA certificate
-		# For the unknown reason the middleware of the manufacturer of gemalto (axalto, gemplus)
-		# card reports as '0' the CKA_ID of CA cartificates.
-		# Maybe someone else will need it. (Would be nice to know who and what for -- VTA)
-		#
-		# Default: false
-		# zero_ckaid_for_ca_certs = true;
-
 		# Symbolic names of PINs for which slots are created
 		# Card can contain more then one PINs or more then one on-card application with
 		#   its own PINs. Normally, to access all of them with the PKCS#11 API a slot has to be

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -36,15 +36,6 @@ app default {
 	#
 	# profile_dir = @PROFILE_DIR@;
 
-	# Paranoid memory allocation.
-	#
-	# If set to 'true', then refuse to continue when locking of non-pageable
-	# memory fails. This can cause subtle failures but is more secure when
-	# you have a swap disk.
-	# Default: false
-	#
-	# paranoid_memory = false;
-
 	# Dsiable pop-ups of built-in GUI
 	#
 	# Default: false

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -38,6 +38,14 @@ app default {
 	# Default: false
 	# enable_default_driver = true;
 
+	# List of readers to ignore
+	# If any of the strings listed below is matched in a reader name (case
+	# sensitive, partial matching possible), the reader is ignored by OpenSC.
+	# Use `opensc-tool --list-readers` to see all currently connected readers.
+	#
+	# Default: empty
+	# ignored_readers = "CardMan 1021", "SPR 532";
+
 	# CT-API module configuration.
 	reader_driver ctapi {
 		# module @LIBDIR@@LIB_PRE@towitoko@DYN_LIB_EXT@ {
@@ -1080,13 +1088,6 @@ app opensc-pkcs11 {
 		#
 		# Default: false
 		# zero_ckaid_for_ca_certs = true;
-
-		# List of readers to ignore
-		# If any of the strings listed below is matched (case sensitive) in a reader name,
-		# the reader is ignored by the PKCS#11 module.
-		#
-		# Default: empty
-		# ignored_readers = "CardMan 1021", "SPR 532";
 
 		# Symbolic names of PINs for which slots are created
 		# Card can contain more then one PINs or more then one on-card application with

--- a/solaris/opensc.conf-dist
+++ b/solaris/opensc.conf-dist
@@ -136,15 +136,6 @@ app default {
 		# atr = 55:66:77:88:99:aa:bb;
 	# }
 
-	# Force using specific card driver
-	#
-	# If this option is present, OpenSC will use the supplied
-	# driver with all inserted cards.
-	#
-	# Default: autodetect
-	#
-	# force_card_driver = miocos;
-
 	# Below are the framework specific configuration blocks.
 
 	# PKCS #15

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -136,7 +136,6 @@ static const struct _sc_driver_entry old_card_drivers[] = {
 struct _sc_ctx_options {
 	struct _sc_driver_entry cdrv[SC_MAX_CARD_DRIVERS];
 	int ccount;
-	char *forced_card_driver;
 };
 
 
@@ -363,13 +362,6 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 	if (scconf_get_bool (block, "enable_default_driver",
 				ctx->flags & SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER))
 		ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;
-
-	val = scconf_get_str(block, "force_card_driver", NULL);
-	if (val) {
-		if (opts->forced_card_driver)
-			free(opts->forced_card_driver);
-		opts->forced_card_driver = strdup(val);
-	}
 
 	list = scconf_find_list(block, "card_drivers");
 	if (list != NULL)
@@ -827,16 +819,10 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 	load_card_drivers(ctx, &opts);
 	load_card_atrs(ctx);
 
-	if (!opts.forced_card_driver) {
-		char *driver = getenv("OPENSC_DRIVER");
-		if(driver) {
-			opts.forced_card_driver = strdup(driver);
-		}
-	}
-	if (opts.forced_card_driver) {
-		if (SC_SUCCESS != sc_set_card_driver(ctx, opts.forced_card_driver))
-			sc_log(ctx, "Warning: Could not load %s.", opts.forced_card_driver);
-		free(opts.forced_card_driver);
+	char *driver = getenv("OPENSC_DRIVER");
+	if (driver) {
+		if (SC_SUCCESS != sc_set_card_driver(ctx, driver))
+			sc_log(ctx, "Warning: Could not load %s.", driver);
 	}
 	del_drvs(&opts);
 	sc_ctx_detect_readers(ctx);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -364,10 +364,6 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 		sc_ctx_log_to_file(ctx, NULL);
 	}
 
-	if (scconf_get_bool (block, "paranoid-memory",
-				ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY))
-		ctx->flags |= SC_CTX_FLAG_PARANOID_MEMORY;
-
 	if (scconf_get_bool (block, "disable_popups",
 				ctx->flags & SC_CTX_FLAG_DISABLE_POPUPS))
 		ctx->flags |= SC_CTX_FLAG_DISABLE_POPUPS;

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -303,12 +303,10 @@ int sc_ctx_log_to_file(sc_context_t *ctx, const char* filename)
 		ctx->debug_file = NULL;
 	}
 
-	if (ctx->reopen_log_file)   {
-		if (!ctx->debug_filename)   {
-			if (!filename)
-				filename = "stderr";
-			ctx->debug_filename = strdup(filename);
-		}
+	if (!ctx->debug_filename)   {
+		if (!filename)
+			filename = "stderr";
+		ctx->debug_filename = strdup(filename);
 	}
 
 	if (!filename)
@@ -338,12 +336,6 @@ load_parameters(sc_context_t *ctx, scconf_block *block, struct _sc_ctx_options *
 #ifdef _WIN32
 	char expanded_val[PATH_MAX];
 	DWORD expanded_len;
-#endif
-
-#ifdef _WIN32
-	ctx->reopen_log_file = 1;
-#else
-	ctx->reopen_log_file = scconf_get_bool(block, "reopen_debug_file", 0);
 #endif
 
 	debug = scconf_get_int(block, "debug", ctx->debug);

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -130,7 +130,6 @@ sc_list_files
 sc_lock
 sc_logout
 sc_make_cache_dir
-sc_mem_alloc_secure
 sc_mem_clear
 sc_mem_reverse
 sc_match_atr_block

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -688,6 +688,7 @@ typedef struct {
  * calling sc_disconnect_card.
  */
 #define SC_CTX_FLAG_TERMINATE				0x00000001
+/** removed in 0.18.0 and later */
 #define SC_CTX_FLAG_PARANOID_MEMORY			0x00000002
 #define SC_CTX_FLAG_DEBUG_MEMORY			0x00000004
 #define SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER	0x00000008
@@ -1324,7 +1325,6 @@ int sc_base64_decode(const char *in, u8 *out, size_t outlen);
  * @param  len  length of the memory buffer
  */
 void sc_mem_clear(void *ptr, size_t len);
-void *sc_mem_alloc_secure(sc_context_t *ctx, size_t len);
 int sc_mem_reverse(unsigned char *buf, size_t len);
 
 int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -699,7 +699,6 @@ typedef struct sc_context {
 	scconf_block *conf_blocks[3];
 	char *app_name;
 	int debug;
-	int reopen_log_file;
 	unsigned long flags;
 
 	FILE *debug_file;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2568,7 +2568,7 @@ sc_pkcs15_allocate_object_content(struct sc_context *ctx, struct sc_pkcs15_objec
 	/* Need to pass by temporary variable,
 	 * because 'value' and 'content.value' pointers can be the sames.
 	 */
-	tmp_buf = (unsigned char *)sc_mem_alloc_secure(ctx, len);
+	tmp_buf = calloc(sizeof *tmp_buf, len);
 	if (!tmp_buf)
 		return SC_ERROR_OUT_OF_MEMORY;
 

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1262,7 +1262,9 @@ int pcsc_add_reader(sc_context_t *ctx,
 
 	ret = _sc_add_reader(ctx, reader);
 
-	refresh_attributes(reader);
+	if (ret == SC_SUCCESS) {
+		refresh_attributes(reader);
+	}
 
 err1:
 	return ret;

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -826,40 +826,8 @@ int _sc_parse_atr(sc_reader_t *reader)
 	return SC_SUCCESS;
 }
 
-void *sc_mem_alloc_secure(sc_context_t *ctx, size_t len)
-{
-    void *pointer;
-    int locked = 0;
-
-    pointer = calloc(len, sizeof(unsigned char));
-    if (!pointer)
-	return NULL;
-#ifdef HAVE_SYS_MMAN_H
-    /* TODO mprotect */
-    /* Do not swap the memory */
-    if (mlock(pointer, len) >= 0)
-	locked = 1;
-#endif
-#ifdef _WIN32
-	/* Do not swap the memory */
-	if (VirtualLock(pointer, len) != 0)
-		locked = 1;
-#endif
-    if (!locked) {
-	if (ctx->flags & SC_CTX_FLAG_PARANOID_MEMORY) {
-	    sc_do_log (ctx, 0, NULL, 0, NULL, "cannot lock memory, failing allocation because paranoid set");
-	    free (pointer);
-	    pointer = NULL;
-	} else {
-	    sc_do_log (ctx, 0, NULL, 0, NULL, "cannot lock memory, sensitive data may be paged to disk");
-	}
-    }
-    return pointer;
-}
-
 void sc_mem_clear(void *ptr, size_t len)
 {
-	/* FIXME: Bug in 1.0.0-beta series crashes with 0 length */
 	if (len > 0)   {
 #ifdef ENABLE_OPENSSL
 		OPENSSL_cleanse(ptr, len);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3324,14 +3324,15 @@ pkcs15_cert_get_attribute(struct sc_pkcs11_session *session, void *object, CK_AT
 		*(CK_CERTIFICATE_TYPE*)attr->pValue = CKC_X_509;
 		break;
 	case CKA_ID:
-		if (cert->cert_info->authority && sc_pkcs11_conf.zero_ckaid_for_ca_certs) {
+#ifdef ZERO_CKAID_FOR_CA_CERTS
+		if (cert->cert_info->authority) {
 			check_attribute_buffer(attr, 1);
 			*(unsigned char*)attr->pValue = 0;
+			break;
 		}
-		else {
-			check_attribute_buffer(attr, cert->cert_info->id.len);
-			memcpy(attr->pValue, cert->cert_info->id.value, cert->cert_info->id.len);
-		}
+#endif
+		check_attribute_buffer(attr, cert->cert_info->id.len);
+		memcpy(attr->pValue, cert->cert_info->id.value, cert->cert_info->id.len);
 		break;
 	case CKA_TRUSTED:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -187,7 +187,7 @@ CK_RV push_login_state(struct sc_pkcs11_slot *slot,
 	}
 
 	if (pPin && ulPinLen) {
-		login->pPin = sc_mem_alloc_secure(context, (sizeof *pPin)*ulPinLen);
+		login->pPin = calloc((sizeof *pPin), ulPinLen);
 		if (login->pPin == NULL) {
 			goto err;
 		}

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -458,7 +458,6 @@ void load_pkcs11_parameters(struct sc_pkcs11_config *conf, sc_context_t * ctx)
 	conf->init_sloppy = 1;
 	conf->pin_unblock_style = SC_PKCS11_PIN_UNBLOCK_NOT_ALLOWED;
 	conf->create_puk_slot = 0;
-	conf->zero_ckaid_for_ca_certs = 0;
 	conf->create_slots_flags = SC_PKCS11_SLOT_CREATE_ALL;
 
 	conf_block = sc_get_conf_block(ctx, "pkcs11", NULL, 1);
@@ -484,7 +483,6 @@ void load_pkcs11_parameters(struct sc_pkcs11_config *conf, sc_context_t * ctx)
 		conf->pin_unblock_style = SC_PKCS11_PIN_UNBLOCK_SO_LOGGED_INITPIN;
 
 	conf->create_puk_slot = scconf_get_bool(conf_block, "create_puk_slot", conf->create_puk_slot);
-	conf->zero_ckaid_for_ca_certs = scconf_get_bool(conf_block, "zero_ckaid_for_ca_certs", conf->zero_ckaid_for_ca_certs);
 
 	create_slots_for_pins = (char *)scconf_get_str(conf_block, "create_slots_for_pins", "all");
 	conf->create_slots_flags = 0;
@@ -503,8 +501,8 @@ void load_pkcs11_parameters(struct sc_pkcs11_config *conf, sc_context_t * ctx)
 
 	sc_log(ctx, "PKCS#11 options: max_virtual_slots=%d slots_per_card=%d "
 		 "hide_empty_tokens=%d lock_login=%d atomic=%d pin_unblock_style=%d "
-		 "zero_ckaid_for_ca_certs=%d create_slots_flags=0x%X",
+		 "create_slots_flags=0x%X",
 		 conf->max_virtual_slots, conf->slots_per_card,
 		 conf->hide_empty_tokens, conf->lock_login, conf->atomic, conf->pin_unblock_style,
-		 conf->zero_ckaid_for_ca_certs, conf->create_slots_flags);
+		 conf->create_slots_flags);
 }

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -77,7 +77,6 @@ struct sc_pkcs11_config {
 	unsigned char init_sloppy;
 	unsigned int pin_unblock_style;
 	unsigned int create_puk_slot;
-	unsigned int zero_ckaid_for_ca_certs;
 	unsigned int create_slots_flags;
 	unsigned char ignore_pin_length;
 };

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -155,21 +155,6 @@ CK_RV initialize_reader(sc_reader_t *reader)
 	unsigned int i;
 	CK_RV rv;
 
-	scconf_block *conf_block = NULL;
-	const scconf_list *list = NULL;
-
-	conf_block = sc_get_conf_block(context, "pkcs11", NULL, 1);
-	if (conf_block != NULL) {
-		list = scconf_find_list(conf_block, "ignored_readers");
-		while (list != NULL) {
-			if (strstr(reader->name, list->data) != NULL) {
-				sc_log(context, "Ignoring reader \'%s\' because of \'%s\'\n", reader->name, list->data);
-				return CKR_OK;
-			}
-			list = list->next;
-		}
-	}
-
 	for (i = 0; i < sc_pkcs11_conf.slots_per_card; i++) {
 		rv = create_slot(reader);
 		if (rv != CKR_OK)


### PR DESCRIPTION
This cleans up some code and removes the following options:
- paranoid-memory (has never been used anyway)
- reopen_debug_file (now, always use this setting on Windows, never on other systems)
- force_card_driver (not needed, we have card_drivers)
- zero_ckaid_for_ca_certs (proprietary use, if needed pass the define CKAID_FOR_CA_CERTS)
- generalized ignored_readers

More details can be found in the commit messages.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated