### PR TITLE
compact TLV - add generic sc_compacttlv_find_tag() function

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -507,32 +507,25 @@ static void
 pgp_parse_hist_bytes(sc_card_t *card, u8 *ctlv, size_t ctlv_len)
 {
 	struct pgp_priv_data *priv = DRVDATA(card);
-	size_t offs;
+	const u8 *ptr;
 
-	for (offs = 0; offs < ctlv_len; offs++) {
-		switch (ctlv[offs]) {
-			case 0x73: /* IS07816-4 hist bytes 3rd function table */
-				if (offs+3 < ctlv_len) {
-					/* bit 0x40 in byte 3 of TL 0x73 means "extended Le/Lc" */
-					if (ctlv[offs+3] & 0x40) {
-						card->caps |= SC_CARD_CAP_APDU_EXT;
-						priv->ext_caps |= EXT_CAP_APDU_EXT;
-					}
-					/* bit 0x80 in byte 3 of TL 0x73 means "Command chaining" */
-					if ((ctlv[offs+3] & 0x40) &&
-					    (priv->bcd_version >= OPENPGP_CARD_3_0)) {
-						priv->ext_caps |= EXT_CAP_CHAINING;
-					}
-				}
-				break;
-			case 0x31:
-				if ((offs + 1 < ctlv_len) &&
-				    (priv->bcd_version >= OPENPGP_CARD_3_0)) {
-					// ToDo ...
-				}
-				break;
+	/* IS07816-4 hist bytes: 3rd function table */
+	if ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x73)) != NULL) {
+		/* bit 0x40 in byte 3 of TL 0x73 means "extended Le/Lc" */
+		if (ptr[2] & 0x40) {
+			card->caps |= SC_CARD_CAP_APDU_EXT;
+			priv->ext_caps |= EXT_CAP_APDU_EXT;
 		}
-		offs += ctlv[offs] & 0x0F;
+		/* bit 0x80 in byte 3 of TL 0x73 means "Command chaining" */
+		if ((ptr[2] & 0x80) &&
+		    (priv->bcd_version >= OPENPGP_CARD_3_0)) {
+			priv->ext_caps |= EXT_CAP_CHAINING;
+		}
+	}
+
+	if ((priv->bcd_version >= OPENPGP_CARD_3_0) &&
+	    ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x73)) != NULL)) {
+		// ToDo ...
 	}
 }
 

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -510,7 +510,7 @@ pgp_parse_hist_bytes(sc_card_t *card, u8 *ctlv, size_t ctlv_len)
 	const u8 *ptr;
 
 	/* IS07816-4 hist bytes: 3rd function table */
-	if ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x73)) != NULL) {
+	if ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x73, NULL)) != NULL) {
 		/* bit 0x40 in byte 3 of TL 0x73 means "extended Le/Lc" */
 		if (ptr[2] & 0x40) {
 			card->caps |= SC_CARD_CAP_APDU_EXT;
@@ -524,7 +524,7 @@ pgp_parse_hist_bytes(sc_card_t *card, u8 *ctlv, size_t ctlv_len)
 	}
 
 	if ((priv->bcd_version >= OPENPGP_CARD_3_0) &&
-	    ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x73)) != NULL)) {
+	    ((ptr = sc_compacttlv_find_tag(ctlv, ctlv_len, 0x31, NULL)) != NULL)) {
 		// ToDo ...
 	}
 }

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1358,6 +1358,15 @@ scconf_block *sc_match_atr_block(sc_context_t *ctx, struct sc_card_driver *drive
 unsigned sc_crc32(const unsigned char *value, size_t len);
 
 /**
+ * Find a given tag in a compact TLV structure
+ * @param  buf  input buffer holding the compact TLV structure
+ * @param  len  length of the input buffer @buf in bytes
+ * @param  tag  compact tag to search for - high nibble: plain tag, low nibble: length
+ * @return pointer to the tag value found within @buf, or NULL if not found/on error
+ */
+const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag);
+
+/**
  * Used to initialize the @c sc_remote_data structure --
  * reset the header of the 'remote APDUs' list, set the handlers
  * to manipulate the list.

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1359,12 +1359,15 @@ unsigned sc_crc32(const unsigned char *value, size_t len);
 
 /**
  * Find a given tag in a compact TLV structure
- * @param  buf  input buffer holding the compact TLV structure
- * @param  len  length of the input buffer @buf in bytes
- * @param  tag  compact tag to search for - high nibble: plain tag, low nibble: length
+ * @param[in]  buf  input buffer holding the compact TLV structure
+ * @param[in]  len  length of the input buffer @buf in bytes
+ * @param[in]  tag  compact tag to search for - high nibble: plain tag, low nibble: length.
+ *                  If length is 0, only the plain tag is used for searching,
+ *                  in any other case, the length must also match.
+ * @param[out] outlen pointer where the size of the buffer returned is to be stored
  * @return pointer to the tag value found within @buf, or NULL if not found/on error
  */
