### PR TITLE
openpgp-tool cleanup

### DIFF
--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -79,7 +79,6 @@ static int opt_userinfo = 0;
 static int opt_cardinfo = 0;
 static char *exec_program = NULL;
 static int opt_genkey = 0;
-static int opt_keylen = 0;
 static u8 key_id = 0;
 static unsigned int key_len = 2048;
 static int opt_verify = 0;
@@ -291,9 +290,7 @@ static int decode_options(int argc, char **argv)
 			actions++;
 			break;
 		case 'L':
-			opt_keylen++;
 			key_len = atoi(optarg);
-			actions++;
 			break;
 		case 'h':
 			util_print_usage_and_die(app_name, options, option_help, NULL);

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -321,8 +321,8 @@ static int decode_options(int argc, char **argv)
 			endptr = NULL;
 			val = strtoul(optarg, &endptr, 16);
 			if (endptr == NULL || endptr == optarg || *endptr != '\0') {
-				printf("Unable to parse DO identifier\n");
-				return 1;
+				util_error("Unable to parse DO identifier");
+				exit(EXIT_FAILURE);
 			}
 			if (opt_dump_do < sizeof(do_dump_idx) / sizeof(*do_dump_idx)) {
 				do_dump_idx[opt_dump_do] = (unsigned int) (val | 0x100);
@@ -354,7 +354,7 @@ static int do_userinfo(sc_card_t *card)
 		sc_format_path(openpgp_data[i].ef, &path);
 		r = sc_select_file(card, &path, &file);
 		if (r) {
-			fprintf(stderr, "Failed to select EF %s: %s\n", openpgp_data[i].ef, sc_strerror(r));
+			util_error("failed to select EF %s: %s", openpgp_data[i].ef, sc_strerror(r));
 			return EXIT_FAILURE;
 		}
 
@@ -363,17 +363,17 @@ static int do_userinfo(sc_card_t *card)
 			continue;
 
 		if (count > sizeof(buf) - 1) {
-			fprintf(stderr, "Too small buffer to read the OpenPGP data\n");
+			util_error("too small buffer to read the OpenPGP data");
 			return EXIT_FAILURE;
 		}
 
 		r = sc_read_binary(card, 0, buf, count, 0);
 		if (r < 0) {
-			fprintf(stderr, "%s: read failed - %s\n", openpgp_data[i].ef, sc_strerror(r));
+			util_error("failed to read %s: %s", openpgp_data[i].ef, sc_strerror(r));
 			return EXIT_FAILURE;
 		}
 		if (r != (signed)count) {
-			fprintf(stderr, "%s: expecting %"SC_FORMAT_LEN_SIZE_T"d, got only %d bytes\n",
+			util_error("%s: expecting %"SC_FORMAT_LEN_SIZE_T"d bytes, got only %d",
 				openpgp_data[i].ef, count, r);
 			return EXIT_FAILURE;
 		}
@@ -395,15 +395,15 @@ static int do_dump_do(sc_card_t *card, unsigned int tag)
 	memset(buffer, '\0', sizeof(buffer));
 
 	if (tag < 0x101 || tag > 0x104) {
-		printf("Illegal DO identifier\n");
-		return 1;
+		util_error("illegal DO identifier %04X", tag);
+		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
 	r = sc_get_data(card, tag, buffer, sizeof(buffer));
 	if (r < 0) {
-		printf("Failed to get data object: %s\n", sc_strerror(r));
+		util_error("failed to get data object DO %04X: %s", tag, sc_strerror(r));
 		if (SC_ERROR_SECURITY_STATUS_NOT_SATISFIED == r) {
-			printf("Make sure the 'verify' and 'pin' parameters are correct.\n");
+			util_error("make sure the 'verify' and 'pin' parameters are correct");
 		}
 		return r;
 	}
@@ -450,8 +450,8 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 	sc_file_t *file;
 
 	if (key_id < 1 || key_id > 3) {
-		printf("Unknown key ID %d.\n", key_id);
-		return 1;
+		util_error("unknown key ID %d", key_id);
+		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keygen_info_t));
 	key_info.keytype = key_id;
@@ -460,22 +460,22 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 	r = sc_card_ctl(card, SC_CARDCTL_OPENPGP_GENERATE_KEY, &key_info);
 	free(key_info.modulus);
 	if (r < 0) {
-		printf("Failed to generate key. Error %s.\n", sc_strerror(r));
-		return 1;
+		util_error("failed to generate key: %s", sc_strerror(r));
+		return EXIT_FAILURE;
 	}
 	sc_format_path("006E007300C5", &path);
 	r = sc_select_file(card, &path, &file);
 	if (r < 0) {
-		printf("Failed to retrieve fingerprints. Error %s.\n", sc_strerror(r));
-		return 1;
+		util_error("failed to retrieve fingerprints: %s", sc_strerror(r));
+		return EXIT_FAILURE;
 	}
 	r = sc_read_binary(card, 0, fingerprints, 60, 0);
 	if (r < 0) {
-		printf("Failed to retrieve fingerprints. Error %s.\n", sc_strerror(r));
-		return 1;
+		util_error("failed to retrieve fingerprints: %s", sc_strerror(r));
+		return EXIT_FAILURE;
 	}
 	printf("Fingerprint:\n%s\n", (char *)sc_dump_hex(fingerprints + 20*(key_id - 1), 20));
-	return 0;
+	return EXIT_SUCCESS;
 }
 
 int do_verify(sc_card_t *card, char *type, const char *pin)
@@ -487,12 +487,12 @@ int do_verify(sc_card_t *card, char *type, const char *pin)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
 	if (strncasecmp("CHV", type, 3) != 0) {
-		printf("Invalid PIN type. Please use CHV1, CHV2 or CHV3.\n");
+		util_error("invalid PIN type. Please use CHV1, CHV2 or CHV3");
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
 	if (type[3] < '1' || type[3] > '3' || type[4] != '\0') {
-		printf("Invalid PIN reference. Please use CHV1, CHV2 or CHV3.\n");
+		util_error("invalid PIN reference. Please use CHV1, CHV2 or CHV3");
 		return SC_ERROR_INVALID_PIN_REFERENCE;
 	}
 
@@ -538,7 +538,7 @@ int delete_key_openpgp(sc_card_t *card, u8 key_id)
 		/* Build APDU from binary array */
 		r = sc_bytes2apdu(card->ctx, buf, len0, &apdu);
 		if (r) {
-			fprintf(stderr, "Failed to build APDU: %s\n", sc_strerror(r));
+			util_error("failed to build APDU: %s", sc_strerror(r));
 			return r;
 		}
 		apdu.resp = rbuf;
@@ -547,7 +547,7 @@ int delete_key_openpgp(sc_card_t *card, u8 key_id)
 		/* Send APDU to card */
 		r = sc_transmit_apdu(card, &apdu);
 		if (r) {
-			fprintf(stderr, "Transmitting APDU failed: %s\n", sc_strerror(r));
+			util_error("transmitting APDU failed: %s", sc_strerror(r));
 			return r;
 		}
 	}
@@ -563,14 +563,15 @@ int do_delete_key(sc_card_t *card, u8 key_id)
 
 	/* Currently, only Gnuk supports deleting keys */
 	if (card->type != SC_CARD_TYPE_OPENPGP_GNUK) {
-		printf("Only Gnuk supports deleting keys. General OpenPGP doesn't.");
+		util_error("only Gnuk supports deleting keys. General OpenPGP doesn't");
 		return SC_ERROR_NOT_SUPPORTED;
 	}
 
 	if (key_id < 1 || (key_id > 3 && key_id != 'a')) {
-		printf("Error: Invalid key id %d", key_id);
+		util_error("invalid key id %d", key_id);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
+
 	if (key_id == 1 || key_id == 'a') {
 		sc_format_path("B601", &path);
 		r |= sc_delete_file(card, &path);
@@ -611,8 +612,7 @@ int main(int argc, char **argv)
 
 	r = sc_context_create(&ctx, &ctx_param);
 	if (r) {
-		util_fatal("failed to establish context: %s\n",
-			sc_strerror(r));
+		util_fatal("failed to establish context: %s", sc_strerror(r));
 		return EXIT_FAILURE;
 	}
 
@@ -623,8 +623,7 @@ int main(int argc, char **argv)
 
 	r = util_connect_card(ctx, &card, opt_reader, opt_wait, verbose);
 	if (r) {
-		util_fatal("failed to connect to card: %s\n",
-			sc_strerror(r));
+		util_fatal("failed to connect to card: %s", sc_strerror(r));
 		return EXIT_FAILURE;
 	}
 
@@ -634,8 +633,7 @@ int main(int argc, char **argv)
 			(card->type != SC_CARD_TYPE_OPENPGP_V2) &&
 			(card->type != SC_CARD_TYPE_OPENPGP_V3) &&
 			(card->type != SC_CARD_TYPE_OPENPGP_GNUK)) {
-		util_error("not an OpenPGP card");
-		fprintf(stderr, "Card type %X\n", card->type);
+		util_error("card type %X: not an OpenPGP card", card->type);
 		exit_status = EXIT_FAILURE;
 		goto out;
 	}


### PR DESCRIPTION
Hi,

please find attached some small cleanups to openpgp-tool:
- remove unused variable
- harmonize error message by using util_error() instead of a wild mixture
  of printf() and fprintf(stderr, ...)
- use symbolic constants for return/error values

Thanks in advance for including it to opensc master
Peter