### PR TITLE
Remove unused SC_PKCS15EMU_FLAGS_NO_CHECK flag

### DIFF
--- a/src/libopensc/pkcs15-actalis.c
+++ b/src/libopensc/pkcs15-actalis.c
@@ -320,12 +320,7 @@ int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t * p15card,
 				 struct sc_aid *aid,
 				 sc_pkcs15emu_opt_t * opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_actalis_init(p15card);
-	else {
-		int r = actalis_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_actalis_init(p15card);
-	}
+	if (actalis_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_actalis_init(p15card);
 }

--- a/src/libopensc/pkcs15-atrust-acos.c
+++ b/src/libopensc/pkcs15-atrust-acos.c
@@ -269,13 +269,7 @@ int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,
 				  struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
-
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_atrust_acos_init(p15card);
-	else {
-		int r = acos_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_atrust_acos_init(p15card);
-	}
+	if (acos_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_atrust_acos_init(p15card);
 }

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -450,12 +450,7 @@ int sc_pkcs15emu_cac_init_ex(sc_pkcs15_card_t *p15card,
 
 	LOG_FUNC_CALLED(ctx);
 
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_cac_init(p15card);
-	else {
-		int r = cac_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_cac_init(p15card);
-	}
+	if (cac_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_cac_init(p15card);
 }

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -724,14 +724,10 @@ sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,
 
 	LOG_FUNC_CALLED(ctx);
 
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		rv = sc_pkcs15emu_coolkey_init(p15card);
-	else {
-		rv = coolkey_detect_card(p15card);
-		if (rv)
-			LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_CARD);
-		rv = sc_pkcs15emu_coolkey_init(p15card);
-	}
+	rv = coolkey_detect_card(p15card);
+	if (rv)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_CARD);
+	rv = sc_pkcs15emu_coolkey_init(p15card);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }

--- a/src/libopensc/pkcs15-din-66291.c
+++ b/src/libopensc/pkcs15-din-66291.c
@@ -267,10 +267,8 @@ int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid
     SC_FUNC_CALLED(p15card->card->ctx, 1);
 
     /* Check card */
