### PR TITLE
upload CI build artifacts to OpenSC/Nightly

### DIFF
--- a/.github/push_artifacts.sh
+++ b/.github/push_artifacts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex -o xtrace
+
+BUILDPATH=${PWD}
+BRANCH="`git log --max-count=1 --date=short --abbrev=8 --pretty=format:"%cd_%h"`"
+
+git clone https://${GH_TOKEN}@github.com/OpenSC/Nightly.git > /dev/null 2>&1
+cd Nightly
+git checkout -b "${BRANCH}"
+
+for file in ${BUILDPATH}/win32/Output/OpenSC*.exe ${BUILDPATH}/opensc*.tar.gz ${BUILDPATH}/OpenSC*.dmg ${BUILDPATH}/OpenSC*.msi ${BUILDPATH}/OpenSC*.zip
+do
+    if [ -f ${file} ]
+    then
+        cp ${file} .
+        git add `basename ${file}`
+    fi
+done
+
+git commit --message "$1"
+if ! git push --quiet --set-upstream origin "${BRANCH}"
+then
+    sleep $[ ( $RANDOM % 32 )  + 1 ]s
+    git pull --rebase origin "${BRANCH}"
+    git push --quiet --set-upstream origin "${BRANCH}"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ addons:
 
 env:
   global:
-    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-    #   via the "travis encrypt" command using the project repo's public key
+    # The next declaration are encrypted envirnmet variables, created via the
+    # "travis encrypt" command using the project repo's public key
+    # COVERITY_SCAN_TOKEN
     - secure: "UkHn7wy4im8V1nebCWbAetnDSOLRUbOlF6++ovk/7Bnso1/lnhXHelyzgRxfD/oI68wm9nnRV+RQEZ9+72Ug1CyvHxyyxxkwal/tPeHH4B/L+aGdPi0id+5OZSKIm77VP3m5s102sJMJgH7DFd03+nUd0K26p0tk8ad4j1geV4c="
+    # GH_TOKEN
+    - secure: "cUAvpN/XUPMIN5cgWAbIOhghRoLXyw7SCydzGaJ1Ucqb9Ml2v5iuLLuN57YbZHTiWw03vy6rYVzzwMDrHX8r3oUALsv7ViJHG4PzIe7fAFZsZpHECmGsp6SEnue7m7BNy3FT8KYbiXxnxDO0SxmFXlrPAYR0WMZCWx2TENYcafs="
     - COVERITY_SCAN_BRANCH_PATTERN="(master|coverity.*)"
     - COVERITY_SCAN_NOTIFICATION_EMAIL="viktor.tarasov@gmail.com"
     - COVERITY_SCAN_BUILD_COMMAND="make -j 4"
@@ -30,6 +33,7 @@ matrix:
   include:
     - compiler: clang
       os: osx
+      env: DO_PUSH_ARTIFACT=yes
     - compiler: gcc
       os: osx
     - compiler: clang
@@ -39,9 +43,13 @@ matrix:
       os: linux
       env: ENABLE_DOC=--enable-doc
     - os: linux
-      env: HOST=x86_64-w64-mingw32
+      env:
+        - HOST=x86_64-w64-mingw32
+        - DO_PUSH_ARTIFACT=yes
     - os: linux
-      env: HOST=i686-w64-mingw32
+      env:
+        - HOST=i686-w64-mingw32
+        - DO_PUSH_ARTIFACT=yes
     - os: linux
       env: DO_COVERITY_SCAN=yes
 
@@ -93,6 +101,13 @@ after_script:
   # https://github.com/moodlerooms/moodle-plugin-ci/issues/33 for details
   - if [ ! -z "$HOST" ]; then
       killall services.exe;
+    fi
+
+  # keep in sync with appveyor.yml
+  - if [ "${DO_PUSH_ARTIFACT}" = "yes" ]; then
+      git config --global user.email "builds@travis-ci.org";
+      git config --global user.name "Travis CI";
+      .github/push_artifacts.sh "Travis CI build ${TRAVIS_JOB_NUMBER}";
     fi
 
 cache: ccache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ configuration:
   - Light-Release
 
 environment:
+  GH_TOKEN:
+    secure: M8XHRk7KURKU/tMDsOGvOoyIJ7FMBF71IsoW24RFxy7czXwSSyiSHIO9WPjpsGVx
   matrix:
     - VSVER: 14
     - VSVER: 12
@@ -91,8 +93,8 @@ build_script:
   - bash -c "make -C etc opensc.conf"
   - cp win32/winconfig.h config.h
   - nmake /f Makefile.mak %NMAKE_EXTRA%
-  - cd win32 && nmake /f Makefile.mak %NMAKE_EXTRA% VSVER=%VSVER% OpenSC.msi
-  - move OpenSC.msi %ARTIFACT%.msi
+  - cd win32 && nmake /f Makefile.mak %NMAKE_EXTRA% VSVER=%VSVER% OpenSC.msi && cd ..
+  - move win32\OpenSC.msi %ARTIFACT%.msi
   - appveyor PushArtifact %ARTIFACT%.msi
   # put all pdb files for dump analysis, but this consumes approx 100 MB per build
   - md %ARTIFACT%-Debug
@@ -102,6 +104,11 @@ build_script:
       }
   - appveyor PushArtifact %ARTIFACT%-Debug.zip
 
+  # keep in sync with .travis.yml
+  - bash -c "git config --global user.email 'no-reply@appveyor.com'"
+  - bash -c "git config --global user.name 'AppVeyor'"
+  - bash -c ".github/push_artifacts.sh \"AppVeyor build ${APPVEYOR_BUILD_NUMBER}.${APPVEYOR_JOB_NUMBER}\""
+
 cache:
   - C:\zlib -> appveyor.yml
   - C:\zlib-Win32 -> appveyor.yml
@@ -110,17 +117,3 @@ cache:
   - C:\openpace-Win32 -> appveyor.yml
   - C:\openpace-Win64 -> appveyor.yml
   - cngsdk.msi -> appveyor.yml
-
-deploy:
-  - provider: GitHub
-    tag: $(APPVEYOR_REPO_TAG_NAME)
-    release: OpenSC-$(APPVEYOR_REPO_TAG_NAME)
-    description: 'release OpenSC $(APPVEYOR_REPO_TAG_NAME)'
-    auth_token:
-      secure: NGaTqWohBQa7fgE62rEm2sp9jkv6S9FRc3YEi3T5CpaoyIY6K89FJjqzaoPLr8vj
-    artifact: /OpenSC-.*\.msi/
-    draft: false
-    prerelease: true
-    on:
-      branch: /0.16.0-rc.*/		# here branch is release tag
-      appveyor_repo_tag: true  		# deploy on tag push only


### PR DESCRIPTION
builds are uploaded as seperate branches to
https://github.com/OpenSC/Nightly If the repository gets too big,
branches can easily be removed. The repository is written via Travis CI
and AppVeyor with a secure token from user https://github.com/OpenSC-CI

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
