### PR TITLE
Fix Coverity issues in p11test

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2364,7 +2364,7 @@ static int piv_validate_general_authentication(sc_card_t *card,
 	 * alg_id=06 is a place holder for all RSA keys.
 	 * Derive the real alg_id based on the size of the
 	 * the data, as we are always using raw mode.
-	 * Non RSA keys needs some work in thia area.
+	 * Non RSA keys needs some work in this area.
 	 */
 
 	real_alg_id = priv->alg_id;

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -312,7 +312,10 @@ int callback_public_keys(test_certs_t *objects,
 		} else { /* store the public key for future use */
 			o->type = EVP_PK_RSA;
 			o->key.rsa = RSA_new();
-			RSA_set0_key(o->key.rsa, n, e, NULL);
+			if (RSA_set0_key(o->key.rsa, n, e, NULL) != 1) {
+				fail_msg("Unable to set key params");
+				return -1;
+			}
 			o->bits = RSA_bits(o->key.rsa);
 			n = NULL;
 			e = NULL;

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -444,7 +444,7 @@ int search_objects(test_certs_t *objects, token_info_t *info,
 		/* store handle */
 		if (i >= objects_length) {
 			objects_length += 4; // do not realloc after each row
-			object_handles = realloc(object_handles, objects_length * sizeof(CK_OBJECT_HANDLE_PTR));
+			object_handles = realloc(object_handles, objects_length * sizeof(CK_OBJECT_HANDLE));
 			if (object_handles == NULL) {
 		 		fail_msg("Realloc failed. Need to store object handles.\n");
 				return -1;

--- a/src/tests/p11test/p11test_case_common.h
+++ b/src/tests/p11test/p11test_case_common.h
@@ -103,16 +103,19 @@ int is_pss_mechanism(CK_MECHANISM_TYPE mech);
 #define P11TEST_PASS(info) do { _P11TEST_FINALIZE(info, "pass") } while(0);
 
 #define P11TEST_FAIL(info, msg, ...) do { \
-	if (info->log.fd && info->log.in_test) { \
-		fprintf(info->log.fd, ",\n\t\"fail_reason\": \"" msg "\"", ##__VA_ARGS__); \
-	} \
-	_P11TEST_FINALIZE(info, "fail") \
-	fail_msg(msg, ##__VA_ARGS__); \
+		if (info->log.fd && info->log.in_test) { \
+			fprintf(info->log.fd, ",\n\t\"fail_reason\": \"" msg "\"", ##__VA_ARGS__); \
+		} \
+		_P11TEST_FINALIZE(info, "fail") \
+		fail_msg(msg, ##__VA_ARGS__); \
+		exit(1); \
 	} while (0);
 
 #define P11TEST_DATA_ROW(info, cols, ...) if (info->log.fd) { \
-	if (info->log.in_test == 0) \
+	if (info->log.in_test == 0) {\
 		fail_msg("Can't add data outside of the test");\
+		exit(1); \
+	} \
 	if (info->log.in_data == 0) {\
 		fprintf(info->log.fd, ",\n\t\"data\": [");\
 		info->log.in_data = 1;\

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -546,8 +546,10 @@ int sign_verify_test(test_cert_t *o, token_info_t *info, test_mech_t *mech,
 	CK_ULONG sign_length = 0;
 	int rv = 0;
 
-	if (message_length > strlen(SHORT_MESSAGE_TO_SIGN))
+	if (message_length > strlen(SHORT_MESSAGE_TO_SIGN)) {
 		fail_msg("Truncate is longer than the actual message");
+		return -1;
+	}
 
 	if (o->private_handle == CK_INVALID_HANDLE) {
 		debug_print(" [SKIP %s ] Missing private key", o->id_str);


### PR DESCRIPTION
Recently, the Coverity was run against the `p11test` and there is a possibility that the `fail_msg` will not `exit()`, it showed quite much issues. The PR is trying to fix them as well as few more issues reported by coverity. 

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
