### PR TITLE
Always allocate resp buffer in DNIe.

### DIFF
--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -1431,11 +1431,9 @@ int cwa_encode_apdu(sc_card_t * card,
 		   sizeof(u8));
 	ccbuf = calloc(MAX(SC_MAX_APDU_BUFFER_SIZE, 20 + from->datalen),
 		   sizeof(u8));
-	if (!to->resp) {
-		/* if no response create a buffer for the encoded response */
-		to->resp = calloc(MAX_RESP_BUFFER_SIZE, sizeof(u8));
-		to->resplen = MAX_RESP_BUFFER_SIZE;
-	}
+	/* always create a new buffer for the encoded response */
+	to->resp = calloc(MAX_RESP_BUFFER_SIZE, sizeof(u8));
+	to->resplen = MAX_RESP_BUFFER_SIZE;
 	if (!apdubuf || !ccbuf || (!from->resp && !to->resp)) {
 		res = SC_ERROR_OUT_OF_MEMORY;
 		goto err;


### PR DESCRIPTION
PR to always allocate the _resp_ buffer in DNIe when using the secure channel. See the conversation in PR #1249. DNIe until now only allocates the _resp_ buffer if the original apdu didn't have one. From now on it is always allocated and freed.

##### Checklist
- [ X] Tested with the following card: DNIe v3.0
	- [X ] tested PKCS#11
