### PR TITLE
pkcs15-tool: inconsistent -r option fix

### DIFF
--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -209,8 +209,7 @@
 
 				<varlistentry>
 					<term>
-						<option>--read-certificate</option> <replaceable>cert</replaceable>,
-						<option>-r</option> <replaceable>cert</replaceable>
+						<option>--read-certificate</option> <replaceable>cert</replaceable>
 					</term>
 					<listitem><para>Reads the certificate with the given id.</para></listitem>
 				</varlistentry>


### PR DESCRIPTION
Option -r is used in other opensc tools to specify card reader.  pkcs15-tool
uses -r to specify cerfificate.  This fix intorduces warning message if -r
is used, and for future versions of pkcs15-tool -r is used to specify
reader. Fixes #1704


##### Checklist

- [x ] Documentation is added or updated
