### PR TITLE
Fix PKCS#11 Object Restrictions

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -58,7 +58,7 @@ struct pkcs15_slot_data {
 	}                                       \
 	attr->ulValueLen = size;
 
-#define MAX_OBJECTS	64
+#define MAX_OBJECTS	128
 struct pkcs15_fw_data {
 	struct sc_pkcs15_card *		p15_card;
 	struct pkcs15_any_object *	objects[MAX_OBJECTS];
@@ -773,7 +773,7 @@ __pkcs15_create_prkey_object(struct pkcs15_fw_data *fw_data,
 	if (prkey_object != NULL)
 		*prkey_object = (struct pkcs15_any_object *) object;
 
-	return 0;
+	return rv;
 }
 
 
@@ -794,7 +794,7 @@ __pkcs15_create_data_object(struct pkcs15_fw_data *fw_data,
 	if (data_object != NULL)
 		*data_object = (struct pkcs15_any_object *) dobj;
 
-	return 0;
+	return rv;
 }
 
 
@@ -813,7 +813,7 @@ __pkcs15_create_secret_key_object(struct pkcs15_fw_data *fw_data,
 	if (skey_object != NULL)
 		*skey_object = (struct pkcs15_any_object *) skey;
 
-	return 0;
+	return rv;
 }
 
 
@@ -4606,10 +4606,9 @@ pkcs15_dobj_get_value(struct sc_pkcs11_session *session,
 	if (!out_data)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	if (dobj->info->data.len == 0)
-	/* CKA_VALUE is empty */
+	/* CKA_VALUE is empty we may need to read it */
 	{
 		*out_data = NULL;
-		return sc_to_cryptoki_error(SC_SUCCESS, "C_GetAttributeValue");
 	}
 
 	fw_data = (struct pkcs15_fw_data *) p11card->fws_data[session->slot->fw_data_idx];


### PR DESCRIPTION
Framework-pkcs15.c silently ignores adding objects if MAX_OBJECTS
is exceeded while creating the fw_data objects. This simple fix
is to change the MAX_OBJECTS from 64 to 128. A better fix would
be to realloc the objects arrays as needed.

__pkcs15_create_data_object and __pkcs15_create_secret_key_object
now return rv like the other  __pkcs15_create_*_object routines.

pkcs15_dobj_get_value now calls sc_pkcs15_read_data_object just like
the other pkcs15_*_get_value routines. The problem was introduced
in 0c3412bb 2018-04-09 which added:
 `return sc_to_cryptoki_error(SC_SUCCESS, "C_GetAttributeValue");`
before trying to read the data object.

The MAX_OBJECT problem was discovered while trying to use a new PIV
card with 24 standard cert objects and 10 other objects for a total
of 106 objects. Each cert object corresponds to a cert, pubkey,
private key, and the cert object itself for a possible 112 data objects.

The pkcs15_dobj_get_value was found while running:
running pkcs11-tool -r -y data --application-id 2.16.840.1.101.3.7.2.1.1
using git bisect to locate the bad commit.  The pkcs11 data objects are
created last from the pkcs15 objects which are a linked list with no limits.

 On branch fix-object-restrictions
	modified:   src/pkcs11/framework-pkcs15.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

Tested with PIV test cards, using `pkcs11-tool --test --login`
and  `pkcs11-tool -r -y data --application-id 2.16.840.1.101.3.7.2.1.1 > /tmp/cert.object`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested


