### PR TITLE
fixed more clang-tidy warnings

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -8,10 +8,29 @@ dist_noinst_DATA = \
 	LICENSE.compat_getopt compat_getopt.txt \
 	compat_getopt_main.c \
 	README.compat_strlcpy compat_strlcpy.3
+noinst_HEADERS = compat_strlcat.h compat_strlcpy.h compat_strnlen.h compat_getpass.h compat_getopt.h simclist.h libpkcs11.h libscdl.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
 libcompat_la_SOURCES = \
+	compat_dummy.c \
+	compat_strlcat.c \
+	compat_strlcpy.c \
+	compat_strnlen.c \
+	compat_getpass.c \
+	compat_getopt.c \
+	compat_report_rangecheckfailure.c \
+	compat___iob_func.c \
+	simclist.c
+
+compat_getopt_main_LDADD = libcompat.la
+
+libpkcs11_la_SOURCES = libpkcs11.c
+
+libscdl_la_SOURCES = libscdl.c
+
+TIDY_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+TIDY_FILES = \
 	compat_dummy.c \
 	compat_strlcat.h compat_strlcat.c \
 	compat_strlcpy.h compat_strlcpy.c \
@@ -20,10 +39,8 @@ libcompat_la_SOURCES = \
 	compat_getopt.h compat_getopt.c \
 	compat_report_rangecheckfailure.c \
 	compat___iob_func.c \
-	simclist.c simclist.h
+	simclist.c simclist.h \
+	libpkcs11.c libscdl.c
 
-compat_getopt_main_LDADD = libcompat.la
-
-libpkcs11_la_SOURCES = libpkcs11.c libpkcs11.h
-
-libscdl_la_SOURCES = libscdl.c libscdl.h
+check-local:
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi

