### PR TITLE
OpenPGP: error message cleanupup

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1855,7 +1855,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 				if (data->pin1.len == 0 &&
 				    !(data->flags & SC_PIN_CMD_USE_PINPAD))
 					LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
-						     "v2 cards don't support implicit old PIN for PIN change.");
+							"v2 cards don't support implicit old PIN for PIN change");
 
 				data->flags &= ~SC_PIN_CMD_IMPLICIT_CHANGE;
 			}
@@ -1875,12 +1875,12 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	if (data->cmd == SC_PIN_CMD_UNBLOCK && data->pin2.len == 0 &&
 	    !(data->flags & SC_PIN_CMD_USE_PINPAD))
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
-			     "new PIN must be provided for unblock operation.");
+				"new PIN must be provided for unblock operation");
 
 	/* ensure pin_reference is 81, 82, 83 */
 	if (!(data->pin_reference == 0x81 || data->pin_reference == 0x82 || data->pin_reference == 0x83)) {
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
-					 "key-id should be 1, 2, 3.");
+				"key-id should be 1, 2, 3");
 	}
 
 	/* emulate SC_PIN_CMD_GET_INFO command for cards not supporting it */
@@ -2356,7 +2356,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 	/* store to DO */
 	sc_log(card->ctx, "Writing to DO %04X.", tag);
 	r = pgp_put_data(card, tag, fingerprint, SHA_DIGEST_LENGTH);
-	LOG_TEST_RET(card->ctx, r, "Cannot write to DO.");
+	LOG_TEST_RET(card->ctx, r, "Cannot write to DO");
 
 	/* update the blob containing fingerprints (00C5) */
 	sc_log(card->ctx, "Updating fingerprint blob 00C5.");
