### PR TITLE
Remove unused sc_pkcs15emu_opt_t structure

### DIFF
--- a/src/libopensc/pkcs15-actalis.c
+++ b/src/libopensc/pkcs15-actalis.c
@@ -37,8 +37,6 @@
 #include "libopensc/pkcs15.h"
 #include "libopensc/log.h"
 
-int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
 static int (*set_security_env) (sc_card_t *, const sc_security_env_t *, int);
 
 static int set_sec_env(sc_card_t * card, const sc_security_env_t *env,
@@ -317,8 +315,7 @@ static int actalis_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t * p15card,
-				 struct sc_aid *aid,
-				 sc_pkcs15emu_opt_t * opts)
+				 struct sc_aid *aid)
 {
 	if (actalis_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-atrust-acos.c
+++ b/src/libopensc/pkcs15-atrust-acos.c
@@ -34,8 +34,6 @@
 #define MANU_ID		"A-Trust"
 #define CARD_LABEL	"a.sign Premium a"
 
-int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *, struct sc_aid *aid, sc_pkcs15emu_opt_t *);
-
 typedef struct cdata_st {
 	const char *label;
 	int	    authority;
@@ -266,8 +264,7 @@ static int sc_pkcs15emu_atrust_acos_init(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,
-				  struct sc_aid *aid,
-				  sc_pkcs15emu_opt_t *opts)
+				  struct sc_aid *aid)
 {
 	if (acos_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -45,9 +45,6 @@
 /* probably should get manufacturer ID from cuid */
 #define MANU_ID		"Common Access Card"
 
-int sc_pkcs15emu_cac_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
-
 
 typedef struct pdata_st {
 	const char *id;
@@ -443,7 +440,7 @@ fail:
 }
 
 int sc_pkcs15emu_cac_init_ex(sc_pkcs15_card_t *p15card,
-		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
+		struct sc_aid *aid)
 {
 	sc_card_t   *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -41,9 +41,6 @@
 #include "pkcs15.h"
 #include "../pkcs11/pkcs11.h"
 
-int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
-
 typedef struct pdata_st {
 	const char *id;
 	const char *label;
@@ -716,7 +713,7 @@ fail:
 
 int
 sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,
-		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
+		struct sc_aid *aid)
 {
 	sc_card_t      *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;

--- a/src/libopensc/pkcs15-din-66291.c
+++ b/src/libopensc/pkcs15-din-66291.c
@@ -258,8 +258,7 @@ sc_pkcs15emu_din_66291_init(sc_pkcs15_card_t *p15card)
     return SC_SUCCESS;
 }
 
-int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
-        sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
     if (!p15card || ! p15card->card)
         return SC_ERROR_INVALID_ARGUMENTS;
@@ -267,8 +266,8 @@ int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid
     SC_FUNC_CALLED(p15card->card->ctx, 1);
 
     /* Check card */
-	if (!din_66291_match_p15card(p15card, aid))
-		return SC_ERROR_WRONG_CARD;
+    if (!din_66291_match_p15card(p15card, aid))
+        return SC_ERROR_WRONG_CARD;
 
     /* Init card */
     return sc_pkcs15emu_din_66291_init(p15card);

--- a/src/libopensc/pkcs15-dnie.c
+++ b/src/libopensc/pkcs15-dnie.c
@@ -274,8 +274,7 @@ static int sc_pkcs15emu_dnie_init(sc_pkcs15_card_t * p15card)
 /* public functions for in-built module */
 /****************************************/
 int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t * p15card,
-			      struct sc_aid *aid,
-			      sc_pkcs15emu_opt_t * opts)
+				  struct sc_aid *aid)
 {
 	int r=SC_SUCCESS;
 	sc_context_t *ctx = p15card->card->ctx;

--- a/src/libopensc/pkcs15-esinit.c
+++ b/src/libopensc/pkcs15-esinit.c
@@ -29,8 +29,6 @@
 
 #define MANU_ID		"entersafe"
 
-int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
 static int entersafe_detect_card( sc_pkcs15_card_t *p15card)
 {
 	sc_card_t *card = p15card->card;
@@ -79,8 +77,7 @@ static int sc_pkcs15emu_entersafe_init( sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *p15card,
-				   struct sc_aid *aid,
-				  sc_pkcs15emu_opt_t *opts)
+				   struct sc_aid *aid)
 {
 	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
 

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -211,9 +211,7 @@ sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 	return SC_SUCCESS;
 }
 
-int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *p15card,
-				struct sc_aid *aid,
-				sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	if (p15card->card->type == SC_CARD_TYPE_MCRD_ESTEID_V30)
 		return sc_pkcs15emu_esteid_init(p15card);

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -35,8 +35,6 @@
 
 #define MANU_ID		"GemSAFE on GPK16000"
 
-int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
 static int (*pin_cmd_save)(struct sc_card *, struct sc_pin_cmd_data *, 
 		int *tries_left);
 
@@ -509,8 +507,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 	return SC_SUCCESS;
 }
 
-int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
-				  sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	sc_card_t   *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -40,8 +40,6 @@
 #define GEMSAFE_READ_QUANTUM    248
 #define GEMSAFE_MAX_OBJLEN      28672
 
-int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *, struct sc_aid *,sc_pkcs15emu_opt_t *);
-
 static int
 sc_pkcs15emu_add_cert(sc_pkcs15_card_t *p15card,
 	int type, int authority,
@@ -438,8 +436,7 @@ static int sc_pkcs15emu_gemsafeV1_init( sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_gemsafeV1_init_ex( sc_pkcs15_card_t *p15card,
-			struct sc_aid *aid,
-			sc_pkcs15emu_opt_t *opts)
+			struct sc_aid *aid)
 {
 	if (gemsafe_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -230,8 +230,7 @@ static int sc_pkcs15emu_gids_init (sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
-				struct sc_aid *aid,
-				sc_pkcs15emu_opt_t *opts)
+				struct sc_aid *aid)
 {
 	if (p15card->card->type != SC_CARD_TYPE_GIDS_GENERIC && p15card->card->type != SC_CARD_TYPE_GIDS_V1 && p15card->card->type != SC_CARD_TYPE_GIDS_V2) {
 		return SC_ERROR_WRONG_CARD;
@@ -242,8 +241,7 @@ int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
 #else
 
 int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *p15card,
-				struct sc_aid *aid,
-				sc_pkcs15emu_opt_t *opts)
+				struct sc_aid *aid)
 {
 	return SC_ERROR_WRONG_CARD;
 }

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -202,7 +202,7 @@ sc_pkcs15emu_iasecc_init (struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 
 
 int
-sc_pkcs15emu_iasecc_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid, struct sc_pkcs15emu_opt *opts)
+sc_pkcs15emu_iasecc_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 {
 	if (iasecc_pkcs15emu_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -52,8 +52,6 @@
 #include <openssl/x509v3.h>
 #endif
 
-int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
 static const char path_serial[] = "10001003";
 
 /* Manufacturers */
@@ -862,8 +860,7 @@ static int itacns_init(sc_pkcs15_card_t *p15card)
 	return r;
 }
 
-int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
-		sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	sc_card_t *card = p15card->card;
 	SC_FUNC_CALLED(card->ctx, 1);

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -33,9 +33,6 @@
 #include "pkcs15.h"
 #include "jpki.h"
 
-int sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t *, struct sc_aid *,
-		sc_pkcs15emu_opt_t *);
-
 static int
 sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 {
@@ -224,7 +221,7 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 
 int
 sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t * p15card,
-			  struct sc_aid *aid, sc_pkcs15emu_opt_t * opts)
+			  struct sc_aid *aid)
 {
 	if (p15card->card->type != SC_CARD_TYPE_JPKI_BASE)
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -92,8 +92,6 @@ static int sc_pkcs15emu_oberthur_add_pubkey(struct sc_pkcs15_card *, unsigned, u
 static int sc_pkcs15emu_oberthur_add_cert(struct sc_pkcs15_card *, unsigned);
 static int sc_pkcs15emu_oberthur_add_data(struct sc_pkcs15_card *, unsigned, unsigned, int);
 
-int sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card *, struct sc_aid *, struct sc_pkcs15emu_opt *);
-
 static int sc_oberthur_parse_tokeninfo (struct sc_pkcs15_card *, unsigned char *, size_t, int);
 static int sc_oberthur_parse_containers (struct sc_pkcs15_card *, unsigned char *, size_t, int);
 static int sc_oberthur_parse_publicinfo (struct sc_pkcs15_card *, unsigned char *, size_t, int);
@@ -1049,8 +1047,7 @@ oberthur_detect_card(struct sc_pkcs15_card * p15card)
 
 
 int
-sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card, struct sc_aid *aid,
-				   struct sc_pkcs15emu_opt * opts)
+sc_pkcs15emu_oberthur_init_ex(struct sc_pkcs15_card * p15card, struct sc_aid *aid)
 {
 	int rv;
 

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -33,7 +33,6 @@
 #include "pkcs15.h"
 #include "log.h"
 
-int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 static int sc_pkcs15emu_openpgp_add_data(sc_pkcs15_card_t *);
 
 
@@ -462,8 +461,7 @@ static int openpgp_detect_card(sc_pkcs15_card_t *p15card)
 		return SC_ERROR_WRONG_CARD;
 }
 
-int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid,
-				 sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	if (openpgp_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -40,8 +40,6 @@
 
 #define MANU_ID		"piv_II "
 
-int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *, struct sc_aid *aid, sc_pkcs15emu_opt_t *);
-
 typedef struct objdata_st {
 	const char *id;
 	const char *label;
@@ -1205,7 +1203,7 @@ sc_log(card->ctx,  "DEE Adding pin %d label=%s",i, label);
 }
 
 int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,
-		struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
+		struct sc_aid *aid)
 {
 	sc_card_t   *card = p15card->card;
 	sc_context_t    *ctx = card->ctx;

--- a/src/libopensc/pkcs15-pteid.c
+++ b/src/libopensc/pkcs15-pteid.c
@@ -49,7 +49,6 @@
 #include "pkcs15.h"
 
 static int pteid_detect_card(struct sc_card *card);
-int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
 
 static
 int dump_ef(sc_card_t * card, const char *path, u8 * buf, size_t * buf_len)
@@ -340,7 +339,7 @@ static int pteid_detect_card(struct sc_card *card)
 	return SC_ERROR_WRONG_CARD;
 }
 
-int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid, sc_pkcs15emu_opt_t *opts)
+int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	int r=SC_SUCCESS;
 	sc_context_t *ctx = p15card->card->ctx;

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -1031,8 +1031,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 
 
 int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *p15card,
