### PR TITLE
Slightly adjust pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,17 @@
 <!--
 Thank you for your pull request.
 
-If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
+If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
+(without quotes) in the commit message.
+
+Mention which card(s) are used during testing. To get the name of your card,
+run this command: `opensc-tool -n`
 -->
 
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 - [ ] Documentation is added or updated
 - [ ] New files have a LGPL 2.1 license statement
-- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
-	- [ ] tested PKCS#11
-	- [ ] tested Windows Minidriver
-	- [ ] tested macOS Tokend
+- [ ] PKCS#11 module is tested
+- [ ] Windows minidriver is tested
+- [ ] macOS tokend is tested


### PR DESCRIPTION
_This is a suggestion, because I realize the pull request template exists to help the maintainers. Any feedback or other changes are certainly welcome._

During a pull request, it might not be possible for all components (such as the PKCS#11 module, Windows minidriver, or macOS tokend) to be tested by the same person using the same card; not everyone has access to all of the platforms supported by OpenSC. When there are no card-specific changes, each component might be tested by a different person using a different type of card.

The pull request template contains a checklist with each component that needs to be tested (which can be adapted as needed). However, this checklist also includes an item for the type of card used for testing. This should certainly be included in the message, but it doesn't quite seem to belong in the checklist as a separate item, particularly when considering the multiple-card testing situation described above. It seems that the checklist is intended to track specific tasks that still need to be completed.

This change slightly adjusts the template in order to handle this. (It is still just a template, and it can be adapted for each pull request as needed.)