### PR TITLE
OpenPGP: extend manufacturer list in pkcs15-openpgp.c

### DIFF
--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -106,18 +106,25 @@ typedef struct _pgp_manuf_map {
 } pgp_manuf_map_t;
 
 static const pgp_manuf_map_t manuf_map[] = {
-	{ 0x0001, "PPC Card Systems" },
-	{ 0x0002, "Prism"            },
-	{ 0x0003, "OpenFortress"     },
-	{ 0x0004, "Wewid AB"         },
-	{ 0x0005, "ZeitControl"      },
-	{ 0x0006, "Yubico"           },
-	{ 0x0007, "OpenKMS"          },
-	{ 0x0008, "LogoEmail"        },
-	{ 0x002A, "Magrathea"        },
-	{ 0xF517, "FSIJ"             },
-	{ 0x0000, "test card"        },
-	{ 0xffff, "test card"        },
+	{ 0x0001, "PPC Card Systems"   },
+	{ 0x0002, "Prism"              },
+	{ 0x0003, "OpenFortress"       },
+	{ 0x0004, "Wewid AB"           },
+	{ 0x0005, "ZeitControl"        },
+	{ 0x0006, "Yubico"             },
+	{ 0x0007, "OpenKMS"            },
+	{ 0x0008, "LogoEmail"          },
+	{ 0x0009, "Fidesmo"            },
+	{ 0x000A, "Dangerous Things"   },
+	{ 0x002A, "Magrathea"          },
+	{ 0x0042, "GnuPG e.V."         },
+	{ 0x1337, "Warsaw Hackerspace" },
+	{ 0x2342, "warpzone"           },
+	{ 0x63AF, "Trustica"           },
+	{ 0xBD0E, "Paranoidlabs"       },
+	{ 0xF517, "FSIJ"               },
+	{ 0x0000, "test card"          },
+	{ 0xffff, "test card"          },
 	{ 0, NULL }
 };
 


### PR DESCRIPTION
Hi,

this PR is a small extension to pkcs15-openpgp.c that extends the list of OpenPGP card manufacturers,
and brings them in line with those in GnuPG.

Please add this PR to OpenSC master.

Best
Peter