### PR TITLE
pkcs11-tool: let -m accept hexadecimal strings, e.g., 0x80001234

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -231,7 +231,8 @@
 					</term>
 					<listitem><para>Use the specified <replaceable>mechanism</replaceable>
 					for token operations. See <option>-M</option> for a list
-					of mechanisms supported by your token.</para></listitem>
+					of mechanisms supported by your token. The mechanism can also be specified in
+					hexadecimal, e.g., <replaceable>0x80001234</replaceable>.</para></listitem>
 				</varlistentry>
 
 				<varlistentry>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -234,7 +234,7 @@ static const char *option_help[] = {
 	"Hash some data",
 	"Derive a secret key using another key and some data",
 	"Derive ECDHpass DER encoded pubkey for compatibility with some PKCS#11 implementations",
-	"Specify mechanism (use -M for a list of supported mechanisms)",
+	"Specify mechanism (use -M for a list of supported mechanisms), or by hexadecimal, e.g., 0x80001234",
 	"Specify hash algorithm used with RSA-PKCS-PSS signature and RSA-PKCS-OAEP decryption",
 	"Specify MGF (Message Generation Function) used for RSA-PSS signature and RSA-OAEP decryption (possible values are MGF1-SHA1 to MGF1-SHA512)",
 	"Specify how many bytes should be used for salt in RSA-PSS signatures (default is digest size)",
@@ -6076,6 +6076,9 @@ static CK_MECHANISM_TYPE p11_name_to_mechanism(const char *name)
 {
 	struct mech_info *mi;
 
+	if (strncasecmp("0x", name, 2) == 0) {
+		return strtoul(name, NULL, 0);
+	}
 	for (mi = p11_mechanisms; mi->name; mi++) {
 		if (!strcasecmp(mi->name, name)
 		 || (mi->short_name && !strcasecmp(mi->short_name, name)))


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend


Fixes #1301: convert user specified mechanisms `-m mechtype-0xNNNNNNNN` to UL (CK_MECHANISM_TYPE).

To work with vendor HSMs that require proprietary mechanisms such as AWS CloudHSM in FIPS-mode which uses `0x80000142` `0x80000143` for RSA keypairgen instead of the pkcs11-tool defaults of `CKM_RSA_PKCS_KEY_PAIR_GEN`, `CKM_RSA_X9_31_KEY_PAIR_GEN`

-----
[UPDATE] remove `mechtype-` as prefix, specify mechanism-in-hex as `-m 0x80001234` for example

-----
[UPDATE] updated XML documentation

