### PR TITLE
fix logic of send/recv sizes in config files

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1191,13 +1191,6 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 		}
 	}
 
-	/* max send/receive sizes: with default values only short APDU supported */
-	reader->max_send_size = priv->gpriv->force_max_send_size ?
-		priv->gpriv->force_max_send_size :
-		SC_READER_SHORT_APDU_MAX_SEND_SIZE;
-	reader->max_recv_size = priv->gpriv->force_max_recv_size ?
-		priv->gpriv->force_max_recv_size :
-		SC_READER_SHORT_APDU_MAX_RECV_SIZE;
 	if (priv->get_tlv_properties) {
 		/* Try to set reader max_send_size and max_recv_size based on
 		 * detected max_data */
@@ -1206,7 +1199,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 		if (max_data > 0) {
 			sc_log(ctx, "Reader supports transceiving %d bytes of data",
 					max_data);
-			if (priv->gpriv->force_max_send_size)
+			if (!priv->gpriv->force_max_send_size)
 				reader->max_send_size = max_data;
 			else
 				sc_log(ctx, "Sending is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
@@ -1275,6 +1268,14 @@ int pcsc_add_reader(sc_context_t *ctx,
 		ret = SC_ERROR_OUT_OF_MEMORY;
 		goto err1;
 	}
+
+	/* max send/receive sizes: with default values only short APDU supported */
+	reader->max_send_size = priv->gpriv->force_max_send_size ?
+		priv->gpriv->force_max_send_size :
+		SC_READER_SHORT_APDU_MAX_SEND_SIZE;
+	reader->max_recv_size = priv->gpriv->force_max_recv_size ?
+		priv->gpriv->force_max_recv_size :
+		SC_READER_SHORT_APDU_MAX_RECV_SIZE;
 
 	ret = _sc_add_reader(ctx, reader);
 


### PR DESCRIPTION
- they are not set if
  SCardControl(card_handle, CM_IOCTL_GET_FEATURE_REQUEST, ...
  fails
- regarding max_send_size the logic is inverted

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
