### PR TITLE
p11test: Use function compatible with OpenSSL 1.0.2

### DIFF
--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -371,7 +371,7 @@ int callback_public_keys(test_certs_t *objects,
 			o->key.ec = EC_KEY_new_by_curve_name(nid);
 			EC_KEY_set_public_key(o->key.ec, ecpoint);
 			EC_KEY_set_group(o->key.ec, ecgroup);
-			o->bits = EC_GROUP_order_bits(ecgroup);
+			o->bits = EC_GROUP_get_degree(ecgroup);
 		}
 	} else {
 		debug_print(" [WARN %s ] non-RSA, non-EC key. Key type: %02lX",


### PR DESCRIPTION
Because of my oversight, I used a function that is not available in OpenSSL 1.0.2, while there is quite equivalent one already used in other parts of OpenSC. This should fix the CI on RHEL7 using the old OpenSSL.