### PR TITLE
Trustonic pkcs11

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5258,21 +5258,10 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 	int             failed;
 	CK_RV           rv;
 	int             pad;
-	CK_MECHANISM_TYPE hash_alg = CKM_SHA_1;
+	CK_MECHANISM_TYPE hash_alg;
 	CK_RSA_PKCS_OAEP_PARAMS oaep_params;
 
 	printf("    %s: ", p11_mechanism_to_name(mech_type));
-
-	if ((mech_type == CKM_RSA_PKCS) || (mech_type == CKM_RSA_PKCS_OAEP)) {
-		if (opt_hash_alg == 0) {
-			hash_alg = CKM_SHA_1;
-		} else if (opt_hash_alg != CKM_SHA_1) {
-			printf("Only CKM_SHA_1 supported\n");
-			return 0;
-		} else {
-			hash_alg = opt_hash_alg;
-		}
-	}
 
 	pkey = get_public_key(session, privKeyObject);
 	if (pkey == NULL)
@@ -5292,6 +5281,14 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		in_len = mod_len-11;
 		break;
 	case CKM_RSA_PKCS_OAEP: {
+		if (opt_hash_alg == 0) {
+			hash_alg = CKM_SHA_1;
+		} else if (opt_hash_alg != CKM_SHA_1) {
+			printf("Only CKM_RSA_PKCS_OAEP with CKM_SHA_1 supported\n");
+			return 0;
+		} else {
+			hash_alg = opt_hash_alg;
+		}
 		pad = RSA_PKCS1_OAEP_PADDING;
 		/* Limit the input length to <= mod_len-2-2*hlen */
 		size_t len = 2+2*hash_length(hash_alg);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5334,18 +5334,6 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 			oaep_params.mgf = CKG_MGF1_SHA1;
 			break;
 		}
-		break;
-	case CKM_RSA_PKCS:
-		mech.pParameter = NULL;
-		mech.ulParameterLen = 0;
-		break;
-	default:
-		util_fatal("Mechanism %s illegal or not supported\n", p11_mechanism_to_name(mech_type));
-	}
-
-
-	/* If an RSA-OAEP mechanism, it needs parameters */
-	if (oaep_params.hashAlg) {
 		if (opt_mgf != 0)
 			oaep_params.mgf = opt_mgf;
 
@@ -5354,6 +5342,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		oaep_params.pSourceData = NULL; /* PKCS#11 standard: this must be NULLPTR */
 		oaep_params.ulSourceDataLen = 0; /* PKCS#11 standard: this must be 0 */
 
+		/* If an RSA-OAEP mechanism, it needs parameters */
 		mech.pParameter = &oaep_params;
 		mech.ulParameterLen = sizeof(oaep_params);
 
@@ -5363,9 +5352,14 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 			oaep_params.source,
 			oaep_params.pSourceData,
 			oaep_params.ulSourceDataLen);
-
+		break;
+	case CKM_RSA_PKCS:
+		mech.pParameter = NULL;
+		mech.ulParameterLen = 0;
+		break;
+	default:
+		util_fatal("Mechanism %s illegal or not supported\n", p11_mechanism_to_name(mech_type));
 	}
-
 
 	mech.mechanism = mech_type;
 	rv = p11->C_DecryptInit(session, &mech, privKeyObject);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5340,7 +5340,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		mech.ulParameterLen = 0;
 		break;
 	default:
-		util_fatal("Mechanism %s illegal or not supported\n", p11_mechanism_to_name(opt_mechanism));
+		util_fatal("Mechanism %s illegal or not supported\n", p11_mechanism_to_name(mech_type));
 	}
 
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1985,7 +1985,7 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			r = read(fd, in_buffer, sizeof(in_buffer));
 		} while (r > 0);
 
-		sig_len = sizeof(sig_buffer);
+		sig_len = r2;
 		rv = p11->C_VerifyFinal(session, sig_buffer, sig_len);
 		if (rv != CKR_OK)
 			p11_fatal("C_VerifyFinal", rv);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5361,7 +5361,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		return 0;
 	}
 
-	if (in_len >= sizeof(orig_data)) {
+	if (in_len > sizeof(orig_data)) {
 		printf("Private key size is too long\n");
 		return 0;
 	}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5371,12 +5371,19 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 			md = EVP_sha512();
 			break;
 		}
