### PR TITLE
OpenPGP extensions

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -662,7 +662,6 @@ pgp_get_card_features(sc_card_t *card)
 					if ((priv->sm_algo == SM_ALGO_NONE) && (priv->ext_caps & EXT_CAP_SM))
 						priv->sm_algo = SM_ALGO_UNKNOWN;
 				}
-				/* TODO read Extended length information from DO 7F66 in OpenPGP 3.0 and later */
 			}
 		}
 
@@ -691,6 +690,16 @@ pgp_get_card_features(sc_card_t *card)
 
 					_sc_card_add_rsa_alg(card, keylen, flags, 0);
 				}
+			}
+		}
+
+		if (priv->bcd_version >= OPENPGP_CARD_3_0) {
+			/* v3.0+: get length info from "extended length information" DO */
+			if ((pgp_get_blob(card, blob6e, 0x7f66, &blob) >= 0) &&
+				(blob->data != NULL) && (blob->len >= 8)) {
+				/* kludge: treat as SIMPLE DO and use appropriate offsets */
+				card->max_send_size = bebytes2ushort(blob->data + 2);
+				card->max_recv_size = bebytes2ushort(blob->data + 6);
 			}
 		}
 	}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -315,13 +315,12 @@ static struct do_info		pgp33_objects[] = {	/* OpenPGP card spec 3.3 */
 	{ 0x5f48, CONSTRUCTED, READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x5f50, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  sc_get_data,        sc_put_data },
 	{ 0x5f52, SIMPLE,      READ_ALWAYS | WRITE_NEVER, sc_get_data,        NULL        },
-	/* The 7F21 is constructed DO in spec, but in practice, its content can be retrieved
-	 * as simple DO (no need to parse TLV). */
+	/* DO 7F21 is CONSTRUCTED in spec; we treat it as SIMPLE: no need to parse TLV */
 	{ DO_CERT, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  sc_get_data,        sc_put_data },
 	{ 0x7f48, CONSTRUCTED, READ_NEVER  | WRITE_NEVER, NULL,               NULL        },
 	{ 0x7f49, CONSTRUCTED, READ_ALWAYS | WRITE_NEVER, NULL,               NULL        },
 	{ DO_AUTH,     CONSTRUCTED, READ_ALWAYS | WRITE_NEVER, pgp_get_pubkey,     NULL   },
-	/* The 0xA401, 0xB601, 0xB801 are just symbolic, it does not represent any real DO.
+	/* The DOs 0xA401, 0xB601, 0xB801 are virtual DOs, they do not represent any real DO.
 	 * However, their R/W access condition may block the process of importing key in pkcs15init.
 	 * So we set their accesses condition as WRITE_PIN3 (writable). */
 	{ DO_AUTH_SYM, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  pgp_get_pubkey_pem, NULL   },

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -195,7 +195,7 @@ static int		pgp_get_pubkey_pem(sc_card_t *, unsigned int,
 /* Gnuk only supports 1 key length (2048 bit) */
 #define MAXLEN_RESP_PUBKEY_GNUK  271
 
-static struct do_info		pgp1_objects[] = {	/* OpenPGP card spec 1.1 */
+static struct do_info		pgp1x_objects[] = {	/* OpenPGP card spec 1.1 */
 	{ 0x004f, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               NULL        },
 	{ 0x005b, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x005e, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  sc_get_data,        sc_put_data },
@@ -244,7 +244,9 @@ static struct do_info		pgp1_objects[] = {	/* OpenPGP card spec 1.1 */
 	{ 0, 0, 0, NULL, NULL },
 };
 
-static struct do_info		pgp2_objects[] = {	/* OpenPGP card spec 2.0 */
+static struct do_info		pgp21_objects[] = {	/* OpenPGP card spec 2.1 */
+	{ 0x00d5, SIMPLE,      READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
+	/* OpenPGP card spec 2.0 */
 	{ 0x004d, CONSTRUCTED, READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x004f, SIMPLE,      READ_ALWAYS | WRITE_NEVER, sc_get_data,        NULL        },
 	{ 0x005b, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
@@ -303,6 +305,9 @@ static struct do_info		pgp2_objects[] = {	/* OpenPGP card spec 2.0 */
 	{ DO_ENCR_SYM, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  pgp_get_pubkey_pem, NULL   },
 	{ 0, 0, 0, NULL, NULL },
 };
+
+static struct do_info		*pgp20_objects = pgp21_objects + 1;
+
 
 #define DRVDATA(card)        ((struct pgp_priv_data *) ((card)->drv_data))
 struct pgp_priv_data {
@@ -461,11 +466,9 @@ pgp_init(sc_card_t *card)
 	}
 
 	/* set pointer to correct list of card objects */
-	if (priv->bcd_version < OPENPGP_CARD_2_0) {
-		priv->pgp_objects = pgp1_objects;
-	} else {
-		priv->pgp_objects = pgp2_objects;
-	}
+	priv->pgp_objects = (priv->bcd_version < OPENPGP_CARD_2_0) ? pgp1x_objects
+			  : (priv->bcd_version < OPENPGP_CARD_2_1) ? pgp20_objects
+			  :					     pgp21_objects;
 
 	/* change file path to MF for re-use in MF */
 	sc_format_path("3f00", &file->path);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -903,13 +903,15 @@ pgp_new_blob(sc_card_t *card, pgp_blob_t *parent, unsigned int file_id,
 			*p = blob;
 		}
 		else {
-			u8 id_str[2];
+			char path[10] = "0000";	/* long enough */
 
 			/* no parent: set file's path = file's id */
-			/* FIXME sc_format_path expects an hex string of a file
-			 * identifier. ushort2bebytes instead delivers a two bytes binary
-			 * string */
-			sc_format_path((char *) ushort2bebytes(id_str, file_id), &blob->file->path);
+			if (4 != snprintf(path, sizeof(path), "%04X", file_id & 0xFFFF)) {
+				free(blob);
+				return NULL;
+			}
+
+			sc_format_path(path, &blob->file->path);
 		}
 
 		/* find matching DO info: set file type depending on it */

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -443,7 +443,6 @@ pgp_init(sc_card_t *card)
 	sc_file_t	*file = NULL;
 	struct do_info	*info;
 	int		r;
-	pgp_blob_t 	*child = NULL;
 
 	LOG_FUNC_CALLED(card->ctx);
 
@@ -525,8 +524,9 @@ pgp_init(sc_card_t *card)
 
 	/* populate MF - add matching blobs listed in the pgp_objects table */
 	for (info = priv->pgp_objects; (info != NULL) && (info->id > 0); info++) {
-		if (((info->access & READ_MASK) != READ_NEVER) &&
-			(info->get_fn != NULL)) {
+		if (((info->access & READ_MASK) != READ_NEVER) && (info->get_fn != NULL)) {
+			pgp_blob_t *child = NULL;
+
 			child = pgp_new_blob(card, priv->mf, info->id, sc_file_new());
 
 			/* catch out of memory condition */

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -382,6 +382,8 @@ pgp_match_card(sc_card_t *card)
 {
 	int i;
 
+	LOG_FUNC_CALLED(card->ctx);
+
 	i = _sc_match_atr(card, pgp_atrs, &card->type);
 	if (i >= 0) {
 		card->name = pgp_atrs[i].name;
@@ -421,10 +423,10 @@ pgp_match_card(sc_card_t *card)
 				snprintf(card_name, sizeof(card_name), "OpenPGP card V%u.%u", major, minor);
 			}
 			sc_file_free(file);
-			return 1;
+			LOG_FUNC_RETURN(card->ctx, 1);
 		}
 	}
-	return 0;
+	LOG_FUNC_RETURN(card->ctx, 0);
 }
 
 
@@ -447,7 +449,7 @@ pgp_init(sc_card_t *card)
 
 	priv = calloc (1, sizeof *priv);
 	if (!priv)
-		return SC_ERROR_OUT_OF_MEMORY;
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 	card->drv_data = priv;
 
 	card->cla = 0x00;
@@ -471,7 +473,7 @@ pgp_init(sc_card_t *card)
 		r = get_full_pgp_aid(card, file);
 		if (r < 0) {
 			pgp_finish(card);
-			return SC_ERROR_INVALID_CARD;
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_CARD);
 		}
 	}
 

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1835,11 +1835,11 @@ pgp_decipher(sc_card_t *card, const u8 *in, size_t inlen,
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	/* There's some funny padding indicator that must be
-	 * prepended... hmm. */
+	/* padding according to OpenPGP card spec 1.1, 2.x & 3.x section 7.2.9 */
 	if (!(temp = malloc(inlen + 1)))
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
-	temp[0] = '\0';
+	/* padding byte: 0x00 = RSA; 0x02 = AES [v2.1+ only] */
+	temp[0] = 0x00;
 	memcpy(temp + 1, in, inlen);
 	in = temp;
 	inlen += 1;

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -364,10 +364,13 @@ struct pgp_priv_data {
 static int
 get_full_pgp_aid(sc_card_t *card, sc_file_t *file)
 {
-	int r = 0;
-	/* explicitly get the full aid */
-	r = sc_get_data(card, 0x004F, file->name, sizeof file->name);
-	file->namelen = MAX(r, 0);
+	int r = SC_ERROR_INVALID_ARGUMENTS;
+
+	if (file != NULL) {
+		/* explicitly get the full aid */
+		r = sc_get_data(card, 0x004F, file->name, sizeof file->name);
+		file->namelen = MAX(r, 0);
+	}
 
 	return r;
 }

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -358,6 +358,9 @@ struct pgp_priv_data {
 };
 
 
+/**
+ * Internal: get OpenPGP application identifier from AID DO 004F
+ */
 static int
 get_full_pgp_aid(sc_card_t *card, sc_file_t *file)
 {
@@ -369,9 +372,10 @@ get_full_pgp_aid(sc_card_t *card, sc_file_t *file)
 	return r;
 }
 
+
 /**
  * ABI: check if card's ATR matches one of driver's
- * or if the OpenPGP application is present.
+ * or if the OpenPGP application is present on the card.
  */
 static int
 pgp_match_card(sc_card_t *card)
@@ -427,7 +431,7 @@ pgp_match_card(sc_card_t *card)
 #define BCD2CHAR(x) (((((x) & 0xF0) >> 4) * 10) + ((x) & 0x0F))
 
 /**
- * ABI: initialize driver.
+ * ABI: initialize driver & allocate private data.
  */
 static int
 pgp_init(sc_card_t *card)
@@ -537,8 +541,9 @@ pgp_init(sc_card_t *card)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
+
 /**
- * Internal: get features of the card: capabilities, ...
+ * Internal: parse historic bytes to get card capabilities.
  */
 static void
 pgp_parse_hist_bytes(sc_card_t *card, u8 *ctlv, size_t ctlv_len)
@@ -565,6 +570,7 @@ pgp_parse_hist_bytes(sc_card_t *card, u8 *ctlv, size_t ctlv_len)
 		// ToDo ...
 	}
 }
+
 
 /**
  * Internal: get features of the card: capabilities, ...
@@ -716,7 +722,7 @@ pgp_get_card_features(sc_card_t *card)
 
 
 /**
- * ABI: terminate driver.
+ * ABI: terminate driver & free private data.
  */
 static int
 pgp_finish(sc_card_t *card)
@@ -994,7 +1000,7 @@ pgp_read_blob(sc_card_t *card, pgp_blob_t *blob)
 }
 
 
-/*
+/**
  * Internal: enumerate contents of a data blob.
  * The OpenPGP card has a TLV encoding according ASN.1 BER-encoding rules.
  */
@@ -1188,7 +1194,7 @@ pgp_strip_path(sc_card_t *card, const sc_path_t *path)
 
 
 /**
- * ABI: SELECT FILE.
+ * ABI: ISO 7816-4 SELECT FILE - search given file & make it the currently selected one.
  */
 static int
 pgp_select_file(sc_card_t *card, const sc_path_t *path, sc_file_t **ret)
@@ -1268,7 +1274,7 @@ pgp_select_file(sc_card_t *card, const sc_path_t *path, sc_file_t **ret)
 
 
 /**
- * ABI: LIST FILES.
+ * ABI: ISO 7816-4 LIST FILES - enumerate all files in current DF.
  */
 static int
 pgp_list_files(sc_card_t *card, u8 *buf, size_t buflen)
@@ -1303,6 +1309,10 @@ pgp_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 	LOG_FUNC_RETURN(card->ctx, k);
 }
 
+
+/**
+ * ABI: ISO 7816-4 GET CHALLENGE - generate random byte sequence.
+ */
 static int
 pgp_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 {
@@ -1324,7 +1334,7 @@ pgp_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
 
 
 /**
- * ABI: READ BINARY.
+ * ABI: ISO 7816-4 READ BINARY - read data from currently selected EF.
  */
 static int
 pgp_read_binary(sc_card_t *card, unsigned int idx,
@@ -1360,7 +1370,7 @@ pgp_read_binary(sc_card_t *card, unsigned int idx,
 
 
 /**
- * ABI: WRITE BINARY.
+ * ABI: ISO 7816-4 WRITE BINARY - write data to currently selected EF.
  */
 static int
 pgp_write_binary(sc_card_t *card, unsigned int idx,
@@ -1371,7 +1381,7 @@ pgp_write_binary(sc_card_t *card, unsigned int idx,
 
 
 /**
- * Internal: get public key from card: as DF + sub-wEFs.
+ * Internal: get public key from card - as DF + sub-wEFs.
  */
 static int
 pgp_get_pubkey(sc_card_t *card, unsigned int tag, u8 *buf, size_t buf_len)
@@ -1403,7 +1413,7 @@ pgp_get_pubkey(sc_card_t *card, unsigned int tag, u8 *buf, size_t buf_len)
 
 
 /**
- * Internal: get public key from card: as one wEF.
+ * Internal: get public key from card - as one wEF.
  */
 static int
 pgp_get_pubkey_pem(sc_card_t *card, unsigned int tag, u8 *buf, size_t buf_len)
@@ -1445,7 +1455,7 @@ pgp_get_pubkey_pem(sc_card_t *card, unsigned int tag, u8 *buf, size_t buf_len)
 
 
 /**
- * ABI: GET DATA.
+ * ABI: ISO 7816-4 GET DATA - get contents of a DO.
  */
 static int
 pgp_get_data(sc_card_t *card, unsigned int tag, u8 *buf, size_t buf_len)
@@ -1553,7 +1563,7 @@ pgp_put_data_plain(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	/* Extended Header list (004D DO) needs a variant of PUT DATA command */
+	/* Extended Header list (DO 004D) needs a variant of PUT DATA command */
 	if (tag == 0x004D) {
 		ins = 0xDB;
 		p1 = 0x3F;
@@ -1591,7 +1601,7 @@ pgp_put_data_plain(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_
 
 
 /**
- * ABI: PUT DATA.
+ * ABI: ISO 7816-4 PUT DATA - write contents of a DO.
  */
 static int
 pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
@@ -1662,7 +1672,7 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 
 
 /**
- * ABI: PIN cmd: verify/change/unblock a PIN.
+ * ABI: ISO 7816-9 PIN CMD - verify/change/unblock a PIN.
  */
 static int
 pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
@@ -1742,6 +1752,9 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 }
 
 
+/**
+ * ABI: ISO 7816-8 LOGOUT - reset all access rights gained.
+ */
 int pgp_logout(struct sc_card *card)
 {
 	int r = SC_SUCCESS;
@@ -1773,7 +1786,7 @@ int pgp_logout(struct sc_card *card)
 
 
 /**
- * ABI: set security environment.
+ * ABI: ISO 7816-8 SET SECURITY ENVIRONMENT.
  */
 static int
 pgp_set_security_env(sc_card_t *card,
@@ -1826,7 +1839,7 @@ pgp_set_security_env(sc_card_t *card,
 
 
 /**
- * ABI: COMPUTE DIGITAL SIGNATURE.
+ * ABI: ISO 7816-8 COMPUTE DIGITAL SIGNATURE.
  */
 static int
 pgp_compute_signature(sc_card_t *card, const u8 *data,
@@ -1882,7 +1895,7 @@ pgp_compute_signature(sc_card_t *card, const u8 *data,
 
 
 /**
- * ABI: DECIPHER.
+ * ABI: ISO 7816-8 DECIPHER - perform deciphering operation.
  */
 static int
 pgp_decipher(sc_card_t *card, const u8 *in, size_t inlen,
@@ -2815,7 +2828,7 @@ pgp_erase_card(sc_card_t *card)
 
 
 /**
- * ABI: card ctl: perform special card-specific operations.
+ * ABI: ISO 7816-9 CARD CTL - perform special card-specific operations.
  */
 static int
 pgp_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
@@ -2852,7 +2865,7 @@ pgp_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 
 
 /**
- * Internal: delete key.
+ * Internal: delete key (GnuK only).
  */
 static int
 gnuk_delete_key(sc_card_t *card, u8 key_id)
@@ -2894,7 +2907,7 @@ gnuk_delete_key(sc_card_t *card, u8 key_id)
 
 
 /**
- * ABI: DELETE FILE.
+ * ABI: ISO 7816-9 DELETE FILE - delete EF or DF given.
  */
 static int
 pgp_delete_file(sc_card_t *card, const sc_path_t *path)
@@ -2913,7 +2926,7 @@ pgp_delete_file(sc_card_t *card, const sc_path_t *path)
 	/* save "current" blob */
 	blob = priv->current;
 
-	/* do try to delete MF */
+	/* don't try to delete MF */
 	if (blob == priv->mf)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
@@ -2944,7 +2957,7 @@ pgp_delete_file(sc_card_t *card, const sc_path_t *path)
 
 
 /**
- * ABI: UPDATE BINARY.
+ * ABI: ISO 7816-4 UPDATE BINARY - update data in current EF.
  */
 static int
 pgp_update_binary(sc_card_t *card, unsigned int idx,
@@ -2971,6 +2984,9 @@ pgp_update_binary(sc_card_t *card, unsigned int idx,
 }
 
 
+/**
+ * ABI: card reader lock obtained - re-select card applet if necessary.
+ */
 static int pgp_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 {
 	struct pgp_priv_data *priv = DRVDATA(card); /* may be null during initialization */
@@ -3007,6 +3023,9 @@ static int pgp_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 }
 
 
+/**
+ * API: integrate OpenPGP driver into OpenSC's driver list.
+ */
 struct sc_card_driver *
 sc_get_openpgp_driver(void)
 {

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -251,7 +251,17 @@ static struct do_info		pgp1x_objects[] = {	/* OpenPGP card spec 1.1 */
 	{ 0, 0, 0, NULL, NULL },
 };
 
-static struct do_info		pgp21_objects[] = {	/* OpenPGP card spec 2.1 */
+static struct do_info		pgp33_objects[] = {	/* OpenPGP card spec 3.3 */
+	{ 0x00f9, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	/* OpenPGP card spec 3.0 - 3.2 */
+	{ 0x00d6, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00d7, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00d8, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	/* DO 7F66 is CONSTRUCTED in spec; we treat it as SIMPLE: no need to parse TLV */
+	{ 0x7f66, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               sc_put_data },
+	/* DO 7F74 is CONSTRUCTED in spec; we treat it as SIMPLE for the time being */
+	{ 0x7f74, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               sc_put_data },
+	/* OpenPGP card spec 2.1 & 2.2 */
 	{ 0x00d5, SIMPLE,      READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
 	/* OpenPGP card spec 2.0 */
 	{ 0x004d, CONSTRUCTED, READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
@@ -313,7 +323,9 @@ static struct do_info		pgp21_objects[] = {	/* OpenPGP card spec 2.1 */
 	{ 0, 0, 0, NULL, NULL },
 };
 
-static struct do_info		*pgp20_objects = pgp21_objects + 1;
+static struct do_info		*pgp30_objects = pgp33_objects + 1;
+static struct do_info		*pgp21_objects = pgp33_objects + 6;
+static struct do_info		*pgp20_objects = pgp33_objects + 7;
 
 
 #define DRVDATA(card)        ((struct pgp_priv_data *) ((card)->drv_data))
@@ -475,7 +487,9 @@ pgp_init(sc_card_t *card)
 	/* set pointer to correct list of card objects */
 	priv->pgp_objects = (priv->bcd_version < OPENPGP_CARD_2_0) ? pgp1x_objects
 			  : (priv->bcd_version < OPENPGP_CARD_2_1) ? pgp20_objects
-			  :					     pgp21_objects;
+			  : (priv->bcd_version < OPENPGP_CARD_3_0) ? pgp21_objects
+			  : (priv->bcd_version < OPENPGP_CARD_3_3) ? pgp30_objects
+			  :					     pgp33_objects;
 
 	/* change file path to MF for re-use in MF */
 	sc_format_path("3f00", &file->path);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -730,13 +730,14 @@ pgp_get_card_features(sc_card_t *card)
 			/* Can be generated in card */
 			flags |= SC_ALGORITHM_ONBOARD_KEY_GEN;
 
-			if ((pgp_get_blob(card, blob73, i, &blob) >= 0) &&
-				(blob->data != NULL) && (blob->len >= 4)) {
-				if (blob->data[0] == 0x01) {	/* Algorithm ID [RFC4880]: RSA */
-					unsigned int keylen = bebytes2ushort(blob->data + 1);  /* Measured in bit */
+			/* OpenPGP card spec 1.1 & 2.x section 4.3.3.6 / v3.x section 4.4.3.7 */
+			if ((pgp_get_blob(card, blob73, i, &blob) >= 0) && (blob->data != NULL)) {
+				if (blob->len >= 3 && blob->data[0] == 0x01) {	/* RSA [RFC 4880] */
+					unsigned int keybits = bebytes2ushort(blob->data + 1);
 
-					_sc_card_add_rsa_alg(card, keylen, flags, 0);
+					_sc_card_add_rsa_alg(card, keybits, flags, 0);
 				}
+				/* v3.0+: [RFC 4880 & 6637] 0x12 = ECDH, 0x13 = ECDSA */
 			}
 		}
 


### PR DESCRIPTION
Hi,

this pull request is a cleaned-up version of PR #1407, addressing the issues mentioned there.

It cleans up some FIXMEs/ToDos and starts the way towards v3+ support.

In particular, it
* adds DOs introduced with OpenPGP card specs v2.1, v3.0 and v3.3 resp.
* updates and extends comments & references to the specs
* improves parsing of the "extended capabilities" DO, including v3.x support
* starts parsing the "extended length" DO introduced with v3.0
* improves debugging capabilities: "symmetric" calls of LOG_FUNC_...
* increases resilience by more/better error checks
* recognizes the card in question in more detail [e.g. with version number] on init.

Please merge it into OpenSC master, as it paves the ground for better v3+ support.

Best
PEter
