### PR TITLE
PIN-pad related fixes in Cryptotoken-kit based reader module

### DIFF
--- a/src/libopensc/reader-cryptotokenkit.m
+++ b/src/libopensc/reader-cryptotokenkit.m
@@ -325,9 +325,6 @@ TKSmartCardPINFormat *getPINFormat(struct sc_pin_cmd_pin *pin)
 	}
 	format.minPINLength = pin->min_length;
 	format.maxPINLength = pin->max_length;
-	if (pin->length_offset > 4) {
-		format.PINLengthBitOffset = (pin->length_offset-5)*8;
-	}
 
 	return format;
 }
@@ -363,7 +360,7 @@ int cryptotokenkit_perform_verify(struct sc_reader *reader, struct sc_pin_cmd_da
 		case SC_PIN_CMD_VERIFY:
 			format = getPINFormat(pin_ref);
 			NSInteger offset;
-			if (data->pin1.length_offset != 4) {
+			if (data->pin1.offset >= 5) {
 				offset = data->pin1.offset - 5;
 			} else {
 				offset = 0;
@@ -378,13 +375,10 @@ int cryptotokenkit_perform_verify(struct sc_reader *reader, struct sc_pin_cmd_da
 			/* TODO: set confirmation and text */
 			format = getPINFormat(pin_ref);
 			NSInteger oldOffset, newOffset;
-			if (data->pin1.length_offset != 4) {
-				oldOffset = data->pin1.offset - 5;
-				newOffset = data->pin2.offset - 5;
-			} else {
-				oldOffset = 0;
-				newOffset = 0;
-			}
+
+			/* Set offsets if available, otherwise default to 0 */
+			oldOffset = (data->pin1.offset >= 5 ? data->pin1.offset - 5 : 0);
+			newOffset = (data->pin2.offset >= 5 ? data->pin2.offset - 5 : 0);
 			interaction = [priv->tksmartcard userInteractionForSecurePINChangeWithPINFormat:format APDU:apdu currentPINByteOffset:oldOffset newPINByteOffset:newOffset];
 		break;
 	default:


### PR DESCRIPTION
Synchronizes the code with similar changes in reader-pcsc.c. Fixes build error on OSX introduced with commit 48d939b05719e0e47af7891bf438c09647929f64
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
