### PR TITLE
Improved Handling of CK_SLOT_ID values returned to C_GetSlotList

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -50,6 +50,8 @@ sc_context_t *context = NULL;
 struct sc_pkcs11_config sc_pkcs11_conf;
 list_t sessions;
 list_t virtual_slots;
+CK_SLOT_ID next_slot_id = 0;
+int slot_id_wrapped = 0;
 #if !defined(_WIN32)
 pid_t initialized_pid = (pid_t)-1;
 #endif
@@ -486,21 +488,6 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 			slot->flags |= SC_PKCS11_SLOT_FLAG_SEEN;
 		}
 		prev_reader = slot->reader;
-	}
-
-	/* Slot list can only change in v2.20 */
-	if (pSlotList == NULL_PTR) {
-		/* slot->id is derived from its location in the list virtual_slots.
-		 * When the slot list changes, so does slot->id, so we reindex the
-		 * slots here the same way it is done in `create_slot()`
-		 *
-		 * TODO use a persistent CK_SLOT_ID, e.g. by using something like
-		 * `slot->id = sc_crc32(slot, sizeof *slot);` (this example, however,
-		 * is currently not thread safe).  */
-		for (i=0; i<list_size(&virtual_slots); i++) {
-			slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
-			slot->id = (CK_SLOT_ID) list_locate(&virtual_slots, slot);
-		}
 	}
 
 	if (pSlotList == NULL_PTR) {

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -344,6 +344,8 @@ extern struct sc_pkcs11_config sc_pkcs11_conf;
 extern list_t sessions;
 extern list_t virtual_slots;
 extern list_t cards;
+extern CK_SLOT_ID next_slot_id;
+extern int slot_id_wrapped;
 
 /* Framework definitions */
 extern struct sc_pkcs11_framework_ops framework_pkcs15;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1278,7 +1278,7 @@ static void list_slots(int tokens, int refresh, int print)
 
 	printf("Available slots:\n");
 	for (n = 0; n < p11_num_slots; n++) {
-		printf("Slot %lu (0x%lx): ", n, p11_slots[n]);
+		printf("Slot %lu CK_SLOT_ID 0x%lx: ", n, p11_slots[n]);
 		rv = p11->C_GetSlotInfo(p11_slots[n], &info);
 		if (rv != CKR_OK) {
 			printf("(GetSlotInfo failed, %s)\n", CKR2Str(rv));


### PR DESCRIPTION
Partially Fixes #1945  
Partially Fixes #1935 

Firefox 72.0.2 still does not handle deleting of slots. See https://bugzilla.mozilla.org/show_bug.cgi?id=1613632

Previously the CK_SLOT_IDs where derived from the place on the
virtual_slot list. This means that if a reader was removed, the position
on the list could change. An application such as Firefox is also keeping
track of data based on the previous slot list. So the application
could get confused.

PKCS11 v2.30 code in in OpenSC to keep deleted slots on the list until the
application has see the slot once since itmiht have been deleted. But the
slot also looked like an available hotplug which might g reused before
the application ha seen it. This was fixed so it could not be reused until
the application had a chance to see it.

The CK_SLOT_ID now starts at 0, and increased by 1 each time a new slot
is created which occues when a reader is inserted. There is an upper limit
of 2^32 calls to create_slot. In practics this will never be reached but
the code has a "TODO" to add code to reuse slot IDs.

Pkcs11-tool.c has improved wording for listing slots.
 On branch PKCS11-SLOTS
 Changes to be committed:
	modified:   pkcs11-global.c
	modified:   sc-pkcs11.h
	modified:   slot.c
	modified:   ../tools/pkcs11-tool.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested using FireFox
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
