### PR TITLE
incomplete mechanims list reported after merging RSA-PSS in some drivers

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -12,7 +12,8 @@ noinst_HEADERS = cards.h ctbcs.h internal.h esteid.h muscle.h muscle-filesystem.
 	errors.h types.h compression.h itacns.h iso7816.h \
 	authentic.h iasecc.h iasecc-sdo.h sm.h card-sc-hsm.h \
 	pace.h cwa14890.h cwa-dnie.h card-gids.h aux-data.h \
-	jpki.h sc-ossl-compat.h card-npa.h ccid-types.h reader-tr03119.h
+	jpki.h sc-ossl-compat.h card-npa.h ccid-types.h reader-tr03119.h \
+	card-cac-common.h
 
 AM_CPPFLAGS = -D'OPENSC_CONF_PATH="$(sysconfdir)/opensc.conf"' \
      -D'DEFAULT_SM_MODULE_PATH="$(DEFAULT_SM_MODULE_PATH)"' \

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -784,18 +784,25 @@ size_t coolkey_list_meter(const void *el) {
 	return sizeof(sc_cardctl_coolkey_object_t);
 }
 
+static void coolkey_free_private_data(coolkey_private_data_t *priv);
+
 static coolkey_private_data_t *coolkey_new_private_data(void)
 {
 	coolkey_private_data_t *priv;
+
 	/* allocate priv and zero all the fields */
 	priv = calloc(1, sizeof(coolkey_private_data_t));
 	if (!priv)
 		return NULL;
+
 	/* set other fields as appropriate */
 	priv->key_id = COOLKEY_INVALID_KEY;
-	list_init(&priv->objects_list);
-	list_attributes_comparator(&priv->objects_list, coolkey_compare_id);
-	list_attributes_copy(&priv->objects_list, coolkey_list_meter, 1);
+	if (list_init(&priv->objects_list) != 0 ||
+	    list_attributes_comparator(&priv->objects_list, coolkey_compare_id) != 0 ||
+	    list_attributes_copy(&priv->objects_list, coolkey_list_meter, 1) != 0) {
+		coolkey_free_private_data(priv);
+		return NULL;
+	}
 
 	return priv;
 }

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -345,7 +345,7 @@ static int sc_pkcs1_add_pss_padding(unsigned int hash, unsigned int mgf1_hash,
 		if (EVP_DigestInit_ex(ctx, mgf1_md, NULL) != 1 ||
 		    EVP_DigestUpdate(ctx, out + dblen, hlen) != 1 || /* H (Z parameter of MGF1) */
 		    EVP_DigestUpdate(ctx, buf, 4) != 1 || /* C */
-		    EVP_DigestFinal_ex(ctx, mask, NULL)) {
+		    EVP_DigestFinal_ex(ctx, mask, NULL) != 1) {
 			goto done;
 		}
 		/* this is no longer part of the MGF1, but actually

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -867,6 +867,9 @@ void *sc_mem_secure_alloc(size_t len)
 	}
 
 	p = malloc(len);
+	if (p == NULL) {
+		return NULL;
+	}
 #ifdef _WIN32
 	VirtualLock(p, len);
 #else

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5159,14 +5159,14 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	}
 
 #ifdef ENABLE_OPENSSL
-		/* all our software hashes are in OpenSSL */
-		/* Only if card did not list the hashes, will we
-		 * help it a little, by adding all the OpenSSL hashes
-		 * that have PKCS#11 mechanisms.
-		 */
-		if (!(rsa_flags & SC_ALGORITHM_RSA_HASHES)) {
-			rsa_flags |= SC_ALGORITHM_RSA_HASHES;
-		}
+	/* all our software hashes are in OpenSSL */
+	/* Only if card did not list the hashes, will we
+	 * help it a little, by adding all the OpenSSL hashes
+	 * that have PKCS#11 mechanisms.
+	 */
+	if (!(rsa_flags & SC_ALGORITHM_RSA_HASHES)) {
+		rsa_flags |= SC_ALGORITHM_RSA_HASHES;
+	}
 #endif
 
 	/* No need to Check for PKCS1  We support it in software and turned it on above so always added it */
@@ -5182,32 +5182,44 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		 * Either the card set the hashes or we helped it above */
 
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA1) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_SHA1_RSA_PKCS, CKM_SHA_1, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_SHA1_RSA_PKCS, CKM_SHA_1, mt);
+			if (rc != CKR_OK)
+				return rc;
+		}
+		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA224) {
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_SHA224_RSA_PKCS, CKM_SHA224, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA256) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_SHA256_RSA_PKCS, CKM_SHA256, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_SHA256_RSA_PKCS, CKM_SHA256, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA384) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_SHA384_RSA_PKCS, CKM_SHA384, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_SHA384_RSA_PKCS, CKM_SHA384, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA512) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_SHA512_RSA_PKCS, CKM_SHA512, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_SHA512_RSA_PKCS, CKM_SHA512, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_MD5) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_MD5_RSA_PKCS, CKM_MD5, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_MD5_RSA_PKCS, CKM_MD5, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_RIPEMD160) {
-			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card, CKM_RIPEMD160_RSA_PKCS, CKM_RIPEMD160, mt);
+			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
+				CKM_RIPEMD160_RSA_PKCS, CKM_RIPEMD160, mt);
 			if (rc != CKR_OK)
 				return rc;
 		}

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5164,7 +5164,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	 * help it a little, by adding all the OpenSSL hashes
 	 * that have PKCS#11 mechanisms.
 	 */
-	if (!(rsa_flags & SC_ALGORITHM_RSA_HASHES)) {
+	if (!(rsa_flags & (SC_ALGORITHM_RSA_HASHES & ~SC_ALGORITHM_RSA_HASH_NONE))) {
 		rsa_flags |= SC_ALGORITHM_RSA_HASHES;
 	}
 #endif

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3781,6 +3781,9 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 	case CKM_SHA1_RSA_PKCS:
 		flags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_SHA1;
 		break;
+	case CKM_SHA224_RSA_PKCS:
+		flags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_SHA224;
+		break;
 	case CKM_SHA256_RSA_PKCS:
 		flags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_SHA256;
 		break;

--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -815,6 +815,10 @@ void pss_oaep_test(void **state) {
 	for (i = 0; i < objects.count; i++) {
 		test_cert_t *o = &objects.data[i];
 
+		/* Do not go through incomplete pairs */
+		if (o->private_handle == CK_INVALID_HANDLE)
+			continue;
+
 		/* Do not list non-RSA keys here */
 		if (o->type != EVP_PK_RSA)
 			continue;


### PR DESCRIPTION
After merging the change #1435 (RSA-PSS emulation), the cardos card stopped reporting the hashed mechanisms (for example `SHA1-RSA-PKCS`). This is done by changing of the semantics of the constant `SC_ALGORITHM_RSA_HASH_NONE`. ~~The attached patch resolves the issue for CardOS, cards we have around, but we might need some more system solution, because there might be more affected card drivers I can not test.~~

~~I will leave the PR as it is now, but I will have a look tomorrow if there is a way how to resolve it systematically (sigh ... there is no sensible explanation what is the `SC_ALGORITHM_RSA_HASH_NONE` supposed to mean initially). Comments and proposals welcomed.~~

The current patch solves the issue in the mechanism registration function, which was wrong since the RSA-PSS implementation. Also other cards that depended on this behavior should start working with this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
