### PR TITLE
Improve Coolkey matching code

### DIFF
--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -211,7 +211,7 @@ typedef struct cac_private_data {
 
 #define CAC_DATA(card) ((cac_private_data_t*)card->drv_data)
 
-int cac_list_compare_path(const void *a, const void *b)
+static int cac_list_compare_path(const void *a, const void *b)
 {
 	if (a == NULL || b == NULL)
 		return 1;
@@ -220,7 +220,7 @@ int cac_list_compare_path(const void *a, const void *b)
 }
 
 /* For SimCList autocopy, we need to know the size of the data elements */
-size_t cac_list_meter(const void *el) {
+static size_t cac_list_meter(const void *el) {
 	return sizeof(cac_object_t);
 }
 

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -2225,13 +2225,32 @@ cleanup:
 static int coolkey_match_card(sc_card_t *card)
 {
 	int r;
+
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	/* Since we send an APDU, the card's logout function may be called...
 	 * however it may be in dirty memory */
 	card->ops->logout = NULL;
 
 	r = coolkey_select_applet(card);
-	return (r >= SC_SUCCESS);
+	if (r == SC_SUCCESS) {
+		sc_apdu_t apdu;
+
+		/* The GET STATUS INS with P1 = 1 returns invalid instruction (0x6D00)
+		 * on Coolkey applet (reserved for GetMemory function),
+		 * while incorrect P1 (0x9C10) on Muscle applets
+		 */
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_1, COOLKEY_INS_GET_STATUS, 0x01, 0x00);
+		apdu.cla = COOLKEY_CLASS;
+		apdu.le = 0x00;
+		apdu.resplen = 0;
+		apdu.resp = NULL;
+		r = sc_transmit_apdu(card, &apdu);
+		if (r == SC_SUCCESS && apdu.sw1 == 0x6d && apdu.sw2 == 0x00) {
+			return 1;
+		}
+		return 0;
+	}
+	return 0;
 }
 
 

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -128,6 +128,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 
 /* Here should be placed drivers that need some APDU transactions in the
  * driver's `match_card()` function. */
+	{ "coolkey",	(void *(*)(void)) sc_get_coolkey_driver },
 	/* MUSCLE card applet returns 9000 on whatever AID is selected, see
 	 * https://github.com/JavaCardOS/MuscleCard-Applet/blob/master/musclecard/src/com/musclecard/CardEdge/CardEdge.java#L326
 	 * put the muscle driver first to cope with this bug. */
@@ -144,7 +145,6 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 #endif
 	{ "openpgp",	(void *(*)(void)) sc_get_openpgp_driver },
 	{ "jpki",	(void *(*)(void)) sc_get_jpki_driver },
-	{ "coolkey",	(void *(*)(void)) sc_get_coolkey_driver },
 	{ "npa",	(void *(*)(void)) sc_get_npa_driver },
 	/* The default driver should be last, as it handles all the
 	 * unrecognized cards. */


### PR DESCRIPTION
As described in #1483, the card matching between coolkey and muscle was problematic, because they share a lot of similar code and same instructions.

This PR is making use of one difference in handling the GET STATUS instruction to reliably distinguish these two. As a result, the coolkey applet can be moved up in the stack since it should not match unrelated cards anymore.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested