### PR TITLE
Bug fixed

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -477,6 +477,10 @@ gen_init_key(struct sc_card *card, unsigned char *key_enc, unsigned char *key_ma
 	else
 		des3_encrypt_cbc(exdata->sk_enc, 16, iv, data, 16 + blocksize, cryptogram);
 
+	/* verify card cryptogram */
+	if (0 != memcmp(&cryptogram[16], &result[20], 8))
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_CARD_CMD_FAILED);
+
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
@@ -510,16 +514,16 @@ verify_init_key(struct sc_card *card, unsigned char *ran_key, unsigned char key_
 	/* calculate host cryptogram */
 	if (KEY_TYPE_AES == key_type) {
 		aes128_encrypt_cbc(exdata->sk_enc, 16, iv, data, 16 + blocksize,
-				cryptogram);
+				   cryptogram);
 	} else {
 		des3_encrypt_cbc(exdata->sk_enc, 16, iv, data, 16 + blocksize,
-				cryptogram);
+				 cryptogram);
 	}
 
-    memset(data, 0, sizeof(data));
-    memcpy(data, "\x84\x82\x03\x00\x10", 5);
-    memcpy(&data[5], &cryptogram[16], 8);
-    memcpy(&data[13], "\x80\x00\x00", 3);
+	memset(data, 0, sizeof(data));
+	memcpy(data, "\x84\x82\x03\x00\x10", 5);
+	memcpy(&data[5], &cryptogram[16], 8);
+	memcpy(&data[13], "\x80\x00\x00", 3);
 
 	/* calculate mac icv */
 	memset(iv, 0x00, 16);
@@ -1606,15 +1610,18 @@ epass2003_set_security_env(struct sc_card *card, const sc_security_env_t * env, 
 		exdata->currAlg = SC_ALGORITHM_EC;
 		if(env->algorithm_flags & SC_ALGORITHM_ECDSA_HASH_SHA1)
 		{
-            sc_log(card->ctx, "setenva EC sha1 Algorithm alg_flags = %0x\n",env->algorithm_flags);
 			sbuf[2] = 0x91;
 			exdata->ecAlgFlags = SC_ALGORITHM_ECDSA_HASH_SHA1;
 		}
-	    else if (env->algorithm_flags & (SC_ALGORITHM_ECDSA_HASH_SHA256 | SC_ALGORITHM_ECDSA_HASH_NONE | SC_ALGORITHM_ECDSA_HASH_SHA1))
+		else if (env->algorithm_flags & SC_ALGORITHM_ECDSA_HASH_SHA256)
 		{
-		    sc_log(card->ctx, "setenva EC sha256 Algorithm alg_flags = %0x\n",env->algorithm_flags);
 			sbuf[2] = 0x92;
 			exdata->ecAlgFlags = SC_ALGORITHM_ECDSA_HASH_SHA256;
+		}
+		else if (env->algorithm_flags & SC_ALGORITHM_ECDSA_HASH_NONE)
+		{
+			sbuf[2] = 0x92;
+			exdata->ecAlgFlags = SC_ALGORITHM_ECDSA_HASH_NONE;
 		}
 		else
 		{
@@ -1709,6 +1716,13 @@ static int epass2003_decipher(struct sc_card *card, const u8 * data, size_t data
 			LOG_TEST_RET(card->ctx, r, "hash_data failed");
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3,0x2A, 0x9E, 0x9A);
 			apdu.data = sbuf;
+			apdu.lc = 0x20;
+			apdu.datalen = 0x20;
+		}
+		else if (exdata->ecAlgFlags & SC_ALGORITHM_ECDSA_HASH_NONE)
+		{
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3,0x2A, 0x9E, 0x9A);
+			apdu.data = data;
 			apdu.lc = 0x20;
 			apdu.datalen = 0x20;
 		}
@@ -2116,13 +2130,11 @@ epass2003_create_file(struct sc_card *card, sc_file_t * file)
 
 	r = epass2003_construct_fci(card, file, sbuf, &len);
 	LOG_TEST_RET(card->ctx, r, "construct_fci() failed");
