### PR TITLE
asn1: prevent null-dereference

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -374,7 +374,7 @@ static void print_tags_recursive(const u8 * buf0, const u8 * buf,
 		size_t len;
 
 		r = sc_asn1_read_tag(&tagp, bytesleft, &cla, &tag, &len);
-		if (r != SC_SUCCESS || (tagp == NULL && tag != SC_ASN1_TAG_EOC)) {
+		if (r != SC_SUCCESS || tagp == NULL || tag != SC_ASN1_TAG_EOC) {
 			printf("Error in decoding.\n");
 			return;
 		}


### PR DESCRIPTION
`tagp == NULL` and `tag != SC_ASN1_TAG_EOC` are a valid result of `sc_asn1_read_tag` (see the "end of data reached" comment in `sc_asn1_read_tag`).

In this case error handling is skipped and `tagp` is used in `hlen = tagp - p`.