### PR TITLE
iso7816: set record_length for any record-oriented EF

### DIFF
--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -384,8 +384,8 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 
 					/* if possible, get additional information for non-DFs */
 					if (file->type != SC_FILE_TYPE_DF) {
-						/* record length for fixed size records */
-						if (length > 2 && byte & 0x02) {
+						/* max. record length for fixed- & variable-sized records */
+						if (length > 2 && byte & 0x06) {
 							file->record_length = (length > 3)
 								? bebytes2ushort(p+2)
 								: p[2];

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -244,7 +244,7 @@ typedef struct sc_file {
 	int sid;	/* short EF identifier (1 byte) */
 	struct sc_acl_entry *acl[SC_MAX_AC_OPS]; /* Access Control List */
 
-	size_t record_length; /* In case of fixed-length or cyclic EF */
+	size_t record_length; /* max. length in case of record-oriented EF */
 	size_t record_count;  /* Valid, if not transparent EF or DF */
 
 	unsigned char *sec_attr;	/* security data in proprietary format. tag '86' */


### PR DESCRIPTION
In my understanding of ISO 7816 tag 82 of the FCI contains the max. record length for all types of record-oriented EFs, and not only the length for fixed-size records.

The appached patch fixes this issue.

Please approve & merge
Peter