### PR TITLE
Improved Handling of PKCS11 Slots

### DIFF
--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -206,6 +206,11 @@ struct sc_pkcs11_card {
  * the application calls `C_GetSlotList` with `NULL`. This flag tracks the
  * visibility to the application */
 #define SC_PKCS11_SLOT_FLAG_SEEN 1
+/* reader-pcsc.c can reuse a removed reader, as the ctx->reader list contains
+ * readers which have been removed retain removed readers.
+ * Take advantage of this feature to allow for reinsertion of a reader*/
+#define SC_PKCS11_SLOT_FLAG_READER_REMOVED 2
+
 
 struct sc_pkcs11_slot {
 	CK_SLOT_ID id;			/* ID of the slot */


### PR DESCRIPTION
OpenSC PKCS11 now retains slots even when the reader is removed.
It can do this because existing OpenSC reader handling in ctx.c,
reader-pcsc.c and PC/SC allow OpenSC to do this.

This simplifies the code, and allow a reader to be reinserted
and use the existing slot. This matching is actually done
in reader-pcsc.c because PC/SC returns the unique ids based on
the OS reader names. This is then used as the manufacturerID

By not deleting slots the slot list can only increase which is a
restriction of Firefox. It does not fix all the Firefox issues, but
it does not go into a loop, when all the readers are removed.

The defaults in opensc.conf for max-virtual-readers and slots-per-card
allow for 4 different readers used during one session.

 On branch PKCS11-SLOTS-3
 Changes to be committed:
	modified:   sc-pkcs11.h
	modified:   slot.c


Fixes: #1945 
Fixes: #1935 

Replaces: #1947 

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist

- [X ] PKCS#11 module is tested Firefox and pkcs11-tool 

