### PR TITLE
Add support for CKA_ALLOWED_MECHANISMS in pkcs11-tool + some more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,7 @@ src/tests/pintest
 src/tests/prngtest
 src/tests/p11test/p11test
 
+tests/*.log
+tests/*.trs
+
 version.m4.ci

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -453,6 +453,17 @@
                                         </listitem>
 				</varlistentry>
 
+                                <varlistentry>
+					<term>
+						<option>--allowed-mechanisms</option> <replaceable>mechanisms</replaceable>
+					</term>
+					<listitem><para>Sets the CKA_ALLOWED_MECHANISMS attribute
+					to a key objects when importing an object or generating
+					a keys. The argument accepts comma-separated list of
+					algorithmsm, that can be used with the given key.</para>
+					</listitem>
+				</varlistentry>
+
 				<varlistentry>
 					<term>
 						<option>--test-ec</option>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,8 @@ dist_noinst_SCRIPTS = test-manpage.sh \
 TESTS = \
 	test-manpage.sh \
         test-pkcs11-tool-sign-verify.sh \
-        test-pkcs11-tool-test.sh
+        test-pkcs11-tool-test.sh \
+        test-pkcs11-tool-allowed-mechanisms.sh
 XFAIL_TESTS = \
-        test-pkcs11-tool-test.sh
+        test-pkcs11-tool-test.sh \
+        test-pkcs11-tool-allowed-mechanisms.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,12 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 dist_noinst_SCRIPTS = test-manpage.sh \
                       test-fuzzing.sh \
+                      test-pkcs11-tool-test.sh \
                       test-pkcs11-tool-sign-verify.sh
 
-TESTS = test-manpage.sh \
-        test-pkcs11-tool-sign-verify.sh
+TESTS = \
+	test-manpage.sh \
+        test-pkcs11-tool-sign-verify.sh \
+        test-pkcs11-tool-test.sh
+XFAIL_TESTS = \
+        test-pkcs11-tool-test.sh

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+## from OpenSC/src/tests/p11test/runtest.sh
+
+SOPIN="12345678"
+PIN="123456"
+PKCS11_TOOL="../src/tools/pkcs11-tool"
+P11LIB="/usr/lib64/pkcs11/libsofthsm2.so"
+
+ERRORS=0
+function assert() {
+	if [[ $1 != 0 ]]; then
+		echo "====> ERROR: $2"
+		ERRORS=1
+	fi
+}
+
+function generate_key() {
+	TYPE="$1"
+	ID="$2"
+	LABEL="$3"
+
+	# Generate key pair
+	$PKCS11_TOOL --keypairgen --key-type="$TYPE" --login --pin=$PIN \
+		--module="$P11LIB" --label="$LABEL" --id=$ID
+
+	if [[ "$?" -ne "0" ]]; then
+		echo "Couldn't generate $TYPE key pair"
+		return 1
+	fi
+
+	# Extract public key from the card
+	$PKCS11_TOOL --read-object --id $ID --type pubkey --output-file $ID.der \
+		--module="$P11LIB"
+
+	# convert it to more digestible PEM format
+	if [[ ${TYPE:0:3} == "RSA" ]]; then
+		openssl rsa -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
+	else
+		openssl ec -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
+	fi
+	rm $ID.der
+}
+
+function card_setup() {
+	echo "directories.tokendir = .tokens/" > .softhsm2.conf
+	mkdir ".tokens"
+	export SOFTHSM2_CONF=".softhsm2.conf"
+	# Init token
+	softhsm2-util --init-token --slot 0 --label "SC test" --so-pin="$SOPIN" --pin="$PIN"
+
+	# Generate 1024b RSA Key pair
+	generate_key "RSA:1024" "01" "RSA_auth"
+	# Generate 2048b RSA Key pair
+	generate_key "RSA:2048" "02" "RSA2048"
+	# Generate 256b ECC Key pair
+	# generate_key "EC:secp256r1" "03" "ECC_auth"
+	# Generate 521b ECC Key pair
+	# generate_key "EC:secp521r1" "04" "ECC521"
+	# TODO ECDSA keys tests
+}
+
+function card_cleanup() {
+	rm .softhsm2.conf
+	rm -rf ".tokens"
+	rm 0{1,2}.pub
+}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -41,12 +41,16 @@ function generate_key() {
 	rm $ID.der
 }
 
-function card_setup() {
+function softhsm_initialize() {
 	echo "directories.tokendir = .tokens/" > .softhsm2.conf
 	mkdir ".tokens"
 	export SOFTHSM2_CONF=".softhsm2.conf"
 	# Init token
 	softhsm2-util --init-token --slot 0 --label "SC test" --so-pin="$SOPIN" --pin="$PIN"
+}
+
+function card_setup() {
+	softhsm_initialize
 
 	# Generate 1024b RSA Key pair
 	generate_key "RSA:1024" "01" "RSA_auth"
@@ -58,8 +62,12 @@ function card_setup() {
 	generate_key "EC:secp521r1" "04" "ECC521"
 }
 
-function card_cleanup() {
+function softhsm_cleanup() {
 	rm .softhsm2.conf
 	rm -rf ".tokens"
+}
+
+function card_cleanup() {
+	softhsm_cleanup
 	rm 0{1,2,3,4}.pub
 }

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -53,14 +53,13 @@ function card_setup() {
 	# Generate 2048b RSA Key pair
 	generate_key "RSA:2048" "02" "RSA2048"
 	# Generate 256b ECC Key pair
-	# generate_key "EC:secp256r1" "03" "ECC_auth"
+	generate_key "EC:secp256r1" "03" "ECC_auth"
 	# Generate 521b ECC Key pair
-	# generate_key "EC:secp521r1" "04" "ECC521"
-	# TODO ECDSA keys tests
+	generate_key "EC:secp521r1" "04" "ECC521"
 }
 
 function card_cleanup() {
 	rm .softhsm2.conf
 	rm -rf ".tokens"
-	rm 0{1,2}.pub
+	rm 0{1,2,3,4}.pub
 }

--- a/tests/test-pkcs11-tool-allowed-mechanisms.sh
+++ b/tests/test-pkcs11-tool-allowed-mechanisms.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+source common.sh
+
+echo "======================================================="
+echo "Setup SoftHSM"
+echo "======================================================="
+if [[ ! -f $P11LIB ]]; then
+    echo "WARNINIG: The SoftHSM is not installed. Can not run this test"
+    exit 77;
+fi
+softhsm_initialize
+# XXX This is broken in currently released SoftHSM
+# P11LIB=/home/jjelen/devel/SoftHSMv2/src/lib/.libs/libsofthsm2.so
+
+echo "======================================================="
+echo "Generate key-pair with CKA_ALLOWED_MECHANISMS"
+echo "======================================================="
+ID="05"
+MECHANISMS="RSA-PKCS,SHA1-RSA-PKCS,RSA-PKCS-PSS"
+# Generate key pair
+$PKCS11_TOOL --keypairgen --key-type="RSA:" --login --pin=$PIN \
+	--module="$P11LIB" --label="test" --id="$ID" \
+	--allowed-mechanisms="$MECHANISMS"
+assert $? "Failed to Generate RSA key pair"
+
+# Check the attributes are visible
+$PKCS11_TOOL --list-objects --login --pin=$PIN \
+	--module="$P11LIB" --id=$ID > objects.list
+assert $? "Failed to list objects"
+grep -q "Allowed mechanisms" objects.list
+assert $? "Allowed mechanisms not in the object list"
+grep -q "$MECHANISMS" objects.list
+assert $? "The $MECHANISMS is not in the list"
+
+# Make sure we are not allowed to use forbidden mechanism
+echo "data to sign (max 100 bytes)" > data
+$PKCS11_TOOL --id $ID -s -p $PIN -m SHA256-RSA-PKCS --module $P11LIB \
+       --input-file data --output-file data.sig &> sign.log
+grep -q CKR_MECHANISM_INVALID sign.log
+assert $? "It was possible to sign using non-allowed mechanism"
+rm -f data{,.sig}
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+softhsm_cleanup
+
+rm objects.list 
+
+exit $ERRORS

--- a/tests/test-pkcs11-tool-sign-verify.sh
+++ b/tests/test-pkcs11-tool-sign-verify.sh
@@ -1,67 +1,6 @@
-## from OpenSC/src/tests/p11test/runtest.sh
-SOPIN="12345678"
-PIN="123456"
-PKCS11_TOOL="../src/tools/pkcs11-tool"
-P11LIB="/usr/lib64/pkcs11/libsofthsm2.so"
+#!/bin/bash
 
-ERRORS=0
-function assert() {
-	if [[ $1 != 0 ]]; then
-		echo "====> ERROR: $2"
-		ERRORS=1
-	fi
-}
-
-function generate_key() {
-	TYPE="$1"
-	ID="$2"
-	LABEL="$3"
-
-	# Generate key pair
-	$PKCS11_TOOL --keypairgen --key-type="$TYPE" --login --pin=$PIN \
-		--module="$P11LIB" --label="$LABEL" --id=$ID
-
-	if [[ "$?" -ne "0" ]]; then
-		echo "Couldn't generate $TYPE key pair"
-		return 1
-	fi
-
-	# Extract public key from the card
-	$PKCS11_TOOL --read-object --id $ID --type pubkey --output-file $ID.der \
-		--module="$P11LIB"
-
-	# convert it to more digestible PEM format
-	if [[ ${TYPE:0:3} == "RSA" ]]; then
-		openssl rsa -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
-	else
-		openssl ec -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
-	fi
-	rm $ID.der
-}
-
-function card_setup() {
-	echo "directories.tokendir = .tokens/" > .softhsm2.conf
-	mkdir ".tokens"
-	export SOFTHSM2_CONF=".softhsm2.conf"
-	# Init token
-	softhsm2-util --init-token --slot 0 --label "SC test" --so-pin="$SOPIN" --pin="$PIN"
-
-	# Generate 1024b RSA Key pair
-	generate_key "RSA:1024" "01" "RSA_auth"
-	# Generate 2048b RSA Key pair
-	generate_key "RSA:2048" "02" "RSA2048"
-	# Generate 256b ECC Key pair
-	# generate_key "EC:secp256r1" "03" "ECC_auth"
-	# Generate 521b ECC Key pair
-	# generate_key "EC:secp521r1" "04" "ECC521"
-	# TODO ECDSA keys tests
-}
-
-function card_cleanup() {
-	rm .softhsm2.conf
-	rm -rf ".tokens"
-	rm 0{1,2}.pub
-}
+source common.sh
 
 echo "======================================================="
 echo "Setup SoftHSM"
@@ -73,6 +12,10 @@ fi
 card_setup
 echo "data to sign (max 100 bytes)" > data
 
+
+echo "======================================================="
+echo "Test"
+echo "======================================================="
 for HASH in "" "SHA1" "SHA224" "SHA256" "SHA384" "SHA512"; do
     for SIGN_KEY in "01" "02"; do
         METHOD="RSA-PKCS"
@@ -171,5 +114,7 @@ echo "======================================================="
 echo "Cleanup"
 echo "======================================================="
 card_cleanup
+
+rm data
 
 exit $ERRORS

--- a/tests/test-pkcs11-tool-test.sh
+++ b/tests/test-pkcs11-tool-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source common.sh
+
+echo "======================================================="
+echo "Setup SoftHSM"
+echo "======================================================="
+if [[ ! -f $P11LIB ]]; then
+    echo "WARNINIG: The SoftHSM is not installed. Can not run this test"
+    exit 77;
+fi
+card_setup
+
+echo "======================================================="
+echo "Test"
+echo "======================================================="
+$PKCS11_TOOL --test -p $PIN --module $P11LIB
+assert $? "Failed running tests"
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+card_cleanup
+
+exit $ERRORS


### PR DESCRIPTION
The CKA_ALLOWED_MECHANISMS PKCS#11 attribute allows to limit the mechanisms that are allowed for the given object. This can be expecially helpful for the RSA-PSS, where we should be able to limit the key only to the PSS mechanisms to prevent key material leakage as much as possible.

This patch-set adds support for creating objects with this attributes in the pkcs11-tool, listing this attribute in the object list (for private keys) and testing it against softhsm, which is now broken on the softhsm side (therefore the new tests are marked as `XFAIL`):

https://github.com/opendnssec/SoftHSMv2/pull/456

This adds a test for #1600 (now marked as failing) and test 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation is added or updated