### PR TITLE
Bump Openssl and clean up openssl requirements up to 1.0.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ define([VS_FF_PRODUCT_URL], [https://github.com/OpenSC/OpenSC])
 
 m4_sinclude(version.m4.ci)
 
+m4_define([openssl_minimum_version], [1.0.1])
+
 AC_INIT([PRODUCT_NAME],[PACKAGE_VERSION_MAJOR.PACKAGE_VERSION_MINOR.PACKAGE_VERSION_FIX[]PACKAGE_SUFFIX],[PRODUCT_BUGREPORT],[PRODUCT_TARNAME],[PRODUCT_URL])
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_HEADERS([config.h])
@@ -630,7 +632,7 @@ fi
 
 PKG_CHECK_MODULES(
 	[OPENSSL],
-	[libcrypto >= 0.9.8],
+	[libcrypto >= openssl_minimum_version],
 	[have_openssl="yes"],
 	[AC_CHECK_LIB(
 		[crypto],

--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -31,6 +31,10 @@
 #include "sm/sm-eac.h"
 #include <string.h>
 
+#ifdef ENABLE_OPENSSL
+#include <openssl/evp.h>
+#endif
+
 static int fread_to_eof(const char *file, unsigned char **buf, size_t *buflen);
 #include "../tools/fread_to_eof.c"
 
@@ -603,10 +607,6 @@ static int npa_standard_pin_cmd(struct sc_card *card,
 	return r;
 }
 
-#ifdef ENABLE_OPENSSL
-#include <openssl/evp.h>
-#endif
-
 int
 npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 		int ask_for_secret, const char *new, size_t new_len)
@@ -617,7 +617,7 @@ npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 
 	if (ask_for_secret && (!new || !new_len)) {
 		if (!(SC_READER_CAP_PIN_PAD & card->reader->capabilities)) {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#ifdef ENABLE_OPENSSL
 			p = malloc(EAC_MAX_PIN_LEN+1);
 			if (!p) {
 				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Not enough memory for new PIN.\n");

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -36,10 +36,8 @@
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-	#ifndef OPENSSL_NO_EC
-	#include <openssl/ec.h>
-	#endif
+#ifndef OPENSSL_NO_EC
+#include <openssl/ec.h>
 #endif
 #endif
 
@@ -678,7 +676,7 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 		DSA_free(src);
 		break;
 		}
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 	case NID_id_GostR3410_2001: {
 		struct sc_pkcs15_prkey_gostr3410 *dst = &pkcs15_key->u.gostr3410;
 		EC_KEY *src = EVP_PKEY_get0(pk);
@@ -755,7 +753,7 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 
 		break;
 	}
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC) */
+#endif /* !defined(OPENSSL_NO_EC) */
 	default:
 		return SC_ERROR_NOT_SUPPORTED;
 	}

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -40,10 +40,8 @@
 #include <openssl/dsa.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #ifndef OPENSSL_NO_EC
 #include <openssl/ec.h>
-#endif
 #endif
 #endif
 
@@ -1611,7 +1609,7 @@ sc_pkcs15_convert_pubkey(struct sc_pkcs15_pubkey *pkcs15_key, void *evp_key)
 		DSA_free(src);
 		break;
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 	case NID_id_GostR3410_2001: {
 		struct sc_pkcs15_pubkey_gostr3410 *dst = &pkcs15_key->u.gostr3410;
 		EC_KEY *eckey = EVP_PKEY_get0(pk);
@@ -1692,7 +1690,7 @@ sc_pkcs15_convert_pubkey(struct sc_pkcs15_pubkey *pkcs15_key, void *evp_key)
 
 		break;
 	}
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC) */
+#endif /* !defined(OPENSSL_NO_EC) */
 	default:
 		return SC_ERROR_NOT_SUPPORTED;
 	}

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -56,9 +56,7 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/pem.h>
-#endif
 #endif
 
 #ifdef ENABLE_OPENPACE
@@ -2475,7 +2473,7 @@ done:
 static DWORD
 md_pkcs15_store_key(PCARD_DATA pCardData, DWORD idx, DWORD key_type, BYTE *blob, DWORD blob_size, PIN_ID PinId)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#ifdef ENABLE_OPENSSL
 	VENDOR_SPECIFIC *vs;
 	struct sc_card *card = NULL;
 	struct sc_profile *profile = NULL;
@@ -2610,7 +2608,7 @@ done:
 #else
 	logprintf(pCardData, 1, "MD store key not supported\n");
 	return SCARD_E_UNSUPPORTED_FEATURE;
-#endif
+#endif /* ENABLE_OPENSSL */
 }
 
 

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -29,7 +29,6 @@
 #include <openssl/rsa.h>
 #include <openssl/opensslv.h>
 #include <openssl/x509.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/conf.h>
 #include <openssl/opensslconf.h> /* for OPENSSL_NO_* */
 #include "libopensc/sc-ossl-compat.h"
@@ -41,7 +40,6 @@
 #endif /* OPENSSL_NO_ENGINE */
 #include <openssl/asn1.h>
 #include <openssl/crypto.h>
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L */
 
 #include "sc-pkcs11.h"
 
@@ -147,7 +145,6 @@ static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 	NULL,			/* free_mech_data */
 };
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	CKM_GOSTR3411,
 	{ 0, 0, CKF_DIGEST },
@@ -166,7 +163,6 @@ static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
 };
-#endif
 
 static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 	CKM_MD5,
@@ -217,7 +213,7 @@ static void * dup_mem(void *in, size_t in_len)
 void
 sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE)
