### PR TITLE
Fixed gcc 8 compilation errors

### DIFF
--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -33,6 +33,7 @@ Some features are undocumented like the format used to store certificates. They 
 
 #include <stdlib.h>
 #include <string.h>
+#include "../common/compat_strlcpy.h"
 
 #ifdef ENABLE_OPENSSL
 /* openssl only needed for card administration */
@@ -462,7 +463,7 @@ static int gids_create_file(sc_card_t *card, char* directory, char* filename) {
 	memset(masterfilebuffer + offset, 0, sizeof(gids_mf_record_t));
 	record = (gids_mf_record_t*) (masterfilebuffer + offset);
 	strncpy(record->directory, directory, 8);
-	strcpy(record->filename, filename);
+	strlcpy(record->filename, filename, sizeof(record->filename));
 	record->fileIdentifier = fileIdentifier;
 	record->dataObjectIdentifier = dataObjectIdentifier;
 

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -462,7 +462,7 @@ static int gids_create_file(sc_card_t *card, char* directory, char* filename) {
 	memset(masterfilebuffer + offset, 0, sizeof(gids_mf_record_t));
 	record = (gids_mf_record_t*) (masterfilebuffer + offset);
 	strncpy(record->directory, directory, 8);
-	strncpy(record->filename, filename, 8);
+	strcpy(record->filename, filename);
 	record->fileIdentifier = fileIdentifier;
 	record->dataObjectIdentifier = dataObjectIdentifier;
 

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -738,7 +738,7 @@ sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 			unsigned int id = path.value[path.len - 2] * 0x100 + path.value[path.len - 1];
 
 			if (id == ccont.id_cert)   {
-				strncpy(kobj.label, objs[ii]->label, sizeof(kobj.label) - 1);
+				strcpy(kobj.label, objs[ii]->label);
 				break;
 			}
 		}

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "../common/compat_strlcpy.h"
 
 #include "pkcs15.h"
 #include "log.h"
@@ -738,7 +739,7 @@ sc_pkcs15emu_oberthur_add_prvkey(struct sc_pkcs15_card *p15card,
 			unsigned int id = path.value[path.len - 2] * 0x100 + path.value[path.len - 1];
 
 			if (id == ccont.id_cert)   {
-				strcpy(kobj.label, objs[ii]->label);
+				strlcpy(kobj.label, objs[ii]->label, sizeof(kobj.label));
 				break;
 			}
 		}


### PR DESCRIPTION
The following errors occured during a compilation using gcc 8 on Fedora 28:

In function »gids_create_file.constprop«,
    inserted by »gids_save_certificate.isra.8« beicard-gids.c:1548:7:
card-gids.c:465:2: Error: »strncpy« output may be truncated copying 8 bytes from a string of length 8 [-Werror=stringop-truncation]
  strncpy(record->filename, filename, 8);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

pkcs15-oberthur.c: In function »sc_pkcs15emu_oberthur_add_prvkey«:
pkcs15-oberthur.c:741:5: Error: »strncpy« output may be truncated copying 254 bytes from a string of length 254 [-Werror=stringop-truncation]
     strncpy(kobj.label, objs[ii]->label, sizeof(kobj.label) - 1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

I was able to authenticate using a "Atos CardOS" card on a Fedora/Linux based system afterwards.  
I'm not able to test the Windows or macOS part due to missing infrastructure. 