### PR TITLE
allow specifying the size of OpenSSL secure memory

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -61,6 +61,7 @@ if ! test -e ${BUILDPATH}/target/$PREFIX/lib/pkgconfig; then
 		--sysconfdir=$PREFIX/etc \
 		--enable-cvcdir=$PREFIX/etc/cvc \
 		--enable-x509dir=$PREFIX/etc/x509 \
+		--enable-openssl-secure-malloc=65536 \
 		--disable-dependency-tracking \
 		--enable-shared \
 		--enable-static \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ install:
         $env:ARTIFACT="${env:ARTIFACT}-Light"
       } Else {
         $env:NMAKE_EXTRA="OPENSSL_DEF=/DENABLE_OPENSSL ${env:NMAKE_EXTRA}"
+        $env:NMAKE_EXTRA="OPENSSL_EXTRA_CFLAGS=/DOPENSSL_SECURE_MALLOC_SIZE=65536 ${env:NMAKE_EXTRA}"
         If (!(Test-Path C:\zlib )) {
           appveyor DownloadFile "https://github.com/madler/zlib/archive/v${env:ZLIB_VER_DOT}.zip" -FileName zlib.zip
           7z x zlib.zip -oC:\

--- a/configure.ac
+++ b/configure.ac
@@ -172,10 +172,17 @@ AC_ARG_ENABLE(
 
 AC_ARG_ENABLE(
 	[openssl],
-	[AS_HELP_STRING([--enable-openssl],[enable openssl linkage @<:@detect@:>@])],
+	[AS_HELP_STRING([--enable-openssl],[enable OpenSSL linkage @<:@detect@:>@])],
 	,
 	[enable_openssl="detect"]
 )
+
+AC_ARG_ENABLE([openssl-secure-malloc],
+    [AC_HELP_STRING([--openssl-secure-malloc=<SIZE_IN_BYTES>],
+        [Enable OpenSSL secure memory by specifying its size in bytes, must be a power of 2 @<:@disabled@:>@])],
+    [], [enable_openssl_secure_malloc=no])
+AS_IF([test $enable_openssl_secure_malloc != no],
+	[AC_DEFINE_UNQUOTED([OPENSSL_SECURE_MALLOC_SIZE],[$enable_openssl_secure_malloc],[Size of OpenSSL secure memory in bytes, must be a power of 2])])
 
 AC_ARG_ENABLE(
 	[openpace],
@@ -1115,6 +1122,7 @@ thread locking support:  ${enable_thread_locking}
 zlib support:            ${enable_zlib}
 readline support:        ${enable_readline}
 OpenSSL support:         ${enable_openssl}
+OpenSSL secure memory:   ${enable_openssl_secure_malloc}
 PC/SC support:           ${enable_pcsc}
 CryptoTokenKit support:  ${enable_cryptotokenkit}
 OpenCT support:          ${enable_openct}

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -833,10 +833,9 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 		return r;
 	}
 
-#ifdef ENABLE_OPENSSL
+#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE)
 	if (!CRYPTO_secure_malloc_initialized()) {
-		/* XXX What's a reasonable amount of secure heap? */
-		CRYPTO_secure_malloc_init(4096, 32);
+		CRYPTO_secure_malloc_init(OPENSSL_SECURE_MALLOC_SIZE, OPENSSL_SECURE_MALLOC_SIZE/8);
 	}
 #endif
 

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -240,6 +240,10 @@ static sc_ossl_inline int CRYPTO_secure_malloc_initialized()
     return 0;
 }
 
+static sc_ossl_inline void CRYPTO_secure_malloc_done()
+{
+}
+
 #else
 
 #include <openssl/crypto.h>

--- a/src/libopensc/sm.h
+++ b/src/libopensc/sm.h
@@ -35,12 +35,6 @@ extern "C" {
 #include <libopensc/types.h>
 #include <common/libscdl.h>
 
-#ifndef SHA_DIGEST_LENGTH
-#define SHA_DIGEST_LENGTH	20
-#define SHA1_DIGEST_LENGTH	20
-#define SHA256_DIGEST_LENGTH	32
-#endif
-
 #define SM_TYPE_GP_SCP01	0x100
 #define SM_TYPE_CWA14890	0x400
 #define SM_TYPE_DH_RSA		0x500

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -48,6 +48,7 @@
 #include "libopensc/log.h"
 #include "libopensc/internal.h"
 #include "libopensc/aux-data.h"
+#include "libopensc/sc-ossl-compat.h"
 #include "ui/notify.h"
 #include "ui/strings.h"
 #include "ui/wchar_from_char_str.h"
@@ -58,6 +59,10 @@
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/pem.h>
 #endif
+#endif
+
+#ifdef ENABLE_OPENPACE
+#include <eac/eac.h>
 #endif
 
 #if defined(__MINGW32__)
@@ -6999,9 +7004,14 @@ BOOL APIENTRY DllMain( HINSTANCE hinstDLL,
 		break;
 	case DLL_PROCESS_DETACH:
 		sc_notify_close();
+		if (lpReserved == NULL) {
 #if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE)
-		CRYPTO_secure_malloc_done();
+			CRYPTO_secure_malloc_done();
 #endif
+#ifdef ENABLE_OPENPACE
+			EAC_cleanup();
+#endif
+		}
 		break;
 	}
 	return TRUE;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -6999,6 +6999,9 @@ BOOL APIENTRY DllMain( HINSTANCE hinstDLL,
 		break;
 	case DLL_PROCESS_DETACH:
 		sc_notify_close();
+#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE)
+		CRYPTO_secure_malloc_done();
+#endif
 		break;
 	}
 	return TRUE;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -27,9 +27,10 @@
 #include "libopensc/cardctl.h"
 #include "ui/notify.h"
 #include "common/compat_strnlen.h"
-
 #ifdef ENABLE_OPENSSL
-#include <openssl/opensslv.h>
+#include <openssl/sha.h>
+#else
+#define SHA_DIGEST_LENGTH	20
 #endif
 
 #include "sc-pkcs11.h"

--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -32,6 +32,8 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/evp.h>
+#else
+#define ssl_error(a)
 #endif
 
 char eac_default_flags = 0;


### PR DESCRIPTION
... and set it for builds where we're linking OpenSSL statically (i.e.
Windows and macOS)

fixes https://github.com/OpenSC/OpenSC/issues/1515

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
