### PR TITLE
Fixes for PIN-pad handling in PCSC reader support

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -2101,7 +2101,7 @@ part10_check_pin_min_max(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 	struct pcsc_global_private_data *gpriv = (struct pcsc_global_private_data *) reader->ctx->reader_drv_data;
 	struct sc_pin_cmd_pin *pin_ref =
 		data->flags & SC_PIN_CMD_IMPLICIT_CHANGE ?
-		&data->pin1 : &data->pin2;
+		&data->pin2 : &data->pin1;
 
 	if (gpriv->fixed_pinlength != 0) {
 		pin_ref->min_length = gpriv->fixed_pinlength;
@@ -2131,11 +2131,11 @@ part10_check_pin_min_max(sc_reader_t *reader, struct sc_pin_cmd_data *data)
 	/* maximum pin size */
 	r = part10_find_property_by_tag(buffer, length,
 		PCSCv2_PART10_PROPERTY_bMaxPINSize);
-	if (r >= 0)
+	if (r > 0)
 	{
 		unsigned int value = r;
 
-		if (pin_ref->max_length > value)
+		if (!pin_ref->max_length || pin_ref->max_length > value)
 			pin_ref->max_length = r;
 	}
 


### PR DESCRIPTION
Fixes for a few issues and inconsistencies related to PIN-pad handling. The main fix is for supporting cards with PIN lengths longer than 15 characters (such as the Idemia Cosmo card issued with the AWP middleware).
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
