### PR TITLE
Add missing ulIvBits field to CK_GCM_PARAMS

### DIFF
--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -791,6 +791,7 @@ C_EncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT
 				(CK_GCM_PARAMS *) pMechanism->pParameter;
 			spy_dump_string_in("pIv[ulIvLen]",
 				param->pIv, param->ulIvLen);
+			spy_dump_ulong_in("ulIvBits", param->ulIvBits);
 			spy_dump_string_in("pAAD[ulAADLen]",
 				param->pAAD, param->ulAADLen);
 			fprintf(spy_output, "pMechanism->pParameter->ulTagBits=%lu\n", param->ulTagBits);

--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -818,6 +818,7 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 typedef struct CK_GCM_PARAMS {
 	void * pIv;
 	unsigned long ulIvLen;
+	unsigned long ulIvBits;
 	void * pAAD;
 	unsigned long ulAADLen;
 	unsigned long ulTagBits;


### PR DESCRIPTION
Impact only pkcs11-spy.

My previous PR in https://github.com/OpenSC/OpenSC/pull/1662 was not complete.

I found the problem because of SoftHSM. see https://github.com/opendnssec/SoftHSMv2/pull/481 and https://github.com/Pkcs11Interop/Pkcs11Interop/issues/126