--- a/src/common/simclist.c
+++ b/src/common/simclist.c
@@ -764,12 +764,12 @@ int list_concat(const list_t *l1, const list_t *l2, list_t *simclist_restrict de
 
     /* fix mid pointer */
     err = l2->numels - l1->numels;
-    if (dest->mid && (err+1)/2 > 0) {        /* correct pos RIGHT (err-1)/2 moves */
+    if ((err+1)/2 > 0) {        /* correct pos RIGHT (err-1)/2 moves */
         err = (err+1)/2;
-        for (cnt = 0; cnt < (unsigned int)err; cnt++) dest->mid = dest->mid->next;
-    } else if (dest->mid && err/2 < 0) { /* correct pos LEFT (err/2)-1 moves */
+        for (cnt = 0; dest->mid && cnt < (unsigned int)err; cnt++) dest->mid = dest->mid->next;
+    } else if (err/2 < 0) { /* correct pos LEFT (err/2)-1 moves */
         err = -err/2;
-        for (cnt = 0; cnt < (unsigned int)err; cnt++) dest->mid = dest->mid->prev;
+        for (cnt = 0; dest->mid && cnt < (unsigned int)err; cnt++) dest->mid = dest->mid->prev;
     }
 
     assert(!(list_repOk(l1) && list_repOk(l2)) || list_repOk(dest));

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -106,5 +106,43 @@ endif
 endif
 
 TIDY_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+TIDY_FILES = \
+	sc.c ctx.c errors.c \
+	asn1.c base64.c sec.c card.c iso7816.c dir.c ef-atr.c \
+	ef-gdo.c padding.c apdu.c simpletlv.c gp.c \
+	\
+	pkcs15-cert.c pkcs15-data.c pkcs15-pin.c \
+	pkcs15-prkey.c pkcs15-pubkey.c pkcs15-skey.c \
+	pkcs15-sec.c pkcs15-algo.c pkcs15-cache.c pkcs15-syn.c \
+	\
+	muscle.c muscle-filesystem.c \
+	\
+	ctbcs.c reader-ctapi.c reader-pcsc.c reader-openct.c reader-tr03119.c \
+	\
+	card-setcos.c card-miocos.c card-flex.c card-gpk.c \
+	card-cardos.c card-tcos.c card-default.c \
+	card-mcrd.c card-starcos.c card-jcop.c \
+	card-oberthur.c card-belpic.c card-atrust-acos.c \
+	card-entersafe.c card-epass2003.c card-coolkey.c card-incrypto34.c \
+	card-cac-common.c card-cac.c card-cac1.c \
+	card-muscle.c card-asepcos.c card-akis.c card-gemsafeV1.c card-rutoken.c \
+	card-rtecp.c card-westcos.c card-myeid.c \
+	card-itacns.c card-authentic.c \
+	card-iasecc.c iasecc-sdo.c iasecc-sm.c card-sc-hsm.c \
+	cwa14890.c cwa-dnie.c \
+	card-isoApplet.c card-masktech.c card-jpki.c \
+	card-npa.c card-esteid2018.c \
+	\
+	pkcs15-openpgp.c \
+	pkcs15-tcos.c pkcs15-esteid.c \
+	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \
+	pkcs15-cac.c pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c \
+	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
+	pkcs15-coolkey.c pkcs15-din-66291.c \
+	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
+	compression.c p15card-helper.c sm.c \
+	aux-data.c \
+	#$(SOURCES)
+
 check-local:
-	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(SOURCES) -- $(TIDY_FLAGS); fi
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -987,21 +987,6 @@ mcrd_select_file(sc_card_t * card, const sc_path_t * path, sc_file_t ** file)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	{
-		char line[256], *linep;
-		size_t i;
-
-		linep = line;
-		linep += sprintf(linep, "ef=%d, curpath=", priv->is_ef);
-
-		for (i = 0; i < priv->curpathlen; i++) {
-			sprintf(linep, "%04X", priv->curpath[i]);
-			linep += 4;
-		}
-		strcpy(linep, "\n");
-		sc_log(card->ctx, "%s", line);
-	}
-
 	if (path->type == SC_PATH_TYPE_DF_NAME) {
 		if (path->len > 16)
 			return SC_ERROR_INVALID_ARGUMENTS;
@@ -1052,19 +1037,6 @@ mcrd_select_file(sc_card_t * card, const sc_path_t * path, sc_file_t ** file)
 		}
 	}
 
-	{
-		char line[256], *linep = line;
-		size_t i;
-		linep +=
-		    sprintf(linep, "  result=%d, ef=%d, curpath=", r,
-			    priv->is_ef);
-		for (i = 0; i < priv->curpathlen; i++) {
-			sprintf(linep, "%04X", priv->curpath[i]);
-			linep += 4;
-		}
-		strcpy(linep, "\n");
-		sc_log(card->ctx, "%s", line);
-	}
 	return r;
 }
 

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1261,7 +1261,7 @@ static int myeid_transmit_decipher(struct sc_card *card, u8 p1, u8 p2,
 		apdu.le = MIN(card->max_recv_size, crgram_len);
 	}
 
-	if (p2 == 0x86 && crgram_len == 256 && !priv->cap_chaining) {
+	if (p2 == 0x86 && crgram_len == 256 && priv && !priv->cap_chaining) {
 		r = myeid_transmit_decipher_pi_split(card, &apdu, sbuf);
 	} else {
 		apdu.flags |= SC_APDU_FLAGS_CHAINING;
@@ -1272,8 +1272,12 @@ static int myeid_transmit_decipher(struct sc_card *card, u8 p1, u8 p2,
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "DECIPHER returned error");
 
-	outlen = MIN(apdu.resplen, outlen);
-	memcpy(out, apdu.resp, outlen);
+	if (out && outlen) {
+		outlen = MIN(apdu.resplen, outlen);
+		memcpy(out, apdu.resp, outlen);
+	} else {
+		outlen = 0;
+	}
 	LOG_FUNC_RETURN(card->ctx, outlen);
 }
 

--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -631,8 +631,10 @@ npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 				return SC_ERROR_INTERNAL;
 			}
 			new_len = strlen(p);
-			if (new_len > EAC_MAX_PIN_LEN)
+			if (new_len > EAC_MAX_PIN_LEN) {
+				free(p);
 				return SC_ERROR_INVALID_PIN_LENGTH;
+			}
 			new = p;
 #else
 			return SC_ERROR_NOT_SUPPORTED;

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -38,6 +38,7 @@
 #endif
 
 #include "common/libscdl.h"
+#include "common/compat_strlcpy.h"
 #include "internal.h"
 #include "sc-ossl-compat.h"
 
