### PR TITLE
Update strings.c

### DIFF
--- a/src/ui/strings.c
+++ b/src/ui/strings.c
@@ -157,7 +157,7 @@ const char *ui_get_str(struct sc_context *ctx, struct sc_atr *atr,
 			|| !find_lang_str(p15card->tokeninfo->preferred_language, &lang)) {
 #ifdef _WIN32
 		LANGID langid = GetUserDefaultUILanguage();
-		if (langid & LANG_GERMAN) {
+		if (langid == LANG_GERMAN) {
 			lang = DE;
 		}
 #else

--- a/src/ui/strings.c
+++ b/src/ui/strings.c
@@ -157,7 +157,7 @@ const char *ui_get_str(struct sc_context *ctx, struct sc_atr *atr,
 			|| !find_lang_str(p15card->tokeninfo->preferred_language, &lang)) {
 #ifdef _WIN32
 		LANGID langid = GetUserDefaultUILanguage();
-		if (langid == LANG_GERMAN) {
+		if ((langid & LANG_GERMAN) == LANG_GERMAN) {
 			lang = DE;
 		}
 #else


### PR DESCRIPTION
The check condition is obviously wrong. It should check for EQUAL. The original bitwise check caused any other language to turn into DE because as long as a bit is filtered, it will hit.