### PR TITLE
pkcs11-tool: Add extractable option to key import

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -321,6 +321,13 @@
 
 				<varlistentry>
 					<term>
+						<option>--extractable</option>
+					</term>
+					<listitem><para>Set the CKA_EXTRACTABLE attribute (object can be extracted)</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--set-id</option> <replaceable>id</replaceable>,
 						<option>-e</option> <replaceable>id</replaceable>
 					</term>
@@ -460,7 +467,7 @@
 					</listitem>
 				</varlistentry>
 
-                                <varlistentry>
+				<varlistentry>
 					<term>
 						<option>--allowed-mechanisms</option> <replaceable>mechanisms</replaceable>
 					</term>


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
