### PR TITLE
pkcs11-tool: allow tests with keys that don't require PIN

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -777,7 +777,7 @@ int main(int argc, char * argv[])
 			opt_sig_format = optarg;
 			break;
 		case 't':
-			need_session |= NEED_SESSION_RO;
+			need_session |= NEED_SESSION_RW;
 			do_test = 1;
 			action_count++;
 			break;


### PR DESCRIPTION
Basically, I want to use the 9e key slot of a PIV card in pkcs11-tool. This key doesn't require authentication of the PIN and `pkcs15-tool -D` shows that the key isn't associated with the PIN. However, `pkcs11-tool --test` can't use this key for a signature because `--test` doesn't activate a RW session, which is a hardcoded requirement in pkcs11-tool.c for signatures.

This PR activates an RW session when testing the card. However, I'm not completely sure whether that's the correct fix. Reading PKCS#11, it isn't really clear to me which functions (e.g. signature/decryption) are available in an RW/RO session. The standard only talks about objects that are available in both cases, not about functions.

Maybe you, @dengert @Jakuje, have some better insight...

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
