### PR TITLE
Fix misleading code indentation

### DIFF
--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -352,10 +352,10 @@ static int entersafe_transmit_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 size_t cipher_data_size,mac_data_size;
 	 int blocks;
 	 int r=SC_SUCCESS;
-	u8 *sbuf=NULL;
-	size_t ssize=0;
+	 u8 *sbuf=NULL;
+	 size_t ssize=0;
 
-	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	 SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
 	 assert(card);
 	 assert(apdu);
@@ -363,11 +363,11 @@ static int entersafe_transmit_apdu(sc_card_t *card, sc_apdu_t *apdu,
 	 if((cipher||mac) && (!key||(keylen!=8 && keylen!=16)))
 		  SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
 
-	r = sc_apdu_get_octets(card->ctx, apdu, &sbuf, &ssize, SC_PROTO_RAW);
-	if (r == SC_SUCCESS)
-		sc_apdu_log(card->ctx, sbuf, ssize, 1);
-	if(sbuf)
-		free(sbuf);
+	 r = sc_apdu_get_octets(card->ctx, apdu, &sbuf, &ssize, SC_PROTO_RAW);
+	 if (r == SC_SUCCESS)
+		  sc_apdu_log(card->ctx, sbuf, ssize, 1);
+	 if(sbuf)
+		  free(sbuf);
 
 	 if(cipher)
 	 {

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2346,8 +2346,8 @@ do_read_private_key(const char *filename, const char *format,
 			r = util_getpass(&passphrase, &len, stdin);
 			if (r < 0 || !passphrase)
 				return SC_ERROR_INTERNAL;
- 			r = do_read_pkcs12_private_key(filename,
- 					passphrase, pk, certs, max_certs);
+			r = do_read_pkcs12_private_key(filename,
+					passphrase, pk, certs, max_certs);
 		}
 	} else {
 		util_error("Error when reading private key. "


### PR DESCRIPTION
Fixes
error: misleading indentation; statement is not part of the previous 'if' [-Werror,-Wmisleading-indentation]
         if(cipher)
         ^
../../../git/src/libopensc/card-entersafe.c:369:2: note: previous statement is here
        if(sbuf)
        ^

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
