### PR TITLE
IsoApplet: Fix uninitialized public key oid during key generation

### DIFF
--- a/src/pkcs15init/pkcs15-isoApplet.c
+++ b/src/pkcs15init/pkcs15-isoApplet.c
@@ -533,6 +533,7 @@ isoApplet_generate_key_ec(const sc_pkcs15_prkey_info_t *key_info, sc_card_t *car
 		goto out;
 	}
 	pubkey->alg_id->algorithm = SC_ALGORITHM_EC;
+	sc_init_oid(&pubkey->alg_id->oid);
 	pubkey->alg_id->params = alg_id_params;
 
 	/* Extract ecpointQ */


### PR DESCRIPTION
During EC key generation public key oid is left uninitialized. This is usually detected by `sc_valid_oid()`, but sometimes garbage oid passes the `sc_valid_oid()` test which leads to invalid public key encoding (the correct oid is _id-ecPublicKey_ 1.2.840.10045.2.1):

```    
[opensc-pkcs11] pkcs15-algo.c:528:sc_asn1_encode_algorithm_id: called
[opensc-pkcs11] pkcs15-algo.c:529:sc_asn1_encode_algorithm_id: type of algorithm to encode: 2
[opensc-pkcs11] pkcs15-algo.c:543:sc_asn1_encode_algorithm_id: encode algo 0.0.0.2003791467.1126203502.1802532407.927146784.892613685.875901749.538976288.538976288.538976288.52437024.-1525677054.839850001.808464944
```    
and consequently key generation fails:
```    
error: PKCS11 function C_GenerateKeyPair failed: rv = unknown PKCS11 error (0xfffffaec)
```