### PR TITLE
is_esteid_card is only used card-mcrd.c

### DIFF
--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -279,7 +279,7 @@ static int mcrd_set_decipher_key_ref(sc_card_t * card, int key_reference)
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, sc_check_sw(card, apdu.sw1, apdu.sw2));
 }
 
-int is_esteid_card(sc_card_t *card)
+static int is_esteid_card(sc_card_t *card)
 {
 	return card->type == SC_CARD_TYPE_MCRD_ESTEID_V30 ? 1 : 0;
 }

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -284,6 +284,16 @@ static int is_esteid_card(sc_card_t *card)
 	return card->type == SC_CARD_TYPE_MCRD_ESTEID_V30 ? 1 : 0;
 }
 
+static int select_esteid_df(sc_card_t * card)
+{
+	int r;
+	sc_path_t tmppath;
+	sc_format_path ("3F00EEEE", &tmppath);
+	r = sc_select_file (card, &tmppath, NULL);
+	LOG_TEST_RET(card->ctx, r, "esteid select DF failed");
+	return r;
+}
+
 static int mcrd_match_card(sc_card_t * card)
 {
 	int i = 0, r = 0;

--- a/src/libopensc/esteid.h
+++ b/src/libopensc/esteid.h
@@ -28,5 +28,4 @@ enum {
 
 #define SC_ESTEID_KEYREF_FILE_RECLEN	21
 
-int select_esteid_df(sc_card_t * card);
 #endif

--- a/src/libopensc/esteid.h
+++ b/src/libopensc/esteid.h
@@ -29,5 +29,4 @@ enum {
 #define SC_ESTEID_KEYREF_FILE_RECLEN	21
 
 int select_esteid_df(sc_card_t * card);
-int is_esteid_card(sc_card_t *card);
 #endif

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -46,17 +46,6 @@ set_string (char **strp, const char *value)
 }
 
 
-int
-select_esteid_df (sc_card_t * card)
-{
-	int r;
-	sc_path_t tmppath;
-	sc_format_path ("3F00EEEE", &tmppath);
-	r = sc_select_file (card, &tmppath, NULL);
-	LOG_TEST_RET(card->ctx, r, "esteid select DF failed");
-	return r;
-}
-
 static int
 sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 {


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
