### PR TITLE
Implemented handling of CKA_ALWAYS_AUTHENTICATE when creating key objects.

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -444,6 +444,15 @@
 					viewable after a login).</para></listitem>
 				</varlistentry>
 
+                                <varlistentry>
+					<term>
+						<option>--always-auth</option>
+					</term>
+					<listitem><para>Set the CKA_ALWAYS_AUTHENTICATE attribute to a private key object.
+                                        If set, the user has to supply the PIN for each use (sign or decrypt) with the key.</para>
+                                        </listitem>
+				</varlistentry>
+
 				<varlistentry>
 					<term>
 						<option>--test-ec</option>

--- a/doc/tools/pkcs15-init.1.xml
+++ b/doc/tools/pkcs15-init.1.xml
@@ -873,6 +873,20 @@ puk		87654321
 					</listitem>
 				</varlistentry>
 
+                                <varlistentry>
+					<term>
+						<option>--user-consent</option> <replaceable>arg</replaceable>
+					</term>
+					<listitem>
+						<para>
+							Specify user-consent. <replaceable>arg</replaceable> is an integer value.
+                                                        If > 0, the value specifies how many times the
+                                                        object can be accessed before a new authentication is required.
+                                                        If zero, the object does not require re-authentication.
+						</para>
+					</listitem>
+				</varlistentry>
+
 				<varlistentry>
 					<term>
 						<option>--insecure</option>

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3670,7 +3670,7 @@ pkcs15_prkey_get_attribute(struct sc_pkcs11_session *session,
 		break;
     case CKA_ALWAYS_AUTHENTICATE:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
-		*(CK_BBOOL*)attr->pValue = prkey->prv_p15obj->user_consent;
+		*(CK_BBOOL*)attr->pValue = prkey->prv_p15obj->user_consent >= 1 ? CK_TRUE : CK_FALSE;
 		break;
 	case CKA_PRIVATE:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
@@ -4847,7 +4847,7 @@ pkcs15_skey_get_attribute(struct sc_pkcs11_session *session,
 		break;
 	case CKA_OPENSC_ALWAYS_AUTH_ANY_OBJECT:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
-		*(CK_BBOOL*)attr->pValue = skey->base.p15_object->user_consent == 1 ? CK_TRUE : CK_FALSE;
+		*(CK_BBOOL*)attr->pValue = skey->base.p15_object->user_consent >= 1 ? CK_TRUE : CK_FALSE;
 		break;
 	case CKA_VALUE_LEN:
 		check_attribute_buffer(attr, sizeof(CK_ULONG));

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2323,7 +2323,7 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 			if (pkcs15_check_bool_cka(attr, 1))
 				args.access_flags |= SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE;
 			break;
-		case CKA_ALWAYS_AUTHENTICATE:
+		case CKA_OPENSC_ALWAYS_AUTH_ANY_OBJECT:
 			args.user_consent = (int) (pkcs15_check_bool_cka(attr, 1));
 			break;
 		default:
@@ -4845,9 +4845,9 @@ pkcs15_skey_get_attribute(struct sc_pkcs11_session *session,
 					&& (skey->base.p15_object->flags & SC_PKCS15_PRKEY_ACCESS_NEVEREXTRACTABLE) == 0
 					&& (skey->base.p15_object->flags & SC_PKCS15_PRKEY_ACCESS_ALWAYSSENSITIVE) == 0) ? CK_TRUE : CK_FALSE;
 		break;
-	case CKA_ALWAYS_AUTHENTICATE:
+	case CKA_OPENSC_ALWAYS_AUTH_ANY_OBJECT:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
-		*(CK_BBOOL*)attr->pValue = skey->base.p15_object->user_consent;
+		*(CK_BBOOL*)attr->pValue = skey->base.p15_object->user_consent == 1 ? CK_TRUE : CK_FALSE;
 		break;
 	case CKA_VALUE_LEN:
 		check_attribute_buffer(attr, sizeof(CK_ULONG));

--- a/src/pkcs11/pkcs11-opensc.h
+++ b/src/pkcs11/pkcs11-opensc.h
@@ -20,4 +20,10 @@
 
 #define CKA_SPKI			(CKA_VENDOR_DEFINED | SC_VENDOR_DEFINED | 2UL)
 
+/* In PKCS#11 CKA_ALWAYS_AUTHENTICATE attribute is only associated with private keys.
+ * The corresponding userConsent field in PKCS#15 is allowed for any object type. This attribute can be used
+ * to set userConsent=1 for other objects than private keys via PKCS#11. */
+#define CKA_OPENSC_ALWAYS_AUTH_ANY_OBJECT (CKA_VENDOR_DEFINED | SC_VENDOR_DEFINED | 3UL)
+
+
 #endif

--- a/src/pkcs15init/pkcs15-init.h
+++ b/src/pkcs15init/pkcs15-init.h
@@ -228,6 +228,7 @@ struct sc_pkcs15init_prkeyargs {
 	unsigned long		x509_usage;
 	unsigned int		flags;
 	unsigned int		access_flags;
+	int			user_consent;
 
 	union {
 		struct sc_pkcs15init_keyarg_gost_params gost;
@@ -269,13 +270,14 @@ struct sc_pkcs15init_skeyargs {
 	struct sc_pkcs15_id	id;
 	struct sc_pkcs15_id	auth_id;
 	const char *		label;
-	unsigned long           usage;
+	unsigned long		usage;
 	unsigned int		flags;
 	unsigned int		access_flags;
 	unsigned long		algorithm; /* User requested algorithm */
 	unsigned long		value_len; /* User requested length */
 	int			session_object;	 /* If nonzero. this is a session object, which will
 						be cleared from card when the session is closed.*/
+	int			user_consent;
 	struct sc_pkcs15_skey	key;
 };
 

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -1211,6 +1211,7 @@ sc_pkcs15init_init_prkdf(struct sc_pkcs15_card *p15card, struct sc_profile *prof
 	key_info->key_reference = 0;
 	key_info->modulus_length = keybits;
 	key_info->access_flags = keyargs->access_flags;
+	object->user_consent = keyargs->user_consent;
 	/* Path is selected below */
 
 	if (keyargs->access_flags & SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE) {
@@ -1351,6 +1352,8 @@ sc_pkcs15init_init_skdf(struct sc_pkcs15_card *p15card, struct sc_profile *profi
 
 	if (keyargs->session_object > 0)
 	    object->session_object = 1;
+
+	object->user_consent = keyargs->user_consent;
 
 	/* Select a Key ID if the user didn't specify one,
 	 * otherwise make sure it's compatible with our intended use */

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -152,6 +152,7 @@ enum {
 	OPT_SALT,
 	OPT_VERIFY,
 	OPT_SIGNATURE_FILE,
+	OPT_ALWAYS_AUTH
 };
 
 static const struct option options[] = {
@@ -221,6 +222,7 @@ static const struct option options[] = {
 	{ "test-fork",		0, NULL,		OPT_TEST_FORK },
 #endif
 	{ "generate-random",	1, NULL,		OPT_GENERATE_RANDOM },
+	{ "always-auth",	0,	NULL,	OPT_ALWAYS_AUTH },
 
 	{ NULL, 0, NULL, 0 }
 };
@@ -292,6 +294,7 @@ static const char *option_help[] = {
 	"Test forking and calling C_Initialize() in the child",
 #endif
 	"Generate given amount of random data",
+	"Set the CKA_ALWAYS_AUTHENTICATE attribute to a key object (require PIN verification for each use)",
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */
@@ -340,6 +343,7 @@ static CK_MECHANISM_TYPE opt_hash_alg = 0;
 static unsigned long	opt_mgf = 0;
 static long	        opt_salt_len = 0;
 static int		opt_salt_len_given = 0; /* 0 - not given, 1 - given with input parameters */
+static int		opt_always_auth = 0;
 
 static void *module = NULL;
 static CK_FUNCTION_LIST_PTR p11 = NULL;
@@ -886,7 +890,9 @@ int main(int argc, char * argv[])
 			do_generate_random = 1;
 			action_count++;
 			break;
-
+		case OPT_ALWAYS_AUTH:
+			opt_always_auth = 1;
+			break;
 		default:
 			util_print_usage_and_die(app_name, options, option_help, NULL);
 		}
@@ -2380,6 +2386,12 @@ static int gen_keypair(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		n_pubkey_attr++;
 	}
 
+	if (opt_always_auth != 0) {
+		FILL_ATTR(privateKeyTemplate[n_privkey_attr], CKA_ALWAYS_AUTHENTICATE,
+				&_true, sizeof(_true));
+		n_privkey_attr++;
+	}
+
 	rv = p11->C_GenerateKeyPair(session, &mechanism,
 		publicKeyTemplate, n_pubkey_attr,
 		privateKeyTemplate, n_privkey_attr,
@@ -2498,6 +2510,12 @@ gen_key(CK_SLOT_ID slot, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE *hSecretKey
 		n_attr++;
 		FILL_ATTR(keyTemplate[n_attr], CKA_VALUE_LEN, &key_length, sizeof(key_length));
 		n_attr++;
+
+		if (opt_always_auth != 0) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_ALWAYS_AUTHENTICATE,
+				&_true, sizeof(_true));
+			n_attr++;
+		}
 
 		mechanism.mechanism = opt_mechanism;
 	}
@@ -2967,6 +2985,11 @@ static int write_object(CK_SESSION_HANDLE session)
 		}
 		if (opt_key_usage_derive != 0) {
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_DERIVE, &_true, sizeof(_true));
+			n_privkey_attr++;
+		}
+		if (opt_always_auth != 0) {
+			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_ALWAYS_AUTHENTICATE,
+				&_true, sizeof(_true));
 			n_privkey_attr++;
 		}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -217,12 +217,12 @@ static const struct option options[] = {
 	{ "verbose",		0, NULL,		'v' },
 	{ "private",		0, NULL,		OPT_PRIVATE },
 	{ "sensitive",		0, NULL,		OPT_SENSITIVE },
+	{ "always-auth",	0, NULL,		OPT_ALWAYS_AUTH },
 	{ "test-ec",		0, NULL,		OPT_TEST_EC },
 #ifndef _WIN32
 	{ "test-fork",		0, NULL,		OPT_TEST_FORK },
 #endif
 	{ "generate-random",	1, NULL,		OPT_GENERATE_RANDOM },
-	{ "always-auth",	0,	NULL,	OPT_ALWAYS_AUTH },
 
 	{ NULL, 0, NULL, 0 }
 };
@@ -289,12 +289,12 @@ static const char *option_help[] = {
 	"Verbose operation. (Set OPENSC_DEBUG to enable OpenSC specific debugging)",
 	"Set the CKA_PRIVATE attribute (object is only viewable after a login)",
 	"Set the CKA_SENSITIVE attribute (object cannot be revealed in plaintext)",
+	"Set the CKA_ALWAYS_AUTHENTICATE attribute to a key object (require PIN verification for each use)",
 	"Test EC (best used with the --login or --pin option)",
 #ifndef _WIN32
 	"Test forking and calling C_Initialize() in the child",
 #endif
-	"Generate given amount of random data",
-	"Set the CKA_ALWAYS_AUTHENTICATE attribute to a key object (require PIN verification for each use)",
+	"Generate given amount of random data"
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */
@@ -2510,12 +2510,6 @@ gen_key(CK_SLOT_ID slot, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE *hSecretKey
 		n_attr++;
 		FILL_ATTR(keyTemplate[n_attr], CKA_VALUE_LEN, &key_length, sizeof(key_length));
 		n_attr++;
-
-		if (opt_always_auth != 0) {
-			FILL_ATTR(keyTemplate[n_attr], CKA_ALWAYS_AUTHENTICATE,
-				&_true, sizeof(_true));
-			n_attr++;
-		}
 
 		mechanism.mechanism = opt_mechanism;
 	}

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -206,6 +206,7 @@ const struct option	options[] = {
 	{ "update-existing",	no_argument,       NULL,	OPT_UPDATE_EXISTING},
 
 	{ "extractable",	no_argument, NULL,		OPT_EXTRACTABLE },
+	{ "user-consent",	required_argument, NULL, OPT_USER_CONSENT},
 	{ "insecure",		no_argument, NULL,		OPT_INSECURE },
 	{ "use-default-transport-keys",
 				no_argument, NULL,		'T' },
@@ -219,7 +220,6 @@ const struct option	options[] = {
 	{ "wait",		no_argument, NULL,		'w' },
 	{ "help",		no_argument, NULL,		'h' },
 	{ "verbose",		no_argument, NULL,		'v' },
-	{ "user-consent",	required_argument, NULL, OPT_USER_CONSENT},
 
 	/* Hidden options for testing */
 	{ "assert-pristine",	no_argument, NULL,		OPT_ASSERT_PRISTINE },
@@ -273,6 +273,7 @@ static const char *		option_help[] = {
 	"Store or update existing certificate",
 
 	"Private key stored as an extractable key",
+	"Set userConsent. Default = 0",
 	"Insecure mode: do not require a PIN for private key",
 	"Do not ask for transport keys if the driver thinks it knows the key",
 	"Do not prompt the user; if no PINs supplied, pinpad will be used",
@@ -285,7 +286,6 @@ static const char *		option_help[] = {
 	"Wait for card insertion",
 	"Display this message",
 	"Verbose operation. Use several times to enable debug output.",
-	"Set userConsent. Default = 0",
 
 	NULL,
 	NULL,

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -147,6 +147,7 @@ enum {
 	OPT_UPDATE_EXISTING,
 	OPT_MD_CONTAINER_GUID,
 	OPT_VERSION,
+	OPT_USER_CONSENT,
 
 	OPT_PIN1      = 0x10000,	/* don't touch these values */
 	OPT_PUK1      = 0x10001,
@@ -218,6 +219,7 @@ const struct option	options[] = {
 	{ "wait",		no_argument, NULL,		'w' },
 	{ "help",		no_argument, NULL,		'h' },
 	{ "verbose",		no_argument, NULL,		'v' },
+	{ "user-consent",	required_argument, NULL, OPT_USER_CONSENT},
 
 	/* Hidden options for testing */
 	{ "assert-pristine",	no_argument, NULL,		OPT_ASSERT_PRISTINE },
@@ -283,6 +285,7 @@ static const char *		option_help[] = {
 	"Wait for card insertion",
 	"Display this message",
 	"Verbose operation. Use several times to enable debug output.",
+	"Set userConsent. Default = 0",
 
 	NULL,
 	NULL,
@@ -394,6 +397,7 @@ static unsigned int		opt_secret_count;
 static int			opt_ignore_ca_certs = 0;
 static int			opt_update_existing = 0;
 static int			verbose = 0;
+static int			opt_user_consent = 0;
 
 static struct sc_pkcs15init_callbacks callbacks = {
 	get_pin_callback,	/* get_pin() */
@@ -1814,6 +1818,7 @@ static int init_prkeyargs(struct sc_pkcs15init_prkeyargs *args)
 		args->guid = (unsigned char *)opt_md_container_guid;
 		args->guid_len = strlen(opt_md_container_guid);
 	}
+	args->user_consent = opt_user_consent;
 
 	return 0;
 }
@@ -1842,6 +1847,7 @@ static int init_skeyargs(struct sc_pkcs15init_skeyargs *args)
 	if ((opt_x509_usage & SC_PKCS15INIT_X509_KEY_ENCIPHERMENT) == SC_PKCS15INIT_X509_KEY_ENCIPHERMENT) {
 	    args->usage |= SC_PKCS15_PRKEY_USAGE_WRAP | SC_PKCS15_PRKEY_USAGE_UNWRAP;
 	}
+	args->user_consent = opt_user_consent;
 
 	return 0;
 }
@@ -2847,6 +2853,10 @@ handle_option(const struct option *opt)
 		break;
 	case OPT_VERSION:
 		this_action = ACTION_PRINT_VERSION;
+		break;
+	case OPT_USER_CONSENT:
+		if (optarg != NULL)
+			opt_user_consent = atoi(optarg);
 		break;
 	default:
 		util_print_usage_and_die(app_name, options, option_help, NULL);


### PR DESCRIPTION
Implemented handling of CKA_ALWAYS_AUTHENTICATE attribute to framework-pkcs15.c when importing and creating keys. CKA_ALWAYS_AUTHENTICATE = CK_TRUE sets user_consent = 1 in PKCS#15 level.  
Added command line options to tools:   
In pkcs11-tool --always-auth sets CKA_ALWAYS_AUTHENTICATE to CK_TRUE.
In pkcs15-init, you can set for example --user-consent 1
pkcs15-init allows using also other values as defined in PKCS#15 specification.

Tested with both tools and a MyEID card. userConsent field was encoded into commonObjectAttributes and the user_consent value was passed to the driver. Verified that userConsent was effective when using the created keys.

- [x ] PKCS#11 module is tested
