### PR TITLE
Allow chaining for pkcs15-init --store-private-key EC keys

### DIFF
--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -928,6 +928,10 @@ isoApplet_put_data_prkey_ec(sc_card_t *card, sc_cardctl_isoApplet_import_key_t *
 	apdu.lc = p - sbuf;
 	apdu.datalen = p - sbuf;
 	apdu.data = sbuf;
+	if ((apdu.datalen > 255) && !(card->caps & SC_CARD_CAP_APDU_EXT))
+	{
+		apdu.flags |= SC_APDU_FLAGS_CHAINING;
+	}
 	r = sc_transmit_apdu(card, &apdu);
 	if(r < 0)
 	{


### PR DESCRIPTION
When importing a private key onto a pkcs15 card, if the card does not support
extended APDUs, we need to use chaining to store keys longer than 255 bytes.

While for RSA keys, this check was included, it was missing for EC keys.
This patch adds the SC_APDU_FLAGS_CHAINING flag to apdu.flags if data length is
greater than 255 and the card caps does not include SC_CARD_CAP_APDU_EXT.

This is particularly the case for secp384r1 keys.

This fixes #1747. 

##### Checklist
- [x] PKCS#11 module is tested
