### PR TITLE
fixed checking SW in iso7816_read_binary_sfid

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1320,9 +1320,13 @@ int iso7816_read_binary_sfid(sc_card_t *card, unsigned char sfid,
 	apdu.le = read;
 
 	r = sc_transmit_apdu(card, &apdu);
+	if (r < 0)
+		goto err;
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r < 0 && r != SC_ERROR_FILE_END_REACHED)
+		goto err;
 	/* emulate the behaviour of sc_read_binary */
-	if (r >= 0)
-		r = apdu.resplen;
+	r = apdu.resplen;
 
 	while(1) {
 		if (r >= 0 && ((size_t) r) != read) {


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/1360

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

tested with nPA, Cryptoflex, Gemsafe