### PR TITLE
Fix files to allow build without openssl and openpace

### DIFF
--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -146,7 +146,9 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 #endif
 	{ "openpgp",	(void *(*)(void)) sc_get_openpgp_driver },
 	{ "jpki",	(void *(*)(void)) sc_get_jpki_driver },
+#ifdef ENABLE_OPENPACE
 	{ "npa",	(void *(*)(void)) sc_get_npa_driver },
+#endif
 	/* The default driver should be last, as it handles all the
 	 * unrecognized cards. */
 	{ "default",	(void *(*)(void)) sc_get_default_driver },

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -30,6 +30,10 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/opensslv.h>
+#else
+#ifndef SHA_DIGEST_LENGTH
+#define SHA_DIGEST_LENGTH	20
+#endif
 #endif
 
 #include "sc-pkcs11.h"


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

I wanted to build OpenSC without openssl and openpace on windows and found the following only 2 places, which prevented it:
- the npa driver uses openpace, so I can exclude it from the build, but additionally it should have been suppressed in ctx.c
- pkcs15_prkey_sign in framework-pkcs15.c references SHA_DIGEST_LENGTH even when openssl is not enabled, so I set it

I used CMake to generate Visual Studio 2017 Solution and Project files, with this patch I could build 32 and 64 bit binaries. I tested it with opensc-explorer on cards: Atos CardOS and StarCOS 3.4