### PR TITLE
Change u8 *data to const because sc_apdu unsigned char *data is const

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -101,7 +101,7 @@ void sc_format_apdu_cse_lc_le(struct sc_apdu *apdu)
 }
 
 void sc_format_apdu_ex(struct sc_card *card, struct sc_apdu *apdu,
-		u8 ins, u8 p1, u8 p2, u8 *data, size_t datalen, u8 *resp, size_t resplen)
+		u8 ins, u8 p1, u8 p2, const u8 *data, size_t datalen, u8 *resp, size_t resplen)
 {
 	if (!apdu) {
 		return;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -811,11 +811,12 @@ typedef struct sc_context {
  */
 int sc_transmit_apdu(struct sc_card *card, struct sc_apdu *apdu);
 
-void sc_format_apdu(struct sc_card *, struct sc_apdu *, int, int, int, int);
+void sc_format_apdu(struct sc_card *card, struct sc_apdu *apdu,
+		int cse, int ins, int p1, int p2);
 
 void sc_format_apdu_ex(struct sc_card *card, struct sc_apdu *apdu,
 		u8 ins, u8 p1, u8 p2,
-	   	u8 *data, size_t datalen, u8 *resp, size_t resplen);
+		const u8 *data, size_t datalen, u8 *resp, size_t resplen);
 
 int sc_check_apdu(struct sc_card *, const struct sc_apdu *);
 


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
