### PR TITLE
Fix a bug for public key display error

### DIFF
--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -639,6 +639,11 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_NORMAL, r,
 		    "generate RSA key pair failed");
 
+	if (!gendat.modulus) {
+		r = SC_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+	
 	/* get the modulus */
 	if (pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_RSA) {
 		u8 *buf;

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -640,7 +640,7 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		    "generate RSA key pair failed");
 
 	/* get the modulus */
-	if (pubkey) {
+	if (pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_RSA) {
 		u8 *buf;
 		struct sc_pkcs15_pubkey_rsa *rsa = &pubkey->u.rsa;
 		/* set the modulus */
@@ -659,7 +659,32 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		rsa->exponent.len = 3;
 
 		pubkey->algorithm = SC_ALGORITHM_RSA;
-	} else
+	}
+	else if(pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_EC)
+	{
+		struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
+		pubkey->algorithm = SC_ALGORITHM_EC;
+		pubkey->u.ec.ecpointQ.value = malloc(65);
+		if (!pubkey->u.ec.ecpointQ.value) {
+			r = SC_ERROR_OUT_OF_MEMORY;
+			goto err;
+		}
+		memcpy(pubkey->u.ec.ecpointQ.value, gendat.modulus, 65);
+		pubkey->u.ec.ecpointQ.len = 65;
+
+		free(pubkey->u.ec.params.named_curve);
+		pubkey->u.ec.params.named_curve = NULL;
+
+		free(pubkey->u.ec.params.der.value);
+		pubkey->u.ec.params.der.value = NULL;
+		pubkey->u.ec.params.der.len = 0;
+		pubkey->u.ec.params.named_curve = strdup(ecparams->named_curve);
+		if (!pubkey->u.ec.params.named_curve)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		r = sc_pkcs15_fix_ec_parameters(card->ctx, &pubkey->u.ec.params);
+		LOG_TEST_RET(card->ctx, r, "Cannot fix EC parameters");
+	}
+	else
 		/* free public key */
 		free(gendat.modulus);
 


### PR DESCRIPTION
Fixes #1411 
Modify pkcs15-epass2003.c file:
1. Fix a bug for public key display error
2. Add the code from line 662- 687
3. Check the return code
4. line 643 modify the code, check the KEY type, the previous structure is processed according to the structure of RSA, and is now modified to ECC structure.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