@@ -995,9 +996,7 @@ int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize)
 	conf_block = sc_get_conf_block(ctx, "framework", "pkcs15", 1);
 	cache_dir = scconf_get_str(conf_block, "file_cache_dir", NULL);
 	if (cache_dir != NULL) {
-		if (bufsize <= strlen(cache_dir))
-			return SC_ERROR_BUFFER_TOO_SMALL;
-		strcpy(buf, cache_dir);
+		strlcpy(buf, cache_dir, bufsize);
 		return SC_SUCCESS;
 	}
 

--- a/src/libopensc/pkcs15-atrust-acos.c
+++ b/src/libopensc/pkcs15-atrust-acos.c
@@ -154,26 +154,23 @@ static int sc_pkcs15emu_atrust_acos_init(sc_pkcs15_card_t *p15card)
 		return SC_ERROR_INTERNAL;
 	if (p15card->tokeninfo->serial_number)
 		free(p15card->tokeninfo->serial_number);
-	p15card->tokeninfo->serial_number = malloc(strlen(buf2) + 1);
+	p15card->tokeninfo->serial_number = strdup(buf2);
 	if (!p15card->tokeninfo->serial_number)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->serial_number, buf2);
 
 	/* manufacturer ID */
 	if (p15card->tokeninfo->manufacturer_id)
 		free(p15card->tokeninfo->manufacturer_id);
-	p15card->tokeninfo->manufacturer_id = malloc(strlen(MANU_ID) + 1);
+	p15card->tokeninfo->manufacturer_id = strdup(MANU_ID);
 	if (!p15card->tokeninfo->manufacturer_id)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->manufacturer_id, MANU_ID);
 
 	/* card label */
 	if (p15card->tokeninfo->label)
 		free(p15card->tokeninfo->label);
-	p15card->tokeninfo->label = malloc(strlen(CARD_LABEL) + 1);
+	p15card->tokeninfo->label = strdup(CARD_LABEL);
 	if (!p15card->tokeninfo->label)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->label, CARD_LABEL);
 
 	/* set certs */
 	for (i = 0; certs[i].label; i++) {

--- a/src/libopensc/pkcs15-cache.c
+++ b/src/libopensc/pkcs15-cache.c
@@ -35,6 +35,7 @@
 
 #include "internal.h"
 #include "pkcs15.h"
+#include "common/compat_strlcpy.h"
 
 #define RANDOM_UID_INDICATOR 0x08
 static int generate_cache_filename(struct sc_pkcs15_card *p15card,
@@ -94,9 +95,9 @@ static int generate_cache_filename(struct sc_pkcs15_card *p15card,
 					"%02X",  path->value[u + offs]);
 	}
 
-	if (!buf || bufsize < strlen(dir))
+	if (!buf)
 		return SC_ERROR_BUFFER_TOO_SMALL;
-	strcpy(buf, dir);
+	strlcpy(buf, dir, bufsize);
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/pkcs15-esinit.c
+++ b/src/libopensc/pkcs15-esinit.c
@@ -60,18 +60,16 @@ static int sc_pkcs15emu_entersafe_init( sc_pkcs15_card_t *p15card)
 		return SC_ERROR_INTERNAL;
 	if (p15card->tokeninfo->serial_number)
 		free(p15card->tokeninfo->serial_number);
-	p15card->tokeninfo->serial_number = malloc(strlen(buf) + 1);
+	p15card->tokeninfo->serial_number = strdup(buf);
 	if (!p15card->tokeninfo->serial_number)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->serial_number, buf);
 
 	/* the manufacturer ID, in this case Giesecke & Devrient GmbH */
 	if (p15card->tokeninfo->manufacturer_id)
 		free(p15card->tokeninfo->manufacturer_id);
-	p15card->tokeninfo->manufacturer_id = malloc(strlen(MANU_ID) + 1);
+	p15card->tokeninfo->manufacturer_id = strdup(MANU_ID);
 	if (!p15card->tokeninfo->manufacturer_id)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->manufacturer_id, MANU_ID);
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -306,17 +306,15 @@ static int sc_pkcs15emu_gemsafeV1_init( sc_pkcs15_card_t *p15card)
 
 	if (p15card->tokeninfo->label)
 		free(p15card->tokeninfo->label);
