### PR TITLE
SM: fix crash if nested GET RESPONSE issued during sm session fails o…

### DIFF
--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -661,6 +661,10 @@ static int iso_add_sm(struct iso_sm_ctx *sctx, sc_card_t *card,
 static int iso_rm_sm(struct iso_sm_ctx *sctx, sc_card_t *card,
 		sc_apdu_t *sm_apdu, sc_apdu_t *apdu)
 {
+	if (!sctx)
+		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_INVALID_ARGUMENTS,
+			"Invalid SM context. No SM processing performed.");
+
 	if (sctx->post_transmit)
 		SC_TEST_RET(card->ctx, SC_LOG_DEBUG_NORMAL, sctx->post_transmit(card, sctx, sm_apdu),
 				"Could not complete SM specific post transmit routine");


### PR DESCRIPTION
…r returns invalid MAC.

Crash discovered while implementing secure messaging for a new IAS v2 based smart card. During tests, if GET RESPONSE is issued during secure messaging session and if its MAC is wrong, OpenSC frees twice the SM context and we end up calling the function iso_rm_sm with sctx parameter as NULL pointer which caused a crash since their was no check on this parameter before its use.


