### PR TITLE
optimize bin/hex low parsing level functions

### DIFF
--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -128,6 +128,7 @@ sc_get_version
 sc_hex_dump
 sc_dump_hex
 sc_hex_to_bin
+sc_hex_to_bin_seperators
 sc_list_files
 sc_lock
 sc_logout

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -128,7 +128,6 @@ sc_get_version
 sc_hex_dump
 sc_dump_hex
 sc_hex_to_bin
-sc_hex_to_bin_seperators
 sc_list_files
 sc_lock
 sc_logout

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1377,6 +1377,7 @@ const sc_path_t *sc_get_mf_path(void);
 /*             miscellaneous functions                              */
 /********************************************************************/
 
+extern char *sc_hex_to_bin_seperators;
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen);
 int sc_bin_to_hex(const u8 *, size_t, char *, size_t, int separator);
 size_t sc_right_trim(u8 *buf, size_t len);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1377,11 +1377,6 @@ const sc_path_t *sc_get_mf_path(void);
 /*             miscellaneous functions                              */
 /********************************************************************/
 
-/**
- * NUL terminated string containing all characters that are ignored
- * in the input of `sc_hex_to_bin()`.
- */
-extern char *sc_hex_to_bin_seperators;
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen);
 /**
  * Converts an u8 array to a string representing the input as hexadecimal,

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1377,8 +1377,31 @@ const sc_path_t *sc_get_mf_path(void);
 /*             miscellaneous functions                              */
 /********************************************************************/
 
+/**
+ * NUL terminated string containing all characters that are ignored
+ * in the input of `sc_hex_to_bin()`.
+ */
 extern char *sc_hex_to_bin_seperators;
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen);
+/**
+ * Converts an u8 array to a string representing the input as hexadecimal,
+ * human-readable/printable form. It's the inverse function of sc_hex_to_bin.
+ *
+ * @param in The u8 array input to be interpreted, may be NULL iff in_len==0
+ * @param in_len Less or equal to the amount of bytes available from in
+ * @param out output buffer offered for the string representation, *MUST NOT*
+ *             be NULL and *MUST* be sufficiently sized, see out_len
+ * @param out_len *MUST* be at least 1 and state the maximum of bytes available
+ *                 within out to be written, including the \0 termination byte
+ *                 that will be written unconditionally
+ * @param separator The character to be used to separate the u8 string
+ *                   representations. `0` will suppress separation.
+ *
+ * Example: input [0x3f], in_len=1, requiring an out_len>=3, will write to out:
+ * [0x33, 0x66, 0x00] which reads as "3f"
+ * Example: input [0x3f, 0x01], in_len=2, separator=':', req. an out_len>=6,
+ * writes to out: [0x33, 0x66, 0x3A, 0x30, 0x31, 0x00] which reads as "3f:01"
+ */
 int sc_bin_to_hex(const u8 *, size_t, char *, size_t, int separator);
 size_t sc_right_trim(u8 *buf, size_t len);
 scconf_block *sc_get_conf_block(sc_context_t *ctx, const char *name1, const char *name2, int priority);

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -72,11 +72,11 @@ int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen)
 	int byte_needs_nibble = 0;
 	int r = SC_SUCCESS;
 	size_t left = *outlen;
-	u8 byte;
+	u8 byte = 0;
 	while (*in != '\0' && 0 != left) {
 		char c = *in++;
 		u8 nibble;
-		if ('0' <= c && c <= '9')
+		if      ('0' <= c && c <= '9')
 			nibble = c - '0';
 		else if ('a' <= c && c <= 'f')
 			nibble = c - 'a' + 10;

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -61,10 +61,9 @@ const char *sc_get_version(void)
     return sc_version;
 }
 
-char *sc_hex_to_bin_seperators = " :";
-
 int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen)
 {
+	const char *sc_hex_to_bin_separators = " :";
 	if (in == NULL || out == NULL || outlen == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
@@ -83,7 +82,7 @@ int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen)
 		else if ('A' <= c && c <= 'F')
 			nibble = c - 'A' + 10;
 		else {
-			if (strchr(sc_hex_to_bin_seperators, (int) c))
+			if (strchr(sc_hex_to_bin_separators, (int) c))
 				continue;
 			r = SC_ERROR_INVALID_ARGUMENTS;
 			goto err;
@@ -106,9 +105,9 @@ int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen)
 		goto err;
 	}
 
-	/* skip all trailing seperators to see if we missed something */
+	/* skip all trailing separators to see if we missed something */
 	while (*in != '\0') {
-		if (NULL == strchr(sc_hex_to_bin_seperators, (int) *in))
+		if (NULL == strchr(sc_hex_to_bin_separators, (int) *in))
 			break;
 		in++;
 	}

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -123,24 +123,31 @@ err:
 }
 
 int sc_bin_to_hex(const u8 *in, size_t in_len, char *out, size_t out_len,
-		  int in_sep)
+				  int in_sep)
 {
-	unsigned int	n, sep_len;
-	char		*pos, *end, sep;
-
-	sep = (char)in_sep;
-	sep_len = sep > 0 ? 1 : 0;
-	pos = out;
-	end = out + out_len;
-	for (n = 0; n < in_len; n++) {
-		if (pos + 3 + sep_len >= end)
-			return SC_ERROR_BUFFER_TOO_SMALL;
-		if (n && sep_len)
-			*pos++ = sep;
-		sprintf(pos, "%02x", in[n]);
-		pos += 2;
+	if (in == NULL || out == NULL) {
+		return SC_ERROR_INVALID_ARGUMENTS;
 	}
-	*pos = '\0';
+
+	if (in_sep > 0) {
+		if (out_len < in_len*3 || out_len < 1)
+			return SC_ERROR_BUFFER_TOO_SMALL;
+	} else {
+		if (out_len < in_len*2 + 1)
+			return SC_ERROR_BUFFER_TOO_SMALL;
+	}
+
+	const char hex[] = "0123456789abcdef";
+	while (in_len) {
+		unsigned char value = *in++;
+		*out++ = hex[(value >> 4) & 0xF];
+		*out++ = hex[ value       & 0xF];
+		in_len--;
+		if (in_len && in_sep > 0)
+			*out++ = (char)in_sep;
+	}
+	*out = '\0';
+
 	return SC_SUCCESS;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
