### PR TITLE
Fix pkcs15-init for STARCOS SPK 2.3

### DIFF
--- a/src/libopensc/pkcs15-infocamere.c
+++ b/src/libopensc/pkcs15-infocamere.c
@@ -787,7 +787,7 @@ static int infocamere_detect_card(sc_pkcs15_card_t * p15card)
 	sc_card_t *card = p15card->card;
 
 	/* check if we have the correct card OS */
-	if (strcmp(card->name, "STARCOS SPK 2.3")
+	if (strcmp(card->name, "STARCOS")
 			&& strcmp(card->name, "CardOS M4"))
 		return SC_ERROR_WRONG_CARD;
 	return SC_SUCCESS;

--- a/src/libopensc/pkcs15-starcert.c
+++ b/src/libopensc/pkcs15-starcert.c
@@ -106,7 +106,7 @@ static int starcert_detect_card(sc_pkcs15_card_t *p15card)
 	sc_card_t *card = p15card->card;
 
 	/* check if we have the correct card OS */
-	if (strcmp(card->name, "STARCOS SPK 2.3"))
+	if (strcmp(card->name, "STARCOS"))
 		return SC_ERROR_WRONG_CARD;
 	/* read EF_Info file */
 	sc_format_path("3F00FE13", &path);

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3893,7 +3893,7 @@ do_select_parent(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		r = sc_select_file(p15card->card, &path, NULL);
 		LOG_TEST_RET(ctx, r, "Cannot select parent DF");
 	}
-	else if (r == SC_SUCCESS && !strcmp(p15card->card->name, "STARCOS SPK 2.3")) {
+	else if (r == SC_SUCCESS && !strcmp(p15card->card->name, "STARCOS")) {
 		/* in case of starcos spk 2.3 SELECT FILE does not
 		 * give us the ACLs => ask the profile */
 		sc_file_free(*parent);

--- a/src/pkcs15init/starcos.profile
+++ b/src/pkcs15init/starcos.profile
@@ -10,7 +10,7 @@ cardinfo {
 option default {
 	macros {
 		so-pin-flags	= initialized, needs-padding, soPin;
-		isf_acl		= WRITE=$SOPIN;
+		isf_acl		= WRITE=$SOPIN, CREATE=$SOPIN;
 		df_acl		= *=$SOPIN;
 	}
 }


### PR DESCRIPTION
Upon structure creation, STARCOS 2.3 cards were throwing errors (security status not satisfied). This is because the program failed to verify the SO PIN before certain CREATE FILE operations. This fix changes two things:

* Use "STARCOS" as the default card name for 2.3 instead of outdated "STARCOS SPK 2.3" that was still used in some `strcmp` calls throughout the code;

* Changed `isf_acl` on the starcos profile in order to also require SO PIN for CREATE in addition to WRITE.

This seems to fix the aforementioned bug and I'm able to succesfully create a fresh pkcs15 structure on my card by specifying so-pin and so-puk args. However, I haven't tested STARCOS 2.3 functionality thoroughly.
