### PR TITLE
Handle Yubikey reinsertion from browsers more gracefully

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -247,6 +247,7 @@ static int pcsc_internal_transmit(sc_reader_t *reader,
 		case SCARD_W_REMOVED_CARD:
 			return SC_ERROR_CARD_REMOVED;
 		case SCARD_E_INVALID_HANDLE:
+		case SCARD_E_INVALID_VALUE:
 		case SCARD_E_READER_UNAVAILABLE:
 			pcsc_connect(reader);
 			/* return failure so that upper layers will be notified */
@@ -415,7 +416,7 @@ static int refresh_attributes(sc_reader_t *reader)
 				unsigned char atr[SC_MAX_ATR_SIZE];
 				rv = priv->gpriv->SCardStatus(priv->pcsc_card, NULL,
 						&readers_len, &cstate, &prot, atr, &atr_len);
-				if (rv == (LONG)SCARD_W_REMOVED_CARD)
+				if (rv == (LONG)SCARD_W_REMOVED_CARD || rv == (LONG)SCARD_E_INVALID_VALUE)
 					reader->flags |= SC_READER_CARD_CHANGED;
 			}
 		} else {
@@ -660,6 +661,8 @@ static int pcsc_lock(sc_reader_t *reader)
 		PCSC_TRACE(reader, "SCardBeginTransaction returned", rv);
 
 	switch (rv) {
+		case SCARD_E_INVALID_VALUE:
+			/* This is retuned in case of the same reader was re-attached */
 		case SCARD_E_INVALID_HANDLE:
 		case SCARD_E_READER_UNAVAILABLE:
 			r = pcsc_connect(reader);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -591,7 +591,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	memcpy(pInfo, &slot->token_info, sizeof(CK_TOKEN_INFO));
 out:
 	sc_pkcs11_unlock();
-	sc_log(context, "C_GetTokenInfo(%lx) returns 0x%lX", slotID, rv);
+	sc_log(context, "C_GetTokenInfo(%lx) returns %s", slotID, lookup_enum(RV_T, rv));
 	return rv;
 }
 

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -584,12 +584,11 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 	}
 
 	rv = slot_get_slot(slotID, &slot);
-	sc_log(context, "C_GetSlotInfo() get slot rv %lu", rv);
-	if (rv == CKR_OK)   {
-		if (slot->reader == NULL)   {
+	sc_log(context, "C_GetSlotInfo() get slot rv %s", lookup_enum( RV_T, rv));
+	if (rv == CKR_OK) {
+		if (slot->reader == NULL) {
 			rv = CKR_TOKEN_NOT_PRESENT;
-		}
-		else {
+		} else {
 			now = get_current_time();
 			if (now >= slot->slot_state_expires || now == 0) {
 				/* Update slot status */


### PR DESCRIPTION
Based on the discussion in #1822 this patch seems to solve the issues for me most of the time in chromium (the opensc plugged in through p11-kit). The Firefox looks like having some issues with the tokens these days so I did not test with it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