-    
+
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xE0, 0x00, 0x00);
 	apdu.lc = len;
 	apdu.datalen = len;
 	apdu.data = sbuf;
-
-    sc_apdu_log(card->ctx, sbuf, len, 0); 
 
 	r = sc_transmit_apdu_t(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
@@ -2416,7 +2428,6 @@ epass2003_gen_key(struct sc_card *card, sc_epass2003_gen_key_data * data)
 
 	r = sc_transmit_apdu_t(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "generate keypair failed");
 
@@ -2445,33 +2456,33 @@ epass2003_gen_key(struct sc_card *card, sc_epass2003_gen_key_data * data)
 	if (!data->modulus)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 
-
-	if(len == 256)
+	if(256 == len)
 	{
 		unsigned char tmp[256] = {0};
-		int len1 = 0;
-		int len2 = 0;
+		int xCoordinateLen = 0;
+		int yCoordinateLen = 0;
 		//get x value
-		if(rbuf[0] == 0x58 )
-		{
-			len1 = rbuf[1];
-			memcpy(&tmp[0],&rbuf[2],len1);
+		if(0x58 == rbuf[0]){
+			xCoordinateLen = rbuf[1];
+			memcpy(&tmp[0], &rbuf[2], xCoordinateLen);
 		}
-
+		else{
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_VALID);
+		}
 		//get y value
-		if(rbuf[2+len1] == 0x59)
-		{
-			len2 = rbuf[2+len1+1];
-			memcpy(&tmp[len1],&rbuf[2+len1+2],len2);
+		if(0x59 == rbuf[2+xCoordinateLen]){
+			yCoordinateLen = rbuf[2+xCoordinateLen+1];
+			memcpy(&tmp[xCoordinateLen], &rbuf[2+xCoordinateLen+2], yCoordinateLen);
 		}
-
-		memcpy(data->modulus, &tmp[0], len1+len2);
+		else{
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_VALID);
+		}
+		memcpy(data->modulus, &tmp[0], xCoordinateLen+yCoordinateLen);
 	}
 	else
 	{
 		memcpy(data->modulus, rbuf, len);
 	}
-
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
@@ -2698,54 +2709,42 @@ epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	data->flags |= SC_PIN_CMD_NEED_PADDING;
 	kid = data->pin_reference;
 
-    //verify pin 
-    if((unsigned char *)data->pin1.data == NULL && data->pin1.len == 0)
-    {
-        r = external_key_auth(card, kid, (unsigned char *)data->pin1.data,
-                              data->pin1.len);
-        get_external_key_retries(card, 0x80 | kid, &retries);
-        if (retries < pin_low)
-            sc_log(card->ctx, "Verification failed (remaining tries: %d)", retries);
-    }
-    else
-    {
-    	/* get pin retries */
-    	if (data->cmd == SC_PIN_CMD_GET_INFO) {
+	if(NULL == (unsigned char *)data->pin1.data || 0 == data->pin1.len)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_PIN_CODE_INCORRECT);
 
-		    r = get_external_key_retries(card, 0x80 | kid, &retries);
-		    if (r == SC_SUCCESS) {
-			    data->pin1.tries_left = retries;
-			    if (tries_left)
-				    *tries_left = retries;
+	/* get pin retries */
+	if (data->cmd == SC_PIN_CMD_GET_INFO) {
 
-			    r = get_external_key_maxtries(card, &maxtries);
-			    LOG_TEST_RET(card->ctx, r, "get max counter failed");
+		r = get_external_key_retries(card, 0x80 | kid, &retries);
+		if (r == SC_SUCCESS) {
+			data->pin1.tries_left = retries;
+			if (tries_left)
+				*tries_left = retries;
 
-			    data->pin1.max_tries = maxtries;
-		    }
-        //remove below code, because the old implement only return PIN retries, now modify the code and return PIN status
-        //		return r;
-	    }
-	    else if (data->cmd == SC_PIN_CMD_UNBLOCK) { /* verify */
-		    r = external_key_auth(card, (kid + 1), (unsigned char *)data->pin1.data,
-				    data->pin1.len);
-		    LOG_TEST_RET(card->ctx, r, "verify pin failed");
-	    }
-	    else if (data->cmd == SC_PIN_CMD_CHANGE || data->cmd == SC_PIN_CMD_UNBLOCK) { /* change */
-		    r = update_secret_key(card, 0x04, kid, data->pin2.data,
-			    	(unsigned long)data->pin2.len);
-		    LOG_TEST_RET(card->ctx, r, "verify pin failed");
-	    }
-	    else
-        {
-		    r = external_key_auth(card, kid, (unsigned char *)data->pin1.data,
-			    	data->pin1.len);
-		    get_external_key_retries(card, 0x80 | kid, &retries);
-		    if (retries < pin_low)
-			    sc_log(card->ctx, "Verification failed (remaining tries: %d)", retries);
-	    }
-    }
+			r = get_external_key_maxtries(card, &maxtries);
+			LOG_TEST_RET(card->ctx, r, "get max counter failed");
 
+			data->pin1.max_tries = maxtries;
+		}
+	}
+	else if (data->cmd == SC_PIN_CMD_UNBLOCK) { /* verify */
+		r = external_key_auth(card, (kid + 1), (unsigned char *)data->pin1.data,
+				data->pin1.len);
+		LOG_TEST_RET(card->ctx, r, "verify pin failed");
+	}
+	else if (data->cmd == SC_PIN_CMD_CHANGE || data->cmd == SC_PIN_CMD_UNBLOCK) { /* change */
+		r = update_secret_key(card, 0x04, kid, data->pin2.data,
+				(unsigned long)data->pin2.len);
+		LOG_TEST_RET(card->ctx, r, "verify pin failed");
+	}
+	else {
+		r = external_key_auth(card, kid, (unsigned char *)data->pin1.data,
+				data->pin1.len);
+		get_external_key_retries(card, 0x80 | kid, &retries);
+		if (retries < pin_low)
+			sc_log(card->ctx, "Verification failed (remaining tries: %d)", retries);
+
+	}
 	LOG_TEST_RET(card->ctx, r, "verify pin failed");
 
 	if (r == SC_SUCCESS)

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -638,13 +638,14 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	r = sc_card_ctl(card, SC_CARDCTL_ENTERSAFE_GENERATE_KEY, &gendat);
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
 		    "generate RSA key pair failed");
+	
 	if (!gendat.modulus) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto err;
 	}
 
 	/* get the modulus */
-	if (pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_RSA) {
+	if (pubkey && (obj->type == SC_PKCS15_TYPE_PRKEY_RSA)) {
 		u8 *buf;
 		struct sc_pkcs15_pubkey_rsa *rsa = &pubkey->u.rsa;
 		/* set the modulus */
@@ -661,32 +662,37 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		buf[2] = 0x01;
 		rsa->exponent.data = buf;
 		rsa->exponent.len = 3;
+
 		pubkey->algorithm = SC_ALGORITHM_RSA;
 	}
-	else if(pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_EC)
-	{
-		struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
-		pubkey->algorithm = SC_ALGORITHM_EC;
-		pubkey->u.ec.ecpointQ.value = malloc(65);
+	else if(pubkey && (obj->type == SC_PKCS15_TYPE_PRKEY_EC)){
+		struct sc_ec_parameters *ecparams = (struct	
+				sc_ec_parameters *)key_info->params.data;
+		pubkey->algorithm = SC_ALGORITHM_EC; 
+		pubkey->u.ec.ecpointQ.value = (u8 *) malloc(65);
 		if (!pubkey->u.ec.ecpointQ.value) {
 			r = SC_ERROR_OUT_OF_MEMORY;
 			goto err;
 		}
-	    pubkey->u.ec.ecpointQ.value[0]=0x04;
+
+		pubkey->u.ec.ecpointQ.value[0] = 0x04;
 		memcpy(&pubkey->u.ec.ecpointQ.value[1], gendat.modulus, 64);
 		pubkey->u.ec.ecpointQ.len = 65;
 
 		free(pubkey->u.ec.params.named_curve);
-		pubkey->u.ec.params.named_curve = NULL;
+		pubkey->u.ec.params.named_curve = NULL; 
 
 		free(pubkey->u.ec.params.der.value);
 		pubkey->u.ec.params.der.value = NULL;
 		pubkey->u.ec.params.der.len = 0;
-		pubkey->u.ec.params.named_curve = strdup(ecparams->named_curve);
-		if (!pubkey->u.ec.params.named_curve)
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		pubkey->u.ec.params.named_curve = strdup(ecparams->named_curve); 
+
+		if (!pubkey->u.ec.params.named_curve){
+			r = SC_ERROR_OUT_OF_MEMORY;
+			goto err;
+		}
+
 		r = sc_pkcs15_fix_ec_parameters(card->ctx, &pubkey->u.ec.params);
-		LOG_TEST_RET(card->ctx, r, "Cannot fix EC parameters");
 	}
 	else
 		/* free public key */
@@ -696,6 +702,13 @@ err:
 	sc_file_free(pukf);
 	sc_file_free(file);
 	sc_file_free(tfile);
+	
+	if(r < 0 && pubkey->u.ec.ecpointQ.value)
+	{
+		free(pubkey->u.ec.ecpointQ.value);
+		pubkey->u.ec.ecpointQ.value = NULL;
+		pubkey->u.ec.ecpointQ.len = 0;
+	}
 
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
 }

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -638,9 +638,13 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	r = sc_card_ctl(card, SC_CARDCTL_ENTERSAFE_GENERATE_KEY, &gendat);
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
 		    "generate RSA key pair failed");
+	if (!gendat.modulus) {
+		r = SC_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
 
 	/* get the modulus */
-	if (pubkey) {
+	if (pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_RSA) {
 		u8 *buf;
 		struct sc_pkcs15_pubkey_rsa *rsa = &pubkey->u.rsa;
 		/* set the modulus */
@@ -657,9 +661,34 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		buf[2] = 0x01;
 		rsa->exponent.data = buf;
 		rsa->exponent.len = 3;
-
 		pubkey->algorithm = SC_ALGORITHM_RSA;
-	} else
+	}
+	else if(pubkey && obj->type == SC_PKCS15_TYPE_PRKEY_EC)
+	{
+		struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
+		pubkey->algorithm = SC_ALGORITHM_EC;
+		pubkey->u.ec.ecpointQ.value = malloc(65);
+		if (!pubkey->u.ec.ecpointQ.value) {
+			r = SC_ERROR_OUT_OF_MEMORY;
+			goto err;
+		}
+	    pubkey->u.ec.ecpointQ.value[0]=0x04;
+		memcpy(&pubkey->u.ec.ecpointQ.value[1], gendat.modulus, 64);
+		pubkey->u.ec.ecpointQ.len = 65;
+
+		free(pubkey->u.ec.params.named_curve);
+		pubkey->u.ec.params.named_curve = NULL;
+
+		free(pubkey->u.ec.params.der.value);
+		pubkey->u.ec.params.der.value = NULL;
+		pubkey->u.ec.params.der.len = 0;
+		pubkey->u.ec.params.named_curve = strdup(ecparams->named_curve);
+		if (!pubkey->u.ec.params.named_curve)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		r = sc_pkcs15_fix_ec_parameters(card->ctx, &pubkey->u.ec.params);
+		LOG_TEST_RET(card->ctx, r, "Cannot fix EC parameters");
+	}
+	else
 		/* free public key */
 		free(gendat.modulus);
 


### PR DESCRIPTION
1. It solves the problem that can be signed without input PIN, and the new code will check the state that the PIN value
2. The algorithm fails to verify sha256, cause a signature failure
3. The format of distinguishing ECC and RSA key pair is added - after the key pair is generated successfully, ECC and RSA need to be distinguished when reading the public key. The return format of ECC is different from the RSA
4. Fix ECC information display bug - The problem is using pkcs15-tool -D to print ECC key pair information no display correctly
5. Modify the module attribute of generating ECC key pair, and add 0x04 flag according to pkcs11 standard

Fixes #1512 
Fixes #1488 

Tested with Feitian ePass2003 token and card
<!--
Thank you for your pull request.



Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [x] macOS tokend is tested
