### PR TITLE
OpenPGP v3.4 extensions

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -32,6 +32,7 @@
  * https://gnupg.org/ftp/specs/OpenPGP-smart-card-application-3.3.pdf
  * https://gnupg.org/ftp/specs/OpenPGP-smart-card-application-3.3.0.pdf
  * https://gnupg.org/ftp/specs/OpenPGP-smart-card-application-3.3.1.pdf
+ * https://gnupg.org/ftp/specs/OpenPGP-smart-card-application-3.4.pdf
  */
 
 #if HAVE_CONFIG_H
@@ -106,6 +107,7 @@ enum _version {		/* 2-byte BCD-alike encoded version number */
 	OPENPGP_CARD_3_1 = 0x0301,
 	OPENPGP_CARD_3_2 = 0x0302,
 	OPENPGP_CARD_3_3 = 0x0303,
+	OPENPGP_CARD_3_4 = 0x0304,
 };
 
 enum _access {		/* access flags for the respective DO/file */
@@ -297,9 +299,22 @@ static struct do_info		pgp1x_objects[] = {	/* OpenPGP card spec 1.1 */
 	{ 0, 0, 0, NULL, NULL },
 };
 
-static struct do_info		pgp33_objects[] = {	/* OpenPGP card spec 3.3 */
+static struct do_info		pgp34_objects[] = {	/**** OpenPGP card spec 3.4 ****/
+	{ 0x00d9, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00da, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00db, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00dc, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00de, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	{ 0x00de, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               NULL        },
+	/* DO FA is CONSTRUCTED in spec; we treat it as SIMPLE for the time being */
+	{ 0x00fa, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               NULL        },
+	/* DO FB is CONSTRUCTED in spec; we treat it as SIMPLE for the time being */
+	{ 0x00fb, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
+	/* DO FC is CONSTRUCTED in spec; we treat it as SIMPLE for the time being */
+	{ 0x00fc, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               NULL        },
+	/**** OpenPGP card spec 3.3 ****/
 	{ 0x00f9, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
-	/* OpenPGP card spec 3.0 - 3.2 */
+	/**** OpenPGP card spec 3.0 - 3.2 ****/
 	{ 0x00d6, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x00d7, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x00d8, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
@@ -307,9 +322,9 @@ static struct do_info		pgp33_objects[] = {	/* OpenPGP card spec 3.3 */
 	{ 0x7f66, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               sc_put_data },
 	/* DO 7F74 is CONSTRUCTED in spec; we treat it as SIMPLE for the time being */
 	{ 0x7f74, SIMPLE,      READ_ALWAYS | WRITE_NEVER, NULL,               sc_put_data },
-	/* OpenPGP card spec 2.1 & 2.2 */
+	/**** OpenPGP card spec 2.1 & 2.2 ****/
 	{ 0x00d5, SIMPLE,      READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
-	/* OpenPGP card spec 2.0 */
+	/**** OpenPGP card spec 2.0 ****/
 	{ 0x004d, CONSTRUCTED, READ_NEVER  | WRITE_PIN3,  NULL,               sc_put_data },
 	{ 0x004f, SIMPLE,      READ_ALWAYS | WRITE_NEVER, sc_get_data,        NULL        },
 	{ 0x005b, SIMPLE,      READ_ALWAYS | WRITE_PIN3,  NULL,               sc_put_data },
@@ -368,9 +383,10 @@ static struct do_info		pgp33_objects[] = {	/* OpenPGP card spec 3.3 */
 	{ 0, 0, 0, NULL, NULL },
 };
 
-static struct do_info		*pgp30_objects = pgp33_objects + 1;
-static struct do_info		*pgp21_objects = pgp33_objects + 6;
-static struct do_info		*pgp20_objects = pgp33_objects + 7;
+static struct do_info		*pgp33_objects = pgp34_objects +  9;
+static struct do_info		*pgp30_objects = pgp34_objects + 10;
+static struct do_info		*pgp21_objects = pgp34_objects + 15;
+static struct do_info		*pgp20_objects = pgp34_objects + 16;
 
 
 #define DRVDATA(card)        ((struct pgp_priv_data *) ((card)->drv_data))
@@ -572,7 +588,8 @@ pgp_init(sc_card_t *card)
 			  : (priv->bcd_version < OPENPGP_CARD_2_1) ? pgp20_objects
 			  : (priv->bcd_version < OPENPGP_CARD_3_0) ? pgp21_objects
 			  : (priv->bcd_version < OPENPGP_CARD_3_3) ? pgp30_objects
-			  :					     pgp33_objects;
+			  : (priv->bcd_version < OPENPGP_CARD_3_4) ? pgp33_objects
+			  :					     pgp34_objects;
 
 	/* change file path to MF for re-use in MF */
 	sc_format_path("3f00", &file->path);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -67,6 +67,7 @@ static const struct sc_atr_table pgp_atrs[] = {
 	},
 	{ "3b:fc:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:4e:45:4f:72:33:e1", NULL, "Yubikey NEO (OpenPGP v2.0)", SC_CARD_TYPE_OPENPGP_V2, 0, NULL },
 	{ "3b:f8:13:00:00:81:31:fe:15:59:75:62:69:6b:65:79:34:d4", NULL, "Yubikey 4 (OpenPGP v2.1)", SC_CARD_TYPE_OPENPGP_V2, 0, NULL },
+	{ "3b:fd:13:00:00:81:31:fe:15:80:73:c0:21:c0:57:59:75:62:69:4b:65:79:40", NULL, "Yubikey 5 (OpenPGP v3.4)", SC_CARD_TYPE_OPENPGP_V3, 0, NULL },
 	{ "3b:da:18:ff:81:b1:fe:75:1f:03:00:31:f5:73:c0:01:60:00:90:00:1c", NULL, default_cardname_v3, SC_CARD_TYPE_OPENPGP_V3, 0, NULL },
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };


### PR DESCRIPTION
Extension of the openpgp driver to
- have inital support for OpenPGP card spec 3.4: show new DOs as files
- add ATR for Yubikey 5 to openpgp driver
  (Yubikey 5 supports v3.4 of OpenPGP spec)
