### PR TITLE
card-piv.c: initialize variable to fix a ppc64el build failure

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2334,7 +2334,7 @@ static int piv_validate_general_authentication(sc_card_t *card,
 
 	u8 sbuf[4096]; /* needs work. for 3072 keys, needs 384+10 or so */
 	u8 *rbuf = NULL;
-	size_t rbuflen;
+	size_t rbuflen = 0;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 


### PR DESCRIPTION
This fixes a build failure with optimized ppc64el and new gcc builds
card-piv.c: In function ‘piv_validate_general_authentication.isra.3’:
card-piv.c:2390:9: error: ‘rbuflen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
    body = sc_asn1_find_tag(card->ctx, rbuf, rbuflen, 0x7c, &bodylen);
    ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
