### PR TITLE
 Address compiler warnings when using --disable-optimization 

### DIFF
--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -83,7 +83,7 @@ iasecc_sdo_convert_acl(struct sc_card *card, struct iasecc_sdo *sdo,
 		{SC_AC_OP_READ,		IASECC_ACL_GET_DATA},
 		{0x00, 0x00}
 	};
-	unsigned char mask = 0x80, op_mask;
+	unsigned char mask = 0x80, op_mask = 0;
 	int ii;
 
 	LOG_FUNC_CALLED(ctx);
@@ -94,10 +94,10 @@ iasecc_sdo_convert_acl(struct sc_card *card, struct iasecc_sdo *sdo,
 			break;
 		}
 	}
-	if (ops[ii].mask == 0)
+	if (op_mask == 0)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
 
-	sc_log(ctx, "OP:%i, mask:0x%X", op, ops[ii].mask);
+	sc_log(ctx, "OP:%i, mask:0x%X", op, op_mask);
 	sc_log(ctx, "AMB:%X, scbs:%s", sdo->docp.amb, sc_dump_hex(sdo->docp.scbs, IASECC_MAX_SCBS));
 	sc_log(ctx, "docp.acls_contact:%s", sc_dump_hex(sdo->docp.acls_contact.value, sdo->docp.acls_contact.size));
 

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -371,7 +371,9 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 			goto failed;
 	}
 
-	/* PKCS#15 DATA object from OpenPGP private DOs */
+	/* Add PKCS#15 DATA objects from other OpenPGP card DOs. The return
+	 * value is ignored, so this will not cause initialization to fail.
+	 */
 	sc_pkcs15emu_openpgp_add_data(p15card);
 
 failed:
@@ -392,7 +394,7 @@ sc_pkcs15emu_openpgp_add_data(sc_pkcs15_card_t *p15card)
 	int i, r;
 
 	LOG_FUNC_CALLED(ctx);
-	/* There is 4 private DO from 0101 to 0104 */
+	/* Optional private use DOs 0101 to 0104 */
 	for (i = 1; i <= PGP_NUM_PRIVDO; i++) {
 		sc_pkcs15_data_info_t dat_info;
 		sc_pkcs15_object_t dat_obj;
@@ -405,8 +407,8 @@ sc_pkcs15emu_openpgp_add_data(sc_pkcs15_card_t *p15card)
 		snprintf(name, 8, "PrivDO%d", i);
 		snprintf(path, 9, "3F00010%d", i);
 
-		/* Check if the DO can be read.
-		 * We won't expose pkcs15 DATA object if DO is empty.
+		/* Check if the DO can be read and is not empty. Otherwise we
+		 * won't expose a PKCS#15 DATA object.
 		 */
 		r = read_file(p15card->card, path, content, sizeof(content));
 		if (r <= 0 ) {
@@ -428,8 +430,9 @@ sc_pkcs15emu_openpgp_add_data(sc_pkcs15_card_t *p15card)
 
 		sc_log(ctx, "Add %s data object", name);
 		r = sc_pkcs15emu_add_data_object(p15card, &dat_obj, &dat_info);
+		LOG_TEST_RET(ctx, r, "Could not add data object to framework");
 	}
-	LOG_FUNC_RETURN(ctx, r);
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
 static int openpgp_detect_card(sc_pkcs15_card_t *p15card)

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -329,7 +329,7 @@ static CK_RV gostr3410_verify_data(const unsigned char *pubkey, int pubkey_len,
 	EVP_PKEY_CTX *pkey_ctx = NULL;
 	EC_POINT *P;
 	BIGNUM *X, *Y;
-	ASN1_OCTET_STRING *octet;
+	ASN1_OCTET_STRING *octet = NULL;
 	const EC_GROUP *group = NULL;
 	char paramset[2] = "A";
 	int r = -1, ret_vrf = 0;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3234,7 +3234,7 @@ find_mechanism(CK_SLOT_ID slot, CK_FLAGS flags,
 	count = get_mechanisms(slot, &mechs, flags);
 	if (count)   {
 		if (list && list_len)   {
-			unsigned ii, jj;
+			unsigned ii = list_len, jj;
 
 			for (jj=0; jj<count; jj++)   {
 				for (ii=0; ii<list_len; ii++)


### PR DESCRIPTION
This fixes issues that prevent OpenSC from building when `--disable-optimization` is passed to `./configure`.

It includes a fix specifically for OpenPGP cards, but I do not have one to test with. (@Jakuje , @mouse07410 , would either of you be able to test that your card works with these changes?)

##### Checklist
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
