### PR TITLE
ASN1 cleanup part 1

### DIFF
--- a/src/libopensc/asn1.h
+++ b/src/libopensc/asn1.h
@@ -127,13 +127,16 @@ int sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx,
 		const unsigned char *in, size_t inlen,
                 unsigned char *buf, size_t buflen);
 
-#define SC_ASN1_CLASS_MASK		0x30000000
+/* long form tags use these */
+/* Same as  SC_ASN1_TAG_* shifted left by 24 bits  */
+#define SC_ASN1_CLASS_MASK		0xC0000000
 #define SC_ASN1_UNI			0x00000000 /* Universal */
-#define SC_ASN1_APP			0x10000000 /* Application */
-#define SC_ASN1_CTX			0x20000000 /* Context */
-#define SC_ASN1_PRV			0x30000000 /* Private */
-#define SC_ASN1_CONS			0x01000000
+#define SC_ASN1_APP			0x40000000 /* Application */
+#define SC_ASN1_CTX			0x80000000 /* Context */
+#define SC_ASN1_PRV			0xC0000000 /* Private */
+#define SC_ASN1_CONS			0x20000000
 
+#define SC_ASN1_CLASS_CONS		0xE0000000 /* CLASS and CONS */
 #define SC_ASN1_TAG_MASK		0x00FFFFFF
 #define SC_ASN1_TAGNUM_SIZE		3
 
@@ -173,6 +176,7 @@ int sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx,
 /* use callback function */
 #define SC_ASN1_CALLBACK		384
 
+/* use with short one byte tags */
 #define SC_ASN1_TAG_CLASS		0xC0
 #define SC_ASN1_TAG_UNIVERSAL		0x00
 #define SC_ASN1_TAG_APPLICATION		0x40
@@ -181,6 +185,7 @@ int sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx,
 
 #define SC_ASN1_TAG_CONSTRUCTED		0x20
 #define SC_ASN1_TAG_PRIMITIVE		0x1F
+#define SC_ASN1_TAG_CLASS_CONS		0xE0
 
 #define SC_ASN1_TAG_EOC			0
 #define SC_ASN1_TAG_BOOLEAN		1


### PR DESCRIPTION
ASN1 tags are represented in two many ways within OpenSC.
This is a trivial change to simplify one aspect of this.
It also makes the code more readable.

SC_ASN1_CLASS_MASK, SC_ASN1_APP, SC_ASN1_CTX, SC_ASN1_PRV,
SC_ASN1_CONS are changed, and SC_ASN1_CLASS_MASK is added.

These then align with the bits defined by SC_ASN1_TAG_CLASS,
SC_ASN1_TAG_APPLICATION, SC_ASN1_TAG_CONTEXT, SC_ASN1_TAG_PRIVATE,
and SC_ASN1_TAG_CONSTRUCTED.

(SC_ASN1_UNI and SC_ASN1_TAG_UNIVERSAL are both 0x00 thus no change
is needed).

(No sign of a right shift of SC_ASN1_CTX or SC_ASN1_PRV causeing
problems has been seen in the code.) If found, can be solved.)

Close examination of the OpenSC code base shows all uses of tags
used by routines and sc_asn1_entry use the defines.

This could allows 26 lines of code in sc_asn1_skip_tag used to test
the 3 CLASS and CONSTRUCTED bits to be replaced by:

	if (((cla << 24) | tag) != tag_in)
		return NULL;

The 26 lines still work as will any other code in OpenSC
that tests the bits using the defines. It also allows new code
to be simplified.

Problem identified while looking at better way to check response
on GET_DATA (0xCB) that returns TLV as used in card-piv.c

Changes tested using pkcs11-tool --test --login with PIV, SC_HSM
and OpenPGP cards.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
