### PR TITLE
macOS: Remove unused build code for the CryptoTokenKit app extension

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -6,16 +6,7 @@
 # You need to have  the following from homebrew or macports or fink:
 # autoconf automake libtool pkg-config
 
-# If you want to compile with OpenSCToken/CryptoTokenKit set the following:
-#ENABLE_CRYPTOTOKENKIT="--disable-pcsc  --enable-cryptotokenkit"
-# When using CryptoTokenKit, code signing is required
-#SIGNING_IDENTITY=BA3CE53D402E3C75246557E2890F929F4A778DDE
-
-if test -z "$ENABLE_CRYPTOTOKENKIT"; then
-	export MACOSX_DEPLOYMENT_TARGET="10.10"
-else
-	export MACOSX_DEPLOYMENT_TARGET="10.12"
-fi
+export MACOSX_DEPLOYMENT_TARGET="10.10"
 
 set -ex
 test -x ./configure || ./bootstrap
@@ -69,7 +60,6 @@ if ! test -e ${BUILDPATH}/target/$PREFIX/lib/pkgconfig; then
 		--sysconfdir=$PREFIX/etc \
 		--enable-cvcdir=$PREFIX/etc/cvc \
 		--enable-x509dir=$PREFIX/etc/x509 \
-		$ENABLE_CRYPTOTOKENKIT \
 		--disable-notify \
 		--disable-dependency-tracking \
 		--enable-shared \
@@ -96,48 +86,34 @@ if ! test -e ${BUILDPATH}/target/$PREFIX/lib/pkgconfig; then
 	./MacOSX/libtool-bundle ${BUILDPATH}/target/$PREFIX/lib/opensc-pkcs11.so ${BUILDPATH}/target/$PREFIX/lib
 fi
 
