### PR TITLE
Padding fixes + yubikey hist. bytes in OpenPGP + p11test improvements

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -710,6 +710,17 @@ pgp_get_card_features(sc_card_t *card)
 					pgp_parse_hist_bytes(card, hist_bytes+2, hist_bytes_len-2);
 				}
 				break;
+			default:
+				/* Something else is non-standard according to
+				 * ISO7816-4 section 8 - Historical bytes,
+				 * but used by Yubico, which should have all
+				 * the needed capabilities*/
+				if (hist_bytes_len >= 7 &&
+					memcmp(hist_bytes, "Yubikey", 7) == 0) {
+					card->caps |= SC_CARD_CAP_APDU_EXT;
+					priv->ext_caps |= EXT_CAP_APDU_EXT
+						| EXT_CAP_CHAINING;
+				}
 		}
 	}
 

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -492,10 +492,10 @@ int sc_get_encoding_flags(sc_context_t *ctx,
 			(iflags & SC_ALGORITHM_RSA_PAD_PSS)) {
 		*sflags |= SC_ALGORITHM_RSA_PAD_PSS;
 
-	} else if (((caps & SC_ALGORITHM_RSA_RAW) &&
-				(iflags & SC_ALGORITHM_RSA_PAD_PKCS1))
-			|| iflags & SC_ALGORITHM_RSA_PAD_PSS
-			|| iflags & SC_ALGORITHM_RSA_PAD_NONE) {
+	} else if ((caps & SC_ALGORITHM_RSA_RAW) &&
+				(iflags & SC_ALGORITHM_RSA_PAD_PKCS1
+				|| iflags & SC_ALGORITHM_RSA_PAD_PSS
+				|| iflags & SC_ALGORITHM_RSA_PAD_NONE)) {
 		/* Use the card's raw RSA capability on the padded input */
 		*sflags = SC_ALGORITHM_RSA_PAD_NONE;
 		*pflags = iflags;

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -410,6 +410,8 @@ int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
 
 	hash_algo = flags & SC_ALGORITHM_RSA_HASHES;
 	pad_algo  = flags & SC_ALGORITHM_RSA_PADS;
+	if (pad_algo == 0)
+		pad_algo = SC_ALGORITHM_RSA_PAD_NONE;
 	sc_log(ctx, "hash algorithm 0x%X, pad algorithm 0x%X", hash_algo, pad_algo);
 
 	if ((pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 || pad_algo == SC_ALGORITHM_RSA_PAD_NONE) &&

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -305,6 +305,7 @@ int callback_public_keys(test_certs_t *objects,
 			o->type = EVP_PK_RSA;
 			o->key.rsa = RSA_new();
 			RSA_set0_key(o->key.rsa, n, e, NULL);
+			o->bits = RSA_bits(o->key.rsa);
 			n = NULL;
 			e = NULL;
 		}
@@ -370,6 +371,7 @@ int callback_public_keys(test_certs_t *objects,
 			o->key.ec = EC_KEY_new_by_curve_name(nid);
 			EC_KEY_set_public_key(o->key.ec, ecpoint);
 			EC_KEY_set_group(o->key.ec, ecgroup);
+			o->bits = EC_GROUP_order_bits(ecgroup);
 		}
 	} else {
 		debug_print(" [WARN %s ] non-RSA, non-EC key. Key type: %02lX",

--- a/src/tests/p11test/p11test_case_multipart.c
+++ b/src/tests/p11test/p11test_case_multipart.c
@@ -36,6 +36,11 @@ void multipart_tests(void **state) {
 
 	debug_print("\nCheck functionality of Multipart Sign&Verify");
 	for (i = 0; i < objects.count; i++) {
+		if (objects.data[i].private_handle == CK_INVALID_HANDLE) {
+			debug_print(" [ SKIP %s ] Skip missing private key",
+			objects.data[i].id_str);
+			continue;
+		}
 		if (objects.data[i].type == EVP_PK_EC) {
 			debug_print(" [ SKIP %s ] EC keys do not support multi-part operations",
 			objects.data[i].id_str);
@@ -79,6 +84,9 @@ void multipart_tests(void **state) {
 			objects.data[i].sign ? "[./] " : "[  ] ",
 			objects.data[i].verify ? " [./] " : " [  ] ",
 			objects.data[i].label);
+		if (objects.data[i].private_handle == CK_INVALID_HANDLE) {
+			continue;
+		}
 		for (j = 0; j < objects.data[i].num_mechs; j++) {
 			test_mech_t *mech = &objects.data[i].mechs[j];
 			if ((mech->usage_flags & CKF_SIGN) == 0) {

--- a/src/tests/p11test/p11test_case_multipart.c
+++ b/src/tests/p11test/p11test_case_multipart.c
@@ -34,7 +34,7 @@ void multipart_tests(void **state) {
 	P11TEST_START(info);
 	search_for_all_objects(&objects, info);
 
-	debug_print("\nCheck functionality of Multipart Sign&Verify and/or Encrypt&Decrypt");
+	debug_print("\nCheck functionality of Multipart Sign&Verify");
 	for (i = 0; i < objects.count; i++) {
 		if (objects.data[i].type == EVP_PK_EC) {
 			debug_print(" [ SKIP %s ] EC keys do not support multi-part operations",
@@ -42,7 +42,7 @@ void multipart_tests(void **state) {
 			continue;
 		}
 		used = 0;
-		/* do the Sign&Verify and/or Encrypt&Decrypt */
+		/* do the Sign&Verify */
 		/* XXX some keys do not have appropriate flags, but we can use them
 		 * or vice versa */
 		//if (objects.data[i].sign && objects.data[i].verify)

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -669,6 +669,9 @@ void readonly_tests(void **state) {
 			printf("  no usable attributes found ... ignored\n");
 			continue;
 		}
+		if (objects.data[i].private_handle == CK_INVALID_HANDLE) {
+			continue;
+		}
 		for (j = 0; j < o->num_mechs; j++) {
 			test_mech_t *mech = &o->mechs[j];
 			if ((mech->usage_flags & CKF_SIGN) == 0) {

--- a/src/tests/p11test/p11test_case_usage.c
+++ b/src/tests/p11test/p11test_case_usage.c
@@ -93,6 +93,11 @@ void usage_test(void **state) {
 		printf("\n[%-6s] [%s]\n",
 			objects.data[i].id_str,
 			objects.data[i].label);
+
+		/* Ignore if there is missing private key */
+		if (objects.data[i].private_handle == CK_INVALID_HANDLE)
+			continue;
+
 		printf("[ %s ] [%6lu] [ %s ] [%s%s] [%s%s] [%s %s] [%s%s] [    %s   ]\n",
 			objects.data[i].key_type == CKK_RSA ? "RSA " :
 				objects.data[i].key_type == CKK_EC ? " EC " : " ?? ",


### PR DESCRIPTION
Based mostly on the discussion in #1551, there were identified few issues with setting padding flags, that are addressed in this PR.

Additionally, the Yubikey historical bytes are not useful for capabilities detection in the OpenPGP driver so I tried to workaround it so we can get correct capabilities also for yubikey.

The last few fixes are minor cleanup in the p11test, so it does not report many empty and useless lines and it can read the key size even without the certificate.

Unfortunately, this all does not unbreak the Yubikey decryption, but from the #1552 I am actually not sure if the keys on yubikey should even work for decryption. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested