### PR TITLE
opensc-explorer cleanup

### DIFF
--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1602,7 +1602,7 @@ err:
 
 static int do_put(int argc, char **argv)
 {
-	u8 buf[256];
+	u8 buf[SC_MAX_EXT_APDU_DATA_SIZE];
 	int r, err = 1;
 	size_t count = 0;
 	unsigned int idx = 0;
@@ -1627,7 +1627,7 @@ static int do_put(int argc, char **argv)
 		r = sc_select_file(card, &path, &file);
 	sc_unlock(card);
 	if (r || file == NULL) {
-		check_ret(r, SC_AC_OP_SELECT, "unable to select file", current_file);
+		check_ret(r, SC_AC_OP_SELECT, "Unable to select file", current_file);
 		goto err;
 	}
 	count = file->size;
@@ -1646,17 +1646,17 @@ static int do_put(int argc, char **argv)
 			r = sc_update_binary(card, idx, buf, c, 0);
 		sc_unlock(card);
 		if (r < 0) {
-			check_ret(r, SC_AC_OP_READ, "update failed", file);
+			check_ret(r, SC_AC_OP_READ, "Update failed", file);
 			goto err;
 		}
 		if (r != c) {
-			fprintf(stderr, "expecting %d, wrote only %d bytes.\n", c, r);
+			fprintf(stderr, "Expecting %d, wrote only %d bytes.\n", c, r);
 			goto err;
 		}
 		idx += c;
 		count -= c;
 	}
-	printf("Total of %d bytes written.\n", idx);
+	printf("Total of %d bytes written to %04X.\n", idx, file->id);
 
 	err = 0;
 err:

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1711,11 +1711,11 @@ static int do_random(int argc, char **argv)
 
 	if (argc < 1 || argc > 2)
 		return usage(do_random);
-
 	count = atoi(argv[0]);
-	if (count < 0 || (size_t) count > sizeof buffer) {
+
+	if (count < 0 || (size_t) count > sizeof(buffer)) {
 		fprintf(stderr, "Number must be in range 0..%"SC_FORMAT_LEN_SIZE_T"u\n",
-			   	sizeof buffer);
+			sizeof(buffer));
 		return -1;
 	}
 

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 #ifdef ENABLE_READLINE
 #include <readline/readline.h>
 #include <readline/history.h>
