### PR TITLE
Fixes an issue in PIN verification: Uninitialized was passed to sc_pkcs15_verify_pin in some situations.

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3801,7 +3801,7 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 
 found:
 	if (pin_obj)   {
-		r = sc_pkcs15_verify_pin(p15card, pin_obj, use_pinpad ? NULL : pinbuf, use_pinpad ? 0 : pinsize);
+		r = sc_pkcs15_verify_pin(p15card, pin_obj, use_pinpad || pinsize == 0 ? NULL : pinbuf, use_pinpad ? 0 : pinsize);
 		LOG_TEST_RET(ctx, r, "Cannot validate pkcs15 PIN");
 	}
 


### PR DESCRIPTION
This fixes an issue that appeared in 6bf9685 (PR #1540). In case use_pinpad ==0 && pinsize == 0, uninitialized pinbuf was passed to sc_pkcs15_verify_pin causing problems.

I encountered this problem when using a pinpad reader and doing the following:

- call C_Login with NULL pin data to trigger prompting for PIN on the reader.
- authenticate PIN #1 successfully
- do crypto-operations that use a key with CKA_ALWAYS_AUTHENTICATE = TRUE. Authentication of PIN 1 is lost after that. 
- call an operation that involved creating a file using pkcs15-init. (pkcs15-lib.c). pkcs15-init notices that it needs AC 1 to create the file and it is not authenticated. sc_pkcs15init_verify_secret is called.

Now pinsize is 0 and pin_obj is found, but use_pinpad does not get set. sc_pkcs15_verify_pin is called with pinbuf pointing to uninitialized data, and we ended up trying to verify this buffer on card, resulting to CKR_PIN_INCORRECT. After this fix, pinpad prompts for PIN and the AC is acquired again when correct PIN is entered.

- [x] PKCS#11 module is tested

