### PR TITLE
card-authentic: fix use of uninitialized rv

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -813,7 +813,7 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;
 	size_t sz, rest, ret_count = 0;
-	int rv;
+	int rv = 0;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx,
@@ -859,7 +859,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;
 	size_t sz, rest;
-	int rv;
+	int rv = 0;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx,
@@ -902,7 +902,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;
 	size_t sz, rest;
-	int rv;
+	int rv = 0;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx,


### PR DESCRIPTION
Fixes:
card-authentic.c: In function authentic_update_binary:
card-authentic.c:928:5: error: rv may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (rv)
     ^
card-authentic.c: In function authentic_write_binary:
card-authentic.c:885:5: error: rv may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (rv)
     ^
card-authentic.c: In function authentic_read_binary:
card-authentic.c:841:5: error: rv may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (rv)   {
     ^
cc1: all warnings being treated as errors

Signed-off-by: William Roberts <william.c.roberts@intel.com>

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