@@ -1395,7 +1396,7 @@ static int do_unblock(int argc, char **argv)
 
 static int do_get(int argc, char **argv)
 {
-	u8 buf[256];
+	u8 buf[SC_MAX_EXT_APDU_RESP_SIZE];
 	int r, err = 1;
 	size_t count = 0;
 	unsigned int idx = 0;
@@ -1422,11 +1423,11 @@ static int do_get(int argc, char **argv)
 		r = sc_select_file(card, &path, &file);
 	sc_unlock(card);
 	if (r || file == NULL) {
-		check_ret(r, SC_AC_OP_SELECT, "unable to select file", current_file);
+		check_ret(r, SC_AC_OP_SELECT, "Unable to select file", current_file);
 		goto err;
 	}
 	if (file->type != SC_FILE_TYPE_WORKING_EF || file->ef_structure != SC_FILE_EF_TRANSPARENT) {
-		fprintf(stderr, "only transparent working EFs may be read\n");
+		fprintf(stderr, "Only transparent working EFs may be read\n");
 		goto err;
 	}
 	count = file->size;
@@ -1436,11 +1437,11 @@ static int do_get(int argc, char **argv)
 
 		r = sc_read_binary(card, idx, buf, c, 0);
 		if (r < 0) {
-			check_ret(r, SC_AC_OP_READ, "read failed", file);
+			check_ret(r, SC_AC_OP_READ, "Read failed", file);
 			goto err;
 		}
 		if ((r != c) && (card->type != SC_CARD_TYPE_BELPIC_EID)) {
-			fprintf(stderr, "expecting %d, got only %d bytes.\n", c, r);
+			fprintf(stderr, "Expecting %d, got only %d bytes.\n", c, r);
 			goto err;
 		}
 		if ((r == 0) && (card->type == SC_CARD_TYPE_BELPIC_EID))

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1807,22 +1807,24 @@ static int do_get_data(int argc, char **argv)
  **/
 static int do_put_data(int argc, char **argv)
 {
+	u8 id[2] = { 0x00, 0x00 };
 	unsigned int tag;
-	u8 buf[SC_MAX_EXT_APDU_BUFFER_SIZE];
+	u8 buf[SC_MAX_EXT_APDU_DATA_SIZE];
 	size_t buflen = sizeof(buf);
 	int r;
 
 	if (argc != 2)
 		return usage(do_put_data);
 
-	/* Extract DO's tag */
-	tag = strtoul(argv[0], NULL, 16);
+	if (arg_to_fid(argv[0], id) != 0)
+		return usage(do_get_data);
+	tag = id[0] << 8 | id[1];
 
 	/* Extract the new content */
 	/* buflen is the max length of reception buffer */
 	r = parse_string_or_hexdata(argv[1], buf, &buflen);
 	if (r < 0) {
-		fprintf(stderr, "error parsing %s: %s\n", argv[1], sc_strerror(r));
+		fprintf(stderr, "Error parsing %s: %s\n", argv[1], sc_strerror(r));
 		return r;
 	}
 
@@ -1832,7 +1834,7 @@ static int do_put_data(int argc, char **argv)
 		r = sc_put_data(card, tag, buf, buflen);
 	sc_unlock(card);
 	if (r < 0) {
-		fprintf(stderr, "Cannot put data to %04X; return %i\n", tag, r);
+		fprintf(stderr, "Failed to put data to DO %04X: %s\n", tag, sc_strerror(r));
 		return -1;
 	}
 

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -707,10 +707,10 @@ static int do_cd(int argc, char **argv)
 			return -1;
 		}
 
-		if (path.type == SC_PATH_TYPE_DF_NAME)   {
+		if (path.type == SC_PATH_TYPE_DF_NAME) {
 			sc_format_path("3F00", &path);
 		}
-		else   {
+		else {
 			path.len -= 2;
 		}
 
@@ -738,7 +738,8 @@ static int do_cd(int argc, char **argv)
 		check_ret(r, SC_AC_OP_SELECT, "unable to select DF", current_file);
 		return -1;
 	}
-	if ((file->type != SC_FILE_TYPE_DF) && (card->type != SC_CARD_TYPE_BELPIC_EID)) {
+	if ((file->type != SC_FILE_TYPE_DF) && (file->type != SC_FILE_TYPE_UNKNOWN) &&
+			(card->type != SC_CARD_TYPE_BELPIC_EID)) {
 		fprintf(stderr, "Error: file is not a DF.\n");
 		sc_file_free(file);
 		select_current_path_or_die();

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -371,7 +371,8 @@ arg_to_path(const char *arg, sc_path_t *path, int is_id)
 	} else {
 		/* file id */
 		u8 cbuf[2];
-        if (arg_to_fid(arg, cbuf) < 0)
+
+		if (arg_to_fid(arg, cbuf) < 0)
 			return -1;
 
 		if ((cbuf[0] == 0x3F && cbuf[1] == 0x00) || is_id) {
@@ -380,8 +381,8 @@ arg_to_path(const char *arg, sc_path_t *path, int is_id)
 			path->type = (is_id) ? SC_PATH_TYPE_FILE_ID : SC_PATH_TYPE_PATH;
 		} else {
 			*path = current_path;
-			if (path->type == SC_PATH_TYPE_DF_NAME)   {
-				if (path->len > sizeof(path->aid.value))   {
+			if (path->type == SC_PATH_TYPE_DF_NAME) {
+				if (path->len > sizeof(path->aid.value)) {
 					fprintf(stderr, "Invalid length of DF_NAME path\n");
 					return -1;
 				}

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -780,7 +780,7 @@ err:
 
 static int read_and_print_record_file(sc_file_t *file, unsigned char sfi)
 {
-	u8 buf[256];
+	u8 buf[SC_MAX_EXT_APDU_RESP_SIZE];
 	int rec, r;
 
 	for (rec = 1; ; rec++) {
@@ -794,12 +794,14 @@ static int read_and_print_record_file(sc_file_t *file, unsigned char sfi)
 		if (r == SC_ERROR_RECORD_NOT_FOUND)
 			return 0;
 		if (r < 0) {
-			check_ret(r, SC_AC_OP_READ, "read failed", file);
+			check_ret(r, SC_AC_OP_READ, "Read failed", file);
 			return -1;
 		}
 		printf("Record %d:\n", rec);
 		util_hex_dump_asc(stdout, buf, r, 0);
 	}
+
+	return 0;
 }
 
 static int do_cat(int argc, char **argv)

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -618,14 +618,12 @@ static int do_find(int argc, char **argv)
 
 static int do_find_tags(int argc, char **argv)
 {
-	u8 start[2], end[2], rbuf[256];
+	u8 start[2] = { 0x00, 0x00 };
+	u8 end[2]   = { 0xFF, 0xFF };
+	u8 rbuf[SC_MAX_EXT_APDU_RESP_SIZE];
 	int r;
 	unsigned int tag, tag_end;
 
-	start[0] = 0x00;
-	start[1] = 0x00;
-	end[0] = 0xFF;
-	end[1] = 0xFF;
 	switch (argc) {
 	case 2:
 		if (arg_to_fid(argv[1], end) != 0)
@@ -650,7 +648,7 @@ static int do_find_tags(int argc, char **argv)
 
 		r = sc_lock(card);
 		if (r == SC_SUCCESS)
-			r = sc_get_data(card, tag, rbuf, sizeof rbuf);
+			r = sc_get_data(card, tag, rbuf, sizeof(rbuf));
 		else
 			r = SC_ERROR_READER_LOCKED;
 		sc_unlock(card);

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1469,7 +1469,7 @@ err:
 
 static int do_update_binary(int argc, char **argv)
 {
-	u8 buf[240];
+	u8 buf[SC_MAX_EXT_APDU_DATA_SIZE];
 	size_t buflen = sizeof(buf);
 	int r, err = 1;
 	int offs;
@@ -1480,13 +1480,11 @@ static int do_update_binary(int argc, char **argv)
 		return usage(do_update_binary);
 	if (arg_to_path(argv[0], &path, 0) != 0)
 		return usage(do_update_binary);
-	offs = strtol(argv[1],NULL,10);
-
-	printf("in: %i; %s\n", offs, argv[2]);
+	offs = strtol(argv[1], NULL, 10);
 
 	r = parse_string_or_hexdata(argv[2], buf, &buflen);
 	if (r < 0) {
-		fprintf(stderr, "unable to parse data\n");
+		fprintf(stderr, "Unable to parse input data: %s\n", strerror(r));
 		return -1;
 	}
 
@@ -1495,11 +1493,11 @@ static int do_update_binary(int argc, char **argv)
 		r = sc_select_file(card, &path, &file);
 	sc_unlock(card);
 	if (r) {
-		check_ret(r, SC_AC_OP_SELECT, "unable to select file", current_file);
+		check_ret(r, SC_AC_OP_SELECT, "Unable to select file", current_file);
 		return -1;
 	}
 
-	if (file->ef_structure != SC_FILE_EF_TRANSPARENT)   {
+	if (file->ef_structure != SC_FILE_EF_TRANSPARENT) {
 		fprintf(stderr, "EF structure should be SC_FILE_EF_TRANSPARENT\n");
 		goto err;
 	}
@@ -1509,11 +1507,11 @@ static int do_update_binary(int argc, char **argv)
 		r = sc_update_binary(card, offs, buf, buflen, 0);
 	sc_unlock(card);
 	if (r < 0) {
-		fprintf(stderr, "Cannot update %04X; return %i\n", file->id, r);
+		fprintf(stderr, "Cannot update %04X: %s\n", file->id, strerror(r));
 		goto err;
 	}
 
-	printf("Total of %d bytes written to %04X at %i offset.\n",
+	printf("Total of %d bytes written to %04X at offset %d.\n",
 	       r, file->id, offs);
 
 	err = 0;

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -553,14 +553,11 @@ static int do_ls(int argc, char **argv)
 
 static int do_find(int argc, char **argv)
 {
-	u8 fid[2], end[2];
+	u8 fid[2] = { 0x00, 0x00 };
+	u8 end[2] = { 0xFF, 0xFF };
 	sc_path_t path;
 	int r;
 
-	fid[0] = 0;
-	fid[1] = 0;
-	end[0] = 0xFF;
-	end[1] = 0xFF;
 	switch (argc) {
 	case 2:
 		if (arg_to_fid(argv[1], end) != 0)
@@ -585,10 +582,10 @@ static int do_find(int argc, char **argv)
 
 		if (current_path.type != SC_PATH_TYPE_DF_NAME) {
 			path = current_path;
-			sc_append_path_id(&path, fid, sizeof fid);
+			sc_append_path_id(&path, fid, sizeof(fid));
 		} else {
-			if (sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, 2, 0, 0) != SC_SUCCESS) {
-				fprintf(stderr, "unable to set path.\n");
+			if (sc_path_set(&path, SC_PATH_TYPE_FILE_ID, fid, sizeof(fid), 0, 0) != SC_SUCCESS) {
+				fprintf(stderr, "Unable to set path.\n");
 				die(1);
 			}
 		}


### PR DESCRIPTION
This PR addresses some issues in `opensc-explorer`, 
mainly:
* magic numbers as buffer sizes, which may be too low as well
* more consistency in error messages: start with upper case
* some fixes to `do_update_record()`

Thanks ind advance for pulling
Peter