-const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag);
+const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag, size_t *outlen);
 
 /**
  * Used to initialize the @c sc_remote_data structure --

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -948,14 +948,20 @@ unsigned sc_crc32(const unsigned char *value, size_t len)
 	return  crc%0xffff;
 }
 
-const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag)
+const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag, size_t *outlen)
 {
 	if (buf != NULL) {
 		size_t idx;
+		u8 plain_tag = tag & 0xF0;
+		size_t expected_len = tag & 0x0F;
 
 	        for (idx = 0; idx < len; idx++) {
-			if (buf[idx] == tag && idx + (tag & 0x0F) < len)
+			if (buf[idx] & 0xF0 == plain_tag && idx + expected_len < len &&
+			    (expected_len == 0 || expected_len == buf[idx] & 0x0F)) {
+				if (outlen != NULL)
+					*outlen = buf[idx] & 0x0F;
 				return buf + (idx + 1);
+			}
 			idx += (buf[idx] & 0x0F);
                 }
         }

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -948,6 +948,20 @@ unsigned sc_crc32(const unsigned char *value, size_t len)
 	return  crc%0xffff;
 }
 
+const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag)
+{
+	if (buf != NULL) {
+		size_t idx;
+
+	        for (idx = 0; idx < len; idx++) {
+			if (buf[idx] == tag && idx + (tag & 0x0F) < len)
+				return buf + (idx + 1);
+			idx += (buf[idx] & 0x0F);
+                }
+        }
+	return NULL;
+}
+
 /**************************** mutex functions ************************/
 
 int sc_mutex_create(const sc_context_t *ctx, void **mutex)

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -956,8 +956,8 @@ const u8 *sc_compacttlv_find_tag(const u8 *buf, size_t len, u8 tag, size_t *outl
 		size_t expected_len = tag & 0x0F;
 
 	        for (idx = 0; idx < len; idx++) {
-			if (buf[idx] & 0xF0 == plain_tag && idx + expected_len < len &&
-			    (expected_len == 0 || expected_len == buf[idx] & 0x0F)) {
+			if ((buf[idx] & 0xF0) == plain_tag && idx + expected_len < len &&
+			    (expected_len == 0 || expected_len == (buf[idx] & 0x0F))) {
 				if (outlen != NULL)
 					*outlen = buf[idx] & 0x0F;
 				return buf + (idx + 1);


### PR DESCRIPTION
Hi,

as promised, here's the pull request that replaces the "proprietary" implementation to parse the compact TLV in the hist_bytes of the openpgp card driver with a generic function in sc.c, and used it in the openpgp card driver.

It has been tested with
* OpenPGP v2.0 card
* OpenPGP v3.3 card
* Yubikey Neo

Please include it into opensc master

##### Checklist
- [x] Documentation is added or updated
