### PR TITLE
Do not display opensc-notify in the application list

### DIFF
--- a/src/tools/org.opensc.notify.desktop.in
+++ b/src/tools/org.opensc.notify.desktop.in
@@ -5,3 +5,4 @@ Comment=Monitor smart card events to send notifications.
 Exec=@bindir@/opensc-notify
 Icon=preferences-system-notifications
 Categories=Security;System;
+NoDisplay=true


### PR DESCRIPTION
opensc-notify doesn't propose a GUI that can be displayed to the users,
so it doesn't make sense to display it in the application list/launcher

Fixes: #1379

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
