### PR TITLE
reset sc_card_t during card detection

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -261,8 +261,22 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 		}
 	}
 	else {
+		sc_card_t uninitialized = *card;
 		sc_log(ctx, "matching built-in ATRs");
 		for (i = 0; ctx->card_drivers[i] != NULL; i++) {
+			/* FIXME If we had a clean API description, we'd propably get a
+			 * cleaner implementation of the driver's match_card and init,
+			 * which should normally *not* modify the card object if
+			 * unsuccessful. However, after years of relentless hacking, reality
+			 * is different: The card object is changed in virtually every card
+			 * driver so in order to prevent unwanted interaction, we reset the
+			 * card object here and hope that the card driver at least doesn't
+			 * allocate any internal ressources that need to be freed. If we
+			 * had more time, we should refactor the existing code to not
+			 * modify sc_card_t until complete success (possibly by combining
+			 * `match_card()` and `init()`) */
+			*card = uninitialized;
+
 			struct sc_card_driver *drv = ctx->card_drivers[i];
 			const struct sc_card_operations *ops = drv->ops;
 


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/1417

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
