### PR TITLE
card-rtecp: Fix list_files on T0 cards

### DIFF
--- a/src/libopensc/card-rtecp.c
+++ b/src/libopensc/card-rtecp.c
@@ -44,18 +44,18 @@ static struct sc_card_driver rtecp_drv = {
 static const struct sc_atr_table rtecp_atrs[] = {
 	/* Rutoken ECP */
 	{ "3B:8B:01:52:75:74:6F:6B:65:6E:20:45:43:50:A0",
-		NULL, "Rutoken ECP", SC_CARD_TYPE_GENERIC_BASE, 0, NULL },
+		NULL, "Rutoken ECP", SC_CARD_TYPE_RUTOKEN_ECP, 0, NULL },
 	/* Rutoken ECP (DS) */
 	{ "3B:8B:01:52:75:74:6F:6B:65:6E:20:44:53:20:C1",
-		NULL, "Rutoken ECP (DS)", SC_CARD_TYPE_GENERIC_BASE, 0, NULL },
+		NULL, "Rutoken ECP (DS)", SC_CARD_TYPE_RUTOKEN_ECP, 0, NULL },
 	/* Rutoken ECP SC T0 */
 	{ "3B:9C:96:00:52:75:74:6F:6B:65:6E:45:43:50:73:63",
 		"00:00:00:00:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF",
-		"Rutoken ECP SC", SC_CARD_TYPE_GENERIC_BASE, 0, NULL },
+		"Rutoken ECP SC", SC_CARD_TYPE_RUTOKEN_ECP_SC, 0, NULL },
 	/* Rutoken ECP SC T1 */
 	{ "3B:9C:94:80:11:40:52:75:74:6F:6B:65:6E:45:43:50:73:63:C3",
 		"00:00:00:00:00:00:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:00",
-		"Rutoken ECP SC", SC_CARD_TYPE_GENERIC_BASE, 0, NULL },
+		"Rutoken ECP SC", SC_CARD_TYPE_RUTOKEN_ECP_SC, 0, NULL },
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -85,8 +85,8 @@ static struct sc_card_driver rutoken_drv = {
 };
 
 static const struct sc_atr_table rutoken_atrs[] = {
-	{ "3b:6f:00:ff:00:56:72:75:54:6f:6b:6e:73:30:20:00:00:90:00", NULL, NULL, SC_CARD_TYPE_GENERIC_BASE, 0, NULL }, /* Aktiv Rutoken S */
-	{ "3b:6f:00:ff:00:56:75:61:54:6f:6b:6e:73:30:20:00:00:90:00", NULL, NULL, SC_CARD_TYPE_GENERIC_BASE, 0, NULL }, /* Aktiv uaToken S */
+	{ "3b:6f:00:ff:00:56:72:75:54:6f:6b:6e:73:30:20:00:00:90:00", NULL, NULL, SC_CARD_TYPE_RUTOKENS, 0, NULL }, /* Aktiv Rutoken S */
+	{ "3b:6f:00:ff:00:56:75:61:54:6f:6b:6e:73:30:20:00:00:90:00", NULL, NULL, SC_CARD_TYPE_RUTOKENS, 0, NULL }, /* Aktiv uaToken S */
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -251,6 +251,11 @@ enum {
 	/* EstEID cards */
 	SC_CARD_TYPE_ESTEID = 35000,
 	SC_CARD_TYPE_ESTEID_2018,
+
+	/* Rutoken cards */
+	SC_CARD_TYPE_RUTOKENS = 36000,
+	SC_CARD_TYPE_RUTOKEN_ECP,
+	SC_CARD_TYPE_RUTOKEN_ECP_SC,
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);


### PR DESCRIPTION
Rutoken ECP SC over T0 expects Get Response after SW1=61 which
is not called with zero le.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
