### PR TITLE
Unbreak oss-fuzz build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
       os: osx
       osx_image: xcode9.4
       env: DO_PUSH_ARTIFACT=yes
+    - compiler: clang
+      os: linux
+      dist: bionic
     - compiler: gcc
       os: linux
       dist: bionic

--- a/configure.ac
+++ b/configure.ac
@@ -419,7 +419,19 @@ AC_CHECK_FUNCS([ \
 	strdup strerror memset_s explicit_bzero \
 	strnlen sigaction
 ])
-AC_CHECK_DECLS([strlcpy, strlcat], [], [], [[#include <string.h>]])
+
+# Do not check for strlcpy and strlcat in Linux because it is not implemented
+# and autotools can not detect it in AC_CHECK_DECLS because build does not fail
+# in this test.
+# https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22192
+case "${host_os}" in
+	linux*)
+		;;
+	*)
+		AC_CHECK_DECLS([strlcpy, strlcat], [], [], [[#include <string.h>]])
+		;;
+esac
+
 AC_CHECK_SIZEOF(void *)
 if test "${ac_cv_sizeof_void_p}" = 8; then
 	LIBRARY_BITNESS="64"


### PR DESCRIPTION
Moving the check in 178c4a9e from `AC_CHECK_FUNCS` to `AC_CHECK_DECLS` addresses the issue on OSX, but breaks on Linux for clang, which wrongly reports that `strlcpy` and `strlcat` are available, even though it reports warning and they are nowhere to be found.

This broke the oss-fuzz builds. There is a fix in autoconf for this, but it was never released:

http://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=82ef7805faffa151e724aa76c245ec590d174580

Locally reproducible:
```
CC=clang ./configure
CC=clang make
```

We need some workaround to be able to build both on osx and with clang on Linux. From the least intrusive solutions, I came up with skipping this check on Linux altogether (I found only some altlinux, which provides these functions in their glibc)

Some more informations and investigations can be found in the attached oss-fuzz bug tracker:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22192

This PR also adds a Linux x clang Travis target, but it did not reproduce the issue for me for some reason (running clang 7):

https://travis-ci.org/github/Jakuje/OpenSC/jobs/688438200

Locally (clang 9) and in oss-fuzz images (clang 10), it reproduces. There is no newer version of clang available in travis at this moment.