### PR TITLE
Improved Handling of PKCS11 Slots (2)

### DIFF
--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -360,14 +360,14 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 			}
 
 			if ( gsdata[idx1] == 0x30 &&
-				is_seq(gsdata + idx1, &seq_size1, &seq_len1) &&
-			 	is_seq(gsdata + idx1 + seq_size1, &seq_size2, &seq_len2) &&
-			    gsdata[idx1 + seq_size1 + seq_size2 + 0] == 0xa0 &&
-				gsdata[idx1 + seq_size1 + seq_size2 + 1] == 0x03 &&
-				gsdata[idx1 + seq_size1 + seq_size2 + 2] == 0x02 &&
-				gsdata[idx1 + seq_size1 + seq_size2 + 3] == 0x01 &&
-				gsdata[idx1 + seq_size1 + seq_size2 + 4] == 0x02 &&
-				idx1 + 4 + seq_len1 < file->size) {
+					is_seq(gsdata + idx1, &seq_size1, &seq_len1) &&
+					is_seq(gsdata + idx1 + seq_size1, &seq_size2, &seq_len2) &&
+					gsdata[idx1 + seq_size1 + seq_size2 + 0] == 0xa0 &&
+					gsdata[idx1 + seq_size1 + seq_size2 + 1] == 0x03 &&
+					gsdata[idx1 + seq_size1 + seq_size2 + 2] == 0x02 &&
+					gsdata[idx1 + seq_size1 + seq_size2 + 3] == 0x01 &&
+					gsdata[idx1 + seq_size1 + seq_size2 + 4] == 0x02 &&
+					idx1 + 4 + seq_len1 < file->size) {
 				/* we have a cert (I hope) */
 				/* read in rest if needed */
 				idxlen = idx1 + seq_len1 + 4 - idx2; 
@@ -386,7 +386,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 					return SC_ERROR_OUT_OF_MEMORY;
 
 				memcpy(cert_info.value.value, gsdata + idx1, cert_info.value.len);
-			idx1 = idx1 + cert_info.value.len;
+				idx1 = idx1 + cert_info.value.len;
 				break;
 			}
 			idx1++;

--- a/src/libopensc/reader-cryptotokenkit.m
+++ b/src/libopensc/reader-cryptotokenkit.m
@@ -577,6 +577,7 @@ static int cryptotokenkit_detect_readers(sc_context_t *ctx)
 		if (j < [slotNames count]) {
 			/* existing reader found; remove it from the list */
 			[slotNames removeObjectAtIndex:j];
+			reader->flags &= ~SC_READER_REMOVED;
 		} else {
 			/* existing reader not found */
 			reader->flags |= SC_READER_REMOVED;

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -475,10 +475,8 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 		 */
 		if ((!tokenPresent && !slot->reader)
 				|| (!tokenPresent && slot->reader != prev_reader)
-				|| (slot->slot_info.flags & CKF_TOKEN_PRESENT)
-				|| (slot->flags & SC_PKCS11_SLOT_FLAG_SEEN)) {
+				|| (slot->slot_info.flags & CKF_TOKEN_PRESENT)) {
 			found[numMatches++] = slot->id;
-			slot->flags |= SC_PKCS11_SLOT_FLAG_SEEN;
 		}
 		prev_reader = slot->reader;
 	}

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -468,8 +468,7 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 	for (i=0; i<list_size(&virtual_slots); i++) {
 		slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
 		/* the list of available slots contains:
-		 * - if present, virtual hotplug slot;
-		 * - without token(s), one empty slot per reader;
+		 * - without token(s), at least one empty slot per reader;
 		 * - any slot with token;
 		 * - any slot that has already been seen;
 		 */
@@ -550,7 +549,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 	sc_log(context, "C_GetSlotInfo(0x%lx)", slotID);
 
 	if (sc_pkcs11_conf.init_sloppy) {
-		/* Most likely virtual_slots only contains the hotplug slot and has not
+		/* Most likely virtual_slots is empty and has not
 		 * been initialized because the caller has *not* called C_GetSlotList
 		 * before C_GetSlotInfo, as required by PKCS#11.  Initialize
 		 * virtual_slots to make things work and hope the caller knows what

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -65,7 +65,6 @@ struct sc_pkcs11_slot;
 struct sc_pkcs11_card;
 
 struct sc_pkcs11_config {
-	unsigned int plug_and_play;
 	unsigned int max_virtual_slots;
 	unsigned int slots_per_card;
 	unsigned char lock_login;

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -201,16 +201,6 @@ struct sc_pkcs11_card {
 	unsigned int nmechanisms;
 };
 
-/* If the slot did already show with `C_GetSlotList`, then we need to keep this
- * slot alive. PKCS#11 2.30 allows allows adding but not removing slots until
- * the application calls `C_GetSlotList` with `NULL`. This flag tracks the
- * visibility to the application */
-#define SC_PKCS11_SLOT_FLAG_SEEN 1
-/* reader-pcsc.c can reuse a removed reader, as the ctx->reader list contains
- * readers which have been removed retain removed readers.
- * Take advantage of this feature to allow for reinsertion of a reader*/
-#define SC_PKCS11_SLOT_FLAG_READER_REMOVED 2
-
 
 struct sc_pkcs11_slot {
 	CK_SLOT_ID id;			/* ID of the slot */
@@ -231,7 +221,6 @@ struct sc_pkcs11_slot {
 	int flags;
 };
 typedef struct sc_pkcs11_slot sc_pkcs11_slot_t;
-
 
 /* Forward decl */
 typedef struct sc_pkcs11_operation sc_pkcs11_operation_t;

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -206,6 +206,11 @@ struct sc_pkcs11_card {
  * the application calls `C_GetSlotList` with `NULL`. This flag tracks the
  * visibility to the application */
 #define SC_PKCS11_SLOT_FLAG_SEEN 1
+/* reader-pcsc.c can reuse a removed reader, as the ctx->reader list contains
+ * readers which have been removed retain removed readers.
+ * Take advantage of this feature to allow for reinsertion of a reader*/
+#define SC_PKCS11_SLOT_FLAG_READER_REMOVED 2
+
 
 struct sc_pkcs11_slot {
 	CK_SLOT_ID id;			/* ID of the slot */


### PR DESCRIPTION
This PR extends https://github.com/OpenSC/OpenSC/pull/1961 to

- simplify the PKCS#11 state tracking
- remove duplicated initialization code
- identifies a slot's reader based on the reader description instead of the reader's handle

Fixes: #1945
Fixes: #1935

Replaces: #1947