### PR TITLE
no OPTSWITHARGS produces invalid completion file

### DIFF
--- a/doc/tools/Makefile.am
+++ b/doc/tools/Makefile.am
@@ -36,7 +36,7 @@ tools.html: $(srcdir)/tools.xml $(wildcard $(srcdir)/*.1.xml) $(wildcard $(srcdi
 				| sort -u | grep -- '^\-' | tr '\n' ' ')," \
 		| sed "s,OPTSWITHARGS,\
 			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*,\1,pg' $< \
-				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,')," \
+				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,' | grep ^ || echo "!*")," \
 		| sed "s,FILEOPTS,\
 			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*filename.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,' | grep ^ || echo "!*"),"  \


### PR DESCRIPTION
Fixes #1421, when a tool has no OPTSWITHARGS it will produce invalid bash (completion) output syntax.

I did a diff on the the bash completions produced before this patch and the output of this change and the only change is to opensc-asn1 which is now valid.

##### Checklist
- [x] Documentation is added or updated