### PR TITLE
opensc.conf: allow global use of ignore_private_certificate

### DIFF
--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1144,6 +1144,30 @@ app <replaceable>application</replaceable> {
 				</varlistentry>
 				<varlistentry>
 					<term>
+						<option>private_certificate = <replaceable>value</replaceable>;</option>
+					</term>
+					<listitem><para>
+							How to handle a PIN-protected certificate. Known
+							parameters:
+							<itemizedlist>
+								<listitem><para>
+										<literal>protect</literal>: The certificate stays PIN-protected.
+								</para></listitem>
+								<listitem><para>
+										<literal>declassify</literal>: Allow
+										reading the certificate without
+										enforcing verification of the PIN.
+								</para></listitem>
+								<listitem><para>
+										<literal>ignore</literal>: Ignore PIN-protected certificates.
+								</para></listitem>
+							</itemizedlist>
+							(Default: <literal>ignore</literal> in Tokend,
+							<literal>protect</literal> otherwise).
+					</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>enable_pkcs15_emulation = <replaceable>bool</replaceable>;</option>
 					</term>
 					<listitem><para>
@@ -1309,17 +1333,6 @@ app <replaceable>application</replaceable> {
 							Score for <application>OpenSC.tokend</application>
 							(Default: <literal>300</literal>).  The tokend with
 							the highest score shall be used.
-					</para></listitem>
-				</varlistentry>
-				<varlistentry>
-					<term>
-						<option>ignore_private_certificate = <replaceable>bool</replaceable>;</option>
-					</term>
-					<listitem><para>
-							Tokend ignore to read PIN protected certificate
-							that is set
-							<literal>SC_PKCS15_CO_FLAG_PRIVATE</literal> flag
-							(Default: <literal>true</literal>).
 					</para></listitem>
 				</varlistentry>
 			</variablelist>

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -873,7 +873,7 @@ app default {
 		# (with certificate check)  where $HOME is not set
 		# Default: path in user home
 		# file_cache_dir = /var/lib/opensc/cache
-                #
+
 		# Use PIN caching?
 		# Default: true
 		# use_pin_caching = false;
@@ -886,7 +886,12 @@ app default {
 		# may need to set this to get signatures to work with some cards.
 		# Default: false
 		# pin_cache_ignore_user_consent = true;
-		#
+
+		# How to handle a PIN-protected certificate
+		# Valid values: protect, declassify, ignore.
+		# Default: ignore in tokend, protect otherwise
+		# private_certificate = declassify;
+
 		# Enable pkcs15 emulation.
 		# Default: yes
 		# enable_pkcs15_emulation = no;

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -488,6 +488,16 @@ sc_pkcs15_decode_cdf_entry(struct sc_pkcs15_card *p15card, struct sc_pkcs15_obje
 	}
 	sc_log(ctx, "Certificate path '%s'", sc_print_path(&info.path));
 
+	switch (p15card->opts.private_certificate) {
+		case SC_PKCS15_CARD_OPTS_PRIV_CERT_DECLASSIFY:
+			sc_log(ctx, "Declassifying certificate");
+			obj->flags &= ~SC_PKCS15_CO_FLAG_PRIVATE;
+			break;
+		case SC_PKCS15_CARD_OPTS_PRIV_CERT_IGNORE:
+			sc_log(ctx, "Ignoring certificate");
+			return 0;
+	}
+
 	obj->type = SC_PKCS15_TYPE_CERT_X509;
 	obj->data = malloc(sizeof(info));
 	if (obj->data == NULL)

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1188,6 +1188,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 	struct sc_context *ctx = card->ctx;
 	scconf_block *conf_block = NULL;
 	int r, emu_first, enable_emu;
+	const char *private_certificate;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx, "application(aid:'%s')", aid ? sc_dump_hex(aid->value, aid->len) : "empty");
@@ -1204,19 +1205,33 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 	p15card->opts.use_pin_cache = 1;
 	p15card->opts.pin_cache_counter = 10;
 	p15card->opts.pin_cache_ignore_user_consent = 0;
+	if(0 == strcmp(ctx->app_name, "tokend")) {
+		private_certificate = "ignore";
+		p15card->opts.private_certificate = SC_PKCS15_CARD_OPTS_PRIV_CERT_IGNORE;
+	} else {
+		private_certificate = "protect";
+		p15card->opts.private_certificate = SC_PKCS15_CARD_OPTS_PRIV_CERT_PROTECT;
+	}
 
 	conf_block = sc_get_conf_block(ctx, "framework", "pkcs15", 1);
-
 	if (conf_block) {
 		p15card->opts.use_file_cache = scconf_get_bool(conf_block, "use_file_caching", p15card->opts.use_file_cache);
 		p15card->opts.use_pin_cache = scconf_get_bool(conf_block, "use_pin_caching", p15card->opts.use_pin_cache);
 		p15card->opts.pin_cache_counter = scconf_get_int(conf_block, "pin_cache_counter", p15card->opts.pin_cache_counter);
-		p15card->opts.pin_cache_ignore_user_consent =  scconf_get_bool(conf_block, "pin_cache_ignore_user_consent",
+		p15card->opts.pin_cache_ignore_user_consent = scconf_get_bool(conf_block, "pin_cache_ignore_user_consent",
 				p15card->opts.pin_cache_ignore_user_consent);
+		private_certificate = scconf_get_str(conf_block, "private_certificate", private_certificate);
 	}
-	sc_log(ctx, "PKCS#15 options: use_file_cache=%d use_pin_cache=%d pin_cache_counter=%d pin_cache_ignore_user_consent=%d",
+	if (0 == strcmp(private_certificate, "protect")) {
+		p15card->opts.private_certificate = SC_PKCS15_CARD_OPTS_PRIV_CERT_PROTECT;
+	} else if (0 == strcmp(private_certificate, "ignore")) {
+		p15card->opts.private_certificate = SC_PKCS15_CARD_OPTS_PRIV_CERT_IGNORE;
+	} else if (0 == strcmp(private_certificate, "declassify")) {
+		p15card->opts.private_certificate = SC_PKCS15_CARD_OPTS_PRIV_CERT_DECLASSIFY;
+	}
+	sc_log(ctx, "PKCS#15 options: use_file_cache=%d use_pin_cache=%d pin_cache_counter=%d pin_cache_ignore_user_consent=%d private_certificate=%d",
 			p15card->opts.use_file_cache, p15card->opts.use_pin_cache,p15card->opts.pin_cache_counter,
-			p15card->opts.pin_cache_ignore_user_consent);
+			p15card->opts.pin_cache_ignore_user_consent, p15card->opts.private_certificate);
 
 	r = sc_lock(card);
 	if (r) {

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -593,6 +593,7 @@ typedef struct sc_pkcs15_card {
 		int use_pin_cache;
 		int pin_cache_counter;
 		int pin_cache_ignore_user_consent;
+		int private_certificate;
 	} opts;
 
 	unsigned int magic;
@@ -612,6 +613,11 @@ typedef struct sc_pkcs15_card {
 
 /* flags suitable for struct sc_pkcs15_card */
 #define SC_PKCS15_CARD_FLAG_EMULATED			0x02000000
+
+/* suitable for struct sc_pkcs15_card.opts.private_certificate */
+#define SC_PKCS15_CARD_OPTS_PRIV_CERT_PROTECT		0
+#define SC_PKCS15_CARD_OPTS_PRIV_CERT_IGNORE		1
+#define SC_PKCS15_CARD_OPTS_PRIV_CERT_DECLASSIFY	2
 
 /* X509 bits for certificate usage extension */
 #define SC_X509_DIGITAL_SIGNATURE     0x0001UL


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/1430

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
