### PR TITLE
Card IsoApplet - add support for no_padding algortihm RSA-X-509 (no padding)/raw RSA) …

### DIFF
--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -31,6 +31,7 @@
 
 #define ISOAPPLET_ALG_REF_ECDSA 0x21
 #define ISOAPPLET_ALG_REF_RSA_PAD_PKCS1 0x11
+#define ISOAPPLET_ALG_REF_RSA_NOPAD 0x12
 
 #define ISOAPPLET_API_VERSION_MAJOR 0x00
 #define ISOAPPLET_API_VERSION_MINOR 0x06
@@ -249,6 +250,7 @@ isoApplet_init(sc_card_t *card)
 	flags = 0;
 	/* Padding schemes: */
 	flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+	flags |= SC_ALGORITHM_RSA_RAW;
 	/* Hashes are to be done by the host for RSA */
 	flags |= SC_ALGORITHM_RSA_HASH_NONE;
 	/* Key-generation: */
@@ -1106,6 +1108,10 @@ isoApplet_set_security_env(sc_card_t *card,
 			if( env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1 )
 			{
 				drvdata->sec_env_alg_ref = ISOAPPLET_ALG_REF_RSA_PAD_PKCS1;
+			}
+		   	else if( env->algorithm_flags & SC_ALGORITHM_RSA_RAW )
+			{
+				drvdata->sec_env_alg_ref = ISOAPPLET_ALG_REF_RSA_NOPAD;
 			}
 			else
 			{


### PR DESCRIPTION
RSA-X-509 (CKM_RSA_X_509) seems to be used by OpenSSL during the authentication handshake for OpenVPN with hardware tokens. 
OpenSSL pre-pads the data to be sent to the token. without the support of this algorithm OpenVPN client cannot connect using IsoApplet Card.

With normal PKCS#1 padding I have the same issue as described by another user in the following link 
http://openssl.6102.n7.nabble.com/Issue-with-smartcard-authentication-for-openvpn-td76415.html

The RSA-X-509 mechanism (mech=3) is used with OpenSSL 1.1.1 and TLS version >= 1.2

- [ x] PKCS#11 module is tested
