### PR TITLE
openpgp: don't treat OpenPGP v3 cards special in src/libopensc/pkcs15…

### DIFF
--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -82,6 +82,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_OPENPGP_V1:
 		case SC_CARD_TYPE_OPENPGP_V2:
 		case SC_CARD_TYPE_OPENPGP_GNUK:
+		case SC_CARD_TYPE_OPENPGP_V3:
 		case SC_CARD_TYPE_SC_HSM:
 		case SC_CARD_TYPE_SC_HSM_SOC:
 		case SC_CARD_TYPE_DNIE_BASE:


### PR DESCRIPTION
…-syn.c

As OpenPGP v3 cards are backward compatible with earlier versions
and do - according to the specs - do not appear to have native
PKCS#15, fix an inconsistency in src/libopensc/pkcs15-syn.c and 
mark them also as only having emulated PKCS#14.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Tested with the following card: <!-- use `opensc-tool -n` to get the name of your card -->
	- [ ] tested PKCS#11
	- [ ] tested Windows Minidriver
	- [ ] tested macOS Tokend
