### PR TITLE
Avoid memory leaks from the failed card detections

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1652,8 +1652,8 @@ static int sc_hsm_init(struct sc_card *card)
 		if (file->prop_attr[1] & 0x04) {
 			card->caps |= SC_CARD_CAP_SESSION_PIN;
 		}
-		sc_file_free(file);
 	}
+	sc_file_free(file);
 
 	card->max_send_size = 1431;		// 1439 buffer size - 8 byte TLV because of odd ins in UPDATE BINARY
 	if (card->type == SC_CARD_TYPE_SC_HSM_SOC


### PR DESCRIPTION
While debugging #1377, I say a lot of memory leaks from failed card detection and it looks obvious the allocated memory is not freed in the case card detection fails somewhere in the `card_detect()` function. This might be significant issue if the opensc is invoked fron long running process, the smart cards are used frequently and detection might be failing for some reason.

The leaks looked like this:
```
==105404== 7,576 (72 direct, 7,504 indirect) bytes in 1 blocks are definitely lost in loss record 144 of 165
==105404==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==105404==    by 0x7944A49: card_detect (slot.c:256)
==105404==    by 0x79451B8: initialize_reader (slot.c:167)
==105404==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==105404==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==105404==    by 0x4091DB: token_initialize (p11test_helpers.c:63)
==105404==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==105404==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==105404==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==105404==    by 0x402613: main (p11test.c:129)
==105404== 
[...]
==105404== 75,760 (720 direct, 75,040 indirect) bytes in 10 blocks are definitely lost in loss record 165 of 165
==105404==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==105404==    by 0x7944A49: card_detect (slot.c:256)
==105404==    by 0x7945414: card_detect_all (slot.c:388)
==105404==    by 0x793F994: C_GetSlotInfo (pkcs11-global.c:513)
==105404==    by 0x402841: get_slot_with_card (p11test_loader.c:66)
==105404==    by 0x40915D: initialize_cryptoki (p11test_helpers.c:52)
==105404==    by 0x4093C8: prepare_token (p11test_helpers.c:138)
==105404==    by 0x409433: user_login_setup (p11test_helpers.c:167)
==105404==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==105404==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==105404==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==105404==    by 0x402613: main (p11test.c:129)
==105404== 
```
After taking care of the first one (freeing the `p11card`), other dependent structures showed up, such as:
```
==105852== 600 bytes in 1 blocks are definitely lost in loss record 89 of 150
==105852==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==105852==    by 0x794A71C: pkcs15_bind (framework-pkcs15.c:313)
==105852==    by 0x7944DBF: card_detect (slot.c:323)
==105852==    by 0x7945198: initialize_reader (slot.c:167)
==105852==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==105852==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==105852==    by 0x4091DB: token_initialize (p11test_helpers.c:63)
==105852==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==105852==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==105852==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==105852==    by 0x402613: main (p11test.c:129)
==105852== 
[...]
==105852== 69,040 (14,000 direct, 55,040 indirect) bytes in 10 blocks are definitely lost in loss record 150 of 150
==105852==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==105852==    by 0x7B90E0A: sc_card_new (card.c:73)
==105852==    by 0x7B90E0A: sc_connect_card (card.c:200)
==105852==    by 0x7944C16: card_detect (slot.c:266)
==105852==    by 0x79453F4: card_detect_all (slot.c:404)
==105852==    by 0x793F994: C_GetSlotInfo (pkcs11-global.c:513)
==105852==    by 0x402841: get_slot_with_card (p11test_loader.c:66)
==105852==    by 0x40915D: initialize_cryptoki (p11test_helpers.c:52)
==105852==    by 0x4093C8: prepare_token (p11test_helpers.c:138)
==105852==    by 0x409433: user_login_setup (p11test_helpers.c:167)
==105852==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==105852==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==105852==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==105852==    by 0x402613: main (p11test.c:129)
==105852== 
```
In the meantime, there showed up also some of the leaks from other drivers, such as `sc-hsm` introduced by recent changes:
```
==108537== 448 bytes in 1 blocks are definitely lost in loss record 52 of 57
==108537==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==108537==    by 0x7B86642: sc_file_new (sc.c:548)
==108537==    by 0x7B9556C: iso7816_select_file (iso7816.c:579)
==108537==    by 0x7C382D9: sc_hsm_select_file_ex (card-sc-hsm.c:176)
==108537==    by 0x7C39FD3: sc_hsm_init (card-sc-hsm.c:1614)
==108537==    by 0x7B91DBD: sc_connect_card (card.c:286)
==108537==    by 0x7944C2E: card_detect (slot.c:266)
==108537==    by 0x79451B8: initialize_reader (slot.c:167)
==108537==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==108537==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==108537==    by 0x4091DB: token_initialize (p11test_helpers.c:63)
==108537==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==108537== 
==108537== 1,344 bytes in 3 blocks are definitely lost in loss record 56 of 57
==108537==    at 0x4C2B955: calloc (vg_replace_malloc.c:711)
==108537==    by 0x7B86642: sc_file_new (sc.c:548)
==108537==    by 0x7B9556C: iso7816_select_file (iso7816.c:579)
==108537==    by 0x7C382D9: sc_hsm_select_file_ex (card-sc-hsm.c:176)
==108537==    by 0x7C39FD3: sc_hsm_init (card-sc-hsm.c:1614)
==108537==    by 0x7B91DBD: sc_connect_card (card.c:286)
==108537==    by 0x7944C2E: card_detect (slot.c:266)
==108537==    by 0x79451B8: initialize_reader (slot.c:167)
==108537==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==108537==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==108537==    by 0x4093C8: prepare_token (p11test_helpers.c:138)
==108537==    by 0x409433: user_login_setup (p11test_helpers.c:167)
==108537== 
```

There are still some left from the muscle driver, that I was not able to track down yet how to get rid of them, even though, these structures looks like properly cleaned up during the `finish()`:
```
==107429== 40 bytes in 1 blocks are definitely lost in loss record 31 of 57
==107429==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==107429==    by 0x7BB509D: mscfs_new (muscle-filesystem.c:46)
==107429==    by 0x7C03F55: muscle_init (card-muscle.c:467)
==107429==    by 0x7B91DBD: sc_connect_card (card.c:286)
==107429==    by 0x7944C2E: card_detect (slot.c:266)
==107429==    by 0x79451B8: initialize_reader (slot.c:167)
==107429==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==107429==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==107429==    by 0x4091DB: token_initialize (p11test_helpers.c:63)
==107429==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==107429==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==107429==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==107429==    by 0x402613: main (p11test.c:129)
==107429== 
==107429== 120 bytes in 3 blocks are definitely lost in loss record 40 of 57
==107429==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==107429==    by 0x7BB509D: mscfs_new (muscle-filesystem.c:46)
==107429==    by 0x7C03F55: muscle_init (card-muscle.c:467)
==107429==    by 0x7B91DBD: sc_connect_card (card.c:286)
==107429==    by 0x7944C2E: card_detect (slot.c:266)
==107429==    by 0x79451B8: initialize_reader (slot.c:167)
==107429==    by 0x79401DD: C_Initialize (pkcs11-global.c:278)
==107429==    by 0x409150: initialize_cryptoki (p11test_helpers.c:46)
==107429==    by 0x4093C8: prepare_token (p11test_helpers.c:138)
==107429==    by 0x409433: user_login_setup (p11test_helpers.c:167)
==107429==    by 0x550CDB5: cmocka_run_one_test_or_fixture (cmocka.c:2621)
==107429==    by 0x550D601: cmocka_run_one_tests (cmocka.c:2706)
==107429==    by 0x550D601: _cmocka_run_group_tests (cmocka.c:2839)
==107429== 
```
Note, that I might have missed something how the card detection is handled in the big picture when these structures can be freed or not.

With the above changes, the testsute passed for me for CAC card (while coolkey card inserted is the one was failing to be matched).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested