### PR TITLE
Remove redundant logging

### DIFF
--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -70,7 +70,6 @@ cosm_write_tokeninfo (struct sc_pkcs15_card *p15card, struct sc_profile *profile
 	ctx = p15card->card->ctx;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(ctx,  "cosm_write_tokeninfo() label '%s'; flags 0x%X", label, flags);
 	if (sc_profile_get_file(profile, COSM_TITLE"-token-info", &file)) {
 		rv = SC_ERROR_INCONSISTENT_PROFILE;
 		SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "Cannot find "COSM_TITLE"-token-info");


### PR DESCRIPTION
Same information is printed a few line below in same function, the only
difference is that there it takes care of case when label is NULL pointer
unlike this line

secondly, every function call to cosm_write_tokeninfo() in this file
passes label=NULL, and then it tries to print a null pointer

Fixes errors like
src/libopensc/log.h:48:47: error: '%s' directive argument is null
[-Werror=format-overflow=]

Signed-off-by: Khem Raj <raj.khem@gmail.com>
