### PR TITLE
Update pkcs15-sec.c

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -652,7 +652,8 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 * block from PKCS1 padding. */
 	if ((flags == (SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE)) &&
 	    !(alg_info->flags & SC_ALGORITHM_RSA_RAW) &&
-	    !(alg_info->flags & (SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE))) {
+	    !(alg_info->flags & SC_ALGORITHM_RSA_HASH_NONE) &&
+	    (alg_info->flags & SC_ALGORITHM_RSA_PAD_PKCS1)) {
 		unsigned int algo;
 		size_t tmplen = sizeof(buf);
 


### PR DESCRIPTION
When card supports SC_ALGORITHM_RSA_PAD_PKCS1 but not SC_ALGORITHM_RSA_HASH_NONE, then the DigestInfo need to be removed.

Current check requires the card to not support both SC_ALGORITHM_RSA_PAD_PKCS1 and SC_ALGORITHM_RSA_HASH_NONE to have the removal done.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
