### PR TITLE
Some cards may return RSA signatures without leading zero bytes Fixes #1283

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -452,6 +452,15 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);
 	LOG_TEST_RET(ctx, r, "use_key() failed");
+
+	/* Some cards may return RSA signature as integer without leading zero bytes */
+	/* Already know outlen >= modlen and r >= 0 */
+	if (obj->type == SC_PKCS15_TYPE_PRKEY_RSA && (unsigned)r < modlen) {
+		memmove(out + modlen - r, out, r);
+		memset(out, 0, modlen - r);
+		r = modlen;
+	}
+
 	sc_mem_clear(buf, sizeof(buf));
 
 	LOG_FUNC_RETURN(ctx, r);


### PR DESCRIPTION
Add leading zero bytes in a signature so it is the size of modulus.
Fixes #1283 

 On branch short-signatures
 Changes to be committed:
	modified:   libopensc/pkcs15-sec.c

<!--
Thank you for your pull request.


-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
