### PR TITLE
OpenPGP start towards EC

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2134,6 +2134,11 @@ pgp_update_new_algo_attr(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_
 	int r = SC_SUCCESS;
 
 	LOG_FUNC_CALLED(card->ctx);
+
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
 	/* get old algorithm attributes */
 	r = pgp_seek_blob(card, priv->mf, tag, &algo_blob);
 	LOG_TEST_RET(card->ctx, r, "Cannot get old algorithm attributes");
@@ -2243,6 +2248,10 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
+
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	if (modulus == NULL || exponent == NULL || mlen == 0 || elen == 0) {
 		sc_log(card->ctx, "Null data (modulus or exponent)");
@@ -2455,6 +2464,10 @@ pgp_update_card_algorithms(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *ke
 
 	LOG_FUNC_CALLED(card->ctx);
 
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
 	if (id > card->algorithm_count) {
 		sc_log(card->ctx,
 		       "This key ID %u is out of the card's algorithm list.",
@@ -2488,6 +2501,10 @@ pgp_gen_key(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_info)
 	int r = SC_SUCCESS;
 
 	LOG_FUNC_CALLED(card->ctx);
+
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	/* FIXME the compilers don't assure that the buffers set here as
 	 * apdu_data are present until the end of the function */
@@ -2691,6 +2708,10 @@ pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info
 
 	LOG_FUNC_CALLED(ctx);
 
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
+
 	if (key_info->rsa.keyformat == SC_OPENPGP_KEYFORMAT_RSA_STDN
 		|| key_info->rsa.keyformat == SC_OPENPGP_KEYFORMAT_RSA_CRTN)
 		comp_to_add = 4;
@@ -2820,6 +2841,10 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 	int r;
 
 	LOG_FUNC_CALLED(ctx);
+
+	/* temporary workaround: protect v3 cards against non-RSA */
+	if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 
 	/* Validate */
 	if (key_info->key_id < 1 || key_info->key_id > 3) {

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -577,11 +577,14 @@ pgp_init(sc_card_t *card)
 	/* get card_features from ATR & DOs */
 	pgp_get_card_features(card);
 
-	/* add supported algorithms based on specification for pkcs15-init */
-	if (strcmp(card->ctx->app_name, "pkcs15-init") == 0){
-		unsigned long flags;
-		flags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE;
-		flags |= SC_ALGORITHM_ONBOARD_KEY_GEN; // Can be generated in card
+	/* if algorithm attributes can be changed,
+         * add supported algorithms based on specification for pkcs15-init */
+	if ((priv->ext_caps & EXT_CAP_ALG_ATTR_CHANGEABLE) &&
+	    (strcmp(card->ctx->app_name, "pkcs15-init") == 0)) {
+		/* OpenPGP card spec 1.1 & 2.x, section 7.2.9 & 7.2.10 / v3.x section 7.2.11 & 7.2.12 */
+		unsigned long flags = SC_ALGORITHM_RSA_PAD_PKCS1 |
+				      SC_ALGORITHM_RSA_HASH_NONE |
+				      SC_ALGORITHM_ONBOARD_KEY_GEN;	/* key gen. on card */
 
 		switch (card->type) {
 			case SC_CARD_TYPE_OPENPGP_V3:

--- a/src/libopensc/cardctl.h
+++ b/src/libopensc/cardctl.h
@@ -952,24 +952,41 @@ typedef struct sc_cardctl_piv_genkey_info_st {
 typedef struct sc_cardctl_openpgp_keygen_info {
 	u8 key_id;		/* SC_OPENPGP_KEY_... */
 	u8 algorithm;		/* SC_OPENPGP_KEYALGO_... */
-	u8 *modulus;		/* New-generated pubkey info responded from the card */
-	size_t modulus_len;	/* Length of modulus in bit */
-	u8 *exponent;
-	size_t exponent_len;
+	union {			/* anonymous union */
+		struct {
+			u8 *modulus;		/* New-generated pubkey info responded from the card */
+			size_t modulus_len;	/* Length of modulus in bit */
+			u8 *exponent;
+			size_t exponent_len;
+			u8 keyformat;	/* SC_OPENPGP_KEYFORMAT_RSA_... */
+		} rsa;
+		struct {
+			u8 dummy;	/* placeholder */
+			// TODO: replace placeholder with real attributes
+		} ec;
+	};
 } sc_cardctl_openpgp_keygen_info_t;
 
 typedef struct sc_cardctl_openpgp_keystore_info {
 	u8 key_id;		/* SC_OPENPGP_KEY_... */
 	u8 algorithm;		/* SC_OPENPGP_KEYALGO_... */
-	u8 keyformat;
-	u8 *e;
-	size_t e_len;
-	u8 *p;
-	size_t p_len;
-	u8 *q;
-	size_t q_len;
-	u8 *n;
-	size_t n_len;
+	union {			/* anonymous union */
+		struct {
+			u8 keyformat;	/* SC_OPENPGP_KEYFORMAT_RSA_... */
+			u8 *e;
+			size_t e_len;
+			u8 *p;
+			size_t p_len;
+			u8 *q;
+			size_t q_len;
+			u8 *n;
+			size_t n_len;
+		} rsa;
+		struct {
+			u8 dummy;	/* placeholder */
+			// TODO: replace placeholder with real attributes
+		} ec;
+	};
 	time_t creationtime;
 } sc_cardctl_openpgp_keystore_info_t;
 

--- a/src/libopensc/cardctl.h
+++ b/src/libopensc/cardctl.h
@@ -942,21 +942,25 @@ typedef struct sc_cardctl_piv_genkey_info_st {
 #define SC_OPENPGP_KEY_ENCR		2
 #define SC_OPENPGP_KEY_AUTH		3
 
-#define SC_OPENPGP_KEYFORMAT_STD	0    /* See 4.3.3.6 Algorithm Attributes */
-#define SC_OPENPGP_KEYFORMAT_STDN	1    /* OpenPGP card spec v2 */
-#define SC_OPENPGP_KEYFORMAT_CRT	2
-#define SC_OPENPGP_KEYFORMAT_CRTN	3
+#define	SC_OPENPGP_KEYALGO_RSA		0x01
+
+#define SC_OPENPGP_KEYFORMAT_RSA_STD	0    /* See 4.3.3.6 Algorithm Attributes */
+#define SC_OPENPGP_KEYFORMAT_RSA_STDN	1    /* OpenPGP card spec v2 */
+#define SC_OPENPGP_KEYFORMAT_RSA_CRT	2
+#define SC_OPENPGP_KEYFORMAT_RSA_CRTN	3
 
 typedef struct sc_cardctl_openpgp_keygen_info {
-	u8 keytype;		      /* SC_OPENPGP_KEY_ */
-	u8 *modulus;          /* New-generated pubkey info responded from the card */
-	size_t modulus_len;   /* Length of modulus in bit */
+	u8 key_id;		/* SC_OPENPGP_KEY_... */
+	u8 algorithm;		/* SC_OPENPGP_KEYALGO_... */
+	u8 *modulus;		/* New-generated pubkey info responded from the card */
+	size_t modulus_len;	/* Length of modulus in bit */
 	u8 *exponent;
 	size_t exponent_len;
 } sc_cardctl_openpgp_keygen_info_t;
 
 typedef struct sc_cardctl_openpgp_keystore_info {
-	u8 keytype;
+	u8 key_id;		/* SC_OPENPGP_KEY_... */
+	u8 algorithm;		/* SC_OPENPGP_KEYALGO_... */
 	u8 keyformat;
 	u8 *e;
 	size_t e_len;

--- a/src/pkcs15init/pkcs15-openpgp.c
+++ b/src/pkcs15init/pkcs15-openpgp.c
@@ -128,7 +128,7 @@ static int openpgp_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	}
 
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keystore_info_t));
-	key_info.keytype = kinfo->id.value[0];
+	key_info.key_id = kinfo->id.value[0];
 	key_info.e = rsa->exponent.data;
 	key_info.e_len = rsa->exponent.len;
 	key_info.p = rsa->p.data;
@@ -169,15 +169,15 @@ static int openpgp_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card
 		/* Default key is authentication key. We choose this because the common use
 		 * is to generate from PKCS#11 (Firefox/Thunderbird) */
 		sc_log(ctx, "Authentication key is to be generated.");
-		key_info.keytype = 3;
+		key_info.key_id = 3;
 	}
-	if (!key_info.keytype && (kid->len > 1 || kid->value[0] > 3)) {
+	if (!key_info.key_id && (kid->len > 1 || kid->value[0] > 3)) {
 		sc_log(ctx, "Key ID must be 1, 2 or 3!");
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 	}
 
-	if (!key_info.keytype)
-		key_info.keytype = kid->value[0];
+	if (!key_info.key_id)
+		key_info.key_id = kid->value[0];
 
 	/* Prepare buffer */
 	key_info.modulus_len = required->modulus_length;

--- a/src/pkcs15init/pkcs15-openpgp.c
+++ b/src/pkcs15init/pkcs15-openpgp.c
@@ -129,14 +129,14 @@ static int openpgp_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keystore_info_t));
 	key_info.key_id = kinfo->id.value[0];
-	key_info.e = rsa->exponent.data;
-	key_info.e_len = rsa->exponent.len;
-	key_info.p = rsa->p.data;
-	key_info.p_len = rsa->p.len;
-	key_info.q = rsa->q.data;
-	key_info.q_len = rsa->q.len;
-	key_info.n = rsa->modulus.data;
-	key_info.n_len = rsa->modulus.len;
+	key_info.rsa.e = rsa->exponent.data;
+	key_info.rsa.e_len = rsa->exponent.len;
+	key_info.rsa.p = rsa->p.data;
+	key_info.rsa.p_len = rsa->p.len;
+	key_info.rsa.q = rsa->q.data;
+	key_info.rsa.q_len = rsa->q.len;
+	key_info.rsa.n = rsa->modulus.data;
+	key_info.rsa.n_len = rsa->modulus.len;
 	r = sc_card_ctl(card, SC_CARDCTL_OPENPGP_STORE_KEY, &key_info);
 
 	LOG_FUNC_RETURN(card->ctx, r);
@@ -180,16 +180,16 @@ static int openpgp_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card
 		key_info.key_id = kid->value[0];
 
 	/* Prepare buffer */
-	key_info.modulus_len = required->modulus_length;
-	key_info.modulus = calloc(required->modulus_length >> 3, 1);
-	if (key_info.modulus == NULL)
+	key_info.rsa.modulus_len = required->modulus_length;
+	key_info.rsa.modulus = calloc(required->modulus_length >> 3, 1);
+	if (key_info.rsa.modulus == NULL)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_ENOUGH_MEMORY);
 
 	/* The OpenPGP supports only 32-bit exponent. */
-	key_info.exponent_len = 32;
-	key_info.exponent = calloc(key_info.exponent_len>>3, 1); /* 1/8 */
-	if (key_info.exponent == NULL) {
-		free(key_info.modulus);
+	key_info.rsa.exponent_len = 32;
+	key_info.rsa.exponent = calloc(key_info.rsa.exponent_len>>3, 1); /* 1/8 */
+	if (key_info.rsa.exponent == NULL) {
+		free(key_info.rsa.modulus);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_ENOUGH_MEMORY);
 	}
 
@@ -198,24 +198,24 @@ static int openpgp_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card
 		goto out;
 
 	sc_log(ctx, "Set output modulus info");
-	pubkey->u.rsa.modulus.len = key_info.modulus_len;
-	pubkey->u.rsa.modulus.data = calloc(key_info.modulus_len, 1);
+	pubkey->u.rsa.modulus.len = key_info.rsa.modulus_len;
+	pubkey->u.rsa.modulus.data = calloc(key_info.rsa.modulus_len, 1);
 	if (pubkey->u.rsa.modulus.data == NULL)
 		goto out;
-	memcpy(pubkey->u.rsa.modulus.data, key_info.modulus, key_info.modulus_len);
+	memcpy(pubkey->u.rsa.modulus.data, key_info.rsa.modulus, key_info.rsa.modulus_len);
 
 	sc_log(ctx, "Set output exponent info");
-	pubkey->u.rsa.exponent.len = key_info.exponent_len;
-	pubkey->u.rsa.exponent.data = calloc(key_info.exponent_len>>3, 1); /* 1/8 */
+	pubkey->u.rsa.exponent.len = key_info.rsa.exponent_len;
+	pubkey->u.rsa.exponent.data = calloc(key_info.rsa.exponent_len>>3, 1); /* 1/8 */
 	if (pubkey->u.rsa.exponent.data == NULL)
 		goto out;
-	memcpy(pubkey->u.rsa.exponent.data, key_info.exponent, key_info.exponent_len>>3); /* 1/8 */
+	memcpy(pubkey->u.rsa.exponent.data, key_info.rsa.exponent, key_info.rsa.exponent_len>>3); /* 1/8 */
 
 out:
-	if (key_info.modulus)
-		free(key_info.modulus);
-	if (key_info.exponent)
-		free(key_info.exponent);
+	if (key_info.rsa.modulus)
+		free(key_info.rsa.modulus);
+	if (key_info.rsa.exponent)
+		free(key_info.rsa.exponent);
 	LOG_FUNC_RETURN(ctx, r);
 }
 

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -455,6 +455,7 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 	}
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keygen_info_t));
 	key_info.key_id = key_id;
+	key_info.algorithm = SC_OPENPGP_KEYALGO_RSA;
 	key_info.rsa.modulus_len = key_len;
 	key_info.rsa.modulus = malloc(key_len/8);
 	r = sc_card_ctl(card, SC_CARDCTL_OPENPGP_GENERATE_KEY, &key_info);

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -455,10 +455,10 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 	}
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keygen_info_t));
 	key_info.key_id = key_id;
