### PR TITLE
Add object type "secrkey" to help of --type switch in pkcs11-tool

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -475,8 +475,9 @@
 						<option>-y</option> <replaceable>type</replaceable>
 					</term>
 					<listitem><para>Specify the type of object to operate on.
-					Examples are <literal>cert</literal>, <literal>privkey</literal>
-					and <literal>pubkey</literal>.</para></listitem>
+					Valid value are <literal>cert</literal>, <literal>privkey</literal>,
+					<literal>pubkey</literal>, <literal>secrkey</literal> 
+					and <literal>data</literal>.</para></listitem>
 				</varlistentry>
 
 				<varlistentry>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -269,7 +269,7 @@ static const char *option_help[] = {
 	"Specify the application ID of the data object (use with --type data)",
 	"Specify the issuer in hexadecimal format (use with --type cert)",
 	"Specify the subject in hexadecimal format (use with --type cert/privkey/pubkey)",
-	"Specify the type of object (e.g. cert, privkey, pubkey, data)",
+	"Specify the type of object (e.g. cert, privkey, pubkey, secrkey, data)",
 	"Specify the ID of the object",
 	"Specify the label of the object",
 	"Specify the ID of the slot to use",


### PR DESCRIPTION
Reading an object with pkcs11-tool requires the `--type` switch. The help for that switch is currently incomplete as it is missing the (not very friendly named) *secrkey* option used to read out a secret key object.

I have added this information to the help description.