### PR TITLE
Provide more space for card holder name in CAC token label

### DIFF
--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -173,7 +173,7 @@ cac_map_usage(unsigned int cert_usage, int algorithm, unsigned int *pub_usage_pt
 static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 {
 	static const pindata pins[] = {
-		{ "1", NULL, "", 0x00,
+		{ "1", "PIN", "", 0x00,
 		  SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
 		  8, 4, 8,
 		  SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
@@ -245,7 +245,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		sc_format_path(pins[i].path, &pin_info.path);
 		pin_info.tries_left    = -1;
 
-		label = pins[i].label? pins[i].label : cac_get_name(card->type);
+		label = pins[i].label;
 		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "CAC Adding pin %d label=%s",i, label);
 		strncpy(pin_obj.label, label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 		pin_obj.flags = pins[i].obj_flags;


### PR DESCRIPTION
The PKCS#15 emulation layer for the CAC uses a single PIN. Set its label to "PIN" (rather than the card type "CAC I" or "CAC II"), so that the PIN label will be omitted from the token label, providing more space for the card holder name instead.

This is intended to match the behavior used for PIV cards, which was changed in #1133.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tested PKCS#11
- [ ] tested Windows Minidriver
- [ ] tested macOS Tokend