### PR TITLE
C set attribute value

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2586,11 +2586,6 @@ pkcs15_create_data(struct sc_pkcs11_slot *slot, struct sc_profile *profile,
 		}
 	}
 
-	if (args.der_encoded.len == 0) {
-		rv = CKR_TEMPLATE_INCOMPLETE;
-		goto out;
-	}
-
 	rc = sc_pkcs15init_store_data_object(fw_data->p15_card, profile, &args, &data_obj);
 	if (rc < 0) {
 		rv = sc_to_cryptoki_error(rc, "C_CreateObject");

--- a/src/pkcs15init/pkcs15-init.h
+++ b/src/pkcs15init/pkcs15-init.h
@@ -290,6 +290,7 @@ struct sc_pkcs15init_certargs {
 
 #define P15_ATTR_TYPE_LABEL	0
 #define P15_ATTR_TYPE_ID	1
+#define P15_ATTR_TYPE_VALUE	2
 
 
 extern struct	sc_pkcs15_object *sc_pkcs15init_new_object(int, const char *,


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

Hello, 
PKCS11 standard  v. 2.40 (http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.pdf) states that default value for CKO_DATA object's CKA_VALUE is empty (4.5.2, page 42). That points to the possibility of modifying this attribute for these objects via C_SetAttributeValue (same can be seen in the current code for object's id). 
These commits allow creating data objects with empty CKA_VALUE and modifying it later.