### PR TITLE
tools: release context when card connection fails

### DIFF
--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -1127,7 +1127,7 @@ int main(int argc, char *argv[])
 		}
 		action_count--;
 	}
-      end:
+end:
 	if (card) {
 		sc_unlock(card);
 		sc_disconnect_card(card);

--- a/src/tools/cryptoflex-tool.c
+++ b/src/tools/cryptoflex-tool.c
@@ -1076,6 +1076,8 @@ int main(int argc, char *argv[])
 	}
 
 	err = util_connect_card(ctx, &card, opt_reader, opt_wait, verbose);
+	if (err)
+		goto end;
 	printf("Using card driver: %s\n", card->driver->name);
 
 	if (do_create_pin_file) {

--- a/src/tools/iasecc-tool.c
+++ b/src/tools/iasecc-tool.c
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
 	if (err)
 		goto end;
 
-        if (opt_bind_to_aid)   {
+	if (opt_bind_to_aid)   {
 		struct sc_aid aid;
 
 		aid.len = sizeof(aid.value);

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -876,6 +876,7 @@ int main(int argc, char **argv)
 
 	r = util_connect_card(ctx, &card, opt_reader, opt_wait, verbose);
 	if (r) {
+		sc_release_context(ctx);
 		util_fatal("failed to connect to card: %s", sc_strerror(r));
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