+#if defined(EVP_PKEY_CTX_set_rsa_oaep_md)
 		if (EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) <= 0) {
 			EVP_PKEY_CTX_free(ctx);
 			EVP_PKEY_free(pkey);
 			printf("set md failed, returning\n");
 			return 0;
 		}
+#else
+        if (hash_alg != CKM_SHA_1) {
+            printf("This version of OpenSsl only supports SHA1 for OAEP, returning\n");
+			return 0;
+        }
+#endif
 		switch (mgf) {
 		case CKG_MGF1_SHA1:
 			md = EVP_sha1();

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5461,6 +5461,17 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 		printf("No OpenSSL support, unable to validate decryption\n");
 #else
 		for (n = 0; n < num_mechs; n++) {
+			switch (mechs[n]) {
+			case CKM_RSA_PKCS:
+			case CKM_RSA_PKCS_OAEP:
+			case CKM_RSA_X_509:
+			//case CKM_RSA_PKCS_TPM_1_1:
+			//case CKM_RSA_PKCS_OAEP_TPM_1_1:
+				break;
+			default:
+				printf(" -- mechanism can't be used to decrypt, skipping\n");
+				continue;
+			}
 
 			errors += encrypt_decrypt(sess, mechs[n], privKeyObject);
 		}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5287,7 +5287,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE privKeyObject)
 {
 	EVP_PKEY       *pkey;
-	unsigned char	orig_data[512] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', '\0'};
+	unsigned char	orig_data[512];
 	unsigned char	encrypted[512], data[512];
 	CK_MECHANISM	mech;
 	CK_ULONG	encrypted_len, data_len;
@@ -5299,6 +5299,8 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 	CK_RSA_PKCS_OAEP_PARAMS oaep_params;
 
 	printf("    %s: ", p11_mechanism_to_name(mech_type));
+
+	pseudo_randomize(orig_data, sizeof(orig_data));
 
 	pkey = get_public_key(session, privKeyObject);
 	if (pkey == NULL)

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5461,8 +5461,6 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 			case CKM_RSA_PKCS:
 			case CKM_RSA_PKCS_OAEP:
 			case CKM_RSA_X_509:
-			//case CKM_RSA_PKCS_TPM_1_1:
-			//case CKM_RSA_PKCS_OAEP_TPM_1_1:
 				break;
 			default:
 				printf(" -- mechanism can't be used to decrypt, skipping\n");

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -583,14 +583,6 @@ int main(int argc, char * argv[])
 #ifdef ENABLE_OPENSSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	OPENSSL_config(NULL);
-#endif
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
-	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS
-		| OPENSSL_INIT_ADD_ALL_CIPHERS
-		| OPENSSL_INIT_ADD_ALL_DIGESTS
-		| OPENSSL_INIT_LOAD_CONFIG,
-		NULL);
-#else
 	/* OpenSSL magic */
 	OpenSSL_add_all_algorithms();
 	OPENSSL_malloc_init();

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4567,7 +4567,9 @@ static int sign_verify_openssl(CK_SESSION_HANDLE session,
 		EVP_sha1(),
 		EVP_sha1(),
 		EVP_md5(),
+#ifndef OPENSSL_NO_RIPEMD
 		EVP_ripemd160(),
+#endif
 		EVP_sha256(),
 	};
 #endif
@@ -4650,7 +4652,9 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		CKM_RSA_PKCS,
 		CKM_SHA1_RSA_PKCS,
 		CKM_MD5_RSA_PKCS,
+		#ifndef OPENSSL_NO_RIPEMD
 		CKM_RIPEMD160_RSA_PKCS,
+		#endif
 		CKM_SHA256_RSA_PKCS,
 		0xffffff
 	};
@@ -5231,7 +5235,9 @@ static int test_unwrap(CK_SESSION_HANDLE sess)
 		errors += wrap_unwrap(sess, EVP_des_cbc(), privKeyObject);
 		errors += wrap_unwrap(sess, EVP_des_ede3_cbc(), privKeyObject);
 		errors += wrap_unwrap(sess, EVP_bf_cbc(), privKeyObject);
+		#ifndef OPENSSL_NO_CAST
 		errors += wrap_unwrap(sess, EVP_cast5_cfb(), privKeyObject);
+		#endif
 #endif
 	}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4653,9 +4653,9 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		CKM_RSA_PKCS,
 		CKM_SHA1_RSA_PKCS,
 		CKM_MD5_RSA_PKCS,
