### PR TITLE
opensc-tool print_file: fix addressing records

### DIFF
--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -438,13 +438,13 @@ static int print_file(sc_card_t *in_card, const sc_file_t *file,
 		free(buf);
 	} else {
 		unsigned char buf[256];
-		size_t i;
+		size_t rec_nr;
 
-		for (i=0; i < file->record_count; i++) {
-			printf("Record %"SC_FORMAT_LEN_SIZE_T"u\n", i);
+		for (rec_nr = 1; rec_nr <= file->record_count; rec_nr++) {
+			printf("Record %"SC_FORMAT_LEN_SIZE_T"u\n", rec_nr);
 			r = sc_lock(card);
 			if (r == SC_SUCCESS)
-				r = sc_read_record(in_card, i, buf, 256, 0);
+				r = sc_read_record(in_card, rec_nr, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 			sc_unlock(card);
 			if (r > 0)
 				util_hex_dump_asc(stdout, buf, r, 0);


### PR DESCRIPTION
That was a long standing error:
The output of `opensc-tool --list-files` was wrong for record-based files (sc_read_record), because indexing records began at 0 and SC_RECORD_BY_REC_NR flag was missing.

A reference where else in OpenSC it's done in the same, correct way is:
libopensc/dir.c:sc_enum_apps, lines 223/224
