### PR TITLE
Allow specifying the enable_InitToken without ATR block

### DIFF
--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -263,10 +263,6 @@ app default {
 		#
 		# flags = "rng", "keep_alive", "0x80000000";
 
-		# Enable pkcs11 initialization.
-		# Default: no
-		# pkcs11_enable_InitToken = yes;
-
 		#
 		# Context: PKCS#15 emulation layer
 		#
@@ -951,6 +947,10 @@ app default {
 			# The location of the driver library
 			# module = @LIBDIR@@LIB_PRE@p15emu_custom@DYN_LIB_EXT@;
 		# }
+
+		# Enable initialization and card recognition in PKCS#11 layer.
+		# Default: no
+		# pkcs11_enable_InitToken = yes;
 
 		# some additional application parameters:
 		# - type (generic, protected) used to distinguish the common access application

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1806,14 +1806,13 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 {
 	struct sc_pkcs11_card *p11card = slot->p11card;
 	struct sc_cardctl_pkcs11_init_token args;
-	scconf_block *atrblock = NULL;
+	scconf_block *conf_block = NULL;
 	int rc, enable_InitToken = 0;
 	CK_RV rv;
 
 	sc_log(context, "Get 'enable-InitToken' card configuration option");
-	atrblock = sc_match_atr_block(p11card->card->ctx, NULL, &p11card->reader->atr);
-	if (atrblock)
-		enable_InitToken = scconf_get_bool(atrblock, "pkcs11_enable_InitToken", 0);
+	conf_block = sc_get_conf_block(p11card->card->ctx, "framework", "pkcs15", 1);
+	enable_InitToken = scconf_get_bool(conf_block, "pkcs11_enable_InitToken", 0);
 
 	memset(&args, 0, sizeof(args));
 	args.so_pin = pPin;

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -302,12 +302,17 @@ again:
 		sc_log(context, "%s: Detected framework %d. Creating tokens.", reader->name, i);
 		/* Bind 'generic' application or (emulated?) card without applications */
 		if (app_generic || !p11card->card->app_count)   {
-			scconf_block *atrblock = NULL;
+			scconf_block *conf_block = NULL;
 			int enable_InitToken = 0;
 
-			atrblock = sc_match_atr_block(p11card->card->ctx, NULL, &p11card->reader->atr);
-			if (atrblock)
-				enable_InitToken = scconf_get_bool(atrblock, "pkcs11_enable_InitToken", 0);
+			conf_block = sc_match_atr_block(p11card->card->ctx, NULL,
+				&p11card->reader->atr);
+			if (!conf_block) /* check default block */
+				conf_block = sc_get_conf_block(context,
+					"framework", "pkcs15", 1);
+
+			enable_InitToken = scconf_get_bool(conf_block,
+				"pkcs11_enable_InitToken", 0);
 
 			sc_log(context, "%s: Try to bind 'generic' token.", reader->name);
 			rv = frameworks[i]->bind(p11card, app_generic);


### PR DESCRIPTION
Resolves #1265.

As described in the referenced issue, the problem of the current solution is that we need to know an ATR of the card when creating the configuration file. This pull request is updating the code to allow specifying the option `enable_InitToken` outside of ATR blocks (at this moment in `framework pkcs15` -- not sure if there is a better place for it or better way how to handle it altogether). Comments welcomed.

Given the nature of the issue, it is certainly nothing, that should come by default, but a tools requiring it should present their own `opensc.conf` with these options set and in this case, requiring ATR is burden.

Edit: Other possibility would be to allow wildcard ATRs matches (I know there are masks, but it does not have the flexibility to match different lengths.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation is added or updated
- [X] Tested with the following card: coolkey
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend