### PR TITLE
iso7816_read_binary: do not assume that 6282 is returned with data

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -152,10 +152,8 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 	fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(ctx, r, "APDU transmit failed");
-	if (apdu.resplen == 0)
-		LOG_FUNC_RETURN(ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
 
-	r =  sc_check_sw(card, apdu.sw1, apdu.sw2);
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	if (r == SC_ERROR_FILE_END_REACHED)
 		LOG_FUNC_RETURN(ctx, apdu.resplen);
 	LOG_TEST_RET(ctx, r, "Check SW error");


### PR DESCRIPTION
Instead of a double check_sw call in case there is no data, assume
that a SW is properly sent by the card and do not expose
SC_ERROR_FILE_END_REACHED outside of the function
(most probably sc_pkcs15_read_file)

This is to facilitate Estonian eID 2018+ that instead of properly returning
6282 with trunkated data, 9000 is returned and next READ BINARY returns
6b00 (invalid p1/p2). The change should be generally harmless for well-behaving
cards and makes re-mapping 6B00 to 6282 work as expected.

Tested with Estonian eID (2018+)

Change-Id: I7511ab4841d3bcdf8d6f4a37a9315ea4ac569b10

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested

