### PR TITLE
pkcs11: Support for RSA PSS padding in verify

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -566,6 +566,12 @@ sc_pkcs11_verif_init(struct sc_pkcs11_session *session, CK_MECHANISM_PTR pMechan
 		return rv;
 
 	memcpy(&operation->mechanism, pMechanism, sizeof(CK_MECHANISM));
+	if (pMechanism->pParameter) {
+		memcpy(&operation->mechanism_params, pMechanism->pParameter,
+			pMechanism->ulParameterLen);
+		operation->mechanism.pParameter = &operation->mechanism_params;
+	}
+
 	rv = mt->verif_init(operation, key);
 
 	if (rv != CKR_OK)
@@ -798,6 +804,11 @@ sc_pkcs11_decr_init(struct sc_pkcs11_session *session,
 		return rv;
 
 	memcpy(&operation->mechanism, pMechanism, sizeof(CK_MECHANISM));
+	if (pMechanism->pParameter) {
+		memcpy(&operation->mechanism_params, pMechanism->pParameter,
+		       pMechanism->ulParameterLen);
+		operation->mechanism.pParameter = &operation->mechanism_params;
+	}
 	rv = mt->decrypt_init(operation, key);
 
 	if (rv != CKR_OK)


### PR DESCRIPTION
* Explicitly copies the mechanism parameters during a PKCS#11 `C_VerifyInit`
  operation.
* Resolves issues where the calling application deallocates the `pParameter`
  pointer in the `CK_MECHANISM` struct between calls to `C_VerifyInit` and
  `C_Verify`.
* This commit copies the same fix that was applied to `sc_pkcs11_sign_init` in
  commit e5707b545e5a2dc33b0ca52a8bf63f36f71b3d85 for supporting RSASSA-PSS.



<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
