### PR TITLE
pkcs11-tool: send DER for EC public keys with default compilation flags

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2632,7 +2632,7 @@ parse_ec_pkey(EVP_PKEY *pkey, int private, struct gostkey_info *gost)
 		header_len = point-gost->public.value;
 		memcpy(point, buf, point_len);
 		gost->public.len = header_len+point_len;
-#ifndef EC_POINT_NO_ASN1_OCTET_STRING // workaround for non-compliant cards not expecting DER encoding
+#ifdef EC_POINT_NO_ASN1_OCTET_STRING // workaround for non-compliant cards not expecting DER encoding
 		gost->public.len   -= header_len;
 		gost->public.value += header_len;
 #endif


### PR DESCRIPTION
[UPDATE] PR has been modified according to @DDvO's comment.
By default EC_POINT_NO_ASN1_OCTET_STRING is undefined and you will get standards behaviour.
Define this to get the write to send plain bytes.

-----------------------
This PR specifically fixes the default behaviour of `pkcs11-tool`. Makefile defaults to an undefined EC_POINT_NO_ASN1_OCTET_STRING and therefore EC public keys are written as plain bytes instead of with DER wrapping. 
1. https://github.com/OpenSC/libp11/issues/79
2. https://bugzilla.mozilla.org/show_bug.cgi?id=480280
 This will make pkcs11-tool consistent with the standard.


- Fixes #1286: "Does it even make sense to write EC keys not in DER?"
- the naming of the define was confusing, anyway

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [x] tested PKCS#11 (SafeNet HSM)
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
