### PR TITLE
card-gids: un-break compilation on 32bit Debian testing

### DIFF
--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1092,7 +1092,7 @@ gids_select_key_reference(sc_card_t *card, sc_pkcs15_prkey_info_t* key_info) {
 	PCONTAINER_MAP_RECORD records = (PCONTAINER_MAP_RECORD) data->cmapfile;
 	size_t recordsnum;
 	int r;
-	char ch_tmp[10];
+	char ch_tmp[16];
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -1133,7 +1133,7 @@ gids_select_key_reference(sc_card_t *card, sc_pkcs15_prkey_info_t* key_info) {
 			SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS);
 		}
 	}
-	snprintf(ch_tmp, sizeof(ch_tmp), "3FFFB0%02X", key_info->key_reference);
+	snprintf(ch_tmp, sizeof(ch_tmp), "3FFFB0%02X", 0xFF & (u8) key_info->key_reference);
 	sc_format_path(ch_tmp, &(key_info->path));
 	return SC_SUCCESS;
 }
@@ -1475,9 +1475,9 @@ err:
 // remove a crt file
 static int gids_delete_key_file(sc_card_t *card, int containernum) {
 	int r;
-	char ch_tmp[10];
+	char ch_tmp[16];
 	sc_path_t cpath;
-	snprintf(ch_tmp, sizeof(ch_tmp), "3FFFB0%02X",containernum + GIDS_FIRST_KEY_IDENTIFIER);
+	snprintf(ch_tmp, sizeof(ch_tmp), "3FFFB0%02X", 0xFF & (u8) (containernum + GIDS_FIRST_KEY_IDENTIFIER));
 	sc_format_path(ch_tmp, &cpath);
 	r = gids_select_file(card, &cpath, NULL);
 	SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, r, "unable to select the key file");


### PR DESCRIPTION
A test of the latest master fails to compile card-gids,c with Debian testing in 32-bit
to to a potential overflow of a snprint target string

This PR fixes the issue by
* increasing the target string size
* limiting the value of the argument passed to the snprintf() call to a sensible upper limit

[x] compilation tested on Debian testing in 32- and 64-bit.
I cannot test more, because I do not have a GIDS card.

Fun fact: same configuration on 64-bit compiled without any problems.