-		#ifndef OPENSSL_NO_RIPEMD
+#ifndef OPENSSL_NO_RIPEMD
 		CKM_RIPEMD160_RSA_PKCS,
-		#endif
+#endif
 		CKM_SHA256_RSA_PKCS,
 		0xffffff
 	};
@@ -5236,9 +5236,9 @@ static int test_unwrap(CK_SESSION_HANDLE sess)
 		errors += wrap_unwrap(sess, EVP_des_cbc(), privKeyObject);
 		errors += wrap_unwrap(sess, EVP_des_ede3_cbc(), privKeyObject);
 		errors += wrap_unwrap(sess, EVP_bf_cbc(), privKeyObject);
-		#ifndef OPENSSL_NO_CAST
+#ifndef OPENSSL_NO_CAST
 		errors += wrap_unwrap(sess, EVP_cast5_cfb(), privKeyObject);
-		#endif
+#endif
 #endif
 	}
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2061,6 +2061,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			break;
 		}
 		break;
+	case CKM_RSA_X_509:
 	case CKM_RSA_PKCS:
 		mech.pParameter = NULL;
 		mech.ulParameterLen = 0;
@@ -5353,6 +5354,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 			oaep_params.pSourceData,
 			oaep_params.ulSourceDataLen);
 		break;
+	case CKM_RSA_X_509:
 	case CKM_RSA_PKCS:
 		mech.pParameter = NULL;
 		mech.ulParameterLen = 0;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5418,7 +5418,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		}
 #else
 		if (hash_alg != CKM_SHA_1) {
-			printf("This version of OpenSsl only supports SHA1 for OAEP, returning\n");
+			printf("This version of OpenSSL only supports SHA1 for OAEP, returning\n");
 			return 0;
 		}
 #endif

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5287,7 +5287,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 	CK_RV           rv;
 	int             pad;
 	CK_MECHANISM_TYPE hash_alg = CKM_SHA256;
-	CK_RSA_PKCS_MGF_TYPE mgf;
+	CK_RSA_PKCS_MGF_TYPE mgf = CKG_MGF1_SHA256;
 	CK_RSA_PKCS_OAEP_PARAMS oaep_params;
 
 	printf("    %s: ", p11_mechanism_to_name(mech_type));

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5361,6 +5361,11 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		return 0;
 	}
 
+	if (in_len >= sizeof(orig_data)) {
+		printf("Private key size is too long\n");
+		return 0;
+	}
+
 	EVP_PKEY_CTX *ctx;
 	ctx = EVP_PKEY_CTX_new(pkey, NULL);
 	if (!ctx) {

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5379,10 +5379,10 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 			return 0;
 		}
 #else
-        if (hash_alg != CKM_SHA_1) {
-            printf("This version of OpenSsl only supports SHA1 for OAEP, returning\n");
+		if (hash_alg != CKM_SHA_1) {
+			printf("This version of OpenSsl only supports SHA1 for OAEP, returning\n");
 			return 0;
-        }
+		}
 #endif
 		switch (mgf) {
 		case CKG_MGF1_SHA1:

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1782,7 +1782,7 @@ parse_pss_params(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 				util_fatal("Salt length must be greater or equal "
 				    "to zero, or equal to -1 (meaning: use digest size) "
 				    "or to -2 (meaning: use maximum permissible size");
-		  
+
 			modlen = (get_private_key_length(session, key) + 7) / 8;
 			switch (opt_salt_len) {
 			case -1: /* salt size equals to digest size */
@@ -2024,7 +2024,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 
 	if (opt_hash_alg != 0 && opt_mechanism != CKM_RSA_PKCS_OAEP)
 		util_fatal("The hash-algorithm is applicable only to "
-               "RSA-PKCS-OAEP mechanism"); 
+               "RSA-PKCS-OAEP mechanism");
 
 	if (opt_input == NULL)
 		fd = 0;
@@ -2053,7 +2053,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		case CKM_SHA512:
 			oaep_params.mgf = CKG_MGF1_SHA512;
 			break;
-		default: 
+		default:
 			oaep_params.hashAlg = CKM_SHA_1;
 			/* fall through */
 		case CKM_SHA_1:
@@ -2090,7 +2090,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			oaep_params.pSourceData,
 			oaep_params.ulSourceDataLen);
 
-	} 
+	}
 
 	rv = p11->C_DecryptInit(session, &mech, key);
 	if (rv != CKR_OK)
