### PR TITLE
openpgp: Workaround non-compliant Yubikey 5 OpenPGP applets

### DIFF
--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -166,7 +166,7 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 	sc_context_t	*ctx = card->ctx;
 	char		string[256];
 	u8		c4data[10];
-	u8		c5data[70];
+	u8		c5data[100];
 	int		r, i;
 	const pgp_pin_cfg_t *pin_cfg = (card->type == SC_CARD_TYPE_OPENPGP_V1)
 	                               ? pin_cfg_v1 : pin_cfg_v2;
@@ -257,7 +257,7 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 	 */
 	if ((r = read_file(card, "006E:0073:00C5", c5data, sizeof(c5data))) < 0)
 		goto failed;
-	if (r != 60) {
+	if (r < 60) {
 		sc_log(ctx, 
 			"finger print bytes have unexpected length (expected 60, got %d)\n", r);
 		return SC_ERROR_OBJECT_NOT_VALID;


### PR DESCRIPTION
The OpenPGP card specification explicitly say that the field C5 field has 60 B (three fingerprints per 20 B), but the new yubikey returns 80 (4 fingerprints per 20B), which is unexpected.

This commit is modifying the code to accept also longer data returned, ignoring the additional fingerprint now. It should allow use to progress further with the card initialization, at least.

Fixes #1850

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
