### PR TITLE
PKCS11 C_Initialize locking

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -426,6 +426,22 @@
 
 				<varlistentry>
 					<term>
+						<option>--use-locking</option>
+					</term>
+					<listitem><para>Tell pkcs11 module it should use OS thread locking.
+					</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--test-threads</option> <replaceable>options</replaceable>
+					</term>
+					<listitem><para>Test a pkcs11 module's thread implication. (See source code).
+					</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--token-label</option> <replaceable>label</replaceable>
 					</term>
 					<listitem><para>Specify the label of token.

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -55,9 +55,10 @@ opensc_explorer_LDADD = $(OPTIONAL_READLINE_LIBS)
 pkcs15_tool_SOURCES = pkcs15-tool.c util.c ../pkcs11/pkcs11-display.c ../pkcs11/pkcs11-display.h
 pkcs15_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 pkcs11_tool_SOURCES = pkcs11-tool.c util.c
+pkcs11_tool_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(PTHREAD_CFLAGS)
 pkcs11_tool_LDADD = \
 	$(top_builddir)/src/common/libpkcs11.la \
-	$(OPTIONAL_OPENSSL_LIBS)
+	$(OPTIONAL_OPENSSL_LIBS) $(PTHREAD_CFLAGS)
 if ENABLE_SHARED
 else
 pkcs11_tool_LDADD += \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,7 @@ dist_noinst_SCRIPTS = common.sh \
                       test-manpage.sh \
                       test-fuzzing.sh \
                       test-pkcs11-tool-test.sh \
+                      test-pkcs11-tool-test-threads.sh \
                       test-pkcs11-tool-sign-verify.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh
 
@@ -12,6 +13,8 @@ TESTS = \
         test-duplicate-symbols.sh \
         test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-test.sh \
+        test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-allowed-mechanisms.sh
 XFAIL_TESTS = \
+        test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-test.sh

--- a/tests/test-pkcs11-tool-test-threads.sh
+++ b/tests/test-pkcs11-tool-test-threads.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source common.sh
+
+echo "======================================================="
+echo "Setup SoftHSM"
+echo "======================================================="
+if [[ ! -f $P11LIB ]]; then
+    echo "WARNINIG: The SoftHSM is not installed. Can not run this test"
+    exit 77;
+fi
+
+card_setup
+
+echo "======================================================="
+echo "Test pkcs11 threads OSILGISLT0 "
+echo "======================================================="
+$PKCS11_TOOL --test-threads IN -L
+assert $? "Failed running tests"
+
+
+echo "======================================================="
+echo "Test pkcs11 threads OSILGISLT0 "
+echo "======================================================="
+$PKCS11_TOOL --test-threads OSILGISLT0 -L
+assert $? "Failed running tests"
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+card_cleanup
+
+exit $ERRORS


### PR DESCRIPTION
C_Initialize may be called by multiple threads.
But while trying to setup an OpenSC context, setup global_locking
and detect cards, it is possible that multiple threads may be trying
to do this, as the only test is "if (context == NULL)" but this
may not be set  until it is too late, and  things may be overwritten
such as existing context, causing additional problems, with pcsc.

FireFox appears to do this see #2032

The PR adds a mutex or Critical section to make sure only one
thread creates the context, and does the initial detect cards, etc.

pkcs11-tool.c adds a --test_threads option.  When given only once,
CK_C_INITIALIZE_ARGS  c_initialize_args = {NULL, NULL, NULL, NULL, CKF_OS_LOCKING_OK, NULL};
is passed to C_Initialize. If --test_threads is present more then once,
additional threads are created to test a module's C_Initialize.

Tests on Linux show multiple process do indeed create multiple contexts.

Not yet tested on Windows.

 On branch C_Initialize-locking
 Changes to be committed:
	modified:   ../pkcs11/pkcs11-global.c
	modified:   ../tools/pkcs11-tool.c

May fix #2032 and other recent FireFox issues.

##### Checklist
- [X ] PKCS#11 module is tested
