### PR TITLE
PKCS15 emulator for StarCOS cards with profile eSign/QES

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -57,7 +57,7 @@ libopensc_la_SOURCES_BASE = \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
-	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c \
+	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-starcos-esign_qes.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	compression.c p15card-helper.c sm.c \
 	aux-data.c
@@ -140,7 +140,7 @@ TIDY_FILES = \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
-	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c \
+	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-starcos-esign_qes.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	compression.c p15card-helper.c sm.c \
 	aux-data.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -36,7 +36,7 @@ OBJECTS			= \
 	pkcs15-cac.obj pkcs15-esinit.obj pkcs15-westcos.obj pkcs15-pteid.obj pkcs15-din-66291.obj \
 	pkcs15-oberthur.obj pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
 	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-jpki.obj \
-	pkcs15-esteid2018.obj pkcs15-idprime.obj \
+	pkcs15-esteid2018.obj pkcs15-idprime.obj pkcs15-starcos-esign_qes.obj \
 	compression.obj p15card-helper.obj sm.obj \
 	aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res

--- a/src/libopensc/pkcs15-starcos-esign_qes.c
+++ b/src/libopensc/pkcs15-starcos-esign_qes.c
@@ -1,0 +1,364 @@
+/**
+ * PKCS15 emulation layer for GuD StarCOS 3.x cards with eSign and QES applications
+ *
+ * Copyright (C) 2020, Jozsef Dojcsak
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "common/compat_strlcpy.h"
+#include "internal.h"
+#include "log.h"
+#include "pkcs15.h"
+#include "cards.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define RANDOM_UID_INDICATOR 0x08
+
+static const char name_Card[] = "eSIGN.QES";
+static const char name_ESign[] = "eSIGN";
+static const char name_QES[] = "QES";
+static const char name_Vendor[] = "Giesecke & Devrient";
+static const unsigned char aid_ESIGN[] = {0xA0, 0x00, 0x00, 0x02, 0x45, 0x53, 0x69, 0x67, 0x6E};
+static const unsigned char aid_QES[]   = {0xD2, 0x76, 0x00, 0x00, 0x66, 0x01};
+
+typedef struct cdata_st {
+	const char *label;
+	int	    authority;
+	const char *path;
+	const char *id;
+	int         obj_flags;
+} cdata, *pcdata;
+
+typedef struct pdata_st {
+	const char *id;
+	const char *label;
+	const char *path;
+	int         ref;
+	int         type;
+	unsigned int maxlen;
+	unsigned int minlen;
+	unsigned int storedlen;
+	int         flags;	
+	int         tries_left;
+	const char  pad_char;
+	int         obj_flags;
+} pindata, *ppindata; 
+
+typedef struct prdata_st {
+	const char *id;
+	const char *label;
+	unsigned int modulus_len;
+	int         usage;
+	const char *path;
+	int         ref;
+	const char *auth_id;
+	int         obj_flags;
+} prdata, *pprdata;
+
+typedef struct container_st {
+	const char *id;
+	const pcdata certdata;
+	const ppindata pindata;
+	const pprdata prdata;
+} container;
+
+#define USAGE_NONREP	SC_PKCS15_PRKEY_USAGE_NONREPUDIATION
+#define USAGE_KE	SC_PKCS15_PRKEY_USAGE_ENCRYPT | \
+			SC_PKCS15_PRKEY_USAGE_DECRYPT | \
+			SC_PKCS15_PRKEY_USAGE_WRAP    | \
+			SC_PKCS15_PRKEY_USAGE_UNWRAP
+#define USAGE_AUT	SC_PKCS15_PRKEY_USAGE_ENCRYPT | \
+			SC_PKCS15_PRKEY_USAGE_DECRYPT | \
+			SC_PKCS15_PRKEY_USAGE_WRAP    | \
+			SC_PKCS15_PRKEY_USAGE_UNWRAP  | \
+			SC_PKCS15_PRKEY_USAGE_SIGN
+
+static int get_cert_size(sc_card_t * card, sc_path_t * path, size_t * psize) {
+	int r;
+	sc_file_t * file;
+
+	r = sc_select_file(card, path, &file);
+	LOG_TEST_RET(card->ctx, r, "Failed to select EF certificate");
+
+	*psize = file->size;
+	sc_file_free(file);
+
+	sc_log(card->ctx, "Certificate size: %ld", file->size);
+
+	return SC_SUCCESS;
+}
+
+static int add_app(sc_pkcs15_card_t *p15card, const container * containers, int container_count) {
+	int i, r, containers_added = 0;
+	ppindata installed_pins[2];
+	int installed_pin_count = 0;
+	sc_card_t * card = p15card->card;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	//static_assert(p15card == NULL, "P15card value is not set");
+	//static_assert(card == NULL, "Card value is not set");
+
+	for( i=0; i < container_count; i++ ) {
+		struct sc_pkcs15_cert_info cert_info;
+		struct sc_pkcs15_object    cert_obj;
+		size_t cert_size;
+
+		memset(&cert_info, 0, sizeof(cert_info));
+		memset(&cert_obj,  0, sizeof(cert_obj));
+
+		sc_pkcs15_format_id(containers[i].id, &cert_info.id);
+		cert_info.authority = containers[i].certdata->authority;
+		sc_format_path(containers[i].certdata->path, &cert_info.path);
+
+		if ( get_cert_size(card, &cert_info.path, &cert_size) != SC_SUCCESS ) {
+			sc_log(card->ctx, "Failed to determine certificate %s size", containers[i].certdata->path);
+			continue;
+		}
+
+		strlcpy(cert_obj.label, containers[i].certdata->label, sizeof(cert_obj.label));
+		cert_obj.flags = containers[i].certdata->obj_flags;
+
+		r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+		if (r != SC_SUCCESS) {
+			LOG_TEST_RET(card->ctx, SC_ERROR_INTERNAL, "Failed to add emu certificate");
+		}
+
+		if (containers[i].pindata != 0) {
+			int j;
+			int is_pin_installed = 0;
+			for (j = 0; j < installed_pin_count; j++) {
+				if (installed_pins[j] == containers[i].pindata) {
+					is_pin_installed = 1;
+					break;
+				}
+			}
+
+			if (!is_pin_installed) {
+				struct sc_pkcs15_auth_info pin_info;
+				struct sc_pkcs15_object   pin_obj;
+
+				if ( installed_pin_count < (int)(sizeof(installed_pins)/sizeof(ppindata)) ) {
+					installed_pins[installed_pin_count++] = containers[i].pindata;
+				} else {
+					sc_log(card->ctx, "Warning: using more pins than expected (2).");
+				}
+
+				memset(&pin_info, 0, sizeof(pin_info));
+				memset(&pin_obj, 0, sizeof(pin_obj));
+
+				sc_pkcs15_format_id(containers[i].pindata->id, &pin_info.auth_id);
+				pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
+				pin_info.attrs.pin.reference = containers[i].pindata->ref;
+				pin_info.attrs.pin.flags = containers[i].pindata->flags;
+				pin_info.attrs.pin.type = containers[i].pindata->type;
+				pin_info.attrs.pin.min_length = containers[i].pindata->minlen;
+				pin_info.attrs.pin.stored_length = containers[i].pindata->storedlen;
+				pin_info.attrs.pin.max_length = containers[i].pindata->maxlen;
+				pin_info.attrs.pin.pad_char = containers[i].pindata->pad_char;
+				if (containers[i].pindata->path != NULL) sc_format_path(containers[i].pindata->path, &pin_info.path);
+				pin_info.tries_left = -1;
+
+				strlcpy(pin_obj.label, containers[i].pindata->label, sizeof(pin_obj.label));
+				pin_obj.flags = containers[i].pindata->obj_flags;
+
+				r = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
+				if (r != SC_SUCCESS) {
+					LOG_TEST_RET(card->ctx, SC_ERROR_INTERNAL, "Failed to add emu pin");
+				}
+			}
+		}
+
+		if (containers[i].prdata != 0) {
+			struct sc_pkcs15_prkey_info prkey_info;
+			struct sc_pkcs15_object     prkey_obj;
+			int modulus_len = containers[i].prdata->modulus_len;
+			memset(&prkey_info, 0, sizeof(prkey_info));
+			memset(&prkey_obj, 0, sizeof(prkey_obj));
+
+			sc_pkcs15_format_id(containers[i].id, &prkey_info.id);
+			prkey_info.usage = containers[i].prdata->usage;
+			prkey_info.native = 1;
+			prkey_info.key_reference = containers[i].prdata->ref;
+			prkey_info.modulus_length = modulus_len;
+			sc_format_path(containers[i].prdata->path, &prkey_info.path);
+
+			strlcpy(prkey_obj.label, containers[i].prdata->label, sizeof(prkey_obj.label));
+			prkey_obj.flags = containers[i].prdata->obj_flags;
+			if (containers[i].prdata->auth_id) {
+				sc_pkcs15_format_id(containers[i].prdata->auth_id, &prkey_obj.auth_id);
+			}
+
+			r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+			if (r < 0) {
+				LOG_TEST_RET(card->ctx, SC_ERROR_INTERNAL, "Failed to add emu pin");
+			}
+		}
+
+		containers_added++;
+	}
+	
+	if ( containers_added == 0 ) {
+		return SC_ERROR_FILE_NOT_FOUND;
+	}
+
+	return SC_SUCCESS;
+}
+
+
+static int starcos_add_esign_app(sc_pkcs15_card_t *p15card) {
+	static cdata auth_cert = { "C.CH.AUT", 0, "3F00060843F1", "1", 0 };
+	static cdata encr_cert = { "C.CH.ENC", 0, "3F0006084301", "2", 0 };
+
+	static prdata auth_key = { "1", "PrK.CH.AUT", 2048, USAGE_AUT, "3F000608", 0x81, "1", SC_PKCS15_CO_FLAG_PRIVATE };
+	static prdata encr_key = { "2", "PrK.CH.ENC", 2048, USAGE_KE, "3F000608", 0x83, "1", SC_PKCS15_CO_FLAG_PRIVATE };
+
+	static pindata auth_pin = { "1", "UserPIN", "3F00", 0x01, SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
+		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN,
+		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+
+	static pindata auth_pin_v35 = { "1", "UserPIN", "3F00", 0x06, SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
+		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN,
+		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+	
+	ppindata auth = &auth_pin;
+	if ( p15card->card->type == SC_CARD_TYPE_STARCOS_V3_5 ) {
+		auth = &auth_pin_v35;
+	}
+	const container containers[] = {
+		{ "1", &auth_cert, auth, &auth_key },
+		//Note: the encryption container may not be present on all cards
+		{ "2", &encr_cert, auth, &encr_key },
+	};
+
+	return add_app(p15card, containers, sizeof(containers)/sizeof(container));
+}
+
+static int starcos_add_qes_app(sc_pkcs15_card_t *p15card) {
+	static cdata sign_cert = { "C.CH.QES", 0, "3F0006044301", "3", 0 };
+	static prdata sign_key = { "3", "PrK.CH.QES", 2048, SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_NONREPUDIATION, "3F000604", 0x84, "2", SC_PKCS15_CO_FLAG_PRIVATE };
+	static prdata sign_key_v35 = { "3", "PrK.CH.QES", 3072, SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_NONREPUDIATION, "3F000604", 0x84, "2", SC_PKCS15_CO_FLAG_PRIVATE };
+	static pindata sign_pin = { "2", "SignPIN", "3F000604", 0x81,  SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
+		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_CONFIDENTIALITY_PROTECTED | SC_PKCS15_PIN_FLAG_LOCAL,
+		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+
+	const container containers[] = {
+		//Note: the signature container may not be present on all cards
+		{ "3", &sign_cert, &sign_pin, (p15card->card->type == SC_CARD_TYPE_STARCOS_V3_5 ? &sign_key_v35 : &sign_key) },
+	};
+
+	return add_app(p15card, containers, sizeof(containers)/sizeof(container));
+}
+
+static int starcos_esign_qes_init(sc_pkcs15_card_t *p15card, struct sc_aid *aid) {
+	sc_context_t * ctx;
+	sc_card_t * card;
+	const char * label = name_Card;
+    int r, apps_added;
+
+    if (!p15card || ! p15card->card || !p15card->card->ctx ) return SC_ERROR_INVALID_ARGUMENTS;
+
+	// convenience variables
+	card = p15card->card;
+	ctx = card->ctx;
+	
+    SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
+
+	if (card->type!=SC_CARD_TYPE_STARCOS_V3_4 && card->type!=SC_CARD_TYPE_STARCOS_V3_5) {
+        sc_log(p15card->card->ctx, "Unsupported card type: %d", card->type);
+        return SC_ERROR_WRONG_CARD;
+    }
+
+	apps_added = 0;
+	if ( aid == NULL ) {
+		// no aid: in this case all emulated apps are added
+		r = starcos_add_esign_app(p15card);
+		if ( r == SC_SUCCESS ) apps_added++;
+
+		r = starcos_add_qes_app(p15card);
+		if ( r == SC_SUCCESS ) apps_added++;
+	} else {
+		// aid specified: only the matching app is added
+		if (aid->len == sizeof(aid_ESIGN) && memcmp(aid->value, aid_ESIGN, sizeof(aid_ESIGN)) == 0 ) {
+			r = starcos_add_esign_app(p15card);
+			if ( r == SC_SUCCESS ) {
+				label = name_ESign;
+				apps_added++;
+			}
+		} else if (aid->len == sizeof(aid_QES) && memcmp(aid->value, aid_QES, sizeof(aid_QES)) == 0 ) {
+			r = starcos_add_qes_app(p15card);
+			if ( r == SC_SUCCESS ) {
+				label = name_QES;
+				apps_added++;
+			}
+		}
+
+		if ( apps_added == 1 ) {
+			// pkcs11 requires the file_app
+			struct sc_path  path;
+			struct sc_file *file = NULL;
+			sc_log(p15card->card->ctx, "Selecting application DF");
+			sc_path_set(&path, SC_PATH_TYPE_DF_NAME, aid->value, aid->len, 0, 0);
+			r = sc_select_file(card, &path, &file);
+			if (r != SC_SUCCESS || !file)
+				return SC_ERROR_INTERNAL;
+			sc_file_free(p15card->file_app);
+			p15card->file_app = file;		
+		}
+	}
+
+	if ( apps_added == 0 ) {
+		LOG_TEST_RET(ctx, SC_ERROR_WRONG_CARD, "Neither ESign nor QES initialized");
+	}
+
+    if (p15card->tokeninfo) {
+		sc_pkcs15_free_tokeninfo(p15card->tokeninfo);
+	}
+
+    p15card->tokeninfo = sc_pkcs15_tokeninfo_new();
+    if (!p15card->tokeninfo) {
+		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "unable to create tokeninfo struct");
+	} else {
+        sc_serial_number_t serial;
+		char serial_hex[SC_MAX_SERIALNR*2+2];
+	    r = sc_card_ctl(card, SC_CARDCTL_GET_SERIALNR, &serial);
+		LOG_TEST_RET(ctx, r, "Failed to query card serial number");
+
+		sc_bin_to_hex(serial.value, serial.len , serial_hex, sizeof serial_hex, 0);
+		p15card->tokeninfo->serial_number = strdup(serial_hex);
+		p15card->tokeninfo->label = strdup(label);
+		p15card->tokeninfo->manufacturer_id = strdup(name_Vendor);
+		p15card->tokeninfo->flags = SC_PKCS15_TOKEN_READONLY;
+	}
+
+    return SC_SUCCESS;
+}
+
+int sc_pkcs15emu_starcos_esign_qes_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid) {
+	int r = SC_ERROR_WRONG_CARD;
+
+    if (!p15card || ! p15card->card || !p15card->card->ctx) return SC_ERROR_INVALID_ARGUMENTS;
+
+    r = starcos_esign_qes_init(p15card, aid);
+    sc_log(p15card->card->ctx, "PKCS15Emu for StarCOS Esign/QES init returned: %d", r);
+
+	return r;
+}

--- a/src/libopensc/pkcs15-starcos-esign_qes.c
+++ b/src/libopensc/pkcs15-starcos-esign_qes.c
@@ -104,8 +104,6 @@ static int get_cert_size(sc_card_t * card, sc_path_t * path, size_t * psize) {
 	*psize = file->size;
 	sc_file_free(file);
 
-	sc_log(card->ctx, "Certificate size: %ld", file->size);
-
 	return SC_SUCCESS;
 }
 

--- a/src/libopensc/pkcs15-starcos-esign_qes.c
+++ b/src/libopensc/pkcs15-starcos-esign_qes.c
@@ -38,6 +38,8 @@ static const char name_QES[] = "QES";
 static const char name_Vendor[] = "Giesecke & Devrient";
 static const unsigned char aid_ESIGN[] = {0xA0, 0x00, 0x00, 0x02, 0x45, 0x53, 0x69, 0x67, 0x6E};
 static const unsigned char aid_QES[]   = {0xD2, 0x76, 0x00, 0x00, 0x66, 0x01};
+//static const unsigned char aid_CIA_ESIGN[] = {0xE8, 0x28, 0xBD, 0x08, 0x0F, 0xA0, 0x00, 0x00, 0x02, 0x45, 0x53, 0x69, 0x67, 0x6E};
+//static const unsigned char aid_CIA_QES[]   = {0xE8, 0x28, 0xBD, 0x08, 0x0F, 0xD2, 0x76, 0x00, 0x00, 0x66, 0x01};
 
 typedef struct cdata_st {
 	const char *label;
@@ -58,6 +60,7 @@ typedef struct pdata_st {
 	unsigned int storedlen;
 	int         flags;	
 	int         tries_left;
+	int         max_tries;
 	const char  pad_char;
 	int         obj_flags;
 } pindata, *ppindata; 
@@ -176,6 +179,7 @@ static int add_app(sc_pkcs15_card_t *p15card, const container * containers, int 
 				pin_info.attrs.pin.pad_char = containers[i].pindata->pad_char;
 				if (containers[i].pindata->path != NULL) sc_format_path(containers[i].pindata->path, &pin_info.path);
 				pin_info.tries_left = -1;
+				pin_info.max_tries = containers[i].pindata->max_tries;
 
 				strlcpy(pin_obj.label, containers[i].pindata->label, sizeof(pin_obj.label));
 				pin_obj.flags = containers[i].pindata->obj_flags;
@@ -233,11 +237,11 @@ static int starcos_add_esign_app(sc_pkcs15_card_t *p15card) {
 
 	static pindata auth_pin = { "1", "UserPIN", "3F00", 0x01, SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
 		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN,
-		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+		-1, 3, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
 
 	static pindata auth_pin_v35 = { "1", "UserPIN", "3F00", 0x06, SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
 		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN,
-		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+		-1, 3, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
 	
 	ppindata auth = &auth_pin;
 	if ( p15card->card->type == SC_CARD_TYPE_STARCOS_V3_5 ) {
@@ -258,7 +262,7 @@ static int starcos_add_qes_app(sc_pkcs15_card_t *p15card) {
 	static prdata sign_key_v35 = { "3", "PrK.CH.QES", 3072, SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_NONREPUDIATION, "3F000604", 0x84, "2", SC_PKCS15_CO_FLAG_PRIVATE };
 	static pindata sign_pin = { "2", "SignPIN", "3F000604", 0x81,  SC_PKCS15_PIN_TYPE_UTF8, 16, 6, 0,
 		SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_CONFIDENTIALITY_PROTECTED | SC_PKCS15_PIN_FLAG_LOCAL,
-		-1, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
+		-1, 10, 0x00, SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE };
 
 	const container containers[] = {
 		//Note: the signature container may not be present on all cards

--- a/src/libopensc/pkcs15-starcos-esign_qes.c
+++ b/src/libopensc/pkcs15-starcos-esign_qes.c
@@ -301,16 +301,16 @@ static int starcos_esign_qes_init(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 		if ( r == SC_SUCCESS ) apps_added++;
 	} else {
 		// aid specified: only the matching app is added
-		if (aid->len == sizeof(aid_ESIGN) && memcmp(aid->value, aid_ESIGN, sizeof(aid_ESIGN)) == 0 ) {
-			r = starcos_add_esign_app(p15card);
-			if ( r == SC_SUCCESS ) {
-				label = name_ESign;
-				apps_added++;
-			}
-		} else if (aid->len == sizeof(aid_QES) && memcmp(aid->value, aid_QES, sizeof(aid_QES)) == 0 ) {
+		if (aid->len == sizeof(aid_QES) && memcmp(aid->value, aid_QES, sizeof(aid_QES)) == 0 ) {
 			r = starcos_add_qes_app(p15card);
 			if ( r == SC_SUCCESS ) {
 				label = name_QES;
+				apps_added++;
+			}
+		} else if (aid->len == sizeof(aid_ESIGN) && memcmp(aid->value, aid_ESIGN, sizeof(aid_ESIGN)) == 0 ) {
+			r = starcos_add_esign_app(p15card);
+			if ( r == SC_SUCCESS ) {
+				label = name_ESign;
 				apps_added++;
 			}
 		}

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -61,7 +61,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "din66291",   sc_pkcs15emu_din_66291_init_ex	},
 	{ "esteid2018", sc_pkcs15emu_esteid2018_init_ex	},
 	{ "cardos",     sc_pkcs15emu_cardos_init_ex	},
-
+	{ "esign_qes",  sc_pkcs15emu_starcos_esign_qes_init_ex },
 	{ NULL, NULL }
 };
 

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -55,6 +55,7 @@ int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_idprime_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_cardos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_starcos_esign_qes_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;


### PR DESCRIPTION
The PKCS15 emulator is intended for StarCOS 3.4 and 3.5 cards from BA with a profile which contain eSign/QES and the related CIA applications. As discussed in #1882 the on-card PKCS15 structures are broken, but this emulator does not try to fix the EF(ODF) file, but instead, provides direct access to PINs, certificates and keys. 

Since the signature key on v3.5 is 3072 bits wide, the related card-starcos driver was also updated. During testing PKCS11 and Minidriver several issues were amended as well:
- 3072 bit key support
- card logout v3.x cards
- PIN GET_INFO logged in state support for v3.5 cards (required in PKCS11/Firefox)
- path caching is disabled on Windows, because it may confuse parallel minidriver instances

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested
