### PR TITLE
gio: avoid unneccessary unitialization

### DIFF
--- a/src/ui/notify.c
+++ b/src/ui/notify.c
@@ -442,9 +442,10 @@ static GApplication *application = NULL;
 
 void sc_notify_init(void)
 {
-	sc_notify_close();
-	application = g_application_new("org.opensc.notify", G_APPLICATION_NON_UNIQUE);
-	if (application) {
+	if (!application) {
+		application = g_application_new("org.opensc.notify", G_APPLICATION_NON_UNIQUE);
+	}
+	if (application && FALSE == g_application_get_is_registered(application)) {
 		g_application_register(application, NULL, NULL);
 	}
 }


### PR DESCRIPTION
@loskutov could you check if this helps for https://github.com/OpenSC/OpenSC/issues/1507? During the first initialization however, I fear that `g_application_register()` still forks...

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
