### PR TITLE
Add CI status of CAC and coolkey cards + few more accumulated issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ Wiki is [available online](https://github.com/OpenSC/OpenSC/wiki)
 Please take a look at the documentation before trying to use OpenSC.
 
 [![Travis CI Build Status](https://travis-ci.org/OpenSC/OpenSC.svg)](https://travis-ci.org/OpenSC/OpenSC/branches) [![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/github/OpenSC/OpenSC?branch=master&svg=true)](https://ci.appveyor.com/project/LudovicRousseau/OpenSC/branch/master) [![Coverity Scan Status](https://scan.coverity.com/projects/4026/badge.svg)](https://scan.coverity.com/projects/4026)
+
+Build and test status of specific cards:
+
+| Cards                 | Status |
+|-----------------------|--------|
+| CAC                   | [![CAC](https://gitlab.com/redhat-crypto/OpenSC/badges/cac/build.svg)](https://gitlab.com/redhat-crypto/OpenSC/pipelines) |
+| Coolkey               | [![Coolkey](https://gitlab.com/redhat-crypto/OpenSC/badges/coolkey/build.svg)](https://gitlab.com/redhat-crypto/OpenSC/pipelines) |

--- a/configure.ac
+++ b/configure.ac
@@ -518,9 +518,14 @@ if test "${enable_notify}" = "yes"; then
 	fi
 fi
 
-PKG_CHECK_MODULES( [CMOCKA], [cmocka],
-		  [ have_cmocka="yes" ],
-		  [ have_cmocka="no" ])
+have_cmocka="yes"
+PKG_CHECK_MODULES([CMOCKA], [cmocka >= 1.1.0],,[have_cmocka="no"])
+AC_CHECK_HEADER([setjmp.h])
+AC_CHECK_HEADER([cmocka.h],, [have_cmocka="no"],
+[#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+])
 
 if test "${enable_tests}" = "detect"; then
 	if test "${have_cmocka}" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -531,9 +531,7 @@ if test "${enable_tests}" = "detect"; then
 fi
 
 if test "${enable_tests}" = "yes"; then
-	if test "${have_cmocka}" = "yes"; then
-		AC_DEFINE([ENABLE_TESTS], [1], [Build tests in tests/ subdirectory])
-	else
+	if test "${have_cmocka}" != "yes"; then
 		AC_MSG_ERROR([Tests required, but cmocka is not available])
 	fi
 fi
@@ -1021,7 +1019,7 @@ AM_CONDITIONAL([ENABLE_MINIDRIVER_SETUP_CUSTOMACTION], [test "${enable_minidrive
 AM_CONDITIONAL([ENABLE_SM], [test "${enable_sm}" = "yes"])
 AM_CONDITIONAL([ENABLE_DNIE_UI], [test "${enable_dnie_ui}" = "yes"])
 AM_CONDITIONAL([ENABLE_NPATOOL], [test "${ENABLE_NPATOOL}" = "yes"])
-AM_CONDITIONAL([ENABLE_TESTS], [test "${ENABLE_TESTS}" = "yes"])
+AM_CONDITIONAL([ENABLE_TESTS], [test "${enable_tests}" = "yes"])
 AM_CONDITIONAL([GIT_CHECKOUT], [test "${GIT_CHECKOUT}" = "yes"])
 
 if test "${enable_pedantic}" = "yes"; then

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1224,8 +1224,10 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
 			    "TAG: TV Object nr. %"SC_FORMAT_LEN_SIZE_T"u", i);
-			if (i >= CAC_MAX_OBJECTS)
+			if (i >= CAC_MAX_OBJECTS) {
+				free(rbuf);
 				return SC_SUCCESS;
+			}
 
 			if (cac_parse_properties_object(card, tag, val, len,
 			    &prop->objects[i]) == SC_SUCCESS)
@@ -1240,8 +1242,10 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
 			    "TAG: PKI Object nr. %"SC_FORMAT_LEN_SIZE_T"u", i);
-			if (i >= CAC_MAX_OBJECTS)
+			if (i >= CAC_MAX_OBJECTS) {
+				free(rbuf);
 				return SC_SUCCESS;
+			}
 
 			if (cac_parse_properties_object(card, tag, val, len,
 			    &prop->objects[i]) == SC_SUCCESS)
@@ -1255,6 +1259,7 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 			break;
 		}
 	}
+	free(rbuf);
 	/* sanity */
 	if (i != prop->num_objects)
 		return SC_ERROR_INVALID_DATA;

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -951,12 +951,13 @@ static int cac_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 {
 	/* CAC requires 8 byte response */
 	u8 rbuf[8];
+	u8 *rbufp = &rbuf[0];
 	size_t out_len = sizeof rbuf;
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	r = cac_apdu_io(card, 0x84, 0x00, 0x00, NULL, 0, (u8 **) &rbuf, &out_len);
+	r = cac_apdu_io(card, 0x84, 0x00, 0x00, NULL, 0, &rbufp, &out_len);
 	LOG_TEST_RET(card->ctx, r, "Could not get challenge");
 
 	if (len < out_len) {

--- a/src/libopensc/muscle-filesystem.c
+++ b/src/libopensc/muscle-filesystem.c
@@ -53,6 +53,7 @@ mscfs_t *mscfs_new(void) {
 
 void mscfs_free(mscfs_t *fs) {
 	mscfs_clear_cache(fs);
+	free(fs);
 }
 
 void mscfs_clear_cache(mscfs_t* fs) {

--- a/src/tests/p11test/Makefile.am
+++ b/src/tests/p11test/Makefile.am
@@ -22,8 +22,8 @@ p11test_SOURCES = p11test.c p11test_loader.c \
 	p11test_case_wait.c \
 	p11test_case_pss_oaep.c \
 	p11test_helpers.c
-p11test_CFLAGS = -DNDEBUG
-p11test_LDADD = -lssl -lcrypto -lcmocka
+p11test_CFLAGS = -DNDEBUG $(CMOCKA_CFLAGS)
+p11test_LDADD = -lssl -lcrypto $(CMOCKA_LDLAGS)
 
 if WIN32
 p11test_SOURCES += $(top_builddir)/win32/versioninfo.rc


### PR DESCRIPTION
Based on the discussion in #1258, I tweaked the table in the readme a bit and reworked the CI to report separately for both cards.

Also there were few more minor issues in the master that did not make it to any other PR yet:
 * The sc-hsm initialization code based on the code by @CardContact from #1377
 * Some of the variables in the testsuite build was not correctly defined, which prevented autodetection
 * The cleanup of the muscle applet seemed fine, until I opened the `free_*` function

The CI with valgrind passes as attached badges show.

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested