### PR TITLE
pkcs11: If user consent is ignored through configuration, do not pres…

### DIFF
--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1163,6 +1163,11 @@ app <replaceable>application</replaceable> {
 							<literal>CKA_ALWAYS_AUTHENTICATE</literal> may
 							need to set this to get signatures to work with
 							some cards (Default: <literal>false</literal>).
+					</para>
+					<para>
+							It is recommended to enable also PIN caching using
+							<literal>use_pin_caching</literal> option for OpenSC
+							to be able to provide PIN for the card when needed.
 					</para></listitem>
 				</varlistentry>
 				<varlistentry>

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -903,6 +903,8 @@ app default {
 		# Older PKCS#11 applications not supporting CKA_ALWAYS_AUTHENTICATE
 		# may need to set this to get signatures to work with some cards.
 		# Default: false
+		# It is recommended to enable also use_pin_caching to allow OpenSC
+		# to pass the pin to the card when needed.
 		# pin_cache_ignore_user_consent = true;
 
 		# How to handle a PIN-protected certificate

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3773,9 +3773,13 @@ pkcs15_prkey_get_attribute(struct sc_pkcs11_session *session,
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
 		*(CK_BBOOL*)attr->pValue = (prkey->prv_info->access_flags & SC_PKCS15_PRKEY_ACCESS_LOCAL) != 0;
 		break;
-    case CKA_ALWAYS_AUTHENTICATE:
+	case CKA_ALWAYS_AUTHENTICATE:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));
-		*(CK_BBOOL*)attr->pValue = prkey->prv_p15obj->user_consent >= 1 ? CK_TRUE : CK_FALSE;
+		if (fw_data->p15_card->opts.pin_cache_ignore_user_consent) {
+			*(CK_BBOOL*)attr->pValue = CK_FALSE;
+		} else {
+			*(CK_BBOOL*)attr->pValue = prkey->prv_p15obj->user_consent >= 1 ? CK_TRUE : CK_FALSE;
+		}
 		break;
 	case CKA_PRIVATE:
 		check_attribute_buffer(attr, sizeof(CK_BBOOL));


### PR DESCRIPTION
…ent ALWAYS_AUTHENTICATE attribute

Fixes #2039

This extends the function of `pin_cache_ignore_user_consent` to prevent presenting `CKA_ALWAYS_AUTHENTICATE` to applications, which understand this attribute and issue useless second PIN prompt (even though pin is already cached in OpenSC or not needed at all).

I believe current documentation is fine (man opensc.conf), but if you believe it needs to be updated, please suggest.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
