### PR TITLE
pkcs15-crypt - Handle keys with user_consent - Fixes #1292

### DIFF
--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -330,7 +330,7 @@ static int get_key(unsigned int usage, sc_pkcs15_object_t **result)
 		}
 
 		/* Pin already verified previously */
-		if (pin == prev_pin)
+		if (pin == prev_pin && key->user_consent == 0)
 			return 0;
 
 		pincode = get_pin(pin);
@@ -339,8 +339,25 @@ static int get_key(unsigned int usage, sc_pkcs15_object_t **result)
 			free(pincode);
 			return 5;
 		}
+		
+		/*
+		 * Do what PKCS#11 would do for keys requiring CKA_ALWAYS_AUTHENTICATE
+		 * and CKU_CONTEXT_SPECIFIC login to let driver know this verify will be followed by 
+		 * a crypto operation.  Card drivers can test for SC_AC_CONTEXT_SPECIFIC
+		 * to do any special handling. 
+		 */
+		if (key->user_consent) {
+			int auth_meth_saved;
+			struct sc_pkcs15_auth_info *pinfo = (struct sc_pkcs15_auth_info *) pin->data;
 
-		r = sc_pkcs15_verify_pin(p15card, pin, (const u8 *)pincode, pincode ? strlen(pincode) : 0);
+			auth_meth_saved = pinfo->auth_method;
+
+			pinfo->auth_method = SC_AC_CONTEXT_SPECIFIC;
+			r = sc_pkcs15_verify_pin(p15card, pin, (const u8 *)pincode, pincode ? strlen(pincode) : 0);
+			pinfo->auth_method = auth_meth_saved;
+		} else
+			r = sc_pkcs15_verify_pin(p15card, pin, (const u8 *)pincode, pincode ? strlen(pincode) : 0);
+
 		free(pincode);
 		if (r) {
 			fprintf(stderr, "PIN code verification failed: %s\n", sc_strerror(r));


### PR DESCRIPTION
Fixes #1292 problem as stated in:
https://github.com/OpenSC/OpenSC/issues/1292#issuecomment-431879472

pkcs15-crypt.c will treat keys with user_consent like PKCS#11 would.
SC_AC_CONTEXT_SPECIFIC is set when doing a verify so a card driver can
take action if needed.

card-piv.c is currently the only driver doing so.
It uses this to hold the card lock so both the VERIFY and following crypto
operations are in the same transaction. The card enforces this restriction.
Without this additional APDUs may be sent before every transaction to test
that the expected applet is selected.

Unlike the circumvention of using ignore_user_consent=true and pin caching
this modification allows a pin pad reader to be used for keys requiring user_consent.

 On branch pkcs15-context-specific
 Changes to be committed:
	modified:   pkcs15-crypt.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
Tested with PIV demo cards and Yubico 4 token. 



