### PR TITLE
Retrieve OpenPGP applet version from OpenPGP applet on YubiKey token

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -324,10 +324,7 @@ get_full_pgp_aid(sc_card_t *card, sc_file_t *file)
 	int r = 0;
 	/* explicitly get the full aid */
 	r = sc_get_data(card, 0x004F, file->name, sizeof file->name);
-	if (r < 0)
-		file->namelen = 0;
-	else
-		file->namelen = r;
+	file->namelen = MAX(r, 0);
 
 	return r;
 }
@@ -379,7 +376,7 @@ pgp_match_card(sc_card_t *card)
 						break;
 				}
 				snprintf(card_name, sizeof(card_name), "OpenPGP card V%u.%u", major, minor);
-			} 
+			}
 			sc_file_free(file);
 			LOG_FUNC_RETURN(card->ctx, 1);
 		}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -49,6 +49,7 @@ static struct sc_atr_table pgp_atrs[] = {
 	{ "3b:da:18:ff:81:b1:fe:75:1f:03:00:31:c5:73:c0:01:40:00:90:00:0c", NULL, "CryptoStick v1.2 (OpenPGP v2.0)", SC_CARD_TYPE_OPENPGP_V2, 0, NULL },
 	{ "3b:da:11:ff:81:b1:fe:55:1f:03:00:31:84:73:80:01:80:00:90:00:e4", NULL, "Gnuk v1.0.x (OpenPGP v2.0)", SC_CARD_TYPE_OPENPGP_GNUK, 0, NULL },
 	{ "3b:fc:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:4e:45:4f:72:33:e1", NULL, "Yubikey NEO (OpenPGP v2.0)", SC_CARD_TYPE_OPENPGP_V2, 0, NULL },
+	{ "3b:f8:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:34:d4", NULL, "Yubikey 4 (OpenPGP v2.1)", SC_CARD_TYPE_OPENPGP_V2, 0, NULL },
 	{ "3b:da:18:ff:81:b1:fe:75:1f:03:00:31:f5:73:c0:01:60:00:90:00:1c", NULL, "OpenPGP card V3", SC_CARD_TYPE_OPENPGP_V3, 0, NULL },
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -323,10 +323,10 @@ get_full_pgp_aid(sc_card_t *card, sc_file_t *file)
 	int r = 0;
 	/* explicitly get the full aid */
 	r = sc_get_data(card, 0x004F, file->name, sizeof file->name);
-	if (r < 0) {
+	if (r < 0)
 		file->namelen = 0;
-	}
-	file->namelen = r;
+	else
+		file->namelen = r;
 
 	return r;
 }

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -338,7 +338,6 @@ pgp_match_card(sc_card_t *card)
 {
 	int i;
 
-	LOG_FUNC_CALLED(card->ctx);
 	i = _sc_match_atr(card, pgp_atrs, &card->type);
 	if (i >= 0) {
 		card->name = pgp_atrs[i].name;
@@ -358,7 +357,7 @@ pgp_match_card(sc_card_t *card)
 			card->type = SC_CARD_TYPE_OPENPGP_BASE;
 			card->name = card_name;
 			if (file->namelen != 16)
-				i = get_full_pgp_aid(card, file);
+				(void) get_full_pgp_aid(card, file);
 			if (file->namelen == 16) {
 				unsigned char major = file->name[6];
 				unsigned char minor = file->name[7];
@@ -378,10 +377,10 @@ pgp_match_card(sc_card_t *card)
 				snprintf(card_name, sizeof(card_name), "OpenPGP card V%u.%u", major, minor);
 			}
 			sc_file_free(file);
-			LOG_FUNC_RETURN(card->ctx, 1);
+			return 1;
 		}
 	}
-	LOG_FUNC_RETURN(card->ctx, 0);
+	return 0;
 }
 
 


### PR DESCRIPTION
This PR allows OpenSC to determine OpenPGP applet version when the token is YubiKey NEO or YubiKey 4. This resolves a side-issue brought up in #1253.

- [ ] Documentation is added or updated
- [X] New files have a LGPL 2.1 license statement
- [X] Tested with the following card: YubiKey NEO, YubiKey 4
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [x] tested macOS Tokend
