### PR TITLE
openpgp driver cleanup

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -85,8 +85,11 @@ enum _version {		/* 2-byte BCD-alike encoded version number */
 	OPENPGP_CARD_1_1 = 0x0101,
 	OPENPGP_CARD_2_0 = 0x0200,
 	OPENPGP_CARD_2_1 = 0x0201,
+	OPENPGP_CARD_2_2 = 0x0202,
 	OPENPGP_CARD_3_0 = 0x0300,
 	OPENPGP_CARD_3_1 = 0x0301,
+	OPENPGP_CARD_3_2 = 0x0302,
+	OPENPGP_CARD_3_3 = 0x0303,
 };
 
 enum _access {		/* access flags for the respective DO/file */


### PR DESCRIPTION
Hi,

the commits in this pull requests implement correct parsing of the hist_bytes in ATR and the hist_bytes DO as compact-TLV instead of blindly searching for the key-byte.
In addition they prepare for parsing the hist_byte DO for features becoming available with OpenPGP card version 3.0 and higher.

Tested with:
* ZeitControl OpenPGP card v2.0
* Zeitcontrol OpenPGP card v3.3
* Yubikey NEO
