### PR TITLE
pkcs11: don't try to allocate 0 byte with calloc

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -458,7 +458,8 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 
 	DEBUG_VSS(NULL, "C_GetSlotList after card_detect_all");
 
-	found = calloc(list_size(&virtual_slots), sizeof(CK_SLOT_ID));
+	/* alloc 1 more, to handle case of no virtual_slots */
+	found = calloc(list_size(&virtual_slots) + 1, sizeof(CK_SLOT_ID));
 
 	if (found == NULL) {
 		rv = CKR_HOST_MEMORY;


### PR DESCRIPTION
This should suppress a warning from Electric Fence as reported in:
https://lists.libreswan.org/pipermail/swan-dev/2020-February/003626.html.

While it is is safe to call calloc() with 0 size on glibc systems,
POSIX says the behavior is implementation-defined.

