### PR TITLE
starcos: fixed decipher with 2.3

### DIFF
--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1647,7 +1647,6 @@ static int starcos_decipher(struct sc_card *card,
 	size_t reader_max_send_size = card->reader->max_send_size;
 	size_t card_max_recv_size = card->max_recv_size;
 	size_t reader_max_recv_size = card->reader->max_recv_size;
-	int caps = card->caps;
 
 	if (sc_get_max_send_size(card) < crgram_len + 1) {
 		/* Starcos doesn't support chaining for PSO:DEC, so we just _hope_
@@ -1655,7 +1654,6 @@ static int starcos_decipher(struct sc_card *card,
 		 * (data is prefixed with 1 byte padding content indicator) */
 		card->max_send_size = crgram_len + 1;
 		card->reader->max_send_size = crgram_len + 1;
-		card->caps |= SC_CARD_CAP_APDU_EXT;
 	}
 
 	if (sc_get_max_recv_size(card) < outlen) {
@@ -1664,7 +1662,6 @@ static int starcos_decipher(struct sc_card *card,
 		 */
 		card->max_recv_size = outlen;
 		card->reader->max_recv_size = outlen;
-		card->caps |= SC_CARD_CAP_APDU_EXT;
 	}
 
 	if (card->type == SC_CARD_TYPE_STARCOS_V3_4
@@ -1706,7 +1703,6 @@ static int starcos_decipher(struct sc_card *card,
 	card->reader->max_send_size = reader_max_send_size;
 	card->max_recv_size = card_max_recv_size;
 	card->reader->max_recv_size = reader_max_recv_size;
-	card->caps = caps;
 
 	LOG_FUNC_RETURN(card->ctx, r);
 }

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1642,12 +1642,33 @@ static int starcos_decipher(struct sc_card *card,
 		const u8 * crgram, size_t crgram_len,
 		u8 * out, size_t outlen)
 {
+	int r;
+	size_t card_max_send_size = card->max_send_size;
+	size_t reader_max_send_size = card->reader->max_send_size;
+	size_t card_max_recv_size = card->max_recv_size;
+	size_t reader_max_recv_size = card->reader->max_recv_size;
+	int caps = card->caps;
+
+	if (sc_get_max_send_size(card) < crgram_len + 1) {
+		/* Starcos doesn't support chaining for PSO:DEC, so we just _hope_
+		 * that both, the reader and the card are able to send enough data.
+		 * (data is prefixed with 1 byte padding content indicator) */
+		card->max_send_size = crgram_len + 1;
+		card->reader->max_send_size = crgram_len + 1;
+		card->caps |= SC_CARD_CAP_APDU_EXT;
+	}
+
+	if (sc_get_max_recv_size(card) < outlen) {
+		/* Starcos doesn't support get response for PSO:DEC, so we just _hope_
+		 * that both, the reader and the card are able to receive enough data.
+		 */
+		card->max_recv_size = outlen;
+		card->reader->max_recv_size = outlen;
+		card->caps |= SC_CARD_CAP_APDU_EXT;
+	}
+
 	if (card->type == SC_CARD_TYPE_STARCOS_V3_4
 			|| card->type == SC_CARD_TYPE_STARCOS_V3_5) {
-		int r;
-		size_t card_max_send_size = card->max_send_size;
-		size_t reader_max_send_size = card->reader->max_send_size;
-		int caps = card->caps;
 		sc_apdu_t apdu;
 
 		u8 *sbuf = malloc(crgram_len + 1);
@@ -1665,34 +1686,29 @@ static int starcos_decipher(struct sc_card *card,
 		apdu.lc = crgram_len + 1;
 		apdu.datalen = crgram_len + 1;
 
-		if (sc_get_max_send_size(card) < crgram_len + 1) {
-			/* Starcos doesn't support chaining for PSO:DEC, so we just _hope_
-			 * that both, the reader and the card are able to send enough data.
-			 * (data is prefixed with 1 byte padding content indicator) */
-			card->max_send_size = crgram_len + 1;
-			card->reader->max_send_size = crgram_len + 1;
-			card->caps |= SC_CARD_CAP_APDU_EXT;
-		}
-
 		r = sc_transmit_apdu(card, &apdu);
 		sc_mem_clear(sbuf, crgram_len + 1);
-
-		/* reset whatever we've modified above */
-		card->max_send_size = card_max_send_size;
-		card->reader->max_send_size = reader_max_send_size;
-		card->caps = caps;
 
 		free(sbuf);
 
 		LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 
 		if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
-			LOG_FUNC_RETURN(card->ctx, apdu.resplen);
+			r = apdu.resplen;
 		else
-			LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	} else {
-		return iso_ops->decipher(card, crgram, crgram_len, out, outlen);
+		r = iso_ops->decipher(card, crgram, crgram_len, out, outlen);
 	}
+
+	/* reset whatever we've modified above */
+	card->max_send_size = card_max_send_size;
+	card->reader->max_send_size = reader_max_send_size;
+	card->max_recv_size = card_max_recv_size;
+	card->reader->max_recv_size = reader_max_recv_size;
+	card->caps = caps;
+
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 static int starcos_check_sw(sc_card_t *card, unsigned int sw1, unsigned int sw2)

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1660,8 +1660,14 @@ static int starcos_decipher(struct sc_card *card,
 		/* Starcos doesn't support get response for PSO:DEC, so we just _hope_
 		 * that both, the reader and the card are able to receive enough data.
 		 */
-		card->max_recv_size = outlen;
-		card->reader->max_recv_size = outlen;
+		if (0 == (card->caps & SC_CARD_CAP_APDU_EXT)
+				&& outlen > 256) {
+			card->max_recv_size = 256;
+			card->reader->max_recv_size = 256;
+		} else {
+			card->max_recv_size = outlen;
+			card->reader->max_recv_size = outlen;
+		}
 	}
 
 	if (card->type == SC_CARD_TYPE_STARCOS_V3_4


### PR DESCRIPTION
closes https://github.com/OpenSC/OpenSC/issues/765

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