-    if (!(opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
-        if (!din_66291_match_p15card(p15card, aid))
-            return SC_ERROR_WRONG_CARD;
-    }
+	if (!din_66291_match_p15card(p15card, aid))
+		return SC_ERROR_WRONG_CARD;
 
     /* Init card */
     return sc_pkcs15emu_din_66291_init(p15card);

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -282,9 +282,6 @@ int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t * p15card,
 	LOG_FUNC_CALLED(ctx);
 
 #if defined(ENABLE_OPENSSL) && defined(ENABLE_SM)
-	/* if no check flag execute unconditionally */
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		LOG_FUNC_RETURN(ctx, sc_pkcs15emu_dnie_init(p15card));
 	/* check for proper card */
 	r = dnie_match_card(p15card->card);
 	if (r == 0)

--- a/src/libopensc/pkcs15-esinit.c
+++ b/src/libopensc/pkcs15-esinit.c
@@ -84,12 +84,7 @@ int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *p15card,
 {
 	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_entersafe_init(p15card);
-	else {
-		int r = entersafe_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_entersafe_init(p15card);
-	}
+	if (entersafe_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_entersafe_init(p15card);
 }

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -215,8 +215,6 @@ int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *p15card,
 				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_esteid_init(p15card);
 	if (p15card->card->type == SC_CARD_TYPE_MCRD_ESTEID_V30)
 		return sc_pkcs15emu_esteid_init(p15card);
 	return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -517,12 +517,7 @@ int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *ai
 
 	sc_log(ctx,  "Entering %s", __FUNCTION__);
 
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_gemsafeGPK_init(p15card);
-	else {
-		int r = gemsafe_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_gemsafeGPK_init(p15card);
-	}
+	if (gemsafe_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_gemsafeGPK_init(p15card);
 }

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -441,14 +441,9 @@ int sc_pkcs15emu_gemsafeV1_init_ex( sc_pkcs15_card_t *p15card,
 			struct sc_aid *aid,
 			sc_pkcs15emu_opt_t *opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_gemsafeV1_init(p15card);
-	else {
-		int r = gemsafe_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_gemsafeV1_init(p15card);
-	}
+	if (gemsafe_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_gemsafeV1_init(p15card);
 }
 
 static sc_pkcs15_df_t *

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -233,14 +233,10 @@ int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
 				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
-	if (opts && (opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
-		return sc_pkcs15emu_gids_init(p15card);
-	} else {
-		if (p15card->card->type != SC_CARD_TYPE_GIDS_GENERIC && p15card->card->type != SC_CARD_TYPE_GIDS_V1 && p15card->card->type != SC_CARD_TYPE_GIDS_V2) {
-			return SC_ERROR_WRONG_CARD;
-		}
-		return sc_pkcs15emu_gids_init(p15card);
+	if (p15card->card->type != SC_CARD_TYPE_GIDS_GENERIC && p15card->card->type != SC_CARD_TYPE_GIDS_V1 && p15card->card->type != SC_CARD_TYPE_GIDS_V2) {
+		return SC_ERROR_WRONG_CARD;
 	}
+	return sc_pkcs15emu_gids_init(p15card);
 }
 
 #else

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -204,9 +204,6 @@ sc_pkcs15emu_iasecc_init (struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 int
 sc_pkcs15emu_iasecc_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid, struct sc_pkcs15emu_opt *opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_iasecc_init(p15card, aid);
-
 	if (iasecc_pkcs15emu_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;
 

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -869,14 +869,12 @@ int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
 	SC_FUNC_CALLED(card->ctx, 1);
 
 	/* Check card */
-	if (!(opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
-		if (! (
-				(card->type > SC_CARD_TYPE_ITACNS_BASE &&
-				card->type < SC_CARD_TYPE_ITACNS_BASE + 1000)
-			|| card->type == SC_CARD_TYPE_CARDOS_CIE_V1)
-			)
-			return SC_ERROR_WRONG_CARD;
-	}
+	if (! (
+			(card->type > SC_CARD_TYPE_ITACNS_BASE &&
+			card->type < SC_CARD_TYPE_ITACNS_BASE + 1000)
+		|| card->type == SC_CARD_TYPE_CARDOS_CIE_V1)
+		)
+		return SC_ERROR_WRONG_CARD;
 
 	/* Init card */
 	return itacns_init(p15card);

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -226,13 +226,7 @@ int
 sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t * p15card,
 			  struct sc_aid *aid, sc_pkcs15emu_opt_t * opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK) {
-		return sc_pkcs15emu_jpki_init(p15card);
-	}
-	else {
-		if (p15card->card->type != SC_CARD_TYPE_JPKI_BASE)
-			return SC_ERROR_WRONG_CARD;
-
-		return sc_pkcs15emu_jpki_init(p15card);
-	}
+	if (p15card->card->type != SC_CARD_TYPE_JPKI_BASE)
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_jpki_init(p15card);
 }

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -1055,14 +1055,9 @@ sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card, struct sc_aid *ai
 	int rv;
 
 	LOG_FUNC_CALLED(p15card->card->ctx);
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)   {
+	rv = oberthur_detect_card(p15card);
+	if (!rv)
 		rv = sc_pkcs15emu_oberthur_init(p15card);
-	}
-	else {
-		rv = oberthur_detect_card(p15card);
-		if (!rv)
-			rv = sc_pkcs15emu_oberthur_init(p15card);
-	}
 
 	LOG_FUNC_RETURN(p15card->card->ctx, rv);
 }

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -465,12 +465,7 @@ static int openpgp_detect_card(sc_pkcs15_card_t *p15card)
 int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
 				 sc_pkcs15emu_opt_t *opts)
 {
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_openpgp_init(p15card);
-	else {
-		int r = openpgp_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_openpgp_init(p15card);
-	}
+	if (openpgp_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_openpgp_init(p15card);
 }

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -1212,12 +1212,7 @@ int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_piv_init(p15card);
-	else {
-		int r = piv_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_piv_init(p15card);
-	}
+	if (piv_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_piv_init(p15card);
 }

--- a/src/libopensc/pkcs15-pteid.c
+++ b/src/libopensc/pkcs15-pteid.c
@@ -346,9 +346,6 @@ int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid, sc
 	sc_context_t *ctx = p15card->card->ctx;
 	LOG_FUNC_CALLED(ctx);
 
-	/* if no check flag execute unconditionally */
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		LOG_FUNC_RETURN(ctx, sc_pkcs15emu_pteid_init(p15card));
 	/* check for proper card */
 	r = pteid_detect_card(p15card->card);
 	if (r == SC_ERROR_WRONG_CARD)

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -1034,14 +1034,10 @@ int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *p15card,
 				struct sc_aid *aid,
 				sc_pkcs15emu_opt_t *opts)
 {
-	if (opts && (opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)) {
-		return sc_pkcs15emu_sc_hsm_init(p15card);
-	} else {
-		if (p15card->card->type != SC_CARD_TYPE_SC_HSM
-				&& p15card->card->type != SC_CARD_TYPE_SC_HSM_SOC
-				&& p15card->card->type != SC_CARD_TYPE_SC_HSM_GOID) {
-			return SC_ERROR_WRONG_CARD;
-		}
-		return sc_pkcs15emu_sc_hsm_init(p15card);
+	if (p15card->card->type != SC_CARD_TYPE_SC_HSM
+			&& p15card->card->type != SC_CARD_TYPE_SC_HSM_SOC
+			&& p15card->card->type != SC_CARD_TYPE_SC_HSM_GOID) {
+		return SC_ERROR_WRONG_CARD;
 	}
+	return sc_pkcs15emu_sc_hsm_init(p15card);
 }

--- a/src/libopensc/pkcs15-starcert.c
+++ b/src/libopensc/pkcs15-starcert.c
@@ -276,13 +276,7 @@ int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *p15card,
 				  struct sc_aid *aid,
 				  sc_pkcs15emu_opt_t *opts)
 {
-
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_starcert_init(p15card);
-	else {
-		int r = starcert_detect_card(p15card);
-		if (r)
-			return SC_ERROR_WRONG_CARD;
-		return sc_pkcs15emu_starcert_init(p15card);
-	}
+	if (starcert_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+	return sc_pkcs15emu_starcert_init(p15card);
 }

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -499,11 +499,10 @@ int sc_pkcs15emu_tcos_init_ex(
 	sc_context_t      *ctx = p15card->card->ctx;
 	sc_serial_number_t serialnr;
 	char               serial[30];
-	int i, r;
+	int r;
 
 	/* check if we have the correct card OS unless SC_PKCS15EMU_FLAGS_NO_CHECK */
-	i=(opts && (opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK));
-	if (!i && card->type!=SC_CARD_TYPE_TCOS_V2 && card->type!=SC_CARD_TYPE_TCOS_V3) return SC_ERROR_WRONG_CARD;
+	if (card->type!=SC_CARD_TYPE_TCOS_V2 && card->type!=SC_CARD_TYPE_TCOS_V3) return SC_ERROR_WRONG_CARD;
 
 	/* get the card serial number */
 	r = sc_card_ctl(card, SC_CARDCTL_GET_SERIALNR, &serialnr);

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -253,8 +253,6 @@ int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t * p15card,
 	sc_context_t *ctx = card->ctx;
 	sc_log(ctx, 
 		"sc_pkcs15_init_func_ex westcos\n");
-	if (opts && opts->flags & SC_PKCS15EMU_FLAGS_NO_CHECK)
-		return sc_pkcs15emu_westcos_init(p15card);
 	r = westcos_detect_card(p15card);
 	if (r)
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -1009,8 +1009,6 @@ typedef struct sc_pkcs15emu_opt {
 	unsigned int flags;
 } sc_pkcs15emu_opt_t;
 
-#define SC_PKCS15EMU_FLAGS_NO_CHECK	0x00000001
-
 extern int sc_pkcs15_bind_synthetic(struct sc_pkcs15_card *, struct sc_aid *);
 extern int sc_pkcs15_is_emulation_only(sc_card_t *);
 


### PR DESCRIPTION
Fixes #1634

Signed-off-by: Raul Metsma <raul@metsma.ee>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
