### PR TITLE
Fuzzing issues to be able to improve oss-fuzz integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AC_ARG_WITH(
 )
 
 if test "${enable_optimization}" = "no"; then
-	CFLAGS="-O0 -g"
+	CFLAGS="${CFLAGS} -O0 -g"
 fi
 
 dnl Check for some target-specific stuff

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -961,6 +961,9 @@ static int sc_asn1_decode_utf8string(const u8 *inbuf, size_t inlen,
 	return 0;
 }
 
+/*
+ * This assumes the tag is already encoded
+ */
 int sc_asn1_put_tag(unsigned int tag, const u8 * data, size_t datalen, u8 * out, size_t outlen, u8 **ptr)
 {
 	size_t c = 0;

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -182,10 +182,12 @@ auth_select_aid(struct sc_card *card)
 	LOG_TEST_RET(card->ctx, rv, "select parent failed");
 
 	sc_format_path("3F00", &tmp_path);
+	sc_file_free(auth_current_df);
 	rv = iso_ops->select_file(card, &tmp_path, &auth_current_df);
 	LOG_TEST_RET(card->ctx, rv, "select parent failed");
 
 	sc_format_path("3F00", &card->cache.current_path);
+	sc_file_free(auth_current_ef);
 	sc_file_dup(&auth_current_ef, auth_current_df);
 
 	memcpy(data->aid, aidAuthentIC_V5, lenAidAuthentIC_V5);

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -161,7 +161,7 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 		LOG_FUNC_RETURN(ctx, apdu.resplen);
 	LOG_TEST_RET(ctx, r, "Check SW error");
 
-	if (apdu.resplen < count)   {
+	if (apdu.resplen > 0 && apdu.resplen < count) {
 		r = iso7816_read_binary(card, idx + apdu.resplen, buf + apdu.resplen, count - apdu.resplen, flags);
 		/* Ignore all but 'corrupted data' errors */
 		if (r == SC_ERROR_CORRUPTED_DATA)

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -670,9 +670,6 @@ static int sc_pkcs15emu_coolkey_init(sc_pkcs15_card_t *p15card)
 			sc_log(card->ctx, "Unknown object type %lu, skipping", obj_class);
 			continue;
 		}
-		if (obj_info == NULL) {
-			continue;
-		}
 
 		r = sc_pkcs15emu_object_add(p15card, obj_type, &obj_obj, obj_info);
 		if (r != SC_SUCCESS)

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -1104,7 +1104,7 @@ sc_log(card->ctx,  "DEE Adding pin %d label=%s",i, label);
 				if (ckis[i].cert_keyUsage_present) {
 					pubkey_info.usage = ckis[i].pub_usage;
 				} else {
-				    pubkey_info.usage = pubkeys[i].usage_ec;
+					pubkey_info.usage = pubkeys[i].usage_ec;
 				}
 
 				pubkey_info.field_length = ckis[i].pubkey_len; 

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -851,6 +851,8 @@ sc_pkcs15_encode_pubkey_as_spki(sc_context_t *ctx, struct sc_pkcs15_pubkey *pubk
 			}
 			memcpy(ec_params->der.value, pubkey->u.ec.params.der.value, pubkey->u.ec.params.der.len);
 			ec_params->der.len = pubkey->u.ec.params.der.len;
+			/* This could have been already allocated: avoid memory leak */
+			sc_asn1_clear_algorithm_id(pubkey->alg_id);
 			pubkey->alg_id->params = ec_params;
 		}
 		break;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1895,6 +1895,11 @@ sc_pkcs15_free_object(struct sc_pkcs15_object *obj)
 		sc_pkcs15_free_prkey_info((sc_pkcs15_prkey_info_t *)obj->data);
 		break;
 	case SC_PKCS15_TYPE_PUBKEY:
+		/* This is normally passed to framework-pkcs15,
+		 * but if something fails on the way, it would not get freed */
+		if (obj->emulated) {
+			sc_pkcs15_free_pubkey(obj->emulated);
+		}
 		sc_pkcs15_free_pubkey_info((sc_pkcs15_pubkey_info_t *)obj->data);
 		break;
 	case SC_PKCS15_TYPE_CERT:

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -2550,10 +2550,10 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 			priv->pcsc_card = card_handle;
 			detect_protocol(reader, card_handle);
 			detect_reader_features(reader, card_handle);
+			gpriv->attached_reader = reader;
 		} else {
 			_sc_delete_reader(ctx, reader);
 		}
-		gpriv->attached_reader = reader;
 	}
 
 out:

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -732,7 +732,7 @@ __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 		/* if emulation already created pubkey use it */
 		if (pubkey->emulated && (fw_data->p15_card->flags & SC_PKCS15_CARD_FLAG_EMULATED)) {
 			sc_log(context, "Use emulated pubkey");
-			p15_key = (struct sc_pkcs15_pubkey *) pubkey->emulated;
+			sc_pkcs15_dup_pubkey(context, (struct sc_pkcs15_pubkey *) pubkey->emulated, &p15_key);
 		}
 		else {
 			sc_log(context, "Get pubkey from PKCS#15 object");


### PR DESCRIPTION
Some time ago (1742dfc0), I created first corpus files that go through the whole process of card detection for the cards I have at hand (various CAC, various PIV, CardOS, coolkey). This lead into few crashes in the fuzzers that are currently resolved so I proposed changes to merge them in google/oss-fuzz#3683. But just running with the prepared traces already showed few issues that need to be fixed before the actual changes can be merged in oss-fuzz. There is also one oss-fuzz report fixed from last weeks.

I would like to ask others to contribute their traces as corpus for fuzzers to improve test coverage of their drivers. I would certainly like to add the opengpg trace of the card I have when #1960 will be in), but running with different keys will be also interesting.

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested