### PR TITLE
coolkey: Avoid memory leak

### DIFF
--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -2178,9 +2178,9 @@ static int coolkey_initialize(sc_card_t *card)
 		object_len = bebytes2ulong(object_info.object_length);
 		/* Avoid insanely large data */
 		if (object_len > MAX_FILE_SIZE) {
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_CORRUPTED_DATA);
+			r = SC_ERROR_CORRUPTED_DATA;
+			goto cleanup;
 		}
-
 
 		/* the combined object is a single object that can store the other objects.
 		 * most coolkeys provisioned by TPS has a single combined object that is


### PR DESCRIPTION
Fixup previous attempt to avoid too large allocations

Thanks oss-fuzz

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21059

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
