### PR TITLE
opensc-notify: make arguments to options -t & -m required

### DIFF
--- a/src/tools/opensc-notify.ggo.in
+++ b/src/tools/opensc-notify.ggo.in
@@ -13,13 +13,11 @@ modeoption "title"          t
     "Title of the notification"
     string
     mode="customized"
-    argoptional
     optional
 modeoption "message"        m
     "Main text of the notification"
     string
     mode="customized"
-    argoptional
     optional
 
 modeoption "notify-card-inserted"    I


### PR DESCRIPTION
There is no real point in having the arguments of an option be optional.
If you really do not want the argument to be set, simply do not use the option.

This is especially true, if the option argument is mandatory in the program
logic. In opensc-notify's case, this applies to title which is mandatory for
the GIO case.

Instead of everyone forcing to use the counterintuitive
	opensc-notify -t="title" -m="message text"
syntax, use the well-known
	opensc-notify -t "title" -m "message text"
and have those who whant to have a message with an empty title go the
extra mile of having to write
	opensc-notify -t ""

What's the use case of a notification with an empty title anyway?

Please note: this pull reuest requires postprocessing: 
- gengetopt has to be called to update opensc-notify-cmdline.*
