### PR TITLE
Card API cleanup

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -93,7 +93,7 @@ unsigned char aid_AuthentIC_3_2[] = {
 static int authentic_select_file(struct sc_card *card, const struct sc_path *path, struct sc_file **file_out);
 static int authentic_process_fci(struct sc_card *card, struct sc_file *file, const unsigned char *buf, size_t buflen);
 static int authentic_get_serialnr(struct sc_card *card, struct sc_serial_number *serial);
-static int authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data);
+static int authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struct sc_acl_entry *acls);
 static int authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, int *tries_left);
 static int authentic_select_mf(struct sc_card *card, struct sc_file **file_out);
 static int authentic_card_ctl(struct sc_card *card, unsigned long cmd, void *ptr);
@@ -275,7 +275,7 @@ authentic_decode_pubkey_rsa(struct sc_context *ctx, unsigned char *blob, size_t 
 
 static int
 authentic_parse_credential_data(struct sc_context *ctx, struct sc_pin_cmd_data *pin_cmd,
-		unsigned char *blob, size_t blob_len)
+		struct sc_acl_entry *acls, unsigned char *blob, size_t blob_len)
 {
 	unsigned char *data;
 	size_t data_len;
@@ -298,31 +298,34 @@ authentic_parse_credential_data(struct sc_context *ctx, struct sc_pin_cmd_data *
 	else
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "unsupported Credential type");
 
-	rv = authentic_get_tagged_data(ctx, blob, blob_len, AUTHENTIC_TAG_DOCP_ACLS, &data, &data_len);
-	LOG_TEST_RET(ctx, rv, "failed to get ACLs");
-	sc_log(ctx, "data_len:%"SC_FORMAT_LEN_SIZE_T"u", data_len);
-	if (data_len == 10)   {
-		for (ii=0; ii<5; ii++)   {
-			unsigned char acl = *(data + ii*2);
-			unsigned char cred_id = *(data + ii*2 + 1);
-			unsigned sc = acl * 0x100 + cred_id;
+	/* Parse optional ACLs when requested */
+	if (acls) {
+		rv = authentic_get_tagged_data(ctx, blob, blob_len, AUTHENTIC_TAG_DOCP_ACLS, &data, &data_len);
+		LOG_TEST_RET(ctx, rv, "failed to get ACLs");
+		sc_log(ctx, "data_len:%"SC_FORMAT_LEN_SIZE_T"u", data_len);
+		if (data_len == 10)   {
+			for (ii=0; ii<5; ii++)   {
+				unsigned char acl = *(data + ii*2);
+				unsigned char cred_id = *(data + ii*2 + 1);
+				unsigned sc = acl * 0x100 + cred_id;
 
-			sc_log(ctx, "%i: SC:%X", ii, sc);
-			if (!sc)
-				continue;
+				sc_log(ctx, "%i: SC:%X", ii, sc);
+				if (!sc)
+					continue;
 
-			if (acl & AUTHENTIC_AC_SM_MASK)   {
-				pin_cmd->pin1.acls[ii].method = SC_AC_SCB;
-				pin_cmd->pin1.acls[ii].key_ref = sc;
-			}
-			else if (acl!=0xFF && cred_id)   {
-				sc_log(ctx, "%i: ACL(method:SC_AC_CHV,id:%i)", ii, cred_id);
-				pin_cmd->pin1.acls[ii].method = SC_AC_CHV;
-				pin_cmd->pin1.acls[ii].key_ref = cred_id;
-			}
-			else   {
-				pin_cmd->pin1.acls[ii].method = SC_AC_NEVER;
-				pin_cmd->pin1.acls[ii].key_ref = 0;
+				if (acl & AUTHENTIC_AC_SM_MASK)   {
+					acls[ii].method = SC_AC_SCB;
+					acls[ii].key_ref = sc;
+				}
+				else if (acl!=0xFF && cred_id)   {
+					sc_log(ctx, "%i: ACL(method:SC_AC_CHV,id:%i)", ii, cred_id);
+					acls[ii].method = SC_AC_CHV;
+					acls[ii].key_ref = cred_id;
+				}
+				else   {
+					acls[ii].method = SC_AC_NEVER;
+					acls[ii].key_ref = 0;
+				}
 			}
 		}
 	}
@@ -1312,7 +1315,7 @@ authentic_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 
 	memset(prv_data->pins_sha1[pin_cmd->pin_reference], 0, sizeof(prv_data->pins_sha1[0]));
 
-	rv = authentic_pin_get_policy(card, pin_cmd);
+	rv = authentic_pin_get_policy(card, pin_cmd, NULL);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
 	if (pin_cmd->pin1.len > (int)pin_cmd->pin1.max_length)
@@ -1349,7 +1352,7 @@ authentic_pin_change_pinpad(struct sc_card *card, unsigned reference, int *tries
 	pin_cmd.cmd = SC_PIN_CMD_CHANGE;
 	pin_cmd.flags |= SC_PIN_CMD_USE_PINPAD | SC_PIN_CMD_NEED_PADDING;
 
-	rv = authentic_pin_get_policy(card, &pin_cmd);
+	rv = authentic_pin_get_policy(card, &pin_cmd, NULL);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
 	memset(pin1_data, pin_cmd.pin1.pad_char, sizeof(pin1_data));
@@ -1387,7 +1390,7 @@ authentic_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 	size_t offs;
 	int rv;
 
-	rv = authentic_pin_get_policy(card, data);
+	rv = authentic_pin_get_policy(card, data, NULL);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
 	memset(prv_data->pins_sha1[data->pin_reference], 0, sizeof(prv_data->pins_sha1[0]));
@@ -1447,7 +1450,7 @@ authentic_chv_set_pinpad(struct sc_card *card, unsigned char reference)
 	pin_cmd.cmd = SC_PIN_CMD_UNBLOCK;
 	pin_cmd.flags |= SC_PIN_CMD_USE_PINPAD | SC_PIN_CMD_NEED_PADDING;
 
-	rv = authentic_pin_get_policy(card, &pin_cmd);
+	rv = authentic_pin_get_policy(card, &pin_cmd, NULL);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
 	memset(pin_data, pin_cmd.pin1.pad_char, sizeof(pin_data));
@@ -1470,7 +1473,7 @@ authentic_chv_set_pinpad(struct sc_card *card, unsigned char reference)
 
 
 static int
-authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
+authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struct sc_acl_entry *acls)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;
@@ -1499,7 +1502,7 @@ authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data)
 
 	data->pin1.tries_left = -1;
 
-	rv = authentic_parse_credential_data(ctx, data, apdu.resp, apdu.resplen);
+	rv = authentic_parse_credential_data(ctx, data, acls, apdu.resp, apdu.resplen);
         LOG_TEST_RET(ctx, rv, "Cannot parse credential data");
 
 	data->pin1.encoding = SC_PIN_ENCODING_ASCII;
@@ -1526,6 +1529,7 @@ authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 	struct sc_context *ctx = card->ctx;
 	struct authentic_private_data *prv_data = (struct authentic_private_data *) card->drv_data;
 	struct sc_pin_cmd_data pin_cmd, puk_cmd;
+	struct sc_acl_entry acls[SC_MAX_SDO_ACLS];
 	struct sc_apdu apdu;
 	unsigned reference;
 	int rv, ii;
@@ -1540,17 +1544,17 @@ authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 	pin_cmd.pin_type = data->pin_type;
 	pin_cmd.pin1.tries_left = -1;
 
-	rv = authentic_pin_get_policy(card, &pin_cmd);
+	rv = authentic_pin_get_policy(card, &pin_cmd, acls);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
-	if (pin_cmd.pin1.acls[AUTHENTIC_ACL_NUM_PIN_RESET].method == SC_AC_CHV)   {
+	if (acls[AUTHENTIC_ACL_NUM_PIN_RESET].method == SC_AC_CHV)   {
 		for (ii=0;ii<8;ii++)   {
 			unsigned char mask = 0x01 << ii;
-			if (pin_cmd.pin1.acls[AUTHENTIC_ACL_NUM_PIN_RESET].key_ref & mask)   {
+			if (acls[AUTHENTIC_ACL_NUM_PIN_RESET].key_ref & mask)   {
 				memset(&puk_cmd, 0, sizeof(puk_cmd));
 				puk_cmd.pin_reference = ii + 1;
 
-				rv = authentic_pin_get_policy(card, &puk_cmd);
+				rv = authentic_pin_get_policy(card, &puk_cmd, NULL);
 				LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 
 				if (puk_cmd.pin_type == SC_AC_CHV)
@@ -1626,7 +1630,7 @@ authentic_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 		rv = authentic_pin_reset(card, data, tries_left);
 		break;
 	case SC_PIN_CMD_GET_INFO:
-		rv = authentic_pin_get_policy(card, data);
+		rv = authentic_pin_get_policy(card, data, NULL);
 		break;
 	default:
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Unsupported PIN command");

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1031,7 +1031,6 @@ static int gids_get_pin_policy(struct sc_card *card, struct sc_pin_cmd_data *dat
 	LOG_TEST_RET(card->ctx, r, "gids_get_pin_status failed");
 	data->pin1.max_length = 16;
 	data->pin1.min_length = 4;
-	data->pin1.stored_length = 0;
 	data->pin1.encoding = SC_PIN_ENCODING_ASCII;
 	data->pin1.offset = 5;
 	data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1140,9 +1140,7 @@ static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
 	int r;
 	LOG_FUNC_CALLED(card->ctx);
 	data->pin1.offset = 5;
-	data->pin1.length_offset = 4;
 	data->pin2.offset = 5;
-	data->pin2.length_offset = 4;
 
 	if (is_esteid_card(card) && data->cmd == SC_PIN_CMD_GET_INFO) {
 		sc_path_t tmppath;

--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -661,7 +661,6 @@ npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 		data.cmd = SC_PIN_CMD_CHANGE;
 		data.flags = SC_PIN_CMD_IMPLICIT_CHANGE;
 		data.pin2.encoding = SC_PIN_ENCODING_ASCII;
-		data.pin2.length_offset = 0;
 		data.pin2.offset = 5;
 		data.pin2.max_length = EAC_MAX_PIN_LEN;
 		data.pin2.min_length = EAC_MIN_PIN_LEN;

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -715,9 +715,7 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 #endif
 
 		data->pin1.offset = 5;
-		data->pin1.length_offset = 4;
 		data->pin2.offset = 5;
-		data->pin2.length_offset = 4;
 
 		r = (*iso_ops->pin_cmd)(card, data, tries_left);
 	}

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -437,7 +437,6 @@ struct sc_pin_cmd_pin {
 
 	size_t min_length;	/* min length of PIN */
 	size_t max_length;	/* max length of PIN */
-	size_t stored_length;	/* stored length of PIN */
 
 	unsigned int encoding;	/* ASCII-numeric, BCD, etc */
 

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -429,27 +429,38 @@ typedef struct sc_reader {
 #define SC_PIN_STATE_LOGGED_OUT 0
 #define SC_PIN_STATE_LOGGED_IN  1
 
+/* A card driver receives the sc_pin_cmd_data and sc_pin_cmd_pin structures filled in by the
+ * caller, with the exception of the fields returned by the driver for SC_PIN_CMD_GET_INFO.
+ * It may use and update any of the fields before passing the structure to the ISO 7816 layer for
+ * processing.
+ */
 struct sc_pin_cmd_pin {
 	const char *prompt;	/* Prompt to display */
 
-	const unsigned char *data;		/* PIN, if given by the application */
-	int len;		/* set to -1 to get pin from pin pad */
+	const unsigned char *data; /* PIN, set to NULL when using pin pad */
+	int len;		/* set to 0 when using pin pad */
 
 	size_t min_length;	/* min length of PIN */
 	size_t max_length;	/* max length of PIN */
 
 	unsigned int encoding;	/* ASCII-numeric, BCD, etc */
 
-	size_t pad_length;	/* filled in by the card driver */
+	size_t pad_length;	/* PIN padding options, used with SC_PIN_CMD_NEED_PADDING */
 	unsigned char pad_char;
 
-	size_t offset;		/* PIN offset in the APDU */
+	size_t offset;		/* PIN offset in the APDU when using pin pad */
 
-	int max_tries;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
-	int tries_left;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
-	int logged_in;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
+	int max_tries;		/* Used for signaling back from SC_PIN_CMD_GET_INFO */
+	int tries_left;		/* Used for signaling back from SC_PIN_CMD_GET_INFO */
+	int logged_in;		/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 };
 
+/* A NULL in apdu means that the APDU is prepared by the ISO 7816 layer, which also handles PIN
+ * padding and setting offset fields for the PINs (for PIN-pad use). A non-NULL in APDU means that
+ * the card driver has prepared the APDU (including padding) and set the PIN offset fields.
+ *
+ * Note that flags apply to both PINs for multi-PIN operations.
+ */
 struct sc_pin_cmd_data {
 	unsigned int cmd;
 	unsigned int flags;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -448,8 +448,6 @@ struct sc_pin_cmd_pin {
 	int max_tries;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 	int tries_left;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 	int logged_in;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
-
-	struct sc_acl_entry acls[SC_MAX_SDO_ACLS];
 };
 
 struct sc_pin_cmd_data {

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -445,7 +445,6 @@ struct sc_pin_cmd_pin {
 	unsigned char pad_char;
 
 	size_t offset;		/* PIN offset in the APDU */
-	size_t length_offset;	/* Effective PIN length offset in the APDU */
 
 	int max_tries;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */
 	int tries_left;	/* Used for signaling back from SC_PIN_CMD_GET_INFO */

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -555,13 +555,13 @@ const sc_acl_entry_t * sc_file_get_acl_entry(const sc_file_t *file,
 {
 	sc_acl_entry_t *p;
 	static const sc_acl_entry_t e_never = {
-		SC_AC_NEVER, SC_AC_KEY_REF_NONE, {{0, 0, 0, {0}}}, NULL
+		SC_AC_NEVER, SC_AC_KEY_REF_NONE, NULL
 	};
 	static const sc_acl_entry_t e_none = {
-		SC_AC_NONE, SC_AC_KEY_REF_NONE, {{0, 0, 0, {0}}}, NULL
+		SC_AC_NONE, SC_AC_KEY_REF_NONE, NULL
 	};
 	static const sc_acl_entry_t e_unknown = {
-		SC_AC_UNKNOWN, SC_AC_KEY_REF_NONE, {{0, 0, 0, {0}}}, NULL
+		SC_AC_UNKNOWN, SC_AC_KEY_REF_NONE, NULL
 	};
 
 	if (file == NULL || operation >= SC_MAX_AC_OPS) {

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -204,9 +204,6 @@ struct sc_crt {
 typedef struct sc_acl_entry {
 	unsigned int method;	/* See SC_AC_* */
 	unsigned int key_ref;	/* SC_AC_KEY_REF_NONE or an integer */
-
-	struct sc_crt crts[SC_MAX_CRTS_IN_SE];
-
 	struct sc_acl_entry *next;
 } sc_acl_entry_t;
 


### PR DESCRIPTION
Improve card API design without breaking anything and without changing any functionality.

The card API (especially sc_pin_cmd_data) has become cluttered with fields with unclear purposes, or even with fields which are used only privately in some card drivers. Some fields have also become obsoleted by recent changes in master.

The existence of these fields makes it more complex than necessary to implement new card drivers, since it is not clear how the fields should be handled. The excess fields also make the API harder to use, since it is not obvious which of the fields can be relied upon to be available or not.

In short: this pull request is an attempt at cleaning up, removing unused- and private fields from the public interface and improving public comments.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
