### PR TITLE
Minidriver hScard changed Possible fix for #1763

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -423,6 +423,15 @@ check_card_reader_status(PCARD_DATA pCardData, const char *name)
 		logprintf(pCardData, 1, "HANDLES CHANGED from 0x%08X 0x%08X\n",
 			  (unsigned int)vs->hSCardCtx,
 			  (unsigned int)vs->hScard);
+		if (pCardData->hSCardCtx == vs->hSCardCtx) {
+			/*  only hScard changed, set the provided reader and card handles into ctx */
+			vs->hScard = pCardData->hScard;
+			r = sc_ctx_use_reader(vs->ctx, &vs->hSCardCtx, &vs->hScard);
+			if (r != SC_SUCCESS) {
+				logprintf(pCardData, 0, "sc_ctx_use_reader() failed with %d\n", r);
+				return SCARD_E_COMM_DATA_LOST;
+			}
+		} else
 		return reinit_card_for(pCardData, name);
 	}
 


### PR DESCRIPTION

If the hScard changes but hSCardCtx does not,  don't do call reinit_card_for.

Fixes: #1763 

This is first cut and untested. I don't have a way to test it. This may not be the best way to fix it. 
 

 Changes to be committed:
	modified:   minidriver.c

<!--
Thank you for your pull request.






