### PR TITLE
Tool fixes

### DIFF
--- a/src/tools/npa-tool.c
+++ b/src/tools/npa-tool.c
@@ -443,7 +443,7 @@ main (int argc, char **argv)
 	if (cmdline.cvc_dir_given)
 		EAC_set_cvc_default_dir(cmdline.cvc_dir_arg);
 	if (cmdline.x509_dir_given)
-		EAC_set_x509_default_dir(cmdline.cvc_dir_arg);
+		EAC_set_x509_default_dir(cmdline.x509_dir_arg);
 
 	if (cmdline.break_flag) {
 		/* The biggest number sprintf could write with "%llu is 18446744073709551615 */

--- a/src/tools/opensc-notify-cmdline.c
+++ b/src/tools/opensc-notify-cmdline.c
@@ -40,7 +40,7 @@ const char *gengetopt_args_info_help[] = {
   "  -m, --message[=STRING]      Main text of the notification",
   "\n Mode: standard\n  Manually send standard notifications.",
   "  -I, --notify-card-inserted  See notify_card_inserted in opensc.conf\n                                (default=off)",
-  "  -R, --notify-card-removed   See notify_card_inserted in opensc.conf\n                                (default=off)",
+  "  -R, --notify-card-removed   See notify_card_removed in opensc.conf\n                                (default=off)",
   "  -G, --notify-pin-good       See notify_pin_good in opensc.conf  (default=off)",
   "  -B, --notify-pin-bad        See notify_pin_bad in opensc.conf  (default=off)",
   "\nReport bugs to https://github.com/OpenSC/OpenSC/issues\n\nWritten by Frank Morgner <frankmorgner@gmail.com>",

--- a/src/tools/opensc-notify.ggo.in
+++ b/src/tools/opensc-notify.ggo.in
@@ -27,7 +27,7 @@ modeoption "notify-card-inserted"    I
     flag off
     mode="standard"
 modeoption "notify-card-removed"  R
-    "See notify_card_inserted in opensc.conf"
+    "See notify_card_removed in opensc.conf"
     flag off
     mode="standard"
 modeoption "notify-pin-good"  G


### PR DESCRIPTION
While preparing the DocBook XML files for the new tools' manual pages, I found & fixed some typos in
- npa-tool.c
- opensc-notify.ggo.in / opensc-notify-cmdline.c
