### PR TITLE
Fix some pinpad reader related issues

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1140,6 +1140,11 @@ pkcs15_create_slot(struct sc_pkcs11_card *p11card, struct pkcs15_fw_data *fw_dat
 	/* Fill in the slot/token info from pkcs15 data */
 	if (fw_data)
 		pkcs15_init_slot(fw_data->p15_card, slot, auth, app_info);
+	else {
+		/* Token is not initialized, announce pinpad capability nevertheless */
+		if (slot->reader->capabilities & SC_READER_CAP_PIN_PAD)
+			slot->token_info.flags |= CKF_PROTECTED_AUTHENTICATION_PATH;
+	}
 
 	*out = slot;
 	return CKR_OK;

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -771,6 +771,7 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 	struct sc_app_info	*app;
 	struct sc_file		*df = profile->df_info->file;
 	int			r = SC_SUCCESS;
+	int			has_so_pin = 0;
 
 	LOG_FUNC_CALLED(ctx);
 	p15card->card = card;
@@ -784,8 +785,15 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 	if (card->app_count >= SC_MAX_CARD_APPS)
 		LOG_TEST_RET(ctx, SC_ERROR_TOO_MANY_OBJECTS, "Too many applications on this card.");
 
+	/* In case of pinpad readers check if SO PIN is defined in a profile */
+	if (!args->so_pin_len && (card->reader->capabilities & SC_READER_CAP_PIN_PAD)) {
+		sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &pin_ainfo);
+		/* If found, assume we want SO PIN */
+		has_so_pin = pin_ainfo.attrs.pin.reference != -1;
+	}
+
 	/* If the profile requires an SO PIN, check min/max length */
-	if (args->so_pin_len) {
+	if (args->so_pin_len || has_so_pin) {
 		const char	*pin_label;
 
 		sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &pin_ainfo);
@@ -3788,7 +3796,7 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 
 found:
 	if (pin_obj)   {
-		r = sc_pkcs15_verify_pin(p15card, pin_obj, pinsize ? pinbuf : NULL, pinsize);
+		r = sc_pkcs15_verify_pin(p15card, pin_obj, use_pinpad ? NULL : pinbuf, use_pinpad ? 0 : pinsize);
 		LOG_TEST_RET(ctx, r, "Cannot validate pkcs15 PIN");
 	}
 


### PR DESCRIPTION
1. Show pinpad reader capabilities even for uninitialised tokens. This way pinpad can be used during token initialisation.

2. Make possible to create SO PIN object during initialisation (using pkcs15-init app) even if no SO PIN was provided (on the command line) but pinpad reader is used and card profile contains SO PIN data.

