### PR TITLE
Fix #1731 sc_format_apdu_cse_lc_le fails to set Le correctly

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -67,27 +67,28 @@ void sc_format_apdu_cse_lc_le(struct sc_apdu *apdu)
 {
 	/* TODO calculating the APDU case, Lc and Le should actually only be
 	 * done in sc_apdu2bytes, but to gradually change OpenSC we start here. */
+	/* Let sc_detect_apdu_cse set short or extended  and test for chaining */
 
 	if (!apdu)
 		return;
 	if (apdu->datalen > SC_MAX_APDU_DATA_SIZE
 			|| apdu->resplen > SC_MAX_APDU_RESP_SIZE) {
-		/* extended length */
-		if (apdu->datalen < SC_MAX_EXT_APDU_DATA_SIZE)
+		/* extended length  or data chaining and/or get response */
+		if (apdu->datalen <= SC_MAX_EXT_APDU_DATA_SIZE)
 			apdu->lc = apdu->datalen;
-		if (apdu->resplen < SC_MAX_EXT_APDU_RESP_SIZE)
+		if (apdu->resplen <= SC_MAX_EXT_APDU_RESP_SIZE)
 			apdu->le = apdu->resplen;
 		if (apdu->resplen && !apdu->datalen)
-			apdu->cse = SC_APDU_CASE_2_EXT;
+			apdu->cse = SC_APDU_CASE_2;
 		if (!apdu->resplen && apdu->datalen)
-			apdu->cse = SC_APDU_CASE_3_EXT;
+			apdu->cse = SC_APDU_CASE_3;
 		if (apdu->resplen && apdu->datalen)
-			apdu->cse = SC_APDU_CASE_4_EXT;
+			apdu->cse = SC_APDU_CASE_4;
 	} else {
 		/* short length */
-		if (apdu->datalen < SC_MAX_APDU_DATA_SIZE)
+		if (apdu->datalen <= SC_MAX_APDU_DATA_SIZE)
 			apdu->lc = apdu->datalen;
-		if (apdu->resplen < SC_MAX_APDU_RESP_SIZE)
+		if (apdu->resplen <= SC_MAX_APDU_RESP_SIZE)
 			apdu->le = apdu->resplen;
 		if (!apdu->resplen && !apdu->datalen)
 			apdu->cse = SC_APDU_CASE_1;


### PR DESCRIPTION
This commit is not well tested and needs review.

Fixes #1731 See users comments on this patch. 

Changed four places where "<" should be "<=" so Le will be set correctly
Previous for 65K (extended) or 256 (short) Le is left set to 0.
This then caused Le to be to be not added to APDU as Le==0
Code later converts actual Le in APDU to be set to 0 to mean 256 or 65K.

SC_APDU_CASE_*_EXT are changed to SC_APDU_CASE_* so sc_detect_apdu_cse
to set the cse based on card capabilities as well as data chaining.


 On branch fix-1731
 Changes to be committed:
	modified:   src/libopensc/card.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
