### PR TITLE
Opensc.conf processing

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -30,6 +30,17 @@ opensc.conf.example: opensc.conf.example.in force
 		-e 's|@PROFILE_DIR_DEFAULT[@]|$(PROFILE_DIR_DEFAULT)|g' \
 		< $< > $@
 
+install-exec-hook: opensc.conf
+	$(MKDIR_P) "$(DESTDIR)$(sysconfdir)"
+	if [ -f "$(DESTDIR)$(sysconfdir)/opensc.conf" ]; then \
+		$(INSTALL_DATA) "$(srcdir)/opensc.conf" "$(DESTDIR)$(sysconfdir)/opensc.conf.new"; \
+	else \
+		$(INSTALL_DATA) "$(srcdir)/opensc.conf" "$(DESTDIR)$(sysconfdir)/opensc.conf"; \
+	fi
+
+uninstall-hook: opensc.conf
+	rm -f "$(DESTDIR)$(sysconfdir)/opensc.conf.new" "$(DESTDIR)$(sysconfdir)/opensc.conf"
+
 install-exec-hook: opensc.conf.example
 	$(MKDIR_P) "$(DESTDIR)$(sysconfdir)"
 	if [ -f "$(DESTDIR)$(sysconfdir)/opensc.conf" ]; then \


### PR DESCRIPTION
This is response to comment https://github.com/OpenSC/OpenSC/issues/1449#issuecomment-414085563
for issues #1449 and #1102

Two commits:
One makes sure an user's opensc.conf is not over written in the sysconfdir.
The second causes scconf_parse to not save comments in memory and to remove empty blocks which can address the memory issues in #1102 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