-				struct sc_aid *aid,
-				sc_pkcs15emu_opt_t *opts)
+				struct sc_aid *aid)
 {
 	if (p15card->card->type != SC_CARD_TYPE_SC_HSM
 			&& p15card->card->type != SC_CARD_TYPE_SC_HSM_SOC

--- a/src/libopensc/pkcs15-starcert.c
+++ b/src/libopensc/pkcs15-starcert.c
@@ -33,8 +33,6 @@
 #define MANU_ID		"Giesecke & Devrient GmbH"
 #define STARCERT	"StarCertV2201"
 
-int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *, struct sc_aid *,sc_pkcs15emu_opt_t *);
-
 typedef struct cdata_st {
 	const char *label;
 	int	    authority;
@@ -273,8 +271,7 @@ static int sc_pkcs15emu_starcert_init(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *p15card,
-				  struct sc_aid *aid,
-				  sc_pkcs15emu_opt_t *opts)
+				  struct sc_aid *aid)
 {
 	if (starcert_detect_card(p15card))
 		return SC_ERROR_WRONG_CARD;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -29,33 +29,33 @@ extern "C" {
 #include <libopensc/types.h>
 #include <libopensc/pkcs15.h>
 
-int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_tcos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_cac_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_oberthur_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t *,	struct sc_aid *, sc_pkcs15emu_opt_t *);
-int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
-int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *, sc_pkcs15emu_opt_t *opts);
+int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_openpgp_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_starcert_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_tcos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_esteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_piv_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_cac_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_gemsafeGPK_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_gemsafeV1_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_actalis_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_atrust_acos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_entersafe_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_pteid_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_oberthur_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_itacns_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;
-	int (*handler)(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
+	int (*handler)(sc_pkcs15_card_t *, struct sc_aid *);
 };
 
 #ifdef __cplusplus

--- a/src/libopensc/pkcs15-tccardos.c
+++ b/src/libopensc/pkcs15-tccardos.c
@@ -41,10 +41,6 @@
 #define TC_CARDOS_GLOBALPIN	0x3000
 #define TC_CARDOS_PIN_MASK	0x3000
 
-int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *p15card,
-				  struct sc_aid *,
-				  sc_pkcs15emu_opt_t *opts);
-
 static int read_file(struct sc_card *card, const char *file, u8 *buf,
 	size_t *len)
 {
@@ -350,8 +346,7 @@ static int sc_pkcs15_tccardos_init_func(sc_pkcs15_card_t *p15card)
 }
 
 int sc_pkcs15emu_tccardos_init_ex(sc_pkcs15_card_t *p15card,
-				  struct sc_aid *aid,
-				  sc_pkcs15emu_opt_t *opts)
+				  struct sc_aid *aid)
 {
 	return sc_pkcs15_tccardos_init_func(p15card);
 }

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -33,11 +33,6 @@
 #include "cardctl.h"
 #include "log.h"
 
