### PR TITLE
gids: use file id instead of path in gids_delete_key_file

### DIFF
--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1477,9 +1477,9 @@ static int gids_delete_key_file(sc_card_t *card, int containernum) {
 	int r;
 	char ch_tmp[10];
 	sc_path_t cpath;
-	snprintf(ch_tmp, sizeof(ch_tmp), "IB0%02X",containernum + GIDS_FIRST_KEY_IDENTIFIER);
+	snprintf(ch_tmp, sizeof(ch_tmp), "3FFFB0%02X",containernum + GIDS_FIRST_KEY_IDENTIFIER);
 	sc_format_path(ch_tmp, &cpath);
-	r = iso_ops->select_file(card, &cpath, NULL);
+	r = gids_select_file(card, &cpath, NULL);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "unable to select the key file");
 	// delete current selected file
 	memset(&cpath, 0, sizeof(cpath));

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1477,7 +1477,7 @@ static int gids_delete_key_file(sc_card_t *card, int containernum) {
 	int r;
 	char ch_tmp[10];
 	sc_path_t cpath;
-	snprintf(ch_tmp, sizeof(ch_tmp), "B0%02X",containernum + GIDS_FIRST_KEY_IDENTIFIER);
+	snprintf(ch_tmp, sizeof(ch_tmp), "IB0%02X",containernum + GIDS_FIRST_KEY_IDENTIFIER);
 	sc_format_path(ch_tmp, &cpath);
 	r = iso_ops->select_file(card, &cpath, NULL);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "unable to select the key file");


### PR DESCRIPTION
It is failed to delete a private key from GidsApplet by pkcs11-tool:
```
> pkcs11-tool -b --id 00 --type privkey --pin 0000
Using slot 3 with a present token (0xc)
error: PKCS11 function C_DestroyObject() failed: rv = CKR_DATA_INVALID (0x20)
Aborting.
```

This is caused by a protocol violation that in deleting a private key libopensc select a file by path
which GIDS does not support.

This patch fixes the bug by using file id instead of path.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
