### PR TITLE
fix sc_bin_to_hex: ckecking for SC_ERROR_BUFFER_TOO_SMALL and SC_ERRO…

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1378,7 +1378,31 @@ const sc_path_t *sc_get_mf_path(void);
 /********************************************************************/
 
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen);
-int sc_bin_to_hex(const u8 *, size_t, char *, size_t, int separator);
+/**
+ * Converts an u8 array to a string representing the input as hexadecimal,
+ * human-readable/printable form. It's the inverse function of sc_hex_to_bin.
+ *
+ * @param in: The u8 array input to be interpreted, may be NULL iff in_len==0
+ * @param in_len: Less or equal to the amount of bytes available from in
+ * @param out: output buffer offered for the string representation, *MUST NOT*
+ *             be NULL and *MUST* be sufficiently sized, see out_len
+ * @param out_len: *MUST* be at least 1 and state the maximum of bytes available
+ *                 within out to be written, including the \0 termination byte
+ *                 that will be written unconditionally
+ * @param separator: The character to be used to separate the u8 string
+ *                   representations. Any value<32 (32 corresponds to ' '
+ *                   i.e. space) will suppress separation
+ * The algorithm will require for out_len (otherwise resulting in an error
+ * SC_ERROR_BUFFER_TOO_SMALL):
+ * 1 (\0 termination byte) + 2*in_len + optional_separation_bytes
+ * opt_separation_bytes = 0  if in_len<=1 or separator<' ',  otherwise
+ * opt_separation_bytes = in_len-1, i.e. there will be no trailing separator
+ * Example: input [0x3f], in_len=1, requiring an out_len>=3, will write to out:
+ * [0x33, 0x66, 0x00] which reads as "3f"
+ * Example: input [0x3f, 0x01], in_len=2, separator=':', req. an out_len>=6,
+ * writes to out: [0x33, 0x66, 0x3A, 0x30, 0x31, 0x00] which reads as "3f:01"
+ */
+int sc_bin_to_hex(const u8 *in, size_t in_len, char *out, size_t out_len, int separator);
 size_t sc_right_trim(u8 *buf, size_t len);
 scconf_block *sc_get_conf_block(sc_context_t *ctx, const char *name1, const char *name2, int priority);
 

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -121,12 +121,16 @@ int sc_bin_to_hex(const u8 *in, size_t in_len, char *out, size_t out_len,
 	unsigned int	n, sep_len;
 	char		*pos, *end, sep;
 
+	if (out == NULL || out_len == 0 ||
+		(in == NULL && in_len > 0))
+		return SC_ERROR_INVALID_ARGUMENTS;
 	sep = (char)in_sep;
-	sep_len = sep > 0 ? 1 : 0;
+	sep_len = sep > 31 ? 1 : 0;
 	pos = out;
+	/* end: position one-past allowed to write to */
 	end = out + out_len;
 	for (n = 0; n < in_len; n++) {
-		if (pos + 3 + sep_len >= end)
+		if (pos + 3 + (n && sep_len ? sep_len : 0) > end)
 			return SC_ERROR_BUFFER_TOO_SMALL;
 		if (n && sep_len)
 			*pos++ = sep;


### PR DESCRIPTION
…R_INVALID_ARGUMENTS

Current code is incorrect regarding 4 issues/corner cases:
1. No error condition checking is done for case in_len==0. Then, with out == NULL, SIGSEGV occurs.

2. With in_len>1, SC_ERROR_BUFFER_TOO_SMALL may occur even if enough memory for out is allocated, depending on out_len passed

3. With in_len==1, SC_ERROR_BUFFER_TOO_SMALL may occur even if enough memory for out is allocated, depending on out_len and in_sep passed

4. Don't separate with nonprintable ASCII characters, thus any separator<' ' should suppress separation, same as it's the case for separate=0 currently

IMHO, at least out_len should be documented.

So far I didn't do testing the way I think the PR template asks for: Build opensc and execute with a card and driver (there still is no internal opensc driver for my card), BUT
the PR results from requirements/testing with diverse input to successfully (and with correct results) call sc_bin_to_hex in libopensc.so from Rust code.
The memory-safe Rust wrapping function around the call to sc_bin_to_hex allocates exactly as many bytes as required for out (depending on the other input arguments), but must cheat out_len (for the call to sc_bin_to_hex) to be sizeof(out) +1 or sizeof(out) +2 (depending on arguments) rather than the correct out_len=sizeof(out), in order to get around wrong SC_ERROR_BUFFER_TOO_SMALL issues.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