-if test -z "$ENABLE_CRYPTOTOKENKIT"; then
-	# Check out OpenSC.tokend, if not already fetched.
-	if ! test -e OpenSC.tokend; then
-		git clone http://github.com/OpenSC/OpenSC.tokend.git
-	fi
-
-	# Create the symlink to OpenSC sources
-	test -L OpenSC.tokend/build/opensc-src || ln -sf ${BUILDPATH}/src OpenSC.tokend/build/opensc-src
-
-	# Build and copy OpenSC.tokend
-	xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj install DSTROOT=${BUILDPATH}/target
-
-	#if ! test -e $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications/terminal-notifier.app; then
-		#if ! test -e terminal-notifier-1.7.1.zip; then
-			#curl -L https://github.com/julienXX/terminal-notifier/releases/download/1.7.1/terminal-notifier-1.7.1.zip > terminal-notifier-1.7.1.zip
-		#fi
-		#if ! test -e terminal-notifier-1.7.1; then
-			#unzip terminal-notifier-1.7.1.zip
-		#fi
-		#mkdir -p $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
-		#cp -r terminal-notifier-1.7.1/terminal-notifier.app $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
-	#fi
-
-	if ! test -e NotificationProxy; then
-		git clone http://github.com/frankmorgner/NotificationProxy.git
-	fi
-	xcodebuild -target NotificationProxy -configuration Release -project NotificationProxy/NotificationProxy.xcodeproj install DSTROOT=$BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/
-	mkdir -p "$BUILDPATH/target/Applications"
-	osacompile -o "$BUILDPATH/target/Applications/OpenSC Notify.app" "MacOSX/OpenSC_Notify.applescript"
-else
-	# Check out OpenSCToken, if not already fetched.
-	if ! test -e OpenSCToken; then
-		git clone http://github.com/frankmorgner/OpenSCToken.git
-	fi
-
-	# Build and copy OpenSCTokenApp
-	xcodebuild -target OpenSCTokenApp -configuration Release -project OpenSCToken/OpenSCTokenApp.xcodeproj install DSTROOT=${BUILDPATH}/target
-
-	codesign --sign "$SIGNING_IDENTITY" --force --entitlements MacOSX/opensc.entitlements target/Library/OpenSC/bin/*
-	codesign --sign "$SIGNING_IDENTITY" --force --entitlements MacOSX/opensc.entitlements target/Library/OpenSC/lib/*.dylib
-	codesign --sign "$SIGNING_IDENTITY" --force --entitlements MacOSX/opensc.entitlements --deep target/Library/OpenSC/lib/opensc-pkcs11.bundle
+# Check out OpenSC.tokend, if not already fetched.
+if ! test -e OpenSC.tokend; then
+	git clone http://github.com/OpenSC/OpenSC.tokend.git
 fi
+
+# Create the symlink to OpenSC sources
+test -L OpenSC.tokend/build/opensc-src || ln -sf ${BUILDPATH}/src OpenSC.tokend/build/opensc-src
+
+# Build and copy OpenSC.tokend
+xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj install DSTROOT=${BUILDPATH}/target
+
+#if ! test -e $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications/terminal-notifier.app; then
+	#if ! test -e terminal-notifier-1.7.1.zip; then
+		#curl -L https://github.com/julienXX/terminal-notifier/releases/download/1.7.1/terminal-notifier-1.7.1.zip > terminal-notifier-1.7.1.zip
+	#fi
+	#if ! test -e terminal-notifier-1.7.1; then
+		#unzip terminal-notifier-1.7.1.zip
+	#fi
+	#mkdir -p $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
+	#cp -r terminal-notifier-1.7.1/terminal-notifier.app $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
+#fi
+
+if ! test -e NotificationProxy; then
+	git clone http://github.com/frankmorgner/NotificationProxy.git
+fi
+xcodebuild -target NotificationProxy -configuration Release -project NotificationProxy/NotificationProxy.xcodeproj install DSTROOT=$BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/
+mkdir -p "$BUILDPATH/target/Applications"
+osacompile -o "$BUILDPATH/target/Applications/OpenSC Notify.app" "MacOSX/OpenSC_Notify.applescript"
 
 imagedir=$(mktemp -d)
 

--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Building the installer is only tested and supported on 10.9+ with Xcode 6.0.1
-# Built package targets 10.10
-# Building should also work on older versions with older revisions or slight changes, YMMV
+# Build the macOS installer for the tokend and command line tools.
+#
+# This is only tested and supported on macOS 10.10 or later, using Xcode 6.0.1.
+# Building should also work on older macOS versions with slight changes; YMMV.
 
-# You need to have  the following from homebrew or macports or fink:
-# autoconf automake libtool pkg-config
+# You need to install the following packages from homebrew or macports or fink:
+# autoconf automake libtool pkg-config help2man gengetopt
 
 export MACOSX_DEPLOYMENT_TARGET="10.10"
 

--- a/MacOSX/opensc-uninstall
+++ b/MacOSX/opensc-uninstall
@@ -21,11 +21,6 @@ rm -rf /Library/OpenSC
 rm -rf /Library/Security/tokend/OpenSC.tokend
 rm -rf /System/Library/Security/tokend/OpenSC.tokend
 
-if [ -e "/Library/OpenSC/OpenSCTokenApp.app/Contents/PlugIns/OpenSCToken.appex" ]
-then
-	pluginkit -r /Library/OpenSC/OpenSCTokenApp.app/Contents/PlugIns/OpenSCToken.appex
-fi
-
 # delete receipts on 10.6+
 for file in /var/db/receipts/org.opensc-project.mac.bom /var/db/receipts/org.opensc-project.mac.plist; do
 	test -f $file && rm -f $file

--- a/MacOSX/opensc.entitlements
+++ b/MacOSX/opensc.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.smartcard</key>
-    <true/>
-</dict>
-</plist>

--- a/MacOSX/scripts/postinstall
+++ b/MacOSX/scripts/postinstall
@@ -19,8 +19,4 @@ for f in /Library/OpenSC/bin/*
 do
 	ln -sf $f /usr/local/bin
 done
-if [ -e "/Library/OpenSC/OpenSCTokenApp.app/Contents/PlugIns/OpenSCToken.appex" ]
-then
-	pluginkit -a /Library/OpenSC/OpenSCTokenApp.app/Contents/PlugIns/OpenSCToken.appex
-fi
 exit 0


### PR DESCRIPTION
[OpenSCToken](https://github.com/frankmorgner/OpenSCToken) is now a standalone package that provides the CryptoTokenKit app extension. It includes its own `build-package` script, which handles building the OpenSC library and statically linking against it.

The `MacOSX/` directory in OpenSC itself is only used to build the macOS tokend. Remove unused code for building a CryptoTokenKit app extension from this directory (which no longer works); and update the description at the top of the `MacOSX/build-package` script. This should help to avoid confusion when building OpenSC for macOS.