### PR TITLE
pkcs11: Return CKR_TOKEN_NOT_RECOGNIZED for not recognized cards

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -557,7 +557,11 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	}
 
 	if (slot->p11card == NULL) {
-		rv = CKR_TOKEN_NOT_PRESENT;
+		if (slot->slot_info.flags & CKF_TOKEN_PRESENT) {
+			rv = CKR_TOKEN_NOT_RECOGNIZED;
+		} else {
+			rv = CKR_TOKEN_NOT_PRESENT;
+		}
 		goto out;
 	}
 


### PR DESCRIPTION
Fixes #2030

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
