### PR TITLE
opensc-tool: fix --list-algorithms for AES

### DIFF
--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -582,6 +582,7 @@ static int list_algorithms(void)
 		{ SC_ALGORITHM_GOSTR3411, "gostr3411" },
 		{ SC_ALGORITHM_PBKDF2,    "pbkdf2"    },
 		{ SC_ALGORITHM_PBES2,     "pbes2"     },
+		{ SC_ALGORITHM_AES,       "aes"       },
 		{ 0, NULL }
 	};
 	const id2str_t alg_flag_names[] = {


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

This is a trivial, obvious fix. The wrong behavior was, that list_algorithms(void) just printed the last "known, wrong" content of aname.