### PR TITLE
Fix pkcs11-tool encryption error 

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5545,6 +5545,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 	printf("    %s: ", p11_mechanism_to_name(mech_type));
 
 	pseudo_randomize(orig_data, sizeof(orig_data));
+	orig_data[0] = 0; /* Make sure it is less then modulus */
 
 	pkey = get_public_key(session, privKeyObject);
 	if (pkey == NULL)


### PR DESCRIPTION
Fixes: 1694
Make sure data being encrypted is less then the modulus.


 On branch pkcs11-tool-encryption
 Changes to be committed:
	modified:   ../tools/pkcs11-tool.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
