### PR TITLE
epass2003: Fix buffer underrun in epass2003_decipher(), etc.

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -72,6 +72,9 @@ static struct sc_card_driver epass2003_drv = {
 #define KEY_LEN_DES3	24
 #define HASH_LEN	24
 
+#define SHA1_DIGEST_LENGTH 20
+#define SHA256_DIGEST_LENGTH 32
+
 static unsigned char PIN_ID[2] = { ENTERSAFE_USER_PIN_ID, ENTERSAFE_SO_PIN_ID };
 
 /*0x00:plain; 0x01:scp01 sm*/
@@ -1695,26 +1698,29 @@ static int epass2003_decipher(struct sc_card *card, const u8 * data, size_t data
 
 	if(exdata->currAlg == SC_ALGORITHM_EC)
 	{
-		unsigned char hash[HASH_LEN] = { 0 };
 		if(exdata->ecAlgFlags | SC_ALGORITHM_ECDSA_HASH_SHA1)
 		{
+			unsigned char hash[SHA1_DIGEST_LENGTH] = { 0 };
+
 			hash_data(data, datalen, hash, SC_ALGORITHM_ECDSA_HASH_SHA1);
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3,0x2A, 0x9E, 0x9A);
 			memset(sbuf, 0, sizeof(sbuf));
-			memcpy(sbuf, hash, 0x14);
+			memcpy(sbuf, hash, sizeof(hash));
 			apdu.data = sbuf;
-			apdu.lc = 0x14;
-			apdu.datalen = 0x14;
+			apdu.lc = sizeof(hash);
+			apdu.datalen = sizeof(hash);
 		}
 		else if (exdata->ecAlgFlags | SC_ALGORITHM_ECDSA_HASH_SHA256)
 		{
+			unsigned char hash[SHA256_DIGEST_LENGTH] = { 0 };
+
 			hash_data(data, datalen, hash, SC_ALGORITHM_ECDSA_HASH_SHA256);
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3,0x2A, 0x9E, 0x9A);
 			memset(sbuf, 0, sizeof(sbuf));
-			memcpy(sbuf, hash, 0x20);
+			memcpy(sbuf, hash, sizeof(hash));
 			apdu.data = sbuf;
-			apdu.lc = 0x20;
-			apdu.datalen = 0x20;
+			apdu.lc = sizeof(hash);
+			apdu.datalen = sizeof(hash);
 		}
 		else
 		{
@@ -2626,7 +2632,7 @@ external_key_auth(struct sc_card *card, unsigned char kid,
 
 static int
 update_secret_key(struct sc_card *card, unsigned char ktype, unsigned char kid,
-		unsigned char *data, unsigned long datalen)
+		const unsigned char *data, unsigned long datalen)
 {
 	int r;
 	struct sc_apdu apdu;
@@ -2707,7 +2713,7 @@ epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 
 	if (data->cmd == SC_PIN_CMD_CHANGE || data->cmd == SC_PIN_CMD_UNBLOCK) {
 		/* change */
-		r = update_secret_key(card, 0x04, kid, (unsigned char *)data->pin2.data,
+		r = update_secret_key(card, 0x04, kid, data->pin2.data,
 				(unsigned long)data->pin2.len);
 		LOG_TEST_RET(card->ctx, r, "verify pin failed");
 	}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2547,8 +2547,8 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 {
 	sc_context_t *ctx = card->ctx;
 	sc_cardctl_openpgp_keygen_info_t pubkey;
-	u8 *data;
-	size_t len;
+	u8 *data = NULL;
+	size_t len = 0;
 	int r;
 
 	LOG_FUNC_CALLED(ctx);

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -328,7 +328,7 @@ static int cwa_verify_icc_certificates(sc_card_t * card,
 				       cwa_provider_t * provider,
 				       X509 * sub_ca_cert, X509 * icc_cert)
 {
-	char *msg;
+	char *msg = NULL;
 	int res = SC_SUCCESS;
 	EVP_PKEY *root_ca_key = NULL;
 	EVP_PKEY *sub_ca_key = NULL;
@@ -543,7 +543,7 @@ static int cwa_prepare_external_auth(sc_card_t * card,
 	   then, we should encrypt with our private key and then with icc pub key
 	   returning resulting data
 	 */
-	char *msg;		/* to store error messages */
+	char *msg = NULL;		/* to store error messages */
 	int res = SC_SUCCESS;
 	u8 *buf1;		/* where to encrypt with icc pub key */
 	u8 *buf2;		/* where to encrypt with ifd pub key */

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -653,7 +653,7 @@ static int itacns_check_and_add_keyset(sc_pkcs15_card_t *p15card,
 	sc_path_t path;
 	sc_pkcs15_id_t cert_id;
 	int ext_info_ok;
-	int ku, xku;
+	int ku = 0, xku = 0;
 	int pubkey_usage_flags = 0, prkey_usage_flags = 0;
 
 	cert_id.len = 1;


### PR DESCRIPTION
1. Buffer underrun in epass2003_decipher().
2. The parameter `data' in update_secret_key() must be constant.

(Discovered by Clang 4.0.0 on OpenBSD 6.2.)

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
