### PR TITLE
coolkey: Make uninitialized cards working as expected with ESC

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST = Makefile.mak opensc.dll.manifest
 lib_LTLIBRARIES = libopensc.la
 noinst_HEADERS = cards.h ctbcs.h internal.h esteid.h muscle.h muscle-filesystem.h \
 	internal-winscard.h p15card-helper.h pkcs15-syn.h \
-	opensc.h pkcs15.h \
+	opensc.h pkcs15.h gp.h \
 	cardctl.h asn1.h log.h simpletlv.h \
 	errors.h types.h compression.h itacns.h iso7816.h \
 	authentic.h iasecc.h iasecc-sdo.h sm.h card-sc-hsm.h \
@@ -23,7 +23,7 @@ AM_OBJCFLAGS = $(AM_CFLAGS)
 libopensc_la_SOURCES_BASE = \
 	sc.c ctx.c log.c errors.c \
 	asn1.c base64.c sec.c card.c iso7816.c dir.c ef-atr.c \
-	ef-gdo.c padding.c apdu.c simpletlv.c \
+	ef-gdo.c padding.c apdu.c simpletlv.c gp.c \
 	\
 	pkcs15.c pkcs15-cert.c pkcs15-data.c pkcs15-pin.c \
 	pkcs15-prkey.c pkcs15-pubkey.c pkcs15-skey.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -4,7 +4,7 @@ TARGET                  = opensc.dll opensc_a.lib
 OBJECTS			= \
 	sc.obj ctx.obj log.obj errors.obj \
 	asn1.obj base64.obj sec.obj card.obj iso7816.obj dir.obj ef-atr.obj \
-	ef-gdo.obj padding.obj apdu.obj simpletlv.obj \
+	ef-gdo.obj padding.obj apdu.obj simpletlv.obj gp.obj \
 	\
 	pkcs15.obj pkcs15-cert.obj pkcs15-data.obj pkcs15-pin.obj \
 	pkcs15-prkey.obj pkcs15-pubkey.obj pkcs15-skey.obj \

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -58,6 +58,7 @@
 #include "compression.h"
 #endif
 #include "iso7816.h"
+#include "gp.h"
 #include "../pkcs11/pkcs11.h"
 
 
@@ -1093,15 +1094,6 @@ static int coolkey_select_applet(sc_card_t *card)
 	return coolkey_apdu_io(card, ISO7816_CLASS, ISO7816_INS_SELECT_FILE, 4, 0,
 			&aid[0], sizeof(aid), NULL, NULL,  NULL, 0);
 }
-
-/* select the gp card manager */
-static int coolkey_select_card_mgr(sc_card_t *card)
-{
-	u8 aid[] = { 0xa0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00 };
-	return coolkey_apdu_io(card, ISO7816_CLASS, ISO7816_INS_SELECT_FILE, 4, 0,
-			&aid[0], sizeof(aid), NULL, NULL,  NULL, 0);
-}
-
 
 static void
 coolkey_make_cuid_from_cplc(coolkey_cuid_t *cuid, global_platform_cplc_data_t *cplc_data)
@@ -2224,7 +2216,7 @@ static int coolkey_initialize(sc_card_t *card)
 		/* select the card manager, because a card with applet only will have
 		   already selected the coolkey applet */
 
-		r = coolkey_select_card_mgr(card);
+		r = gp_select_card_manager(card);
 		if (r < 0) {
 			goto cleanup;
 		}

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1094,6 +1094,15 @@ static int coolkey_select_applet(sc_card_t *card)
 			&aid[0], sizeof(aid), NULL, NULL,  NULL, 0);
 }
 
+/* select the gp card manager */
+static int coolkey_select_card_mgr(sc_card_t *card)
+{
+	u8 aid[] = { 0xa0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00 };
+	return coolkey_apdu_io(card, ISO7816_CLASS, ISO7816_INS_SELECT_FILE, 4, 0,
+			&aid[0], sizeof(aid), NULL, NULL,  NULL, 0);
+}
+
+
 static void
 coolkey_make_cuid_from_cplc(coolkey_cuid_t *cuid, global_platform_cplc_data_t *cplc_data)
 {
@@ -1951,7 +1960,7 @@ static int coolkey_select_file(sc_card_t *card, const sc_path_t *in_path, sc_fil
 		*file_out = file;
 	}
 
-    return SC_SUCCESS;
+	return SC_SUCCESS;
 }
 
 static int coolkey_finish(sc_card_t *card)
