### PR TITLE
pkcs11: fixed right padding of token label with ' '

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1122,9 +1122,10 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 							max_tokeninfo_len);
 					slot->token_info.label[max_tokeninfo_len]           = ' ';
 					slot->token_info.label[max_tokeninfo_len+1]         = '(';
-					slot->token_info.label[max_tokeninfo_len+2+pin_len] = ')';
 					strcpy_bp(slot->token_info.label+max_tokeninfo_len+2,
 							auth->label, pin_len);
+					strcpy_bp(slot->token_info.label+max_tokeninfo_len+2+pin_len,
+							")", 32 - max_tokeninfo_len-2-pin_len);
 				}
 			} else {
 				/* PIN label is empty or just says non-useful "PIN",


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/1922

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
- [x] PKCS#11 module is tested
