### PR TITLE
gids: fix gids_delete_cert

### DIFF
--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1626,7 +1626,7 @@ static int gids_delete_cert(sc_card_t *card, sc_pkcs15_object_t* object) {
 	unsigned short fileIdentifier, DO;
 	u8 masterfilebuffer[MAX_GIDS_FILE_SIZE];
 	size_t masterfilebuffersize = 0;
-	gids_mf_record_t *records = (gids_mf_record_t *) masterfilebuffer;
+	gids_mf_record_t *records = (gids_mf_record_t *) (masterfilebuffer+1);
 	size_t recordcount, recordnum = (size_t) -1;
 	size_t i;
 
@@ -1648,7 +1648,7 @@ static int gids_delete_cert(sc_card_t *card, sc_pkcs15_object_t* object) {
 	memcpy(masterfilebuffer, privatedata->masterfile, privatedata->masterfilesize);
 	masterfilebuffersize = privatedata->masterfilesize;
 
-	recordcount = (masterfilebuffersize / sizeof(gids_mf_record_t));
+	recordcount = ((masterfilebuffersize-1) / sizeof(gids_mf_record_t));
 	for (i = 0; i < recordcount; i++) {
 		if (records[i].fileIdentifier == fileIdentifier && records[i].dataObjectIdentifier == DO) {
 			recordnum = i;
@@ -1659,7 +1659,7 @@ static int gids_delete_cert(sc_card_t *card, sc_pkcs15_object_t* object) {
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_FILE_NOT_FOUND);
 	}
 
-	for (i = (recordnum+1) * sizeof(gids_mf_record_t); i < masterfilebuffersize; i++) {
+	for (i = 1 + (recordnum+1) * sizeof(gids_mf_record_t); i < masterfilebuffersize; i++) {
 		masterfilebuffer[i - sizeof(gids_mf_record_t)] = masterfilebuffer[i];
 	}
 	masterfilebuffersize -= sizeof(gids_mf_record_t);


### PR DESCRIPTION
It is failed to delete a certificate from GidsApplet by pkcs11-tool:
```
> pkcs11-tool -b --id 00 --type cert --pin 0000
Using slot 3 with a present token (0xc)
error: PKCS11 function C_DestroyObject() failed: rv = CKR_GENERAL_ERROR (0x5)
Aborting.
```

This is caused by a bug that gids_delete_cert reads MF with wrong offset.

This patch fixes the bug by correcting the offset.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
