### PR TITLE
Improved Debugging of PKCS11 virtual_slots

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -449,6 +449,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 
 	sc_log(context, "C_GetSlotList(token=%d, %s)", tokenPresent,
 			pSlotList==NULL_PTR? "plug-n-play":"refresh");
+	DEBUG_VSS(NULL, "C_GetSlotList before ctx_detect_detect");
 
 	/* Slot list can only change in v2.20 */
 	if (pSlotList == NULL_PTR) {
@@ -459,7 +460,11 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 		}
 	}
 
+	DEBUG_VSS(NULL, "C_GetSlotList after ctx_detect_readers");
+
 	card_detect_all();
+
+	DEBUG_VSS(NULL, "C_GetSlotList after card_detect_all");
 
 	found = calloc(list_size(&virtual_slots), sizeof(CK_SLOT_ID));
 
@@ -487,6 +492,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 		}
 		prev_reader = slot->reader;
 	}
+	DEBUG_VSS(NULL, "C_GetSlotList after card_detect_all");
 
 	/* Slot list can only change in v2.20 */
 	if (pSlotList == NULL_PTR) {
@@ -502,6 +508,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 			slot->id = (CK_SLOT_ID) list_locate(&virtual_slots, slot);
 		}
 	}
+	DEBUG_VSS(NULL, "C_GetSlotList after slot->id reassigned");
 
 	if (pSlotList == NULL_PTR) {
 		sc_log(context, "was only a size inquiry (%lu)\n", numMatches);
@@ -522,6 +529,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 	rv = CKR_OK;
 
 	sc_log(context, "returned %lu slots\n", numMatches);
+	DEBUG_VSS(NULL, "Returning a new slot list");
 
 out:
 	if (found != NULL) {
@@ -561,7 +569,7 @@ static sc_timestamp_t get_current_time(void)
 
 CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 {
-	struct sc_pkcs11_slot *slot;
+	struct sc_pkcs11_slot *slot = NULL;
 	sc_timestamp_t now;
 	CK_RV rv;
 
@@ -584,6 +592,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 	}
 
 	rv = slot_get_slot(slotID, &slot);
+	DEBUG_VSS(slot, "C_GetSlotInfo found");
 	sc_log(context, "C_GetSlotInfo() get slot rv %s", lookup_enum( RV_T, rv));
 	if (rv == CKR_OK) {
 		if (slot->reader == NULL) {

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -227,6 +227,13 @@ struct sc_pkcs11_slot {
 };
 typedef struct sc_pkcs11_slot sc_pkcs11_slot_t;
 
+/* Debug virtual slots. S is slot to be highlighted or NULL
+ * C is a comment format string and args It will be preceeded by "VSS " */
+
+#define DEBUG_VSS(S, C...) sc_log(context,"VSS " C); _debug_virtual_slots(S)
+
+/* called by DEBUG_VSS to print table of virtual slots */
+void  _debug_virtual_slots(sc_pkcs11_slot_t *p);
 
 /* Forward decl */
 typedef struct sc_pkcs11_operation sc_pkcs11_operation_t;
@@ -361,6 +368,7 @@ void sc_pkcs11_print_attrs(int level, const char *file, unsigned int line, const
 CK_RV card_removed(sc_reader_t *reader);
 CK_RV card_detect_all(void);
 CK_RV create_slot(sc_reader_t *reader);
+void init_slot_info(CK_SLOT_INFO_PTR pInfo, sc_reader_t *reader);
 CK_RV initialize_reader(sc_reader_t *reader);
 CK_RV card_detect(sc_reader_t *reader);
 CK_RV slot_get_slot(CK_SLOT_ID id, struct sc_pkcs11_slot **);

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -27,6 +27,32 @@
 
 #include "sc-pkcs11.h"
 
+/* Print virtual_slots list. Called by DEBUG_VSS(S, C) */
+void _debug_virtual_slots(sc_pkcs11_slot_t *p)
+{
+	int i, vs_size;
+	sc_pkcs11_slot_t * slot;
+
+	vs_size = list_size(&virtual_slots);
+	_sc_debug(context, SC_LOG_DEBUG_NORMAL,
+			"VSS size:%d", vs_size);
+	_sc_debug(context, SC_LOG_DEBUG_NORMAL,
+			"VSS  [i] id   flags LU events nsessions slot_info.flags reader p11card description");
+	for (i = 0; i < vs_size; i++) {
+		slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
+		if (slot) {
+			_sc_debug(context, SC_LOG_DEBUG_NORMAL,
+				"VSS %s[%d] 0x%2.2lx 0x%4.4x %d  %d  %d %4.4lx  %p %p %.64s",
+				((slot == p) ? "*" : " "),
+				i, slot->id, slot->flags, slot->login_user, slot->events, slot->nsessions,
+				slot->slot_info.flags,
+				slot->reader, slot->p11card,
+				slot->slot_info.slotDescription);
+		}
+	}
+	_sc_debug(context, SC_LOG_DEBUG_NORMAL, "VSS END");
+}
+
 static struct sc_pkcs11_framework_ops *frameworks[] = {
 	&framework_pkcs15,
 #ifdef USE_PKCS15_INIT
@@ -50,7 +76,7 @@ static struct sc_pkcs11_slot * reader_get_slot(sc_reader_t *reader)
 	return NULL;
 }
 
-static void init_slot_info(CK_SLOT_INFO_PTR pInfo, sc_reader_t *reader)
+void init_slot_info(CK_SLOT_INFO_PTR pInfo, sc_reader_t *reader)
 {
 	if (reader) {
 		strcpy_bp(pInfo->slotDescription, reader->name, 64);

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -70,8 +70,10 @@ static struct sc_pkcs11_slot * reader_get_slot(sc_reader_t *reader)
 	/* Locate a slot related to the reader */
 	for (i = 0; i<list_size(&virtual_slots); i++) {
 		sc_pkcs11_slot_t *slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
-		if (slot->reader == reader)
+		if (slot->reader == reader) {
+			DEBUG_VSS(slot, "reader_get_slot found slot");
 			return slot;
+		}
 	}
 	return NULL;
 }
@@ -129,6 +131,7 @@ CK_RV create_slot(sc_reader_t *reader)
 		if (0 != list_init(&slot->logins)) {
 			return CKR_HOST_MEMORY;
 		}
+		DEBUG_VSS(slot, "Creating new slot");
 	} else {
 		/* reuse the old list of logins/objects since they should be empty */
 		list_t logins = slot->logins;
@@ -138,6 +141,7 @@ CK_RV create_slot(sc_reader_t *reader)
 
 		slot->logins = logins;
 		slot->objects = objects;
+		DEBUG_VSS(slot, "Reusing old slot");
 	}
 
 	slot->login_user = -1;
@@ -152,6 +156,7 @@ CK_RV create_slot(sc_reader_t *reader)
 		slot->slot_info.hardwareVersion.minor = reader->version_minor;
 	}
 	slot->id = (CK_SLOT_ID) list_locate(&virtual_slots, slot);
+	DEBUG_VSS(slot, "Created this slot");
 
 	return CKR_OK;
 }
@@ -165,7 +170,9 @@ void empty_slot(struct sc_pkcs11_slot *slot)
 			 * emptied. We replace the reader with a virtual hotplug slot. */
 			slot->reader = NULL;
 			init_slot_info(&slot->slot_info, NULL);
+			DEBUG_VSS(slot, "Emptied slot with SC_PKCS11_SLOT_FLAG_SEEN");
 		} else {
+			DEBUG_VSS(slot, "About to destroy, delete from VS and free slot");
 			list_destroy(&slot->objects);
 			list_destroy(&slot->logins);
 			list_delete(&virtual_slots, slot);


### PR DESCRIPTION
Improved Debugging of PKCS11 virtual_slots

The handling of these virtual slots with different applications has proved to be elusive. Hopefully the improved debugging will help in understanding how the current code works or does not work.

This PR consist of 2 commits. 

The first commit:
Debug PKCS11 virtual slots
    
Macro DEBUG_VSS and routine _debug_virtual_slots were added.
    
DEBUG_VSS(slot, "printf like format string" [,args...]) will print the virtual_slots
to the opensc-debug.log showing were it was called from.
If slot is not NULL and found in the table it will be highlighted
with an "*".
    
In gdb: `call _debug_virtual_slots(slot)` can be used along with
another window to tail opensc-debug.log anywhere to get the same effect.

The second commit:

Add calls to DEBUG_VSS  

These calls are placed at many places in the PKCS11 code to help show have the virtual_slots are changed.

Several issues are related: #1907, #1935 , #1945 and #1947. 



An example changed that improves FireFox, but not completely
[sample-slot-diff.txt](https://github.com/OpenSC/OpenSC/files/4239737/sample-slot-diff.txt)

Running without this sample shows that `SC_PKCS11_SLOT_FLAG_SEEN` appears to have no effect.  Slots are always deleted. No slot is converted to a "HotPlug" slot.

With this sample a removed reader results in a ""HotPlug" show showing up, but this is not enough if one tries to use more then one token. 

Firefox only expects slots to to increase between calls to C_GetSlotList. It can not handle the situation where all the slots are deleted. For example when a token with built in reader such as a Yubikey is removed.  This is different from a card being removed but the reader is still present.

#1947 is being withdrawn, as it is not complete. 


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X] PKCS#11 module is tested with `Firefox` and `pkcs11-tool --test-hotplug -v`


