### PR TITLE
iso7816: extend iso7816_process_fci()

### DIFF
--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -209,6 +209,7 @@ typedef struct sc_acl_entry {
 } sc_acl_entry_t;
 
 /* File types */
+#define SC_FILE_TYPE_UNKNOWN		0x00
 #define SC_FILE_TYPE_DF			0x04
 #define SC_FILE_TYPE_INTERNAL_EF	0x03
 #define SC_FILE_TYPE_WORKING_EF		0x01


### PR DESCRIPTION
Hi,

this PR extends iso7816_process_fci().  In detail, it
* defines file type SC_FILE_TYPE_UNKNOWN
* explicitly sets file->type to SC_FILE_TYPE_UNKNOWN for unkown files
* stores full-length file type attributes via sc_file_set_type_attr(),
  not only the first byte
* parses # of records for record-oriented EFs,
  if given in the file type attributes
* parses record length for for EFs with fixed-size records,
  if given in the file type attributes

Note:
I am not sure, parsing the record length only for EFs with fixed-size records is the correct approach.
My interpretation of 7816-4 is slightly different, but doing it this way seems
to be in-line what's currently in opensc:
- there's a comment hinting at that interpretation
- otherwise variable size records fail to be read in opensc-explorer
So I leave it this way for now.

As this PR extends the features of the default driver, it helps researching unknown cards.
I intend to use the additional information in opensc-explorer.

Thanks in advance for merging
Peter