### PR TITLE
Fix asn1.c:print_tags_recursive

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -373,7 +373,7 @@ static void print_tags_recursive(const u8 * buf0, const u8 * buf,
 		size_t len;
 
 		r = sc_asn1_read_tag(&tagp, bytesleft, &cla, &tag, &len);
-		if (r != SC_SUCCESS || tagp == NULL) {
+		if (r != SC_SUCCESS || (tagp == NULL && tag != SC_ASN1_TAG_EOC)) {
 			printf("Error in decoding.\n");
 			return;
 		}


### PR DESCRIPTION
opensc-explorer asn1 [<file-id>]: Always reports 'Error in decoding.', even after successful parsing.

This is just annoying once one has discovered: It's just a wrong message!
