### PR TITLE
Small memory leak fix (Fixes#1586 / CVE-2019-6502)

### DIFF
--- a/src/tools/eidenv.c
+++ b/src/tools/eidenv.c
@@ -403,6 +403,7 @@ int main(int argc, char **argv)
 	r = util_connect_card(ctx, &card, opt_reader, opt_wait, 0);
 	if (r) {
 		fprintf(stderr, "Failed to connect to card: %s\n", sc_strerror(r));
+		sc_release_context(ctx);
 		return 1;
 	}
 


### PR DESCRIPTION
CVE-2019-6502 was assigned to what appears to be a very minor
memory leak that only occurs on an error-case in a CLI tool.
If util_connect_card fails, we still need to release the sc
context previously allocated by sc_context_create else memory
will leak.
