### PR TITLE
Bash_completionsdir should use PREFIX as set by configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -840,7 +840,7 @@ if test "${enable_cryptotokenkit}" = "yes"; then
 	AC_DEFINE([ENABLE_CRYPTOTOKENKIT], [1], [Define if CryptoTokenKit is to be enabled])
 fi
 PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
-	[completiondir="`pkg-config --variable=completionsdir bash-completion`"],
+	[completiondir="`pkg-config --variable=completionsdir --define-variable=prefix=${prefix} bash-completion`"],
 	[completiondir="${sysconfdir}/bash_completion.d"])
 AC_SUBST([completiondir])
 


### PR DESCRIPTION
When building OpenSC to be installed in alternate locations,
The bash completions location should also be based on the alternate
location.

In previous code or bash-completion version  less then 2.0:
completiondir="${sysconfdir}/bash_completion.d"
this would work, as ${sysconfdir} was based on ${prefix}

Current master uses the systems location for the completionsdir
completiondir="`pkg-config --variable=completionsdir bash-completion`"

This commit uses the pkg_config ability to overwrite the prefix
to restore the ability to install the completions in an alternate
location:
completiondir="`pkg-config --variable=completionsdir --define-variable=prefix=${prefix} bash-completion`"

 Changes to be committed:
	modified:   ../../configure.ac

For example Ubuntu-16.4  /usr/share/pkgconfig/bash-completion.pc:
```
prefix=/usr
compatdir=/etc/bash_completion.d
completionsdir=${prefix}/share/bash-completion/completions
helpersdir=${prefix}/share/bash-completion/helpers

Name: bash-completion
Description: programmable completion for the bash shell
URL: http://bash-completion.alioth.debian.org/
Version: 2.1
```

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
