### PR TITLE
Make PUK reference available to card driver from PKCS #15 layer for PIN unblock

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -460,6 +460,7 @@ struct sc_pin_cmd_data {
 
 	unsigned int pin_type;		/* usually SC_AC_CHV */
 	int pin_reference;
+	int puk_reference;		/* non-zero means that reference is available */
 
 	struct sc_pin_cmd_pin pin1, pin2;
 

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -581,6 +581,7 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *p15card,
 	struct sc_pin_cmd_data data;
 	struct sc_pkcs15_object *puk_obj;
 	struct sc_pkcs15_auth_info *puk_info = NULL;
+	int pukref = 0;
 	struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 	struct sc_card *card = p15card->card;
 	int r;
@@ -602,6 +603,7 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *p15card,
 	if (r >= 0 && puk_obj) {
 		/* second step:  get the pkcs15 info object of the puk */
 		puk_info = (struct sc_pkcs15_auth_info *)puk_obj->data;
+		pukref = puk_info->attrs.pin.reference;
 	}
 
 	if (!puk_info) {
@@ -627,6 +629,7 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *p15card,
 	data.cmd             = SC_PIN_CMD_UNBLOCK;
 	data.pin_type        = SC_AC_CHV;
 	data.pin_reference   = auth_info->attrs.pin.reference;
+	data.puk_reference   = pukref;
 	data.pin1.data       = puk;
 	data.pin1.len        = puklen;
 	data.pin1.pad_char   = auth_info->attrs.pin.pad_char;


### PR DESCRIPTION
When a PIN is protected with a PUK, some card drivers have no way of locating the PUK file from the PIN file. This could be due to limitations in the card APDU interface. For example, Idemia (Oberthur) Cosmo cards with IAS-ECC, don't allow the SE-SDO object to be read, which is the object containing this information. This limitation has forced some card drivers to hard-code format-specific knowledge.

This was the exact use case for introducing in PKCS #15 info about PIN auth objects (PUKs), and their corresponding CHV reference. By making this information available form the PKCS #15 layer to the card driver layer, the limitation is removed for some card drivers.
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
