### PR TITLE
pkcs11-tool: Add examples section to the manual page

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -559,4 +559,26 @@
 			</variablelist>
 		</para>
 	</refsect1>
+
+	<refsect1>
+		<title>Examples</title>
+		<para>
+			To list all certificates on the smart card:
+				<programlisting>pkcs11-tool --list-objects --type cert</programlisting>
+
+			To read the certificate with ID <replaceable>KEY_ID</replaceable>
+			in DER format from smart card:
+				<programlisting>pkcs11-tool --read-object  --id KEY_ID --type cert --outfile cert.der</programlisting>
+
+			To convert the certificate in DER formato to PEM format, use OpenSSL
+			tools:
+				<programlisting>openssl x509 -inform DER -in cert.der -outform PEM > cert.pem</programlisting>
+
+			To sign some data stored in file <replaceable>data</replaceable>
+			using the private key with ID <replaceable>ID</replaceable> and
+			using the RSA-PKCS mechanism:
+				<programlisting>pkcs11-tool --sign --id ID --mechanism RSA-PKCS --input-file data --output-file data.sig</programlisting>
+		</para>
+	</refsect1>
+
 </refentry>


### PR DESCRIPTION
I did not forget on the #1200 so I put a simple summary from the [wiki](https://github.com/OpenSC/OpenSC/wiki/Using-pkcs11-tool-and-OpenSSL) to the new "Examples" section of the `pkcs11-tool` manual page.

I believe others will have also their common use cases, that could be listed in this section or in other tools.

I hope I used correct markup for the Examples section, but for me it looked fine in `man`.

##### Checklist
- [X] Documentation is added or updated