### PR TITLE
PC/SC: wait up to 6 seconds for locking the card

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -645,7 +645,7 @@ static int pcsc_lock(sc_reader_t *reader)
 
 	rv = priv->gpriv->SCardBeginTransaction(priv->pcsc_card);
 	for (retry = 1; retry <= 3; retry++) {
-		if (rv != SCARD_E_SHARING_VIOLATION)
+		if (rv != (LONG)SCARD_E_SHARING_VIOLATION)
 			break;
 		/* Wait 1 second, 2 seconds and 3 seconds if the card becomes
 		 * available. The total waiting time (6 seconds) is above Windows'


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
