### PR TITLE
Missing header release tarball

### DIFF
--- a/src/tests/p11test/Makefile.am
+++ b/src/tests/p11test/Makefile.am
@@ -8,7 +8,8 @@ noinst_HEADERS = p11test_loader.h p11test_case_common.h \
 	p11test_case_readonly.h p11test_case_multipart.h \
 	p11test_case_mechs.h p11test_case_ec_sign.h \
 	p11test_case_usage.h p11test_case_wait.h \
-	p11test_case_pss_oaep.h p11test_helpers.h
+	p11test_case_pss_oaep.h p11test_helpers.h \
+	p11test_common.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src
 


### PR DESCRIPTION
The 0.19.0 release tarball is missing `p11test_common.h` file. The workaround is to configure without tests (`--disable-tests`).