@@ -5270,45 +5270,45 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 		return 0;
 	}
 	if (mech_type == CKM_RSA_PKCS_OAEP) {
-	    EVP_PKEY_CTX *ctx;
-	    ctx = EVP_PKEY_CTX_new(pkey, NULL);
-	    if (!ctx) {
-            EVP_PKEY_free(pkey);
-            printf("EVP_PKEY_CTX_new failed, returning\n");
-            return 0;
-        }
-        if (EVP_PKEY_encrypt_init(ctx) <= 0) {
-            EVP_PKEY_CTX_free(ctx);
-            EVP_PKEY_free(pkey);
-            printf("EVP_PKEY_encrypt_init failed, returning\n");
-            return 0;
-        }
+		EVP_PKEY_CTX *ctx;
+		ctx = EVP_PKEY_CTX_new(pkey, NULL);
+		if (!ctx) {
+			EVP_PKEY_free(pkey);
+			printf("EVP_PKEY_CTX_new failed, returning\n");
+			return 0;
+		}
+		if (EVP_PKEY_encrypt_init(ctx) <= 0) {
+			EVP_PKEY_CTX_free(ctx);
+			EVP_PKEY_free(pkey);
+			printf("EVP_PKEY_encrypt_init failed, returning\n");
+			return 0;
+		}
 
-	    if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0) {
-            EVP_PKEY_CTX_free(ctx);
-            EVP_PKEY_free(pkey);
-            printf("set OAEP padding failed, returning\n");
-            return 0;
-        }
-        size_t outlen = sizeof(encrypted);
-        if (EVP_PKEY_encrypt(ctx, encrypted, &outlen, orig_data, sizeof(orig_data)) <= 0) {
-            EVP_PKEY_CTX_free(ctx);
-            EVP_PKEY_free(pkey);
-            printf("Encryption failed, returning\n");
-            return 0;
-        }
-        EVP_PKEY_CTX_free(ctx);
-        EVP_PKEY_free(pkey);
-        encrypted_len = outlen;
+		if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0) {
+			EVP_PKEY_CTX_free(ctx);
+			EVP_PKEY_free(pkey);
+			printf("set OAEP padding failed, returning\n");
+			return 0;
+		}
+		size_t outlen = sizeof(encrypted);
+		if (EVP_PKEY_encrypt(ctx, encrypted, &outlen, orig_data, sizeof(orig_data)) <= 0) {
+			EVP_PKEY_CTX_free(ctx);
+			EVP_PKEY_free(pkey);
+			printf("Encryption failed, returning\n");
+			return 0;
+		}
+		EVP_PKEY_CTX_free(ctx);
+		EVP_PKEY_free(pkey);
+		encrypted_len = outlen;
 
-    } else {
-        encrypted_len = EVP_PKEY_encrypt_old(encrypted, orig_data, sizeof(orig_data), pkey);
-        EVP_PKEY_free(pkey);
-        if (((int) encrypted_len) <= 0) {
-            printf("Encryption failed, returning\n");
-            return 0;
-        }
-    }
+	} else {
+		encrypted_len = EVP_PKEY_encrypt_old(encrypted, orig_data, sizeof(orig_data), pkey);
+		EVP_PKEY_free(pkey);
+		if (((int) encrypted_len) <= 0) {
+			printf("Encryption failed, returning\n");
+			return 0;
+		}
+	}
 
 	/* set "default" MGF and hash algorithms. We can overwrite MGF later */
 	switch (mech_type) {
@@ -5461,6 +5461,7 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 		printf("No OpenSSL support, unable to validate decryption\n");
 #else
 		for (n = 0; n < num_mechs; n++) {
+
 			errors += encrypt_decrypt(sess, mechs[n], privKeyObject);
 		}
 #endif


### PR DESCRIPTION
Hi,
In this pull request I am mainly adding the support for CKM_RSA_PKCS_OAEP for the "pkcs11-tool --test" command.
I am also fixing the "pkcs11-tool --verify" when the file to verify is larger than 1025 bytes.
Finally, I fixed a minor build issue because RIPEMD and CAST are not defined by my version of OpenSsl.
I have only tested with my own implementation of the PKCS#11 library.
Notice that this is my first contribution so let me know if I am not doing the things correctly.
Best Regards,
Alexandre.