### PR TITLE
cardos: create pin in mf

### DIFF
--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -201,7 +201,7 @@ cardos_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_file_t *d
 	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;
 
-	r = sc_select_file(card, &df->path, NULL);
+	r = sc_select_file(card, auth_info->attrs.pin.reference & 0x80 ? &df->path : sc_get_mf_path(), NULL);
 	if (r < 0)
 		return r;
 
@@ -499,7 +499,7 @@ cardos_store_pin(sc_profile_t *profile, sc_card_t *card,
 	/* object address: class, id */
 	tlv_next(&tlv, 0x83);
 	tlv_add(&tlv, 0x00);		/* class byte: usage TEST, k=0 */
-	tlv_add(&tlv, auth_info->attrs.pin.reference);
+	tlv_add(&tlv, auth_info->attrs.pin.reference & 0x7f);
 
 	/* parameters */
 	tlv_next(&tlv, 0x85);


### PR DESCRIPTION
If cardos cards are initialized by other software and there is a pinref
without the msb set, also the pin verify works without that bit set.

This patch changes pin initialisation so that the pin is created in mf
which has the effect that pin verify works without | 0x80 to the
pin ref.

Signed-off-by: Andreas Kemnade <andreas@kemnade.info>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
