### PR TITLE
OpenPGP: cleanup "magic" constants

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -3066,7 +3066,7 @@ gnuk_delete_key(sc_card_t *card, u8 key_id)
 {
 	sc_context_t *ctx = card->ctx;
 	int r = SC_SUCCESS;
-	char *data = NULL;
+	u8 data[4] = { 0x4D, 0x02, 0x00, 0x00 };
 
 	LOG_FUNC_CALLED(ctx);
 
@@ -3087,14 +3087,14 @@ gnuk_delete_key(sc_card_t *card, u8 key_id)
 	/* rewrite Extended Header List */
 	sc_log(ctx, "Rewrite Extended Header List");
 
-	if (key_id == 1)
-		data = "\x4D\x02\xB6";
-	else if (key_id == 2)
-		data = "\x4D\x02\xB8";
-	else if (key_id == 3)
-		data = "\x4D\x02\xA4";
+	if (key_id == SC_OPENPGP_KEY_SIGN)
+		ushort2bebytes(data+2, DO_SIGN);
+	else if (key_id == SC_OPENPGP_KEY_ENCR)
+		ushort2bebytes(data+2, DO_ENCR);
+	else if (key_id == SC_OPENPGP_KEY_AUTH)
+		ushort2bebytes(data+2, DO_AUTH);
 
-	r = pgp_put_data(card, 0x4D, (const u8 *)data, strlen((const char *)data) + 1);
+	r = pgp_put_data(card, 0x4D, data, sizeof(data));
 
 	LOG_FUNC_RETURN(ctx, r);
 }

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2819,21 +2819,20 @@ pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info
 		LOG_TEST_GOTO_ERR(ctx, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory.");
 
 	switch (key_info->key_id) {
-	case SC_OPENPGP_KEY_SIGN:
-		data[0] = 0xB6;
-		break;
-	case SC_OPENPGP_KEY_ENCR:
-		data[0] = 0xB8;
-		break;
-	case SC_OPENPGP_KEY_AUTH:
-		data[0] = 0xA4;
-		break;
-	default:
-		sc_log(ctx, "Unknown key type %d.", key_info->key_id);
-		r = SC_ERROR_INVALID_ARGUMENTS;
-		goto err;
+		case SC_OPENPGP_KEY_SIGN:
+			ushort2bebytes(data, DO_SIGN);
+			break;
+		case SC_OPENPGP_KEY_ENCR:
+			ushort2bebytes(data, DO_ENCR);
+			break;
+		case SC_OPENPGP_KEY_AUTH:
+			ushort2bebytes(data, DO_AUTH);
+			break;
+		default:
+			sc_log(ctx, "Unknown key id %d.", key_info->key_id);
+			LOG_TEST_GOTO_ERR(ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid key id");
 	}
-	memcpy(data + 2, tlv_7f48, tlvlen_7f48);
+	memcpy(data + 2,               tlv_7f48, tlvlen_7f48);
 	memcpy(data + 2 + tlvlen_7f48, tlv_5f48, tlvlen_5f48);
 	r = pgp_build_tlv(ctx, 0x4D, data, len, &tlvblock, &tlvlen);
 	LOG_TEST_GOTO_ERR(ctx, r, "Cannot build TLV for Extended Header list");


### PR DESCRIPTION
Hi,

the attached PR replaces magic constants & tricks relying on C's string semantics with 
* symbolic names of well known DOs and other objects
* proper assignments using ushort2bebytes()

Apart from those cleanups, which make the code easier to understand, it does not change the code logic

Thanks in advance for pulling this PR into master.
Peter
