### PR TITLE
pkcs11-tool: Fix mismatched --help text

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -274,6 +274,7 @@ static const char *option_help[] = {
 	"Specify 'sign' key usage flag (sets SIGN in privkey, sets VERIFY in pubkey)",
 	"Specify 'decrypt' key usage flag (RSA only, set DECRYPT privkey, ENCRYPT in pubkey)",
 	"Specify 'derive' key usage flag (EC only)",
+	"Specify 'wrap' key usage flag",
 	"Write an object (key, cert, data) to the card",
 	"Get object's CKA_VALUE attribute (use with --type)",
 	"Delete an object (use with --type cert/data/privkey/pubkey/secrkey)",


### PR DESCRIPTION
The addition of --usage-wrap did not add a corresponding help string, which caused all help text for the options below it to be shifted by one.

Just a small blemish I noticed :)

I used the --usage-wrap help text from the XML file.