### PR TITLE
openpgp-tool extensions

### DIFF
--- a/doc/tools/openpgp-tool.1.xml
+++ b/doc/tools/openpgp-tool.1.xml
@@ -133,12 +133,17 @@
 
 				<varlistentry>
 					<term>
-						<option>--key-length</option> <replaceable>bitlength</replaceable>,
-						<option>-L</option> <replaceable>bitlength</replaceable>
+						<option>--key-type</option> <replaceable>keytype</replaceable>,
+						<option>-t</option> <replaceable>keytype</replaceable>
 					</term>
 					<listitem><para>
-						Specify the length of the key to be generated.
-						If not given, it defaults to 2048 bit.
+						Specify the type of the key to be generated.
+						Supported values for <replaceable>keytype</replaceable> are
+						<literal>rsa</literal> for RSA with 2048 bits,
+						<literal>rsa</literal><replaceable>LENGTH</replaceable>
+						for RSA with a bit length of <replaceable>LENGTH</replaceable>.
+
+						If not given, it defaults to <literal>rsa2048</literal>.
 					</para></listitem>
 				</varlistentry>
 

--- a/doc/tools/openpgp-tool.1.xml
+++ b/doc/tools/openpgp-tool.1.xml
@@ -40,6 +40,16 @@
 			<variablelist>
 				<varlistentry>
 					<term>
+						<option>--card-info</option>,
+						<option>-C</option>
+					</term>
+					<listitem><para>
+						Show card information.
+					</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--del-key</option> <replaceable>arg</replaceable>
 					</term>
 					<listitem><para>

--- a/doc/tools/openpgp-tool.1.xml
+++ b/doc/tools/openpgp-tool.1.xml
@@ -123,6 +123,16 @@
 
 				<varlistentry>
 					<term>
+						<option>--key-info</option>,
+						<option>-K</option>
+					</term>
+					<listitem><para>
+						Show information of keys on the card.
+					</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--key-length</option> <replaceable>bitlength</replaceable>,
 						<option>-L</option> <replaceable>bitlength</replaceable>
 					</term>

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -332,7 +332,7 @@ static char *prettify_name(u8 *data, size_t length)
 			*dst = *src++;
 			length--;
 			if (*dst == '<') {
-				if (*src == '<') {
+				if (length > 0 && *src == '<') {
 					src++;
 					length--;
 				}

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -251,7 +251,7 @@ static char *prettify_date(u8 *data, size_t length)
 		static char result[64];	/* large enough */
 
 		tp = gmtime(&time);
-		strftime(result, sizeof(result), "%Y-%m-%d %T", tp);
+		strftime(result, sizeof(result), "%Y-%m-%d %H:%M:%S", tp);
 		return result;
 	}
 	return NULL;

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -678,7 +678,7 @@ int do_genkey(sc_card_t *card, u8 key_id, const char *keytype)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
-	/* fack back to RSA 2048 if keytype is not given */
+	/* fall back to RSA 2048 if keytype is not given */
 	if (!keytype)
 		keytype = "RSA2048";
 

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -204,15 +204,8 @@ static char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen)
 	if (data != NULL) {
 		int r = sc_bin_to_hex(data, length, buffer, buflen, ':');
 
-		if (r == SC_SUCCESS) {
-			char *ptr;
-
-			/* upper-case the hex-ified string */
-			for (ptr = buffer; *ptr != '\0'; ptr++)
-				*ptr = toupper(*ptr);
-
+		if (r == SC_SUCCESS)
 			return buffer;
-		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
Hi,

this PR 
* replaces the option `-L`  / ` --key-length` which implicitly assumes RSA keys with a more general option `-t` / `--key-type` that allows passing a string as key-type. 
  Currently it only supports `rsa` and `rsaNNNN` where `NNNN` is the modulus length, but allows for easy extension.
* adds two new information options to openpgp-tool
  * `-C` / `--card-info`   to display card-specific details
  * `-K` `--key-info`    to display info about the keys on the card
* adds length checks to `prettify_...()` functions instead of blindly assuming that the arguments are \0-terminated strings

This PR is an extension of the withdrawn PR #1363 addressing the issues mentioned in that old PR's reviews.

Please consider including it in OpenSC master.

##### Checklist
- [x] Documentation is added or updated