-int sc_pkcs15emu_tcos_init_ex(
-	sc_pkcs15_card_t   *p15card,
-	struct sc_aid *,
-	sc_pkcs15emu_opt_t *opts);
-
 static int insert_cert(
 	sc_pkcs15_card_t *p15card,
 	const char       *path,
@@ -492,8 +487,7 @@ static int detect_unicard(
 
 int sc_pkcs15emu_tcos_init_ex(
 	sc_pkcs15_card_t   *p15card,
-	struct sc_aid *aid,
-	sc_pkcs15emu_opt_t *opts
+	struct sc_aid *aid
 ){
 	sc_card_t         *card = p15card->card;
 	sc_context_t      *ctx = p15card->card->ctx;

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -31,8 +31,6 @@
 #include "cardctl.h"
 #include "common/compat_strlcpy.h"
 
-int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t *, struct sc_aid *, sc_pkcs15emu_opt_t *);
-
 static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 {
 	int i, r;
@@ -245,8 +243,7 @@ static int westcos_detect_card(sc_pkcs15_card_t * p15card)
 }
 
 int sc_pkcs15emu_westcos_init_ex(sc_pkcs15_card_t * p15card,
-				 struct sc_aid *aid,
-				 sc_pkcs15emu_opt_t * opts)
+				 struct sc_aid *aid)
 {
 	int r;
 	sc_card_t *card = p15card->card;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -1003,12 +1003,6 @@ typedef struct sc_pkcs15_search_key {
 int sc_pkcs15_search_objects(struct sc_pkcs15_card *, sc_pkcs15_search_key_t *,
 			struct sc_pkcs15_object **, size_t);
 
-/* This structure is passed to the new sc_pkcs15emu_*_init functions */
-typedef struct sc_pkcs15emu_opt {
-	scconf_block *blk;
-	unsigned int flags;
-} sc_pkcs15emu_opt_t;
-
 extern int sc_pkcs15_bind_synthetic(struct sc_pkcs15_card *, struct sc_aid *);
 extern int sc_pkcs15_is_emulation_only(sc_card_t *);
 


### PR DESCRIPTION
Only usage was removed SC_PKCS15EMU_FLAGS_NO_CHECK flag

Signed-off-by: Raul Metsma <raul@metsma.ee>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