-	key_info.modulus_len = key_len;
-	key_info.modulus = malloc(key_len/8);
+	key_info.rsa.modulus_len = key_len;
+	key_info.rsa.modulus = malloc(key_len/8);
 	r = sc_card_ctl(card, SC_CARDCTL_OPENPGP_GENERATE_KEY, &key_info);
-	free(key_info.modulus);
+	free(key_info.rsa.modulus);
 	if (r < 0) {
 		util_error("failed to generate key: %s", sc_strerror(r));
 		return EXIT_FAILURE;

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -454,7 +454,7 @@ int do_genkey(sc_card_t *card, u8 key_id, unsigned int key_len)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	memset(&key_info, 0, sizeof(sc_cardctl_openpgp_keygen_info_t));
-	key_info.keytype = key_id;
+	key_info.key_id = key_id;
 	key_info.modulus_len = key_len;
 	key_info.modulus = malloc(key_len/8);
 	r = sc_card_ctl(card, SC_CARDCTL_OPENPGP_GENERATE_KEY, &key_info);


### PR DESCRIPTION
Hi, 

this PR intends to set the first steps towards EC support with OpenPGP cards.
It
* performs minor cleanups
* exposes additional attributes beyond those mentioned in the algorithm attributes DO C1 - C3 only if the extended capabilities indicate that these DOs can be changed
* fixes some minor glitches in the data structures for key generation & import
* extends those data structures to allow for non-RSA algorithms
* adds security checks to some functions to bail out in case of being called with non-RSA algorithms
* introduces a new function introduce `gpg_parse_algo_attr_blob()`
* refactors `pgp_get_card_features()` to make use of `gpg_parse_algo_attr_blob()`

None of these should change anything in the existing logic, but they pave the ground for further PRs that may be more intrusive.

Please include them in OpenSC master.

Thanks in advance
Peter