+#if !defined(OPENSSL_NO_ENGINE)
 	ENGINE *e;
 /* crypto locking removed in 1.1 */
 #if OPENSSL_VERSION_NUMBER  < 0x10100000L
@@ -261,7 +257,7 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 	if (locking_cb)
 		CRYPTO_set_locking_callback(locking_cb);
 #endif
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_ENGINE) */
+#endif /* !defined(OPENSSL_NO_ENGINE) */
 
 	openssl_sha1_mech.mech_data = EVP_sha1();
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
@@ -277,10 +273,8 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
 	openssl_ripemd160_mech.mech_data = EVP_ripemd160();
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
 	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));
-#endif
 }
 
 
@@ -349,7 +343,7 @@ static void sc_pkcs11_openssl_md_release(sc_pkcs11_operation_t *op)
 	}
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 
 static void reverse(unsigned char *buf, size_t len)
 {
@@ -434,7 +428,7 @@ static CK_RV gostr3410_verify_data(const unsigned char *pubkey, unsigned int pub
 		return CKR_GENERAL_ERROR;
 	return ret_vrf == 1 ? CKR_OK : CKR_SIGNATURE_INVALID;
 }
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC) */
+#endif /* !defined(OPENSSL_NO_EC) */
 
 /* If no hash function was used, finish with RSA_public_decrypt().
  * If a hash function was used, we can make a big shortcut by
@@ -453,7 +447,7 @@ CK_RV sc_pkcs11_verify_data(const unsigned char *pubkey, unsigned int pubkey_len
 
 	if (mech->mechanism == CKM_GOSTR3410)
 	{
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		return gostr3410_verify_data(pubkey, pubkey_len,
 				pubkey_params, pubkey_params_len,
 				data, data_len, signat, signat_len);

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -35,10 +35,8 @@
 
 #include <openssl/opensslv.h>
 #include "libopensc/sc-ossl-compat.h"
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/opensslconf.h>
 #include <openssl/crypto.h>
-#endif
 #include <openssl/conf.h>
 
 #include <openssl/evp.h>

--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -33,10 +33,8 @@
 
 /* Module only built if OPENSSL is enabled */
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/opensslconf.h>
 #include <openssl/crypto.h>
-#endif
 #include <openssl/conf.h>
 
 #include <openssl/rsa.h>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -36,10 +36,8 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/opensslconf.h>
 #include <openssl/crypto.h>
-#endif
 #include <openssl/conf.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
@@ -2838,7 +2836,7 @@ parse_rsa_pkey(EVP_PKEY *pkey, int private, struct rsakey_info *rsa)
 	return 0;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 static int
 parse_gost_pkey(EVP_PKEY *pkey, int private, struct gostkey_info *gost)
 {
@@ -3055,7 +3053,7 @@ static int write_object(CK_SESSION_HANDLE session)
 		if (pk_type == EVP_PKEY_RSA)   {
 			rv = parse_rsa_pkey(evp_key, is_private, &rsa);
 		}
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		else if (pk_type == NID_id_GostR3410_2001)   {
 			rv = parse_gost_pkey(evp_key, is_private, &gost);
 			type = CKK_GOSTR3410;
@@ -3183,7 +3181,7 @@ static int write_object(CK_SESSION_HANDLE session)
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_COEFFICIENT, rsa.coefficient, rsa.coefficient_len);
 			n_privkey_attr++;
 		}
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		else if (pk_type == EVP_PKEY_EC)   {
 			type = CKK_EC;
 
@@ -3218,7 +3216,7 @@ static int write_object(CK_SESSION_HANDLE session)
 		pk_type = EVP_PKEY_base_id(evp_key);
 		if (pk_type == EVP_PKEY_RSA)
 			type = CKK_RSA;
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		else if (pk_type == EVP_PKEY_EC)
 			type = CKK_EC;
 		else if (pk_type == NID_id_GostR3410_2001)
@@ -3283,7 +3281,7 @@ static int write_object(CK_SESSION_HANDLE session)
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_PUBLIC_EXPONENT, rsa.public_exponent, rsa.public_exponent_len);
 			n_pubkey_attr++;
 		}
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		else if (pk_type == EVP_PKEY_EC)   {
 			type = CKK_EC;
 
@@ -4437,7 +4435,7 @@ static int read_object(CK_SESSION_HANDLE session)
 			if (!i2d_RSA_PUBKEY_bio(pout, rsa))
 				util_fatal("cannot convert RSA public key to DER");
 			RSA_free(rsa);
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 		} else if (type == CKK_EC) {
 			EC_KEY *ec;
 			CK_BYTE *params;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -50,13 +50,11 @@
 #include <openssl/bn.h>
 #include <openssl/pkcs12.h>
 #include <openssl/x509v3.h>
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h> /* for OPENSSL_NO_EC */
 #ifndef OPENSSL_NO_EC
 #include <openssl/ec.h>
 #endif /* OPENSSL_NO_EC */
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10000000L */
 
 #include "common/compat_strlcpy.h"
 #include "libopensc/internal.h"
@@ -1874,7 +1872,7 @@ static int init_skeyargs(struct sc_pkcs15init_skeyargs *args)
 static void
 init_gost_params(struct sc_pkcs15init_keyarg_gost_params *params, EVP_PKEY *pkey)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC)
 	EC_KEY *key;
 
 	assert(pkey);


### PR DESCRIPTION
Everything older than 1.0.2 is not longer supported by the OpenSSL team, so this patchset bumps the OpenSSL requirement up to version 1.0.1, due to Ubuntu 14.04 (and our travis) still coming with this version.