### PR TITLE
Fix CardOS RSA mechanism flags

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -161,7 +161,7 @@ static int cardos_have_2048bit_package(sc_card_t *card)
 
 static int cardos_init(sc_card_t *card)
 {
-	unsigned long	flags, rsa_2048 = 0;
+	unsigned long flags = 0, rsa_2048 = 0;
 	size_t data_field_length;
 	sc_apdu_t apdu;
 	u8 rbuf[2];
@@ -171,12 +171,15 @@ static int cardos_init(sc_card_t *card)
 	card->cla = 0x00;
 
 	/* Set up algorithm info. */
-	flags = SC_ALGORITHM_RSA_RAW
-		| SC_ALGORITHM_RSA_HASH_NONE
-		| SC_ALGORITHM_ONBOARD_KEY_GEN
-		;
-	if (card->type != SC_CARD_TYPE_CARDOS_V5_0)
-		flags |= SC_ALGORITHM_NEED_USAGE;
+	flags = 0;
+	if (card->type == SC_CARD_TYPE_CARDOS_V5_0) {
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+	} else {
+		flags |= SC_ALGORITHM_RSA_RAW
+			| SC_ALGORITHM_RSA_HASH_NONE
+			| SC_ALGORITHM_NEED_USAGE
+			| SC_ALGORITHM_ONBOARD_KEY_GEN;
+	}
 
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_2) {
 		r = cardos_have_2048bit_package(card);
@@ -771,7 +774,7 @@ cardos_set_security_env(sc_card_t *card,
 			    int se_num)
 {
 	sc_apdu_t apdu;
-	u8	data[3];
+	u8	data[6];
 	int	key_id, r;
 
 	assert(card != NULL && env != NULL);
@@ -800,10 +803,22 @@ cardos_set_security_env(sc_card_t *card,
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
-	data[0] = 0x83;
-	data[1] = 0x01;
-	data[2] = key_id;
-	apdu.lc = apdu.datalen = 3;
+	if (card->type == SC_CARD_TYPE_CARDOS_V5_0) {
+		/* Private key reference */
+		data[0] = 0x84;
+		data[1] = 0x01;
+		data[2] = key_id;
+		/* Usage qualifier byte */
+		data[3] = 0x95;
+		data[4] = 0x01;
+		data[5] = 0x40;
+		apdu.lc = apdu.datalen = 6;
+	} else {
+		data[0] = 0x83;
+		data[1] = 0x01;
+		data[2] = key_id;
+		apdu.lc = apdu.datalen = 3;
+	}
 	apdu.data = data;
 
 	r = sc_transmit_apdu(card, &apdu);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -544,10 +544,6 @@ struct sc_reader_operations {
  * instead of relying on the ACL info in the profile files. */
 #define SC_CARD_CAP_USE_FCI_AC		0x00000010
 
-/* D-TRUST CardOS cards special flags */
-#define SC_CARD_CAP_ONLY_RAW_HASH		0x00000040
-#define SC_CARD_CAP_ONLY_RAW_HASH_STRIPPED	0x00000080
-
 /* Card (or card driver) supports an protected authentication mechanism */
 #define SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH	0x00000100
 


### PR DESCRIPTION
This patch set removes two constants that are never set (after c463985f) and uses more appropriate flags for RSA operations, so the RAW RSA operation is not wrongly advertised, while all the other hashed mechanisms are working fine.

With my CardOS 5.x card, I am getting clean test output:

```
[jjelen@t470s OpenSC (cardos5-fixes)]$  ./src/tools/pkcs11-tool --slot 4 --test --pin 111111 --login --module ./src/pkcs11/.libs/opensc-pkcs11.so
C_SeedRandom() and C_GenerateRandom():
  seeding (C_SeedRandom) not supported
  seems to be OK
Digests:
  all 4 digest functions seem to work
  MD5: OK
  SHA-1: OK
  RIPEMD160: OK
Signatures (currently only for RSA)
  testing key 0 (Digital Signature) 
  all 4 signature functions seem to work
  testing signature mechanisms:
    RSA-PKCS: OK
    SHA1-RSA-PKCS: OK
    MD5-RSA-PKCS: OK
    RIPEMD160-RSA-PKCS: OK
    SHA256-RSA-PKCS: OK
  testing key 1 (2048 bits, label=Encryption) with 1 signature mechanism -- can't be used to sign/verify, skipping
Verify (currently only for RSA)
  testing key 0 (Digital Signature)
    RSA-PKCS: OK
    SHA1-RSA-PKCS: OK
    MD5-RSA-PKCS: OK
    RIPEMD160-RSA-PKCS: OK
  testing key 1 (Encryption) with 1 mechanism -- can't be used to sign/verify, skipping
Decryption (currently only for RSA)
  testing key 0 (Digital Signature)  -- can't be used to decrypt, skipping
  testing key 1 (Encryption) 
    RSA-PKCS: OK
No errors
```
I would be interested in feedback from others having CardOS cards, mostly 4.x versions, but these should not be affected by my changes.

Fixes #1864 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested