### PR TITLE
Fix C_Login() crashing when using uninitialized card

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ before_script:
       javac -classpath jcardsim/target/jcardsim-3.0.5-SNAPSHOT.jar IsoApplet/src/net/pwendland/javacard/pki/isoapplet/*.java;
       echo "com.licel.jcardsim.card.applet.0.AID=F276A288BCFBA69D34F31001" > isoapplet_jcardsim.cfg;
       echo "com.licel.jcardsim.card.applet.0.Class=net.pwendland.javacard.pki.isoapplet.IsoApplet" >> isoapplet_jcardsim.cfg;
-      echo "com.licel.jcardsim.card.ATR=3B80800101" >> isoapplet_jcardsim.cfg;
+      echo "com.licel.jcardsim.card.ATR=3B8B8001805949736F4170706C6574BA" >> isoapplet_jcardsim.cfg;
       echo "com.licel.jcardsim.vsmartcard.host=localhost" >> isoapplet_jcardsim.cfg;
       echo "com.licel.jcardsim.vsmartcard.port=35963" >> isoapplet_jcardsim.cfg;
 
@@ -254,6 +254,8 @@ script:
       opensc-tool --card-driver default --send-apdu 80b800001a0cf276a288bcfba69d34f310010cf276a288bcfba69d34f3100100;
       opensc-tool -n;
       pkcs15-init --create-pkcs15 --so-pin 123456 --so-puk 0123456789abcdef;
+      pkcs15-tool --change-pin --pin 123456 --new-pin 654321;
+      pkcs15-tool --unblock-pin --puk 0123456789abcdef --new-pin 123456;
       pkcs15-init --generate-key rsa/2048     --id 1 --key-usage decrypt,sign --auth-id FF --pin 123456;
       pkcs15-init --generate-key rsa/2048     --id 2 --key-usage decrypt      --auth-id FF --pin 123456;
       pkcs15-init --generate-key ec/secp256r1 --id 3 --key-usage sign         --auth-id FF --pin 123456;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1603,6 +1603,9 @@ pkcs15_login(struct sc_pkcs11_slot *slot, CK_USER_TYPE userType,
 	if (!fw_data)
 		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_Login");
 	p15card = fw_data->p15_card;
+	if (p15card == NULL) {
+		return CKR_FUNCTION_FAILED;
+	}
 
 	sc_log(context, "pkcs15-login: userType 0x%lX, PIN length %li", userType, ulPinLen);
 	switch (userType) {


### PR DESCRIPTION
`pkcs11-tool --init-pin ...` crashes if the card hasn't been initialized beforehand with `pkcs11-tool --init-token ...` (or by any other means) as p15card == NULL

Tested on IsoApplet javacard.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
