### PR TITLE
Check if card name is null in acos atrust driver

### DIFF
--- a/src/libopensc/card-atrust-acos.c
+++ b/src/libopensc/card-atrust-acos.c
@@ -123,7 +123,7 @@ static int atrust_acos_init(struct sc_card *card)
 		| SC_ALGORITHM_RSA_HASH_RIPEMD160
 		| SC_ALGORITHM_RSA_HASH_MD5_SHA1;
 
-	if (!strcmp(card->name, ACOS_EMV_A05))
+	if (card->name != NULL && !strcmp(card->name, ACOS_EMV_A05))
 		flags |= SC_ALGORITHM_RSA_HASH_SHA256;
 
 	_sc_card_add_rsa_alg(card, 1536, flags, 0x10001);


### PR DESCRIPTION
`opensc-tool` segfaults when trying to read a card that doesn’t populate the name field. This commit adds a null check before calling `strcmp()`.

The card in question is unknown and subject to research. This is probably quite easy to reproduce, though.