### PR TITLE
Remove compiler warnings/errors

### DIFF
--- a/src/common/compat_getopt_main.c
+++ b/src/common/compat_getopt_main.c
@@ -99,7 +99,7 @@ handle(char *progname,
             {
               char rc = letters[(match - letters + rotate) % 26];
               if (isupper(c))
-                rc = toupper(rc);
+                rc = toupper((unsigned char)rc);
               c = rc;
             }
         }

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -284,7 +284,7 @@ static int sc_hsm_match_card(struct sc_card *card)
 static int sc_hsm_encode_sopin(const u8 *sopin, u8 *sopinbin)
 {
 	int i;
-	char digit;
+	unsigned char digit;
 
 	memset(sopinbin, 0, 8);
 	for (i = 0; i < 16; i++) {

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -274,7 +274,7 @@ int sc_format_oid(struct sc_object_id *oid, const char *in)
 		if (!*q)
 			break;
 
-		if (!(q[0] == '.' && isdigit(q[1])))
+		if (!(q[0] == '.' && isdigit((unsigned char)q[1])))
 			goto out;
 
 		p = q + 1;

--- a/src/pkcs15init/profile.c
+++ b/src/pkcs15init/profile.c
@@ -2123,7 +2123,7 @@ get_authid(struct state *cur, const char *value,
 	char	temp[16];
 	size_t	n;
 
-	if (isdigit((int) *value)) {
+	if (isdigit((unsigned char) *value)) {
 		*num = 0;
 		return get_uint(cur, value, type);
 	}
@@ -2183,7 +2183,7 @@ map_str2int(struct state *cur, const char *value,
 	unsigned int	n;
 	const char	*what;
 
-	if (isdigit((int) *value))
+	if (isdigit((unsigned char) *value))
 		return get_uint(cur, value, vp);
 	for (n = 0; map[n].name; n++) {
 		if (!strcasecmp(value, map[n].name)) {
@@ -2270,17 +2270,17 @@ __expr_get(struct num_exp_ctx *ctx, int eof_okay)
 			ctx->argc--;
 		}
 
-		while (isspace(*s))
+		while (isspace((unsigned char)*s))
 			s++;
 	} while (*s == '\0');
 
-	if (isdigit(*s)) {
-		while (isdigit(*s))
+	if (isdigit((unsigned char)*s)) {
+		while (isdigit((unsigned char)*s))
 			expr_put(ctx, *s++);
 	}
 	else if (*s == '$') {
 		expr_put(ctx, *s++);
-		while (isalnum(*s) || *s == '-' || *s == '_')
+		while (isalnum((unsigned char)*s) || *s == '-' || *s == '_')
 			expr_put(ctx, *s++);
 	}
 	else if (strchr("*/+-()|&", *s)) {
@@ -2329,7 +2329,7 @@ expr_term(struct num_exp_ctx *ctx, unsigned int *vp)
 		expr_eval(ctx, vp, 1);
 		expr_expect(ctx, ')');
 	}
-	else if (isdigit(*tok)) {
+	else if (isdigit((unsigned char)*tok)) {
 		char	*ep;
 
 		*vp = strtoul(tok, &ep, 0);

--- a/src/tools/goid-tool.c
+++ b/src/tools/goid-tool.c
@@ -716,7 +716,7 @@ int paccess_main(struct sc_context *ctx, sc_card_t *card, struct gengetopt_args_
                     && SC_SUCCESS == sc_asn1_read_tag(&p, ef_len,
                         &cla, &tag, &ef_len)
                     && (tag | cla) == 0x13) {
-                const char *cardid = (const char *) p;
+                const unsigned char *cardid = (const unsigned char *) p;
                 while (cardid && ef_len) {
                     if (isprint(*cardid)) {
                         printf("%c", *cardid);
@@ -750,7 +750,7 @@ int paccess_main(struct sc_context *ctx, sc_card_t *card, struct gengetopt_args_
                     && SC_SUCCESS == sc_asn1_read_tag((const u8 **) &p, ef_len,
                         &cla, &tag, &ef_len)
                     && (tag | cla) == 0x13) {
-                const char *paccessid = (const char *) p;
+                const unsigned char *paccessid = (const unsigned char *) p;
                 while (paccessid && ef_len) {
                     if (isprint(*paccessid)) {
                         printf("%c", *paccessid);

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -479,7 +479,7 @@ static int pattern_match(const char *pattern, const char *string)
 			int match = 0;
 
 			for (pattern++; end != NULL && pattern != end; pattern++) {
-				if (tolower(*pattern) == tolower(*string))
+				if (tolower((unsigned char) *pattern) == tolower((unsigned char) *string))
 					match++;
 			}
 			if (!match)
@@ -488,7 +488,7 @@ static int pattern_match(const char *pattern, const char *string)
 			string++;
 		}
 		/* single character comparison / wildcard matching a single character */
-		else if (tolower(*pattern) == tolower(*string) || *pattern == '?') {
+		else if (tolower((unsigned char) *pattern) == tolower((unsigned char) *string) || *pattern == '?') {
 			pattern++;
 			string++;
 		}
@@ -498,7 +498,7 @@ static int pattern_match(const char *pattern, const char *string)
 		if (*string == '\0' || *pattern == '\0')
 			break;
 	}
-	return (*pattern != '\0' || *string != '\0' || tolower(*pattern) != tolower(*string)) ? 0 : 1;
+	return (*pattern != '\0' || *string != '\0' || tolower((unsigned char) *pattern) != tolower((unsigned char) *string)) ? 0 : 1;
 }
 
 static int do_ls(int argc, char **argv)

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -756,7 +756,7 @@ parse_alg_spec(const struct alg_spec *types, const char *spec, unsigned int *key
 		spec++;
 
 	if (*spec)   {
-		if (isalpha(*spec) && algorithm == SC_ALGORITHM_EC && prkey) {
+		if (isalpha((unsigned char)*spec) && algorithm == SC_ALGORITHM_EC && prkey) {
 			prkey->u.ec.params.named_curve = strdup(spec);
 		} else {
 			*keybits = strtoul(spec, &end, 10);
@@ -1923,7 +1923,7 @@ parse_secret(struct secret *secret, const char *arg)
 		else
 			goto parse_err;
 		str += 3;
-		if (!isdigit(str[3]))
+		if (!isdigit((unsigned char)str[3]))
 			goto parse_err;
 		secret->reference = strtoul(str, &str, 10);
 		if (*str != '\0')


### PR DESCRIPTION
Recent compilers have activated some additional
checks which let the build fail. (at least with cygwin)
(Normally it would be warnings but opensc compiles
with -Werror)

GCC 9.3:
```
In file included from profile.c:27:
profile.c: In function '__expr_get':
profile.c:2273:18: error: array subscript has type 'char' [-Werror=char-subscripts]
 2273 |   while (isspace(*s))
      |                  ^~
```
clang 8.0.1:
```
compat_getopt_main.c:102:22: error: array subscript is of type 'char' [-Werror,-Wchar-subscripts]
                rc = toupper(rc);
                     ^~~~~~~~~~~
/usr/include/ctype.h:161:25: note: expanded from macro 'toupper'
      (void) __CTYPE_PTR[__x]; (toupper) (__x);})
                        ^~~~
```
Actually the code is correct as isspace and others
are used here with data type char, and are to be used
with data type int.

So either the compiler should have deactivated
this error, or the ctype.h macros have to be
written so the compiler no longer complains.

As there is also a simple workaround by casting
char to int, there is no need to wait for one
of the former options to be happen sometime.
