### PR TITLE
opensc-tool: do not use card driver to read ATR

### DIFF
--- a/src/tools/util.h
+++ b/src/tools/util.h
@@ -45,6 +45,8 @@ const char * util_acl_to_str(const struct sc_acl_entry *e);
 void util_warn(const char *fmt, ...);
 void util_error(const char *fmt, ...);
 NORETURN void util_fatal(const char *fmt, ...);
+
+int util_connect_reader (sc_context_t *ctx, sc_reader_t **reader, const char *reader_id, int do_wait, int verbose);
 /* All singing all dancing card connect routine */
 int util_connect_card_ex(struct sc_context *, struct sc_card **, const char *reader_id, int do_wait, int do_lock, int verbose);
 int util_connect_card(struct sc_context *, struct sc_card **, const char *reader_id, int do_wait, int verbose);


### PR DESCRIPTION
If card driver fails to connect to card, 'opensc-tool -a' may fail to print
ATR even if ATR is available from card reader.  Before use of card driver,
do only card reader connect, then print ATR.  Only if it is neccesary, use
card driver for the rest of opensc-tool functions.  Fixes #1606


