### PR TITLE
Filter certificates other than CKC_X_509

### DIFF
--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -156,6 +156,9 @@ int callback_certificates(test_certs_t *objects,
 	const u_char *cp;
 	test_cert_t *o = NULL;
 
+	if (*(CK_CERTIFICATE_TYPE *)template[3].pValue != CKC_X_509)
+		return 0;
+
 	if ((o = add_object(objects, template[0], template[2])) == NULL)
 		return -1;
 


### PR DESCRIPTION
This patch adds a filter to ignore certificates other than CKC_X_509 (e.g. CVC certificates as used in [1])

[1] https://github.com/CardContact/sc-hsm-embedded