### PR TITLE
Try to run more targets on newer bionic, fixing some new clang compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       sudo: true
     - compiler: gcc
       os: linux
+      dist: bionic
       env:
         - DO_SIMULATION=oseid
       sudo: true

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1709,22 +1709,22 @@ authentic_manage_sdo_encode_prvkey(struct sc_card *card, struct sc_pkcs15_prkey 
 	rsa = prvkey->u.rsa;
 	/* Encode private RSA key part */
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE_P, rsa.p.data, rsa.p.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA P encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA P encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE_Q, rsa.q.data, rsa.q.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA Q encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Q encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE_PQ, rsa.iqmp.data, rsa.iqmp.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA PQ encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA PQ encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE_DP1, rsa.dmp1.data, rsa.dmp1.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA DP1 encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA DP1 encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE_DQ1, rsa.dmq1.data, rsa.dmq1.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA DQ1 encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA DQ1 encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PRIVATE, blob, blob_len, &blob01, &blob01_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA Private encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Private encode error");
 
 	free (blob);
 	blob = NULL;
@@ -1735,24 +1735,27 @@ authentic_manage_sdo_encode_prvkey(struct sc_card *card, struct sc_pkcs15_prkey 
 	       "modulus.len:%"SC_FORMAT_LEN_SIZE_T"u blob_len:%"SC_FORMAT_LEN_SIZE_T"u",
 	       rsa.modulus.len, blob_len);
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PUBLIC_MODULUS, rsa.modulus.data, rsa.modulus.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA Modulus encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Modulus encode error");
 
 	sc_log(ctx,
 	       "exponent.len:%"SC_FORMAT_LEN_SIZE_T"u blob_len:%"SC_FORMAT_LEN_SIZE_T"u",
 	       rsa.exponent.len, blob_len);
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PUBLIC_EXPONENT, rsa.exponent.data, rsa.exponent.len, &blob, &blob_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA Exponent encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Exponent encode error");
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PUBLIC, blob, blob_len, &blob01, &blob01_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA Private encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Private encode error");
 
 	free (blob);
+	blob = NULL;
+	blob_len = 0;
 
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA, blob01, blob01_len, out, out_len);
-	LOG_TEST_RET(ctx, rv, "SDO RSA encode error");
+	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA encode error");
 
+err:
 	free(blob01);
-
+	free(blob);
 	LOG_FUNC_RETURN(ctx, rv);
 }
 

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1448,6 +1448,9 @@ coolkey_find_attribute(sc_card_t *card, sc_cardctl_coolkey_attribute_t *attribut
 			return r;
 		}
 		obj = attribute->object->data;
+		if (obj == NULL) {
+			return SC_ERROR_INTERNAL;
+		}
 	}
 
 	/* should be a static assert so we catch this at compile time */

--- a/src/libopensc/card-jcop.c
+++ b/src/libopensc/card-jcop.c
@@ -539,7 +539,9 @@ static int jcop_create_file(sc_card_t *card, sc_file_t *file) {
 	  
 	  entry = sc_file_get_acl_entry(file, ops[i]);
 	  r = acl_to_ac_nibble(entry);
-	  sec_attr_data[i/2] |= r << ((i % 2) ? 0 : 4);
+	  if (r >= 0) {
+		sec_attr_data[i/2] |= r << ((i % 2) ? 0 : 4);
+	  }
      }
 
      sc_file_set_sec_attr(file, sec_attr_data, 3);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -826,6 +826,7 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 	set_defaults(ctx, &opts);
 
 	if (0 != list_init(&ctx->readers)) {
+		del_drvs(&opts);
 		sc_release_context(ctx);
 		return SC_ERROR_OUT_OF_MEMORY;
 	}
@@ -835,6 +836,7 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 		ctx->thread_ctx = parm->thread_ctx;
 	r = sc_mutex_create(ctx, &ctx->mutex);
 	if (r != SC_SUCCESS) {
+		del_drvs(&opts);
 		sc_release_context(ctx);
 		return r;
 	}
