### PR TITLE
Fix build on cygwin in strict mode

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2459,7 +2459,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 	}
 	else
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
-	sc_log(card->ctx, "pk_packet_len is %lu", pk_packet_len);
+	sc_log(card->ctx, "pk_packet_len is %lu", (unsigned long)pk_packet_len);
 
 	fp_buffer_len = 3 + pk_packet_len;
 	p = fp_buffer = calloc(fp_buffer_len, 1);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2459,7 +2459,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 	}
 	else
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
-	sc_log(card->ctx, "pk_packet_len is %lu", (unsigned long)pk_packet_len);
+	sc_log(card->ctx, "pk_packet_len is %"SC_FORMAT_LEN_SIZE_T"u", pk_packet_len);
 
 	fp_buffer_len = 3 + pk_packet_len;
 	p = fp_buffer = calloc(fp_buffer_len, 1);

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -726,7 +726,7 @@ static int pcsc_cancel(sc_context_t *ctx)
 		return SC_ERROR_NOT_ALLOWED;
 
 #ifndef _WIN32
-	if (gpriv->pcsc_wait_ctx != -1) {
+	if (gpriv->pcsc_wait_ctx != (SCARDCONTEXT)-1) {
 		rv = gpriv->SCardCancel(gpriv->pcsc_wait_ctx);
 		if (rv == SCARD_S_SUCCESS) {
 			 /* Also close and clear the waiting context */
@@ -1509,7 +1509,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 	}
 #ifndef _WIN32
 	/* Establish a new context, assuming that it is called from a different thread with pcsc-lite */
-	if (gpriv->pcsc_wait_ctx == -1) {
+	if (gpriv->pcsc_wait_ctx == (SCARDCONTEXT)-1) {
 		rv = gpriv->SCardEstablishContext(SCARD_SCOPE_USER, NULL, NULL, &gpriv->pcsc_wait_ctx);
 		if (rv != SCARD_S_SUCCESS) {
 			PCSC_LOG(ctx, "SCardEstablishContext(wait) failed", rv);


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
In strict mode (all warnings is errors) there is two cases build broken
First case:
comparison between signed and unsigned integer expressions error
Second case:
format '%lu' expects argument of type 'long unsigned int', but argument has type 'size_t'

In both cases add explicit type conversion
