### PR TITLE
pkcs11-tool: disable wrap/unwrap test

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5370,6 +5370,8 @@ static int test_verify(CK_SESSION_HANDLE sess)
 	return errors;
 }
 
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 20
+#else
 #ifdef ENABLE_OPENSSL
 static int wrap_unwrap(CK_SESSION_HANDLE session,
 	    const EVP_CIPHER *algo, CK_OBJECT_HANDLE privKeyObject)
@@ -5483,6 +5485,7 @@ static int wrap_unwrap(CK_SESSION_HANDLE session,
 	printf("OK\n");
 	return 0;
 }
+#endif
 #endif
 
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5491,6 +5491,10 @@ static int wrap_unwrap(CK_SESSION_HANDLE session,
  */
 static int test_unwrap(CK_SESSION_HANDLE sess)
 {
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 20
+	/* temporarily disable test, see https://github.com/OpenSC/OpenSC/issues/1796 */
+	return 0;
+#else
 	int             errors = 0;
 	CK_RV           rv;
 	CK_OBJECT_HANDLE privKeyObject;
@@ -5542,6 +5546,7 @@ static int test_unwrap(CK_SESSION_HANDLE sess)
 	}
 
 	return errors;
+#endif
 }
 
 #ifdef ENABLE_OPENSSL


### PR DESCRIPTION
... until https://github.com/OpenSC/OpenSC/issues/1796 is resolved

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist

- [ ] PKCS#11 module is tested