@@ -861,6 +863,7 @@ int sc_context_create(sc_context_t **ctx_out, const sc_context_param_t *parm)
 
 	r = ctx->reader_driver->ops->init(ctx);
 	if (r != SC_SUCCESS)   {
+		del_drvs(&opts);
 		sc_release_context(ctx);
 		return r;
 	}

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -621,6 +621,7 @@ iasecc_parse_docp(struct sc_card *card, unsigned char *data, size_t data_len, st
 			sdo->docp.tries_remaining = tlv;
 		}
 		else   {
+			free(tlv.value);
 			LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "iasecc_parse_get_tlv() parse error: non DOCP tag");
 		}
 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -501,14 +501,23 @@ static int sc_pkcs15emu_sc_hsm_get_ec_public_key(struct sc_context *ctx, sc_cvc_
 	pubkey->alg_id->params = ecp;
 
 	pubkey->u.ec.ecpointQ.value = malloc(cvc->publicPointlen);
-	if (!pubkey->u.ec.ecpointQ.value)
+	if (!pubkey->u.ec.ecpointQ.value) {
+		free(pubkey->alg_id);
+		free(ecp->der.value);
+		free(ecp);
 		return SC_ERROR_OUT_OF_MEMORY;
+	}
 	memcpy(pubkey->u.ec.ecpointQ.value, cvc->publicPoint, cvc->publicPointlen);
 	pubkey->u.ec.ecpointQ.len = cvc->publicPointlen;
 
 	pubkey->u.ec.params.der.value = malloc(ecp->der.len);
-	if (!pubkey->u.ec.params.der.value)
+	if (!pubkey->u.ec.params.der.value) {
+		free(pubkey->u.ec.ecpointQ.value);
+		free(pubkey->alg_id);
+		free(ecp->der.value);
+		free(ecp);
 		return SC_ERROR_OUT_OF_MEMORY;
+	}
 	memcpy(pubkey->u.ec.params.der.value, ecp->der.value, ecp->der.len);
 	pubkey->u.ec.params.der.len = ecp->der.len;
 

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -447,8 +447,12 @@ static int sc_pkcs15emu_sc_hsm_get_rsa_public_key(struct sc_context *ctx, sc_cvc
 	pubkey->u.rsa.modulus.data	= malloc(pubkey->u.rsa.modulus.len);
 	pubkey->u.rsa.exponent.len	= cvc->coefficientAorExponentlen;
 	pubkey->u.rsa.exponent.data	= malloc(pubkey->u.rsa.exponent.len);
-	if (!pubkey->u.rsa.modulus.data || !pubkey->u.rsa.exponent.data)
+	if (!pubkey->u.rsa.modulus.data || !pubkey->u.rsa.exponent.data) {
+		free(pubkey->u.rsa.modulus.data);
+		free(pubkey->u.rsa.exponent.data);
+		free(pubkey->alg_id);
 		return SC_ERROR_OUT_OF_MEMORY;
+	}
 
 	memcpy(pubkey->u.rsa.exponent.data, cvc->coefficientAorExponent, pubkey->u.rsa.exponent.len);
 	memcpy(pubkey->u.rsa.modulus.data, cvc->primeOrModulus, pubkey->u.rsa.modulus.len);

--- a/src/libopensc/pkcs15-tccardos.c
+++ b/src/libopensc/pkcs15-tccardos.c
@@ -215,7 +215,7 @@ static int parse_EF_CardInfo(sc_pkcs15_card_t *p15card)
 
 	/* read EF_CardInfo1 */
 	r = read_file(p15card->card, "3F001003b200", info1, &info1_len);
-	if (r != SC_SUCCESS)
+	if (r != SC_SUCCESS || info1_len < 4)
 		return SC_ERROR_WRONG_CARD;
 	/* read EF_CardInfo2 */
 	r = read_file(p15card->card, "3F001003b201", info2, &info2_len);

--- a/src/libopensc/pkcs15-tccardos.c
+++ b/src/libopensc/pkcs15-tccardos.c
@@ -230,10 +230,15 @@ static int parse_EF_CardInfo(sc_pkcs15_card_t *p15card)
 		"found %d private keys\n", (int)key_num);
 	/* set p1 to the address of the first key descriptor */
 	offset = info1_len - 4 - key_num * 2;
-	if (offset >= sizeof info1)
+	if (offset >= info1_len)
 		return SC_ERROR_INVALID_DATA;
 	p1 = info1 + offset;
 	p2 = info2;
+
+	/* This is the minimum amount of data expected by the following code without
+	 * overunning the buffer without additional condition for cert_count == 4 */
+	if (info2_len < key_num * 14)
+		return SC_ERROR_INVALID_DATA;
 	for (i=0; i<key_num; i++) {
 		u8   pinId, keyId, cert_count;
 		int  ch_cert, ca_cert, r1_cert, r2_cert = 0;

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -4,7 +4,22 @@
 SOPIN="12345678"
 PIN="123456"
 PKCS11_TOOL="../src/tools/pkcs11-tool"
-P11LIB="/usr/lib64/pkcs11/libsofthsm2.so"
+
+softhsm_paths="/usr/local/lib/softhsm/libsofthsm2.so \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"
+
+for LIB in $softhsm_paths; do
+	echo "Testing $LIB"
+	if [[ -f $LIB ]]; then
+		P11LIB=$LIB
+		echo "Setting P11LIB=$LIB"
+		break
+	fi
+done
+if [[ -z "$P11LIB" ]]; then
+	echo "Warning: Could not find the softhsm pkcs11 module"
+fi
 
 ERRORS=0
 function assert() {


### PR DESCRIPTION
I reviewed the results of the `make check` on bionic and fixed the most obvious issues from the clang tidy.

The changes look simple enough, but ack from the respective driver owners would be appreciated. @CardContact for sc-hsm, not sure for others.

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
