### PR TITLE
tcos: add missing encryption certificates

### DIFF
--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -382,6 +382,8 @@ static int detect_idkey(
 	insert_cert(p15card, "DF074332", 0x46, 1, "Signatur Zertifikat 2");
 	insert_cert(p15card, "DF074333", 0x47, 1, "Signatur Zertifikat 3");
 	insert_cert(p15card, "DF084331", 0x4B, 1, "Verschluesselungs Zertifikat 1");
+	insert_cert(p15card, "DF084332", 0x4C, 1, "Verschluesselungs Zertifikat 2");
+	insert_cert(p15card, "DF084333", 0x4D, 1, "Verschluesselungs Zertifikat 3");
 	/* TODO should others come here too? */
 
 	insert_key(p15card, "DF074E03", 0x45, 0x84, 2048, 1, "IDKey1");
@@ -391,6 +393,8 @@ static int detect_idkey(
 	insert_key(p15card, "DF074E07", 0x49, 0x88, 2048, 1, "IDKey5");
 	insert_key(p15card, "DF074E08", 0x4A, 0x89, 2048, 1, "IDKey6");
 	insert_key(p15card, "DF084E01", 0x4B, 0x81, 2048, 1, "IDKey7");
+	insert_key(p15card, "DF084E02", 0x4C, 0x82, 2048, 1, "IDKey8");
+	insert_key(p15card, "DF084E03", 0x4D, 0x83, 2048, 1, "IDKey9");
 
 	insert_pin(p15card, "5000", 1, 2, 0x00, 6, "PIN",
 		SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_INITIALIZED


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [x] macOS tokend is tested