-	p15card->tokeninfo->label = malloc(strlen(APPLET_NAME) + 1);
+	p15card->tokeninfo->label = strdup(APPLET_NAME);
 	if (!p15card->tokeninfo->label)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->label, APPLET_NAME);
 
 	if (p15card->tokeninfo->serial_number)
 		free(p15card->tokeninfo->serial_number);
-	p15card->tokeninfo->serial_number = malloc(strlen(DRIVER_SERIAL_NUMBER) + 1);
+	p15card->tokeninfo->serial_number = strdup(DRIVER_SERIAL_NUMBER);
 	if (!p15card->tokeninfo->serial_number)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->serial_number, DRIVER_SERIAL_NUMBER);
 
 	/* the GemSAFE applet version number */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xca, 0xdf, 0x03);
@@ -338,10 +336,9 @@ static int sc_pkcs15emu_gemsafeV1_init( sc_pkcs15_card_t *p15card)
 	/* the manufacturer ID, in this case GemPlus */
 	if (p15card->tokeninfo->manufacturer_id)
 		free(p15card->tokeninfo->manufacturer_id);
-	p15card->tokeninfo->manufacturer_id = malloc(strlen(MANU_ID) + 1);
+	p15card->tokeninfo->manufacturer_id = strdup(MANU_ID);
 	if (!p15card->tokeninfo->manufacturer_id)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->manufacturer_id, MANU_ID);
 
 	/* determine allocated key containers and length of certificates */
 	r = gemsafe_get_cert_len(card);

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -518,7 +518,7 @@ static int itacns_add_data_files(sc_pkcs15_card_t *p15card)
 	 * user-friendlier card name.
 	 */
 	memset(&dinfo, 0, sizeof(dinfo));
-	strcpy(dinfo.app_label, "EF_DatiPersonali");
+	strlcpy(dinfo.app_label, "EF_DatiPersonali", sizeof(dinfo.app_label));
 
 	/* Find EF_DatiPersonali */
 

--- a/src/libopensc/pkcs15-starcert.c
+++ b/src/libopensc/pkcs15-starcert.c
@@ -169,17 +169,15 @@ static int sc_pkcs15emu_starcert_init(sc_pkcs15_card_t *p15card)
 		return SC_ERROR_INTERNAL;
 	if (p15card->tokeninfo->serial_number)
 		free(p15card->tokeninfo->serial_number);
-	p15card->tokeninfo->serial_number = malloc(strlen(buf) + 1);
+	p15card->tokeninfo->serial_number = strdup(buf);
 	if (!p15card->tokeninfo->serial_number)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->serial_number, buf);
 	/* the manufacturer ID, in this case Giesecke & Devrient GmbH */
 	if (p15card->tokeninfo->manufacturer_id)
 		free(p15card->tokeninfo->manufacturer_id);
-	p15card->tokeninfo->manufacturer_id = malloc(strlen(MANU_ID) + 1);
+	p15card->tokeninfo->manufacturer_id = strdup(MANU_ID);
 	if (!p15card->tokeninfo->manufacturer_id)
 		return SC_ERROR_INTERNAL;
-	strcpy(p15card->tokeninfo->manufacturer_id, MANU_ID);
 
 	/* set certs */
 	for (i = 0; certs[i].label; i++) {

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -215,14 +215,7 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 		ti->serial_number = malloc(serial_len * 2 + 1);
 		if (ti->serial_number == NULL)
 			return SC_ERROR_OUT_OF_MEMORY;
-
-		ti->serial_number[0] = 0;
-		for (ii = 0; ii < serial_len; ii++) {
-			char byte[3];
-
-			sprintf(byte, "%02X", serial[ii]);
-			strcat(ti->serial_number, byte);
-		}
+		sc_bin_to_hex(serial, serial_len, ti->serial_number, serial_len * 2 + 1, 0);
 		sc_log(ctx, "TokenInfo.serialNunmber '%s'", ti->serial_number);
 	}
 

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -79,3 +79,12 @@ install-exec-hook:
 	done
 
 endif
+
+TIDY_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(OPENSC_PKCS11_CFLAGS)
+TIDY_FILES = \
+			 pkcs11-global.c pkcs11-session.c pkcs11-object.c slot.c \
+			 mechanism.c openssl.c framework-pkcs15.c \
+			 framework-pkcs15init.c debug.c
+
+check-local:
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
