### PR TITLE
macOS: disable notifications only in PKCS#11 module

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -61,7 +61,6 @@ if ! test -e ${BUILDPATH}/target/$PREFIX/lib/pkgconfig; then
 		--sysconfdir=$PREFIX/etc \
 		--enable-cvcdir=$PREFIX/etc/cvc \
 		--enable-x509dir=$PREFIX/etc/x509 \
-		--disable-notify \
 		--disable-dependency-tracking \
 		--enable-shared \
 		--enable-static \

--- a/src/ui/notify.c
+++ b/src/ui/notify.c
@@ -278,6 +278,17 @@ static void notify_proxy(struct sc_context *ctx,
 	 * we're including NotificationProxy which has similar features */
 	const char notificationproxy[] = "/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications/NotificationProxy.app/Contents/MacOS/NotificationProxy";
 
+	if (ctx && ctx->app_name
+			&& (0 == strcmp(ctx->app_name, "opensc-pkcs11")
+				|| 0 == strcmp(ctx->app_name, "onepin-opensc-pkcs11"))) {
+		/* some programs don't like forking when loading our PKCS#11 module,
+		 * see https://github.com/OpenSC/OpenSC/issues/1174.
+		 * TODO implementing an XPC service which sends the notification should
+		 * work, though. See
+		 * https://github.com/OpenSC/OpenSC/issues/1304#issuecomment-376656003 */
+		return;
+	}
+
 	if (child > 0) {
 		int status;
 		if (0 == waitpid(child, &status, WNOHANG)) {


### PR DESCRIPTION
I was unsatisfied having no notifications at all, so I basically reverted https://github.com/OpenSC/OpenSC/commit/c35eb1c9bc74e284723ffd726478720b69aed970 by applying a more selective fix for https://github.com/OpenSC/OpenSC/issues/1174

@mouse07410 could you please check if your PIN prompt in engine_pkcs11 is still working with this change?

##### Checklist

- [x] PKCS#11 module is tested
- [x] macOS tokend is tested