@@ -2415,7 +2415,7 @@ pgp_update_pubkey_blob(sc_card_t *card, u8* modulus, size_t modulus_len,
 
 	sc_log(card->ctx, "Retrieving blob %04X.", blob_id);
 	r = pgp_get_blob(card, priv->mf, blob_id, &pk_blob);
-	LOG_TEST_RET(card->ctx, r, "Cannot get the blob.");
+	LOG_TEST_RET(card->ctx, r, "Cannot get the blob");
 
 	/* encode pubkey */
 	memset(&pubkey, 0, sizeof(pubkey));
@@ -2426,11 +2426,11 @@ pgp_update_pubkey_blob(sc_card_t *card, u8* modulus, size_t modulus_len,
 	pubkey.u.rsa.exponent.len  = exponent_len >> 3;
 
 	r = sc_pkcs15_encode_pubkey(card->ctx, &pubkey, &data, &len);
-	LOG_TEST_RET(card->ctx, r, "Cannot encode pubkey.");
+	LOG_TEST_RET(card->ctx, r, "Cannot encode pubkey");
 
 	sc_log(card->ctx, "Updating blob %04X's content.", blob_id);
 	r = pgp_set_blob(pk_blob, data, len);
-	LOG_TEST_RET(card->ctx, r, "Cannot update blob content.");
+	LOG_TEST_RET(card->ctx, r, "Cannot update blob content");
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 
@@ -2465,7 +2465,7 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 							 &cla, &tag, &len);
 		if (part == NULL)
 			r = SC_ERROR_ASN1_OBJECT_NOT_FOUND;
-		LOG_TEST_RET(card->ctx, r, "Unexpected end of contents.");
+		LOG_TEST_RET(card->ctx, r, "Unexpected end of contents");
 		/* undo ASN1's split of tag & class */
 		for (tmptag = tag; tmptag > 0x0FF; tmptag >>= 8) {
 			cla <<= 8;
@@ -2501,7 +2501,7 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 	/* calculate and store fingerprint */
 	sc_log(card->ctx, "Calculate and store fingerprint");
 	r = pgp_calculate_and_store_fingerprint(card, ctime, modulus, exponent, key_info);
-	LOG_TEST_RET(card->ctx, r, "Cannot store fingerprint.");
+	LOG_TEST_RET(card->ctx, r, "Cannot store fingerprint");
 	/* update pubkey blobs (B601,B801, A401) */
 	sc_log(card->ctx, "Update blobs holding pubkey info.");
 	r = pgp_update_pubkey_blob(card, modulus, key_info->rsa.modulus_len,
@@ -2825,7 +2825,7 @@ pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info
 
 	/* TLV block for 7F48 */
 	r = pgp_build_tlv(ctx, 0x7F48, pritemplate, tpl_len, &tlv_7f48, &tlvlen_7f48);
-	LOG_TEST_RET(ctx, r, "Failed to build TLV for 7F48.");
+	LOG_TEST_RET(ctx, r, "Failed to build TLV for 7F48");
 	tlv_7f48[0] |= 0x7F;
 	r = pgp_build_tlv(ctx, 0x5f48, kdata, kdata_len, &tlv_5f48, &tlvlen_5f48);
 	LOG_TEST_GOTO_ERR(ctx, r, "Failed to build TLV for 5F48");
@@ -2835,7 +2835,7 @@ pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info
 	/* set data part content */
 	data = calloc(len, 1);
 	if (data == NULL)
-		LOG_TEST_GOTO_ERR(ctx, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory.");
+		LOG_TEST_GOTO_ERR(ctx, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory");
 
 	switch (key_info->key_id) {
 		case SC_OPENPGP_KEY_SIGN:
@@ -2944,7 +2944,7 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 	sc_log(card->ctx, "Calculate and store fingerprint");
 	r = pgp_calculate_and_store_fingerprint(card, key_info->creationtime,
 						key_info->rsa.n, key_info->rsa.e, &pubkey);
-	LOG_TEST_RET(card->ctx, r, "Cannot store fingerprint.");
+	LOG_TEST_RET(card->ctx, r, "Cannot store fingerprint");
 	/* update pubkey blobs (B601,B801, A401) */
 	sc_log(card->ctx, "Update blobs holding pubkey info.");
 	r = pgp_update_pubkey_blob(card, key_info->rsa.n, 8*key_info->rsa.n_len,
@@ -3134,7 +3134,7 @@ pgp_delete_file(sc_card_t *card, const sc_path_t *path)
 
 	/* sc_pkcs15init_delete_by_path() sets the path type to SC_PATH_TYPE_FILE_ID */
 	r = pgp_select_file(card, path, &file);
-	LOG_TEST_RET(card->ctx, r, "Cannot select file.");
+	LOG_TEST_RET(card->ctx, r, "Cannot select file");
 
 	/* save "current" blob */
 	blob = priv->current;

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1878,10 +1878,9 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 				"new PIN must be provided for unblock operation");
 
 	/* ensure pin_reference is 81, 82, 83 */
-	if (!(data->pin_reference == 0x81 || data->pin_reference == 0x82 || data->pin_reference == 0x83)) {
+	if (data->pin_reference < 0x81 || data->pin_reference > 0x83)
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
-				"key-id should be 1, 2, 3");
-	}
+				"Invalid key ID; must be 1, 2, or 3");
 
 	/* emulate SC_PIN_CMD_GET_INFO command for cards not supporting it */
 	if (data->cmd == SC_PIN_CMD_GET_INFO && (card->caps & SC_CARD_CAP_ISO7816_PIN_INFO) == 0) {
@@ -2262,10 +2261,10 @@ pgp_store_creationtime(sc_card_t *card, u8 key_id, time_t *outtime)
 	u8 buf[4];
 
 	LOG_FUNC_CALLED(card->ctx);
-	if (key_id == 0 || key_id > 3) {
-		sc_log(card->ctx, "Invalid key ID %d.", key_id);
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
-	}
+
+	if (key_id < 1 || key_id > 3)
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
+				"Invalid key ID; must be 1, 2, or 3");
 
 	if (outtime != NULL && *outtime != 0)
 		createtime = *outtime;
@@ -2394,7 +2393,7 @@ pgp_update_pubkey_blob(sc_card_t *card, u8* modulus, size_t modulus_len,
 {
 	struct pgp_priv_data *priv = DRVDATA(card);
 	pgp_blob_t *pk_blob;
-	unsigned int blob_id;
+	unsigned int blob_id = 0;
 	sc_pkcs15_pubkey_t pubkey;
 	u8 *data = NULL;
 	size_t len;
@@ -2409,8 +2408,8 @@ pgp_update_pubkey_blob(sc_card_t *card, u8* modulus, size_t modulus_len,
 	else if (key_id == SC_OPENPGP_KEY_AUTH)
 		blob_id = DO_AUTH_SYM;
 	else {
-		sc_log(card->ctx, "Unknown key id %X.", key_id);
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
+				"Invalid key ID; must be 1, 2, or 3");
 	}
 
 	sc_log(card->ctx, "Retrieving blob %04X.", blob_id);
@@ -2571,8 +2570,8 @@ pgp_gen_key(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_info)
 	else if (key_info->key_id == SC_OPENPGP_KEY_AUTH)
 		ushort2bebytes(apdu_data, DO_AUTH);
 	else {
-		sc_log(card->ctx, "Unknown key id %X.", key_info->key_id);
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
+				"Invalid key ID; must be 1, 2, or 3");
 	}
 
 	if (card->type == SC_CARD_TYPE_OPENPGP_GNUK && key_info->rsa.modulus_len != 2048)
@@ -2845,8 +2844,8 @@ pgp_build_extended_header_list(sc_card_t *card, sc_cardctl_openpgp_keystore_info
 			ushort2bebytes(data, DO_AUTH);
 			break;
 		default:
-			sc_log(ctx, "Unknown key id %d.", key_info->key_id);
-			LOG_TEST_GOTO_ERR(ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid key id");
+			LOG_TEST_GOTO_ERR(ctx, SC_ERROR_INVALID_ARGUMENTS,
+						"Invalid key ID; must be 1, 2, or 3");
 	}
 	memcpy(data + 2,               tlv_7f48, tlvlen_7f48);
 	memcpy(data + 2 + tlvlen_7f48, tlv_5f48, tlvlen_5f48);
@@ -2887,10 +2886,10 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_keystore_info_t *key_info)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	/* Validate */
-	if (key_info->key_id < 1 || key_info->key_id > 3) {
-		sc_log(card->ctx, "Unknown key type %d.", key_info->key_id);
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
-	}
+	if (key_info->key_id < 1 || key_info->key_id > 3)
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
+				"Invalid key ID; must be 1, 2, or 3");
+
 	/* we just support standard key format */
 	switch (key_info->rsa.keyformat) {
 	case SC_OPENPGP_KEYFORMAT_RSA_STD:
@@ -3085,10 +3084,9 @@ gnuk_delete_key(sc_card_t *card, u8 key_id)
 
 	LOG_FUNC_CALLED(ctx);
 
-	if (key_id < 1 || key_id > 3) {
-		sc_log(ctx, "Key ID %d is invalid. Should be 1, 2 or 3.", key_id);
-		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
-	}
+	if (key_id < 1 || key_id > 3)
+		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS,
+				"Invalid key ID; must be 1, 2, or 3");
 
 	/* delete fingerprint */
 	sc_log(ctx, "Delete fingerprints");


### PR DESCRIPTION
Hi & Hammy New Year,

this PR
* harmonizes error messages used in LOG_TEST...() calls:
  no period at the end
* replaces `sc_log(); LOG_FUNC_RETURN();` sequences with LOG_TEST_RET()
  if `sc_log()` only has a constant error message
* consolidates error messages for 'key_IDs': same check, same text, same type

Thanks in advance for pulling it into master
Peter