### PR TITLE
card-muscle: be more relaxed in card initialization

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -96,20 +96,23 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 #endif
 	{ "rutoken",	(void *(*)(void)) sc_get_rutoken_driver },
 	{ "rutoken_ecp",(void *(*)(void)) sc_get_rtecp_driver },
-	{ "westcos",	(void *(*)(void)) sc_get_westcos_driver },
 	{ "myeid",      (void *(*)(void)) sc_get_myeid_driver },
-	{ "sc-hsm",		(void *(*)(void)) sc_get_sc_hsm_driver },
 #if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
 	{ "dnie",       (void *(*)(void)) sc_get_dnie_driver },
 #endif
 	{ "masktech",	(void *(*)(void)) sc_get_masktech_driver },
+	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
+	{ "westcos",	(void *(*)(void)) sc_get_westcos_driver },
 
-/* Here should be placed drivers that need some APDU transactions to
- * recognise its cards. */
+/* Here should be placed drivers that need some APDU transactions in the
+ * driver's `match_card()` function. */
+	/* MUSCLE card applet returns 9000 on whatever AID is selected, see
+	 * https://github.com/JavaCardOS/MuscleCard-Applet/blob/master/musclecard/src/com/musclecard/CardEdge/CardEdge.java#L326
+	 * put the muscle driver first to cope with this bug. */
+	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
+	{ "sc-hsm",	(void *(*)(void)) sc_get_sc_hsm_driver },
 	{ "mcrd",	(void *(*)(void)) sc_get_mcrd_driver },
 	{ "setcos",	(void *(*)(void)) sc_get_setcos_driver },
-	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
-	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
 	{ "PIV-II",	(void *(*)(void)) sc_get_piv_driver },
 	{ "cac",	(void *(*)(void)) sc_get_cac_driver },
 	{ "itacns",	(void *(*)(void)) sc_get_itacns_driver },

--- a/src/libopensc/muscle-filesystem.c
+++ b/src/libopensc/muscle-filesystem.c
@@ -224,7 +224,7 @@ int mscfs_loadFileInfo(mscfs_t* fs, const u8 *path, int pathlen, mscfs_file_t **
 		}
 		*file_data = NULL;
 	}
-	if(*file_data == NULL && (0 == memcmp("\x3F\x00\x00\x00", fullPath.id, 4) || 0 == memcmp("\x3F\x00\x3F\x00", fullPath.id, 4 ))) {
+	if(*file_data == NULL && (0 == memcmp("\x3F\x00\x00\x00", fullPath.id, 4) || 0 == memcmp("\x3F\x00\x50\x15", fullPath.id, 4 ) || 0 == memcmp("\x3F\x00\x3F\x00", fullPath.id, 4))) {
 		static mscfs_file_t ROOT_FILE;
 		ROOT_FILE.ef = 0;
 		ROOT_FILE.size = 0;

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3666,12 +3666,12 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 	if (path && path->len)   {
 		struct sc_path tmp_path = *path;
 		int iter;
-
 		r = SC_ERROR_OBJECT_NOT_FOUND;
-		for (iter = tmp_path.len/2; iter >= 0 && r == SC_ERROR_OBJECT_NOT_FOUND; iter--, tmp_path.len -= 2)
+		for (iter = tmp_path.len/2; iter >= 0 && r == SC_ERROR_OBJECT_NOT_FOUND; iter--, tmp_path.len -= 2) {
 			r = sc_pkcs15_find_pin_by_type_and_reference(p15card,
 					tmp_path.len ? &tmp_path : NULL,
 					type, reference, &pin_obj);
+		}
 	}
 	else {
 		r = sc_pkcs15_find_pin_by_type_and_reference(p15card, NULL, type, reference, &pin_obj);


### PR DESCRIPTION
closes https://github.com/OpenSC/OpenSC/pull/1248

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tested with the following card: muscle
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
