### PR TITLE
refactor PIV driver to use sc_compacttlv_find_tag()

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2985,8 +2985,7 @@ static int piv_match_card(sc_card_t *card)
 
 static int piv_match_card_continued(sc_card_t *card)
 {
-	int i, i7e;
-	sc_file_t aidfile;
+	int i;
 	int type  = -1;
 	piv_private_data_t *priv = NULL;
 	int saved_type = card->type;
@@ -3100,6 +3099,8 @@ static int piv_match_card_continued(sc_card_t *card)
 
 	if (i < 0) {
 		/* Detect by selecting applet */
+		sc_file_t aidfile;
+
 		i = piv_find_aid(card, &aidfile);
 	}
 
@@ -3111,7 +3112,8 @@ static int piv_match_card_continued(sc_card_t *card)
 		 * SC_ERROR_FILE_NOT_FOUND means we cannot use discovery 
 		 * to test for active AID.
 		 */
-		i7e = piv_find_discovery(card);
+		int i7e = piv_find_discovery(card);
+
 		if (i7e != 0 && i7e !=  SC_ERROR_FILE_NOT_FOUND) {
 			priv->card_issues |= CI_DISCOVERY_USELESS;
 			priv->obj_cache[PIV_OBJ_DISCOVERY].flags |= PIV_OBJ_CACHE_NOT_PRESENT;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2985,9 +2985,7 @@ static int piv_match_card(sc_card_t *card)
 
 static int piv_match_card_continued(sc_card_t *card)
 {
-	int i, i7e, k;
-	size_t j;
-	u8 *p, *pe;
+	int i, i7e;
 	sc_file_t aidfile;
 	int type  = -1;
 	piv_private_data_t *priv = NULL;
@@ -3042,23 +3040,21 @@ static int piv_match_card_continued(sc_card_t *card)
 			}
 
 			else if (card->reader->atr_info.hist_bytes[0] == 0x80u) { /* compact TLV */
-				p = card->reader->atr_info.hist_bytes;
-				pe = p + card->reader->atr_info.hist_bytes_len;
-				p++; /* skip 0x80u byte */
-				while (p < pe && type == -1) {
-					j = *p & 0x0fu; /* length */
-					if ((*p++ & 0xf0u) == 0xf0u) { /*looking for 15 */
-						if ((p + j) <= pe) {
-							for (k = 0; piv_aids[k].len_long != 0; k++) {
-								if (j == piv_aids[k].len_long
-									&& !memcmp(p, piv_aids[k].value,j)) {
-									type = SC_CARD_TYPE_PIV_II_HIST;
-									break;
-								}
-							}
+				size_t datalen;
+				const u8 *data = sc_compacttlv_find_tag(card->reader->atr_info.hist_bytes + 1,
+									card->reader->atr_info.hist_bytes_len - 1,
+									0xF0, &datalen);
+
+				if (data != NULL) {
+					int k;
+
+					for (k = 0; piv_aids[k].len_long != 0; k++) {
+						if (datalen == piv_aids[k].len_long
+							&& !memcmp(data, piv_aids[k].value, datalen)) {
+							type = SC_CARD_TYPE_PIV_II_HIST;
+							break;
 						}
 					}
-					p += j;
 				}
 			}
 		}


### PR DESCRIPTION
This pull request adapts the PIV driver to use sc_compacttlv_find_tag() to parse the hist bytes.
In addition it limits the scope of some variables.

It is only compile-tested, as I do not own a PIV card.
It is strongly recommended to test with a real PIV card whether it is correct.

@dengert Could you have a look at it.