### PR TITLE
Unbreak build with -fno-common (default in gcc10)

### DIFF
--- a/src/tests/p11test/p11test.c
+++ b/src/tests/p11test/p11test.c
@@ -34,6 +34,9 @@
 
 #define DEFAULT_P11LIB	"../../pkcs11/.libs/opensc-pkcs11.so"
 
+/* Global variable keeping information about token we are using */
+token_info_t token;
+
 void display_usage() {
 	fprintf(stdout,
 		" Usage:\n"

--- a/src/tests/p11test/p11test_common.h
+++ b/src/tests/p11test/p11test_common.h
@@ -84,7 +84,7 @@ typedef struct {
 	size_t  num_keygen_mechs;
 } token_info_t;
 
-token_info_t token;
+extern token_info_t token;
 
 #endif /* P11TEST_COMMON_H */
 


### PR DESCRIPTION
The gcc10 is less tolerant to these errors

https://gcc.gnu.org/gcc-10/porting_to.html