### PR TITLE
Workaround subject and issuer fields overflow

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -350,9 +350,9 @@ struct mech_info {
 	const char *	short_name;
 };
 struct x509cert_info {
-	unsigned char	subject[256];
+	unsigned char	subject[512];
 	int		subject_len;
-	unsigned char	issuer[256];
+	unsigned char	issuer[512];
 	int		issuer_len;
 	unsigned char	serialnum[128];
 	int		serialnum_len;


### PR DESCRIPTION
Structure `x509cert_info` fields `subject` and `issuer`
are doubled in size up to 512 bytes.

We have to use dynamic memory allocation
to completely overcome the issue.

Relates to OpenSC/OpenSC#1412.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
