### PR TITLE
Enable CoolKey driver to handle 2048-bit keys.

### DIFF
--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1168,12 +1168,16 @@ static int coolkey_write_object(sc_card_t *card, unsigned long object_id,
 	size_t operation_len;
 	size_t left = buf_len;
 	int r;
+	size_t max_operation_len;
+
+	/* set limit for the card's maximum send size and short write */
+	max_operation_len = MIN(COOLKEY_MAX_CHUNK_SIZE, (card->max_send_size - sizeof(coolkey_read_object_param_t) - nonce_size));
 
 	ulong2bebytes(&params.head.object_id[0], object_id);
 
 	do {
 		ulong2bebytes(&params.head.offset[0], offset);
-		operation_len = MIN(left, COOLKEY_MAX_CHUNK_SIZE);
+		operation_len = MIN(left, max_operation_len);
 		params.head.length = operation_len;
 		memcpy(params.buf, buf, operation_len);
 		r = coolkey_apdu_io(card, COOLKEY_CLASS, COOLKEY_INS_WRITE_OBJECT, 0, 0,


### PR DESCRIPTION
For a problem description, see <https://github.com/OpenSC/OpenSC/issues/1524>.
In a nutshell, for a card with the CoolKey applet and 2048-bit keys,
the command
`pkcs11-tool --test --login`
fails to complete all of its tests.

This commit consists of a patch from @dengert.

To avoid triggering an error when the data exceeds 255 bytes, this commit
limits the amount of the payload sent to the CoolKey applet on the card based
on the maximum amount of data that the card can receive, and overhead bytes
(namely, a header and nonce) that accompany the payload.

With this change, the command
`pkcs11-tool --test --login`
succeeds.

Fixes #1524 
```
$ /usr/local/bin/opensc-tool -n 
Using reader with a card: SCM Microsystems Inc. SCR 3310 [CCID Interface] (53311549211601) 00 00
COOLKEY
```

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
