### PR TITLE
Added memory locking for secrets

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -38,6 +38,7 @@
 
 #include "common/libscdl.h"
 #include "internal.h"
+#include "sc-ossl-compat.h"
 
 static int ignored_reader(sc_context_t *ctx, sc_reader_t *reader)
 {
@@ -826,6 +827,13 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 		sc_release_context(ctx);
 		return r;
 	}
+
+#ifdef ENABLE_OPENSSL
+	if (!CRYPTO_secure_malloc_initialized()) {
+		/* XXX What's a reasonable amount of secure heap? */
+		CRYPTO_secure_malloc_init(4096, 32);
+	}
+#endif
 
 	process_config_file(ctx, &opts);
 	sc_log(ctx, "==================================="); /* first thing in the log */

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -131,6 +131,8 @@ sc_lock
 sc_logout
 sc_make_cache_dir
 sc_mem_clear
+sc_mem_secure_alloc
+sc_mem_secure_free
 sc_mem_reverse
 sc_match_atr_block
 sc_path_print

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1326,6 +1326,8 @@ int sc_base64_decode(const char *in, u8 *out, size_t outlen);
  * @param  len  length of the memory buffer
  */
 void sc_mem_clear(void *ptr, size_t len);
+void *sc_mem_secure_alloc(size_t len);
+void sc_mem_secure_free(void *ptr, size_t len);
 int sc_mem_reverse(unsigned char *buf, size_t len);
 
 int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize);

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -265,6 +265,19 @@ static sc_ossl_inline int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 }
 #endif /* OPENSSL_NO_EC */
 
+static sc_ossl_inline int CRYPTO_secure_malloc_init(size_t size, int minsize)
+{
+    return 1;
+}
+
+static sc_ossl_inline int CRYPTO_secure_malloc_initialized()
+{
+    return 0;
+}
+
+#else
+
+#include <openssl/crypto.h>
 
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -267,7 +267,7 @@ static sc_ossl_inline int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 
 static sc_ossl_inline int CRYPTO_secure_malloc_init(size_t size, int minsize)
 {
-    return 1;
+    return 0;
 }
 
 static sc_ossl_inline int CRYPTO_secure_malloc_initialized()

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -187,7 +187,7 @@ CK_RV push_login_state(struct sc_pkcs11_slot *slot,
 	}
 
 	if (pPin && ulPinLen) {
-		login->pPin = calloc((sizeof *pPin), ulPinLen);
+		login->pPin = sc_mem_secure_alloc((sizeof *pPin)*ulPinLen);
 		if (login->pPin == NULL) {
 			goto err;
 		}
@@ -207,7 +207,7 @@ err:
 	if (login) {
 		if (login->pPin) {
 			sc_mem_clear(login->pPin, login->ulPinLen);
-			free(login->pPin);
+			sc_mem_secure_free(login->pPin, login->ulPinLen);
 		}
 		free(login);
 	}
@@ -223,7 +223,7 @@ void pop_login_state(struct sc_pkcs11_slot *slot)
 			struct sc_pkcs11_login *login = list_get_at(&slot->logins, size-1);
 			if (login) {
 				sc_mem_clear(login->pPin, login->ulPinLen);
-				free(login->pPin);
+				sc_mem_secure_free(login->pPin, login->ulPinLen);
 				free(login);
 			}
 			if (0 > list_delete_at(&slot->logins, size-1))
@@ -238,7 +238,7 @@ void pop_all_login_states(struct sc_pkcs11_slot *slot)
 		struct sc_pkcs11_login *login = list_fetch(&slot->logins);
 		while (login) {
 			sc_mem_clear(login->pPin, login->ulPinLen);
-			free(login->pPin);
+			sc_mem_secure_free(login->pPin, login->ulPinLen);
 			free(login);
 			login = list_fetch(&slot->logins);
 		}


### PR DESCRIPTION
When caching a PIN in memory or using an OpenSSL private key this data should not be swapped to disk.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested
