### PR TITLE
Fix minidriver padding

### DIFF
--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -412,7 +412,7 @@ int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
 	pad_algo  = flags & SC_ALGORITHM_RSA_PADS;
 	sc_log(ctx, "hash algorithm 0x%X, pad algorithm 0x%X", hash_algo, pad_algo);
 
-	if ((pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 || !pad_algo) &&
+	if ((pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 || pad_algo == SC_ALGORITHM_RSA_PAD_NONE) &&
 	    hash_algo != SC_ALGORITHM_RSA_HASH_NONE) {
 		i = sc_pkcs1_add_digest_info_prefix(hash_algo, in, in_len, out, &tmp_len);
 		if (i != SC_SUCCESS) {

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4728,6 +4728,7 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 			goto err;
 		}
 	}
+	opt_hash_flags |= SC_ALGORITHM_RSA_PAD_NONE;
 	
 	if (pInfo->dwSigningFlags & CARD_PADDING_NONE)
 	{


### PR DESCRIPTION
Commit e5707b545e5a2dc33b0ca52a8bf63f36f71b3d85 broke signing using minidriver on Windows.

More specifically changing `#define SC_ALGORITHM_RSA_PAD_NONE` from `0x00000000` to `0x00000001` caused a call to _sc_pkcs1_encode()_ to fail as the padding algorithm was not specified anywhere in the _CardSignData()_ implementation. It kind of worked as long as `SC_ALGORITHM_RSA_PAD_NONE` was `0x00000000`, but the above mentioned commit broke this.

Now padding algorithm has to be explicitly specified, otherwise a call to `sc_pkcs1_encode()` will fail.
