### PR TITLE
card-piv.c error in using sc_asn1_put_tag

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1670,28 +1670,30 @@ static int piv_general_mutual_authenticate(sc_card_t *card,
 	}
 
 	/* nonce for challenge */
-	tmplen = sc_asn1_put_tag(0x81, NULL, witness_len, NULL, 0, NULL);
-	if (tmplen <= 0) {
+	r = sc_asn1_put_tag(0x81, NULL, witness_len, NULL, 0, NULL);
+	if (r <= 0) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
+	tmplen = r;
 
 	/* plain text witness keep a length separate for the 0x7C tag */
-	tmplen2 = sc_asn1_put_tag(0x80, NULL, witness_len, NULL, 0, NULL);
-	if (tmplen2 <= 0) {
+	r = sc_asn1_put_tag(0x80, NULL, witness_len, NULL, 0, NULL);
+	if (r <= 0) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
-	tmplen2 += tmplen;
+	tmplen += r;
+	tmplen2 = tmplen;
 
 	/* outside 7C tag with 81:80 as innards */
-	tmplen = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
-	if (tmplen <= 0) {
+	r = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
+	if (r <= 0) {
 		r = SC_ERROR_INTERNAL;
 		goto err;
 	}
 
-	built_len = tmplen;
+	built_len = r;
 
 	/* Build the response buffer */
 	p = built = malloc(built_len);


### PR DESCRIPTION
In piv_general_mutual_authenticate sc_asn1_put_tag is not used correctly.

 On branch piv-sc_asn1_put_tag-error
 Changes to be committed:
	modified:   card-piv.c

This is only used by piv-tool when doing piv_general_mutual_authenticate.

Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] piv-tool to create EC key. 

Problem found while testing real PIV card for #2028 See https://github.com/OpenSC/OpenSC/issues/2028#issuecomment-627579440