### PR TITLE
allow single character strings with sc_hex_to_bin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,11 +103,10 @@ build_script:
       Get-ChildItem -recurse C:\projects\OpenSC -exclude vc*.pdb *.pdb | % {
         7z a -tzip ${env:ARTIFACT}-Debug.zip $_.FullName
       }
-
-deploy_script:
   - appveyor PushArtifact %ARTIFACT%.msi
   - appveyor PushArtifact %ARTIFACT%-Debug.zip
 
+deploy_script:
   # keep in sync with .travis.yml
   - bash -c "git config --global user.email 'no-reply@appveyor.com'"
   - bash -c "git config --global user.name 'AppVeyor'"

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -99,6 +99,14 @@ int sc_hex_to_bin(const char *in, u8 *out, size_t *outlen)
 		}
 	}
 
+	if (left == *outlen && 1 == byte_needs_nibble && 0 != left) {
+		/* no output written so far, but we have a valid nibble in the upper
+		 * bits. Allow this special case. */
+		*out = (u8) byte>>4;
+		left--;
+		byte_needs_nibble = 0;
+	}
+
 	/* for ease of implementation we only accept completely hexed bytes. */
 	if (byte_needs_nibble) {
 		r = SC_ERROR_INVALID_ARGUMENTS;


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/1684
fixes https://github.com/OpenSC/OpenSC/issues/1669

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
