### PR TITLE
unittests: Fix out-of-source build

### DIFF
--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -12,11 +12,10 @@ TESTS = asn1 simpletlv
 noinst_HEADERS = torture.h
 
 AM_CFLAGS = -I$(top_srcdir)/src/ \
-	-L$(top_srcdir)/src/libopensc/ \
 	$(CODE_COVERAGE_CFLAGS) \
 	$(CMOCKA_CFLAGS)
 AM_CPPFLAGS =$(CODE_COVERAGE_CPPFLAGS)
-LDADD = $(top_srcdir)/src/libopensc/libopensc.la \
+LDADD = $(top_builddir)/src/libopensc/libopensc.la \
 	$(CODE_COVERAGE_LIBS) \
 	$(OPTIONAL_OPENSSL_LIBS) \
 	$(CMOCKA_LIBS)


### PR DESCRIPTION
Commit 4fd34e28eaf1 unintentionally replaced top_builddir with
top_srcdir when refactoring flags variables in Makefile.am. This causes
out-of-source builds to fail.

Restore top_builddir in LDADD.

Also, remove a superfluous -L flag also referencing top_srcdir from
AM_CFLAGS while at it.

Signed-off-by: Michael Weiser <michael.weiser@gmx.de>

Closes #2027.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
