### PR TITLE
PIV History Object Related Changes - Fixes #1330

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3583,19 +3583,12 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 		goto err;
 	}
 
-	/* can we detect and then select the PIV AID without losing the login state? */
-	if ((priv->card_issues & CI_DISCOVERY_USELESS)
-			&& (priv->card_issues & CI_PIV_AID_LOSE_STATE)) {
-		r = 0; /* do nothing, hope card was not interfered with */
-		goto err;
-	}
-
 	/* make sure our application is active */
 
 	/* first see if AID is active AID by reading discovery object '7E' */
 	/* If not try selecting AID */
 
-	/* but if x card does not support DISCOVERY object we can not use it */
+	/* but if card does not support DISCOVERY object we can not use it */
 	if (priv->card_issues & CI_DISCOVERY_USELESS) {
 	    r =  SC_ERROR_NO_CARD_SUPPORT;
 	} else {
@@ -3603,7 +3596,7 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 	}
 
 	if (r < 0) {
-		if (!(priv->card_issues & CI_PIV_AID_LOSE_STATE)) {
+		if (was_reset > 0 || !(priv->card_issues & CI_PIV_AID_LOSE_STATE)) {
 			r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, temp, &templen);
 		} else {
 			r = 0; /* cant do anything with this card, hope there was no interference */

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2871,7 +2871,7 @@ piv_process_history(sc_card_t *card)
 			}
 			keyref = sc_asn1_find_tag(card->ctx, seq, seqlen, 0x04, &keyreflen);
 			if (!keyref || keyreflen != 1 ||
-					(*keyref < 0x82 && *keyref > 0x95)) {
+					(*keyref < 0x82 || *keyref > 0x95)) {
 				sc_log(card->ctx, "DER problem");
 				r = SC_ERROR_INVALID_ASN1_OBJECT;
 				goto err;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3454,6 +3454,16 @@ piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 		data->pin1.tries_left = priv->tries_left;
 		if (tries_left)
 			*tries_left = priv->tries_left;
+
+		/*
+		 * If called to check on the login state for a context specific login
+		 * return not logged in. Needed because of logic in e6f7373ef066  
+		 */
+		if (data->pin_type == SC_AC_CONTEXT_SPECIFIC) {
+			data->pin1.logged_in = 0;
+			 LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+		}
+
 		if (priv->logged_in == SC_PIN_STATE_LOGGED_IN) {
 			/* Avoid status requests when the user is logged in to handle NIST
 			 * 800-73-4 Part 2:

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -700,7 +700,7 @@ int sc_pkcs15_get_pin_info(struct sc_pkcs15_card *p15card,
 	/* Try to update PIN info from card */
 	memset(&data, 0, sizeof(data));
 	data.cmd = SC_PIN_CMD_GET_INFO;
-	data.pin_type = SC_AC_CHV;
+	data.pin_type = pin_info->auth_method;
 	data.pin_reference = pin_info->attrs.pin.reference;
 
 	r = sc_pin_cmd(card, &data, NULL);

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -528,83 +528,83 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		{ "05", "Retired KEY MAN 1",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x82, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x82, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "06", "Retired KEY MAN 2",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x83, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x83, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "07", "Retired KEY MAN 3",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x84, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x84, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "08", "Retired KEY MAN 4",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x85, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x85, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "09", "Retired KEY MAN 5",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x86, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x86, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "10", "Retired KEY MAN 6",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x87, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x87, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "11", "Retired KEY MAN 7",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x88, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x88, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "12", "Retired KEY MAN 8",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x89, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x89, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "13", "Retired KEY MAN 9",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8A, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8A, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "14", "Retired KEY MAN 10",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8B, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8B, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "15", "Retired KEY MAN 11",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8C, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8C, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "16", "Retired KEY MAN 12",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8D, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8D, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "17", "Retired KEY MAN 13",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8E, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8E, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "18", "Retired KEY MAN 14",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x8F, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x8F, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "19", "Retired KEY MAN 15",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x90, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x90, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "20", "Retired KEY MAN 16",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x91, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x91, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "21", "Retired KEY MAN 17",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x92, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x92, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "22", "Retired KEY MAN 18",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x93, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x93, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "23", "Retired KEY MAN 19",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x94, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1},
+			"", 0x94, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0},
 		{ "24", "Retired KEY MAN 20",
 				/*RSA*/SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP,
 				/*EC*/SC_PKCS15_PRKEY_USAGE_DERIVE,
-			"", 0x95, "01", SC_PKCS15_CO_FLAG_PRIVATE, 1}
+			"", 0x95, "01", SC_PKCS15_CO_FLAG_PRIVATE, 0}
 	};
 
 	int    r, i;
@@ -1142,7 +1142,7 @@ sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 
 		strncpy(prkey_obj.label, prkeys[i].label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 		prkey_obj.flags = prkeys[i].obj_flags;
-		prkey_obj.user_consent = prkeys[i].user_consent;
+		prkey_obj.user_consent = prkeys[i].user_consent; /* only Sign key */
 
 		if (prkeys[i].auth_id)
 			sc_pkcs15_format_id(prkeys[i].auth_id, &prkey_obj.auth_id);
@@ -1165,6 +1165,10 @@ sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 			case SC_ALGORITHM_RSA:
 				if(ckis[i].cert_keyUsage_present) {
 					prkey_info.usage |= ckis[i].priv_usage;
+					/* If retired key and non gov cert has NONREPUDIATION, treat as user_consent */
+					if (i >= 4 && (ckis[i].priv_usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)) {
+						prkey_obj.user_consent = 1;
+					}
 				} else {
 					prkey_info.usage |= prkeys[i].usage_rsa;
 				}
@@ -1174,6 +1178,10 @@ sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "DEE Adding pin %d label=%s",i, label);
 			case SC_ALGORITHM_EC:
 				if (ckis[i].cert_keyUsage_present) {
 					prkey_info.usage  |= ckis[i].priv_usage;
+					/* If retired key and non gov cert has NONREPUDIATION, treat as user_consent */
+					if (i >= 4 && (ckis[i].priv_usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)) {
+						prkey_obj.user_consent = 1;
+					}
 				} else {
 					prkey_info.usage  |= prkeys[i].usage_ec;
 				}


### PR DESCRIPTION
&& is replaced by || in the test of valid key references
for retired keys found in the Historic object.

For retired keys, the user_consent flag was being set by default.
Thus a C_Login(CKU_CONTEXT_SPECIFIC) would be required.
NIST 800-73 only requires PIN_Always on the Sign Key.

To extend the usefullnes of "retired keys" on non government
issued PIV-like cards, code had already been added
to use the certificate keyUsage flags to override the NIST
defined key usage flags. The NONREPUDATION  flag is now used
to set the user_consent flag.

So rather then always requiring C_Login(CKU_CONTEXT_SPECIFIC)
for any retured key, the code only requires it for non government
cards where teh certificate has NONREPUDATION.

 Changes to be committed:
	modified:   card-piv.c
	modified:   pkcs15-piv.c

<!--
Thank you for your pull request.

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] Tested with the following card: NIST and Oberthur demo cards with History Objects and Retired Keys
	- [x] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
