### PR TITLE
Add support for fixed-length pinpad readers

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1635,7 +1635,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 						if (blob->len) {
 							if (digitp (blob->data)) {
 								char *q;
-								size_t n, m;
+								unsigned int n, m;
 		
 								n = strtol ((char*)blob->data, &q, 10);
 								if (q >= (char *)blob->data + blob->len

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1647,7 +1647,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 									m = strtol (q, &q, 10);
 								}
 
-								if (blob->len < ((unsigned char *)q - blob->data))
+								if ((int)blob->len < ((unsigned char *)q - blob->data))
 									break;
 
 								blob->len -= ((unsigned char *)q - blob->data);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1635,7 +1635,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 						if (blob->len) {
 							if (digitp (blob->data)) {
 								char *q;
-								unsigned int n, m;
+								int n, m;
 		
 								n = strtol ((char*)blob->data, &q, 10);
 								if (q >= (char *)blob->data + blob->len

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1635,7 +1635,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 						if (blob->len) {
 							if (digitp (blob->data)) {
 								char *q;
-								int n, m;
+								size_t n, m;
 		
 								n = strtol ((char*)blob->data, &q, 10);
 								if (q >= (char *)blob->data + blob->len


### PR DESCRIPTION
Fixes #1221 

Some pinpad readers have to be told the length of the PIN to accept. OpenPGP has a DO for storing the length. This patch reads the and parses the DO if it is properly configued, and supplies it for use for APDUs.
- Tested with OpenSC and OpenPGP 2.1 card on MacOS and Linux (Ubuntu and Fedora)
