### PR TITLE
Minidriver: removed duplicate code for adding padding

### DIFF
--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -487,18 +487,19 @@ int sc_get_encoding_flags(sc_context_t *ctx,
 		*pflags = 0;
 
 	} else if ((caps & SC_ALGORITHM_RSA_PAD_PSS) &&
-                   (iflags & SC_ALGORITHM_RSA_PAD_PSS)) {
+			(iflags & SC_ALGORITHM_RSA_PAD_PSS)) {
 		*sflags |= SC_ALGORITHM_RSA_PAD_PSS;
 
 	} else if (((caps & SC_ALGORITHM_RSA_RAW) &&
-	            (iflags & SC_ALGORITHM_RSA_PAD_PKCS1))
-	           || iflags & SC_ALGORITHM_RSA_PAD_PSS) {
+				(iflags & SC_ALGORITHM_RSA_PAD_PKCS1))
+			|| iflags & SC_ALGORITHM_RSA_PAD_PSS
+			|| iflags & SC_ALGORITHM_RSA_PAD_NONE) {
 		/* Use the card's raw RSA capability on the padded input */
 		*sflags = SC_ALGORITHM_RSA_PAD_NONE;
 		*pflags = iflags;
 
 	} else if ((caps & (SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE)) &&
-	           (iflags & SC_ALGORITHM_RSA_PAD_PKCS1)) {
+			(iflags & SC_ALGORITHM_RSA_PAD_PKCS1)) {
 		/* A corner case - the card can partially do PKCS1, if we prepend the
 		 * DigestInfo bit it will do the rest. */
 		*sflags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE;


### PR DESCRIPTION
This PR removes the superflous call to sc_pkcs1_encode as discussed in https://github.com/OpenSC/OpenSC/pull/1435.

The bugfix in `padding.c` is simular to https://github.com/OpenSC/OpenSC/pull/1503. @Jakuje and @llogar could you please review?

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested
