### PR TITLE
pkcs15-tool: Add --list-public-key <id> argument

### DIFF
--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -144,6 +144,14 @@
 
 				<varlistentry>
 					<term>
+						<option>--list-public-key</option> <replaceable>id</replaceable>
+					</term>
+					<listitem><para>List public key identified by id stored on the token,
+                                        including key name, id, algorithm and length information.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--list-public-keys</option>
 					</term>
 					<listitem><para>List all public keys stored on the token, including


### PR DESCRIPTION
Add option to print info about a single public key identified by its id.
Will print same Information as --list-public-keys does, while
restricting the output to the specified object.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
