### PR TITLE
Fix #1403 and add GenericName

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -839,6 +839,10 @@ if test "${enable_cryptotokenkit}" = "yes"; then
 	fi
 	AC_DEFINE([ENABLE_CRYPTOTOKENKIT], [1], [Define if CryptoTokenKit is to be enabled])
 fi
+PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+	[completiondir="`pkg-config --variable=completionsdir bash-completion`"],
+	[completiondir="${sysconfdir}/bash_completion.d"])
+AC_SUBST([completiondir])
 
 
 AC_SUBST(DYN_LIB_EXT)

--- a/doc/tools/Makefile.am
+++ b/doc/tools/Makefile.am
@@ -15,7 +15,6 @@ man5_MANS = $(patsubst $(srcdir)/%.xml, %, $(wildcard $(srcdir)/*.5.xml))
 endif
 
 completion_DATA = $(patsubst $(srcdir)/%.1.xml, %, $(wildcard $(srcdir)/*.1.xml))
-completiondir = $(sysconfdir)/bash_completion.d
 
 tools.html: $(srcdir)/tools.xml $(wildcard $(srcdir)/*.1.xml) $(wildcard $(srcdir)/*.5.xml)
 	$(XSLTPROC) --nonet --path "$(srcdir)/..:$(xslstylesheetsdir)/html" --xinclude -o $@ html.xsl $<

--- a/src/tools/org.opensc.notify.desktop.in
+++ b/src/tools/org.opensc.notify.desktop.in
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=OpenSC Notify
+GenericName=Smard card notification
 Type=Application
 Comment=Monitor smart card events to send notifications.
 Exec=@bindir@/opensc-notify


### PR DESCRIPTION
Fix https://github.com/OpenSC/OpenSC/issues/1403

Add GenericName. it is not mandatory by the spec, but in many desktop environments it is used for menu item visual rendering:
- Name: Title of the icon
- GenericName: Subtitle of the icon
- Comment: Pop-up message when user hovers over icon
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
