### PR TITLE
Yubikey reinsertion

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -350,6 +350,11 @@ static int refresh_attributes(sc_reader_t *reader)
 			/* Timeout, no change from previous recorded state. Make sure that
 			 * changed flag is not set. */
 			reader->flags &= ~SC_READER_CARD_CHANGED;
+			/* Make sure to preserve the CARD_PRESENT flag if the reader was
+			 * reattached and we called the refresh_attributes too recently */
+			if (priv->reader_state.dwEventState & SCARD_STATE_PRESENT) {
+				reader->flags |= SC_READER_CARD_PRESENT;
+			}
 			LOG_FUNC_RETURN(reader->ctx, SC_SUCCESS);
 		}
 		

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -218,6 +218,10 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	slot = session->slot;
 	logged_out = (slot_get_logged_in_state(slot) == SC_PIN_STATE_LOGGED_OUT);
+	if (logged_out && slot->login_user > -1) {
+		sc_pkcs11_close_all_sessions(session->slot->id);
+		return CKR_SESSION_HANDLE_INVALID;
+	}
 	if (slot->login_user == CKU_SO && !logged_out) {
 		pInfo->state = CKS_RW_SO_FUNCTIONS;
 	} else if ((slot->login_user == CKU_USER && !logged_out) || (!(slot->token_info.flags & CKF_LOGIN_REQUIRED))) {

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -473,7 +473,7 @@ CK_RV slot_get_token(CK_SLOT_ID id, struct sc_pkcs11_slot ** slot)
 
 CK_RV slot_token_removed(CK_SLOT_ID id)
 {
-    CK_RV rv;
+	CK_RV rv;
 	int token_was_present;
 	struct sc_pkcs11_slot *slot;
 	struct sc_pkcs11_object *object;


### PR DESCRIPTION
This is follow-up work on the #1822, mostly based on my last comment https://github.com/OpenSC/OpenSC/issues/1822#issuecomment-548907733 which I will try to summarize here again with the steps that happens  and causes the issue reported above

* The calling application has working token (lets say it just provided signature for TLS 1.3 session).
* The Yubikey is removed and plugged in again
* The application calls `C_GetSlotInfo()`
* OpenSC checks the status of inserted card: `card_detect_all()` -> `card_detect()` -> `sc_detect_card_presence()` -> `pcsc_detect_card_presence()`
  *  The PCSC reader function `refresh_attributes()` notices the card was changed (`SCardStatus` returns `SCARD_E_INVALID_VALUE` as handled in fb15a7dd )
  * The function returns the card was changed `CARD_CHANGED`
* the card is removed, internal card structures freed `card_removed()`, the reader->flags is reset (`CARD_PRESENT` is removed here)
* sessions are closed
* and detection starts over
* Again `card_detect_all()` -> `card_detect()` -> `sc_detect_card_presence()` -> `pcsc_detect_card_presence()`
  *  The PCSC reader function `refresh_attributes()` notices returns `SCARD_E_TIMEOUT` as there was really no change since last call.
  * This just unsets CARD_CHANGED 
  * I add here the check to restore the CARD_PRESENT attribute.
* Now, we have `CARD_PRESENT` in the reader flags so the card detection can finally start

Here is the raw log of the affected part of the code:
```
pkcs11-global.c:575:C_GetSlotInfo: C_GetSlotInfo(0x0)
slot.c:393:card_detect_all: Detect all cards
slot.c:219:card_detect: Yubico Yubikey 4 OTP+U2F+CCID 00 00: Detecting smart card
sc.c:315:sc_detect_card_presence: called
reader-pcsc.c:443:pcsc_detect_card_presence: called
reader-pcsc.c:333:refresh_attributes: Yubico Yubikey 4 OTP+U2F+CCID 00 00 check
reader-pcsc.c:379:refresh_attributes: current  state: 0x00000022
reader-pcsc.c:380:refresh_attributes: previous state: 0x00000120
reader-pcsc.c:435:refresh_attributes: card present, changed
reader-pcsc.c:448:pcsc_detect_card_presence: returning with: 3
sc.c:320:sc_detect_card_presence: returning with: 3
slot.c:235:card_detect: Yubico Yubikey 4 OTP+U2F+CCID 00 00: Card changed
slot.c:180:card_removed: Yubico Yubikey 4 OTP+U2F+CCID 00 00: card removed
slot.c:481:slot_token_removed: slot_token_removed(0x0)
pkcs11-session.c:143:sc_pkcs11_close_all_sessions: real C_CloseAllSessions(0x0) 1
pkcs11-session.c:109:sc_pkcs11_close_session: real C_CloseSession(0x7fc0551c8f20)
pkcs15-pin.c:844:sc_pkcs15_pincache_clear: called
framework-pkcs15.c:1575:pkcs15_release_token: pkcs15_release_token() not implemented
slot.c:481:slot_token_removed: slot_token_removed(0x1)
pkcs11-session.c:143:sc_pkcs11_close_all_sessions: real C_CloseAllSessions(0x1) 0
slot.c:481:slot_token_removed: slot_token_removed(0x2)
pkcs11-session.c:143:sc_pkcs11_close_all_sessions: real C_CloseAllSessions(0x2) 0
slot.c:481:slot_token_removed: slot_token_removed(0x3)
pkcs11-session.c:143:sc_pkcs11_close_all_sessions: real C_CloseAllSessions(0x3) 0
sc.c:315:sc_detect_card_presence: called
reader-pcsc.c:443:pcsc_detect_card_presence: called
reader-pcsc.c:333:refresh_attributes: Yubico Yubikey 4 OTP+U2F+CCID 00 00 check
reader-pcsc.c:356:refresh_attributes: returning with: 0 (Success)
reader-pcsc.c:448:pcsc_detect_card_presence: returning with: 1
sc.c:320:sc_detect_card_presence: returning with: 1
pkcs15.c:1297:sc_pkcs15_unbind: called
pkcs15-pin.c:844:sc_pkcs15_pincache_clear: called
misc.c:71:sc_to_cryptoki_error_common: libopensc return value: 0 (Success)
card.c:414:sc_disconnect_card: called
card-piv.c:3011:piv_finish: called
reader-pcsc.c:640:pcsc_disconnect: Yubico Yubikey 4 OTP+U2F+CCID 00 00:SCardDisconnect returned: 0x80100011
card.c:436:sc_disconnect_card: returning with: 0 (Success)
sc.c:315:sc_detect_card_presence: called
reader-pcsc.c:443:pcsc_detect_card_presence: called
reader-pcsc.c:333:refresh_attributes: Yubico Yubikey 4 OTP+U2F+CCID 00 00 check
reader-pcsc.c:356:refresh_attributes: returning with: 0 (Success)
reader-pcsc.c:448:pcsc_detect_card_presence: returning with: 1
sc.c:320:sc_detect_card_presence: returning with: 1
slot.c:256:card_detect: Yubico Yubikey 4 OTP+U2F+CCID 00 00: First seen the card
slot.c:265:card_detect: Yubico Yubikey 4 OTP+U2F+CCID 00 00: Connecting ...
```
The second commit bf4ef3f1 is addressing another issue that I noticed on the PKCS#11 level, when the first function after reinsertion was `C_GetSessionInfo()`, the OpenSC sometimes wrongly reported invalid login status, confusing the calling application.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested