### PR TITLE
Fix #1948: `enc_message` may be used uninitialized in p11test_case_ps…

### DIFF
--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -376,7 +376,7 @@ int oaep_encrypt_decrypt_test(test_cert_t *o, token_info_t *info, test_mech_t *m
 	CK_BYTE *dec_message = NULL;
 	int dec_message_length = 0;
 	int message_length = 16;
-	unsigned char *enc_message;
+	unsigned char *enc_message = 0;
 	int enc_message_length, rv;
 
 	if (o->private_handle == CK_INVALID_HANDLE) {


### PR DESCRIPTION
…s_oaep.c

https://github.com/OpenSC/OpenSC/issues/1948

p11test_case_pss_oaep.c: In function 'pss_oaep_test':
p11test_case_pss_oaep.c:424:2: error: 'enc_message' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  424 |  free(enc_message);
      |  ^

This is warning but it is treated as error.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