@@ -2144,12 +2153,6 @@ static int coolkey_initialize(sc_card_t *card)
 	if (card->drv_data) {
 		return SC_SUCCESS;
 	}
-
-	/* Select a coolkey read the coolkey objects out */
-	r = coolkey_select_applet(card);
-	if (r < 0) {
-		return r;
-	}
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"Coolkey Applet found");
 
 	priv = coolkey_new_private_data();
@@ -2161,6 +2164,13 @@ static int coolkey_initialize(sc_card_t *card)
 	if (r < 0) {
 		goto cleanup;
 	}
+
+	/* Select a coolkey read the coolkey objects out */
+	r = coolkey_select_applet(card);
+	if (r < 0) {
+		return r;
+	}
+
 	priv->protocol_version_major = life_cycle.protocol_version_major;
 	priv->protocol_version_minor = life_cycle.protocol_version_minor;
 	priv->pin_count = life_cycle.pin_count;
@@ -2211,6 +2221,14 @@ static int coolkey_initialize(sc_card_t *card)
 	/* if we didn't pull the cuid from the combined object, then grab it now */
 	if (!combined_processed) {
 		global_platform_cplc_data_t cplc_data;
+		/* select the card manager, because a card with applet only will have
+		   already selected the coolkey applet */
+
+		r = coolkey_select_card_mgr(card);
+		if (r < 0) {
+			goto cleanup;
+		}
+
 		r = coolkey_get_cplc_data(card, &cplc_data);
 		if (r < 0) {
 			goto cleanup;

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -45,6 +45,7 @@
 /* #include "sm.h" */
 #include "pkcs15.h"
 /* #include "hash-strings.h" */
+#include "gp.h"
 
 #include "iasecc.h"
 
@@ -90,12 +91,6 @@ static struct sc_atr_table iasecc_known_atrs[] = {
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 
-static struct sc_aid GlobalPlatform_CardManager_AID = {
-	{ 0xA0,0x00,0x00,0x00,0x03,0x00,0x00}, 7
-};
-static struct sc_aid GlobalPlatform_ISD_Default_RID = {
-	{ 0xA0,0x00,0x00,0x01,0x51,0x00,0x00}, 7
-};
 static struct sc_aid OberthurIASECC_AID = {
 	{0xA0,0x00,0x00,0x00,0x77,0x01,0x08,0x00,0x07,0x00,0x00,0xFE,0x00,0x00,0x01,0x00}, 16
 };
@@ -477,8 +472,6 @@ static int
 iasecc_init_oberthur(struct sc_card *card)
 {
 	struct sc_context *ctx = card->ctx;
-	unsigned char resp[0x100];
-	size_t resp_len;
 	unsigned int flags;
 	int rv = 0;
 
@@ -495,10 +488,9 @@ iasecc_init_oberthur(struct sc_card *card)
 
 	iasecc_parse_ef_atr(card);
 
-	resp_len = sizeof(resp);
-	if (iasecc_select_aid(card, &GlobalPlatform_CardManager_AID, resp, &resp_len))   {
-		resp_len = sizeof(resp);
-		iasecc_select_aid(card, &GlobalPlatform_ISD_Default_RID, resp, &resp_len);
+	/* if we fail to select CM, */
+	if (gp_select_card_manager(card)) {
+		gp_select_isd_rid(card);
 	}
 
 	rv = iasecc_oberthur_match(card);

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -39,6 +39,7 @@
 #include "internal.h"
 #include "cardctl.h"
 #include "pkcs15.h"
+#include "gp.h"
 
 #define OBERTHUR_PIN_LOCAL	0x80
 #define OBERTHUR_PIN_REFERENCE_USER	0x81
@@ -157,19 +158,10 @@ auth_select_aid(struct sc_card *card)
 	unsigned char apdu_resp[SC_MAX_APDU_BUFFER_SIZE];
 	struct auth_private_data *data =  (struct auth_private_data *) card->drv_data;
 	int rv, ii;
-	unsigned char cm[7] = {0xA0,0x00,0x00,0x00,0x03,0x00,0x00};
 	struct sc_path tmp_path;
 
 	/* Select Card Manager (to deselect previously selected application) */
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x04, 0x0C);
-	apdu.lc = sizeof(cm);
-	/* apdu.le = sizeof(cm)+4; */
-	apdu.data = cm;
-	apdu.datalen = sizeof(cm);
-	apdu.resplen = sizeof(apdu_resp);
-	apdu.resp = apdu_resp;
-
-	rv = sc_transmit_apdu(card, &apdu);
+	rv = gp_select_card_manager(card);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
 
 	/* Get smart card serial number */

--- a/src/libopensc/gp.c
+++ b/src/libopensc/gp.c
@@ -42,14 +42,23 @@ static int
 gp_select_aid(struct sc_card *card, const struct sc_aid *aid)
 {
 	struct sc_apdu apdu;
+	int rv;
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x04, 0x0C);
 	apdu.lc = aid->len;
 	apdu.data = aid->value;
 	apdu.datalen = aid->len;
 
-	return sc_transmit_apdu(card, &apdu);
+	rv = sc_transmit_apdu(card, &apdu);
 
+	if (rv < 0)
+		return rv;
+
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (rv < 0)
+		return rv;
+
+	return apdu.resplen;
 }
 
 /* Select the Open Platform Card Manager */
@@ -59,7 +68,7 @@ gp_select_card_manager(struct sc_card *card)
 	int rv;
 
 	LOG_FUNC_CALLED(card->ctx);
-	rv =  gp_select_aid(card, &gp_card_manager);
+	rv = gp_select_aid(card, &gp_card_manager);
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
 

--- a/src/libopensc/gp.c
+++ b/src/libopensc/gp.c
@@ -1,0 +1,75 @@
+/*
+ * gp.c: Global Platform Related functions
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Author: Jakub Jelen <jjelen@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "internal.h"
+
+/* The AID of the Card Manager defined by Open Platform 2.0.1 specification */
+static const struct sc_aid gp_card_manager = {
+	{0xA0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00}, 7
+};
+
+/* The AID of the Issuer Security Domain defined by GlobalPlatform 2.3.1 specification. */
+static const struct sc_aid gp_isd_rid = {
+	{0xA0, 0x00, 0x00, 0x01, 0x51, 0x00, 0x00}, 7
+};
+
+
+/* Select AID */
+static int
+gp_select_aid(struct sc_card *card, const struct sc_aid *aid)
+{
+	struct sc_apdu apdu;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x04, 0x0C);
+	apdu.lc = aid->len;
+	apdu.data = aid->value;
+	apdu.datalen = aid->len;
+
+	return sc_transmit_apdu(card, &apdu);
+
+}
+
+/* Select the Open Platform Card Manager */
+int
+gp_select_card_manager(struct sc_card *card)
+{
+	int rv;
+
+	LOG_FUNC_CALLED(card->ctx);
+	rv =  gp_select_aid(card, &gp_card_manager);
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+/* Select Global Platform Card Manager */
+int
+gp_select_isd_rid(struct sc_card *card)
+{
+	int rv;
+
+	LOG_FUNC_CALLED(card->ctx);
+	rv = gp_select_aid(card, &gp_isd_rid);
+	LOG_FUNC_RETURN(card->ctx, rv);
+}

--- a/src/libopensc/gp.h
+++ b/src/libopensc/gp.h
@@ -1,0 +1,42 @@
+/*
+ * gp.h: Global Platform Related functions
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Author: Jakub Jelen <jjelen@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _LIBOPENSC_GP_H
+#define _LIBOPENSC_GP_H
+
+#include <stdio.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int gp_select_card_manager(struct sc_card *card);
+int gp_select_isd_rid(struct sc_card *card);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
These changes are needed for coolkey driver to recognize cards, that are just loaded the coolkey applet, but do not have any certificates and keys in. Also the card manager applet needs to be selected to get correctly the life-cycle information from the card.

Original patch from John Magne <jmagne@redhat.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Tested with the following card: coolkey
	- [X] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend