### PR TITLE
Add support for 4K RSA keys in GemsafeV1

### DIFF
--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -215,6 +215,8 @@ static int gemsafe_init(struct sc_card *card)
 	_sc_card_add_rsa_alg(card,  768, flags, 0);
 	_sc_card_add_rsa_alg(card, 1024, flags, 0);
 	_sc_card_add_rsa_alg(card, 2048, flags, 0);
+	_sc_card_add_rsa_alg(card, 3072, flags, 0);
+	_sc_card_add_rsa_alg(card, 4096, flags, 0);
 
 	/* fake algorithm to persuade register_mechanisms()
 	 * to register these hashes */


### PR DESCRIPTION
Fixes #1858
Card: GemSAFE V1
PTEID

