### PR TITLE
pkcs15-tool: harmonize non-short output for -C, -D,

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -570,6 +570,8 @@ static int list_data_objects(void)
 		else {
 			printf("\tAuth ID:         %s\n", sc_pkcs15_print_id(&objs[i]->auth_id));
 		}
+
+		printf("\n");
 	}
 	return 0;
 }
@@ -1672,7 +1674,7 @@ static void list_info(void)
 			count++;
 		}
 	}
-	printf("\n");
+	printf((compact) ? "\n" : "\n\n");
 }
 
 static int dump(void)


### PR DESCRIPTION
Hi,

this pull requirest fixes a minor glitch in the output of pkcs15-tool's options -C & -D:

Make sure to have an empty line between information printed for individual
objects, but not in short mode.
This makes output of -D and -C more consistent and hence more visually appealing and better readable.

Please add it to OpenSC master

Best
PEter
