### PR TITLE
cac: Dump the data model number, which is useful for the capabilities detection

### DIFF
--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1487,12 +1487,19 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, u8 *tl,
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"TAG: PKCS15 = 0x%02x", *val);
 			break;
 		case CAC_TAG_DATA_MODEL:
+			if (len != 1) {
+				sc_log(card->ctx, "TAG: Registered Data Model Number: "
+				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				break;
+			}
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"TAG: Registered Data Model Number (0x%02x)", *val);
+			break;
 		case CAC_TAG_CARD_APDU:
 		case CAC_TAG_CAPABILITY_TUPLES:
 		case CAC_TAG_STATUS_TUPLES:
 		case CAC_TAG_REDIRECTION:
 		case CAC_TAG_ERROR_CODES:
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"TAG:FSSpecific(0x%02x)", tag);
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"TAG: FSSpecific(0x%02x)", tag);
 			break;
 		case CAC_TAG_ACCESS_CONTROL:
 			/* TODO handle access control later */

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1758,6 +1758,9 @@ parse_pss_params(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 		pss_params->hashAlg = CKM_SHA512;
 		pss_params->mgf = CKG_MGF1_SHA512;
 		break;
+
+	default: /* The non-RSA-PSS algorithms do not need any parameters */
+		return 0;
 	}
 
 	/* One of RSA-PSS mechanisms above: They need parameters */
@@ -1820,8 +1823,6 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	memset(&mech, 0, sizeof(mech));
 	mech.mechanism = opt_mechanism;
 	hashlen = parse_pss_params(session, key, &mech, &pss_params);
-	if (hashlen == 0)
-		util_fatal("Invalid RSA-PSS parameters");
 
 	if (opt_input == NULL)
 		fd = 0;
@@ -1832,11 +1833,10 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	if (r < 0)
 		util_fatal("Cannot read from %s: %m", opt_input);
 
-	if (opt_mechanism == CKM_RSA_PKCS_PSS) {
-		if  ((unsigned long)r != hashlen)
-			util_fatal("For %s mechanism, message size (got %d bytes) "
-			     "must be equal to specified digest length (%lu)\n",
-			    p11_mechanism_to_name(opt_mechanism), r, hashlen);
+	if (opt_mechanism == CKM_RSA_PKCS_PSS && (unsigned long)r != hashlen) {
+		util_fatal("For %s mechanism, message size (got %d bytes) "
+			"must be equal to specified digest length (%lu)\n",
+			p11_mechanism_to_name(opt_mechanism), r, hashlen);
 	}
 
 	rv = CKR_CANCEL;
@@ -1927,8 +1927,6 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	memset(&mech, 0, sizeof(mech));
 	mech.mechanism = opt_mechanism;
 	hashlen = parse_pss_params(session, key, &mech, &pss_params);
-	if (hashlen == 0)
-		util_fatal("Invalid RSA-PSS parameters");
 
 	/* Open a signature file */
 	if (opt_signature_file == NULL)
@@ -1952,11 +1950,10 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	if (r < 0)
 		util_fatal("Cannot read from %s: %m", opt_input);
 
-	if (opt_mechanism == CKM_RSA_PKCS_PSS) {
-		if ((unsigned long)r != hashlen)
-			util_fatal("For %s mechanism, message size (got %d bytes)"
-			    " must be equal to specified digest length (%lu)\n",
-			    p11_mechanism_to_name(opt_mechanism), r, hashlen);
+	if (opt_mechanism == CKM_RSA_PKCS_PSS && (unsigned long)r != hashlen) {
+		util_fatal("For %s mechanism, message size (got %d bytes)"
+			" must be equal to specified digest length (%lu)\n",
+			p11_mechanism_to_name(opt_mechanism), r, hashlen);
 	}
 
 	rv = CKR_CANCEL;


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
