### PR TITLE
Fix setting ATR in fuzzer 

### DIFF
--- a/src/tests/fuzzing/fuzz_pkcs15_reader.c
+++ b/src/tests/fuzzing/fuzz_pkcs15_reader.c
@@ -103,8 +103,8 @@ static int fuzz_reader_connect(sc_reader_t *reader)
 
     fuzz_get_chunk(reader, &chunk, &chunk_size);
 
-    if (chunk_size > reader->atr.len && reader->atr.len > 0)
-        chunk_size = reader->atr.len;
+    if (chunk_size > SC_MAX_ATR_SIZE)
+        chunk_size = SC_MAX_ATR_SIZE;
     else
         reader->atr.len = chunk_size;
 

--- a/src/tests/p11test/p11test_case_common.h
+++ b/src/tests/p11test/p11test_case_common.h
@@ -80,7 +80,7 @@ int is_pss_mechanism(CK_MECHANISM_TYPE mech);
 
 #define P11TEST_START(info) if (info->log.fd) { \
 	if (info->log.in_test) \
-		fprintf(info->log.fd, "\n\t\"result\": \"unknown\"\n}"); \
+		fprintf(info->log.fd, ",\n\t\"result\": \"unknown\"\n}"); \
 	fprintf(info->log.fd, "%s\n{\n\t\"test_id\": \"%s\"", \
 			info->log.first ? "" : ",", __func__); \
 	info->log.in_test = 1; \
@@ -92,7 +92,7 @@ int is_pss_mechanism(CK_MECHANISM_TYPE mech);
 	if (info->log.in_data) {\
 		fprintf(info->log.fd, "]"); \
 	} \
-	if (info->log.fd && info->log.in_test) { \
+	if (info->log.in_test) { \
 		fprintf(info->log.fd, ",\n\t\"result\": \"" result "\"\n}"); \
 		info->log.in_test = 0; \
 	} \

--- a/src/tests/p11test/p11test_case_common.h
+++ b/src/tests/p11test/p11test_case_common.h
@@ -98,9 +98,9 @@ int is_pss_mechanism(CK_MECHANISM_TYPE mech);
 	} \
 	} else {}
 
-#define P11TEST_SKIP(info) do { _P11TEST_FINALIZE(info, "skip")	skip(); } while(0);
+#define P11TEST_SKIP(info) do { _P11TEST_FINALIZE(info, "skip"); skip(); } while(0);
 
-#define P11TEST_PASS(info) do { _P11TEST_FINALIZE(info, "pass") } while(0);
+#define P11TEST_PASS(info) do { _P11TEST_FINALIZE(info, "pass"); } while(0);
 
 #define P11TEST_FAIL(info, msg, ...) do { \
 		if (info->log.fd && info->log.in_test) { \

--- a/src/tests/p11test/p11test_case_ec_sign.c
+++ b/src/tests/p11test/p11test_case_ec_sign.c
@@ -28,7 +28,7 @@ void ec_sign_size_test(void **state) {
 	P11TEST_START(info);
 	if (token.num_ec_mechs == 0 ) {
 		fprintf(stderr, "Token does not support any ECC mechanisms. Skipping.\n");
-		skip();
+		P11TEST_SKIP(info);
 	}
 
 	test_certs_t objects;


### PR DESCRIPTION
This will probably address most of the recent issues reported by oss-fuzz. Not sure what I was on my mind when I was writing my last patch in d1db7932, but it was certainly not correct.

And there were few forgotten commits in the p11tests that I forgot to push earlier, that are related to the JSON output.