### PR TITLE
Make deciphering with AUT-key possible for OpenPGP Card >v3.2 (fixes #1352)

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1898,30 +1898,28 @@ pgp_set_MSE(sc_card_t *card, int key, int command)
 	sc_apdu_t	apdu;
 	u8	apdu_case = SC_APDU_CASE_3;
 	u8	apdu_data[3];
-	u8	com;
 	int	r;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	// check is MSE is supported
+	// check if MSE is supported
 	if (!(priv->ext_caps & EXT_CAP_MSE))
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
-	// translate command into internal byte representation
+	// translate input 'command' into actual internal byte representation
 	switch(command){
 	case 2:
-		com = 0xb8;
+		command = 0xb8;
 		break;
 	case 3:
-		com = 0xa4;
+		command = 0xa4;
 		break;
 	default:
-		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
-				"invalid function call");
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "invalid function call");
 	}
 
 	// create apdu
-	sc_format_apdu(card, &apdu, apdu_case, 0x22, 0x41, com);
+	sc_format_apdu(card, &apdu, apdu_case, 0x22, 0x41, command);
 	apdu.lc = 3;
 	apdu_data[0] = 0x83;
 	apdu_data[1] = 0x01;

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -710,9 +710,9 @@ pgp_get_card_features(sc_card_t *card)
 					if ((priv->sm_algo == SM_ALGO_NONE) && (priv->ext_caps & EXT_CAP_SM))
 						priv->sm_algo = SM_ALGO_UNKNOWN;
 				}
-				if (priv->bcd_version >= OPENPGP_CARD_3_3) {
+				if (priv->bcd_version >= OPENPGP_CARD_3_3 && (blob->len >= 10)) {
 					/* v3.3+: MSE for key numbers 2(DEC) and 3(AUT) supported */
-					if (blob->data[10])
+					if (blob->data[9])
 						priv->ext_caps |= EXT_CAP_MSE;
 				}
 			}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1889,10 +1889,10 @@ pgp_set_security_env(sc_card_t *card,
  * and the AUT-Key (Key.Ref 3) can be linked to the command PSO:DECIPHER also."
  *
  * key: Key-Ref to change (2 for DEC-Key or 3 for AUT-Key) 
- * command: Usage to set (0xb8 for PSO:DECIPHER or 0xa4 for INTERNAL AUTHENTICATE)
+ * p2: Usage to set (0xb8 for PSO:DECIPHER or 0xa4 for INTERNAL AUTHENTICATE)
  **/
 static int
-pgp_set_MSE(sc_card_t *card, int key, int command)
+pgp_set_MSE(sc_card_t *card, int key, u8 p2)
 {
 	struct pgp_priv_data	*priv = DRVDATA(card);
 	sc_apdu_t	apdu;
@@ -1907,7 +1907,7 @@ pgp_set_MSE(sc_card_t *card, int key, int command)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	// create apdu
-	sc_format_apdu(card, &apdu, apdu_case, 0x22, 0x41, command);
+	sc_format_apdu(card, &apdu, apdu_case, 0x22, 0x41, p2);
 	apdu.lc = 3;
 	apdu_data[0] = 0x83;
 	apdu_data[1] = 0x01;


### PR DESCRIPTION
This PR makes it possible to use authentication key slot for decryption as well. x.509 certificates are often used for more than one use case, but OpenPGP Cards are constructed with 3 subkeys for different use cases.

Therefore, it was necessary to copy the same key used in AUT-key slot in DEC-key slot as well, for being able to decrypt data (for example for S/MIME mails). See [note 3 in the documentation](https://github.com/OpenSC/OpenSC/wiki/OpenPGP-card#pairs-of-key--certificate-from-p12-file).

Since OpenPGP Card v3.3 it is possible to define PSO:DECIPHER operation for AUT-key as well. The hardware changes are supported in OpenSC with help of this PR.

Tested with Nitrokey Pro 2 (OpenPGP Card v3.3)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
