### PR TITLE
meta: add clang-format formatting configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: ForIndentation
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+AlignAfterOpenBracket: Align
+AlignTrailingComments: true
+
+BreakBeforeBinaryOperators: NonAssignment
+
+MaxEmptyLinesToKeep: 1
+ColumnLimit: 140
+ReflowComments: false
+
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+SortIncludes:    true


### PR DESCRIPTION
This allows for voluntary formatting with clang-format (or
IDE tools like clang-format plugin for VS Code).

Once a suitable formatting configuration is found, automatic formatting
can be configured

This formatting is used to format new files in esteid-2018 branch.
Change-Id: I9021a98fe90c5ef9f21ce7459fdf05fa645fb56c