### PR TITLE
Support OpenSSL when deprecated defines have been removed Fixes 1755

### DIFF
--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -48,12 +48,14 @@ extern "C" {
  * But for compatability with LibreSSL and older OpenSSL. OpenSC uses the older functions
  */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L  && !defined(LIBRESSL_VERSION_NUMBER)
+# if defined(OPENSSL_API_COMPAT) && OPENSSL_API_COMPAT >= 0x10100000L
 #define ERR_load_crypto_strings(x) {}
 #define SSL_load_error_strings(x)  {}
 #define ERR_free_strings(x)        {}
 #define ENGINE_load_dynamic(x)     {}
 #define EVP_CIPHER_CTX_cleanup(x) EVP_CIPHER_CTX_reset(x)
 #define EVP_CIPHER_CTX_init(x) EVP_CIPHER_CTX_reset(x)
+# endif
 #endif
 
  


### PR DESCRIPTION
Fixes: #1755 

sc-ossl-compat.h will check if OpenSSL has been built with or without some
deprecated defines. These are still usied in OpenSC code to support
older OpenSSL versions and Libresssl.

 On branch fix-1755
 Changes to be committed:
	modified:   src/libopensc/sc-ossl-compat.h

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist

- [x ] PKCS#11 module is tested

