### PR TITLE
spelling fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 
 env:
   global:
-    # The next declaration are encrypted envirnmet variables, created via the
+    # The next declaration are encrypted environment variables, created via the
     # "travis encrypt" command using the project repo's public key
     # COVERITY_SCAN_TOKEN
     - secure: "UkHn7wy4im8V1nebCWbAetnDSOLRUbOlF6++ovk/7Bnso1/lnhXHelyzgRxfD/oI68wm9nnRV+RQEZ9+72Ug1CyvHxyyxxkwal/tPeHH4B/L+aGdPi0id+5OZSKIm77VP3m5s102sJMJgH7DFd03+nUd0K26p0tk8ad4j1geV4c="
@@ -128,7 +128,7 @@ before_script:
       ./configure --host=$HOST --with-completiondir=/tmp --disable-openssl --disable-readline --disable-zlib --disable-notify --prefix=${TRAVIS_BUILD_DIR}/win32/opensc || cat config.log;
     fi
   # Optionally try to upload to Coverity Scan
-  # On error (propably quota is exhausted), just continue
+  # On error (probably quota is exhausted), just continue
   - if [ "${DO_COVERITY_SCAN}" = "yes" ]; then curl -s 'https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh' | bash || true; fi
 
   - if [ "${DO_SIMULATION}" = "javacard" ]; then

--- a/NEWS
+++ b/NEWS
@@ -385,7 +385,7 @@ New separate CAC1 driver using the old CAC specification (#1502)
     * Fixed --id for `C_GenerateKey`, DES and DES3 keygen mechanism (#857)
     * Added `--derive-pass-der` option
     * Added `--generate-random` option
-    * Add GOSTR3410 keypair generation
+    * Add GOSTR3410 key pair generation
 * `npa-tool` (new)
     * Allows read/write access to EAC tokens
     * Allows PIN management for EAC tokens
@@ -513,7 +513,7 @@ New in 0.15.0; 2015-05-11
   allow extended length APDUs
   accept no output for 'SELECT' MF and 'SELECT' DF_NAME APDUs
   fixed sc_driver_version check
-  adjusted send/receive size accoriding to card capabilities
+  adjusted send/receive size according to card capabilities
   in iso7816 make SELECT agnosting to sc_path_t's aid
 * asn1
   support multi-bytes tags

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ AM_CONDITIONAL([HAVE_UNKNOWN_WARNING_OPTION], [test "${have_unknown_warning_opti
 
 AC_ARG_ENABLE(
 	[fuzzing],
-	[AS_HELP_STRING([--enable-fuzzing],[enable compile of fuzzing tests @<:@disabled@:>@, note that CFLAGS and FUZZING_LIBS should be set accoringly, e.g. to something like CFLAGS="-fsanitize=address,fuzzer" FUZZING_LIBS="-fsanitize=fuzzer"])],
+	[AS_HELP_STRING([--enable-fuzzing],[enable compile of fuzzing tests @<:@disabled@:>@, note that CFLAGS and FUZZING_LIBS should be set accordingly, e.g. to something like CFLAGS="-fsanitize=address,fuzzer" FUZZING_LIBS="-fsanitize=fuzzer"])],
 	,
 	[enable_fuzzing="no"]
 )

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -273,7 +273,7 @@
 						<option>--moz-cert</option> <replaceable>filename</replaceable>,
 						<option>-z</option> <replaceable>filename</replaceable>
 					</term>
-					<listitem><para>Test a Mozilla-like keypair generation
+					<listitem><para>Test a Mozilla-like key pair generation
 					and certificate request. Specify the <replaceable>filename</replaceable>
 					to the certificate file.</para></listitem>
 				</varlistentry>

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -12,7 +12,7 @@ nodist_noinst_DATA = opensc.conf.example
 
 # Make sure we build this every time
 # as there is no dependency for this.
-# Can be removed if MSVC is not requried.
+# Can be removed if MSVC is not required.
 force:
 opensc.conf.example: opensc.conf.example.in force
 

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -174,7 +174,7 @@ app default {
 		# QES is only possible with a Comfort Reader (CAT-K), which holds a
 		# cryptographic key to authenticate itself as signature terminal (ST).
 		# We usually will use the reader's capability to sign the data.
-		# However, during develpement you may specify soft certificates and
+		# However, during development you may specify soft certificates and
 		# keys for a ST below.
 		# The following example EAC PKI can be found in vicc's example data:
 		# https://github.com/frankmorgner/vsmartcard/tree/master/virtualsmartcard/npa-example-data
@@ -1065,7 +1065,7 @@ app opensc-pkcs11 {
 		#    init_pin_in_so_session:  C_InitPIN() in CKU_SO logged session:
 		#       User PIN 'UNBLOCK' is protected by SOPIN. (PUK == SOPIN).
 		#       # Actually this style works only for the PKCS15 contents without SOPIN.
-		#       # For those with SOPIN, this mode will be usefull for the cards without
+		#       # For those with SOPIN, this mode will be useful for the cards without
 		#       #   modes 00 and 01 of ISO command 'RESET RETRY COUNTER'. --vt
 		#
 		# Default: none

--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -77,7 +77,7 @@ size_t sc_apdu_get_length(const sc_apdu_t *apdu, unsigned int proto)
  *  @param  apdu    APDU to be encoded as an octet string
  *  @param  proto   protocol version to be used
  *  @param  out     output buffer of size outlen.
- *  @param  outlen  size of hte output buffer
+ *  @param  outlen  size of the output buffer
  *  @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_apdu2bytes(sc_context_t *ctx, const sc_apdu_t *apdu,

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -871,7 +871,7 @@ static int cac_parse_properties_object(sc_card_t *card, u8 type,
 	if (data_len < 11)
 		return -1;
 
-	/* Initilize: non-PKI applet */
+	/* Initialize: non-PKI applet */
 	object->privatekey = 0;
 
 	val = data;
@@ -1299,7 +1299,7 @@ static int cac_parse_aid(sc_card_t *card, cac_private_data_t *priv, const u8 *ai
 	memcpy(new_object.path.aid.value, aid, aid_len);
 	new_object.path.aid.len = aid_len;
 
-	/* Call without OID set will just select the AID without subseqent
+	/* Call without OID set will just select the AID without subsequent
 	 * OID selection, which we need to figure out just now
 	 */
 	cac_select_file_by_type(card, &new_object.path, NULL);

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -332,7 +332,7 @@ static int cardos_init(sc_card_t *card)
 			 * Most, if not all, cardos cards do extended, but not chaining 
 			 */
 			if (card->reader->max_send_size == 255 && card->reader->max_recv_size == 256) {
-				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "reseting reader to use data_field_length");
+				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "resetting reader to use data_field_length");
 				card->reader->max_send_size = data_field_length - 6;
 				card->reader->max_recv_size = data_field_length - 3;
 			}
@@ -628,7 +628,7 @@ static const int ef_acl[9] = {
 	/* XXX: ADMIN should be an ACL type of its own, or mapped
 	 * to erase */
 	SC_AC_OP_UPDATE,	/* ADMIN EF (modify meta information?) */
-	-1,			/* INC (-> cylic fixed files) */
+	-1,			/* INC (-> cyclic fixed files) */
 	-1			/* DEC */
 };
 
@@ -1216,7 +1216,7 @@ cardos_decipher(struct sc_card *card,
 		r = iso_ops->decipher(card, crgram, crgram_len, out, outlen);
 		/*
 		 * 5.3 supports RAW as well as PKCS1 and PSS
-		 * decription may strip padding if card supports it
+		 * description may strip padding if card supports it
 		 * with cards that support RAW, it always appears to 
 		 * drop first 00 that is start of padding.
 		 */

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -1393,7 +1393,7 @@ static int entersafe_gen_key(sc_card_t *card, sc_entersafe_gen_key_data *data)
 
 	r = entersafe_transmit_apdu(card, &apdu,0,0,0,0);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-	LOG_TEST_RET(card->ctx, sc_check_sw(card,apdu.sw1,apdu.sw2),"EnterSafe generate keypair failed");
+	LOG_TEST_RET(card->ctx, sc_check_sw(card,apdu.sw1,apdu.sw2),"EnterSafe generate key pair failed");
 
 	/* read public key via READ PUBLIC KEY */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xE6,  0x2A, data->key_id);

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2436,7 +2436,7 @@ epass2003_gen_key(struct sc_card *card, sc_epass2003_gen_key_data * data)
 	r = sc_transmit_apdu_t(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	LOG_TEST_RET(card->ctx, r, "generate keypair failed");
+	LOG_TEST_RET(card->ctx, r, "generate key pair failed");
 
 	/* read public key */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xb4, 0x02, 0x00);

--- a/src/libopensc/card-incrypto34.c
+++ b/src/libopensc/card-incrypto34.c
@@ -284,7 +284,7 @@ static const int ef_acl[9] = {
 	/* XXX: ADMIN should be an ACL type of its own, or mapped
 	 * to erase */
 	-1,			/* ADMIN EF (modify meta information?) */
-	-1,			/* INC (-> cylic fixed files) */
+	-1,			/* INC (-> cyclic fixed files) */
 	-1			/* DEC */
 };
 

--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -994,7 +994,7 @@ isoApplet_ctl_import_key(sc_card_t *card, sc_cardctl_isoApplet_import_key_t *arg
 	 *
 	 * The first step is to perform a MANAGE SECURITY ENVIRONMENT as it would be done
 	 * with on-card key generation. The second step is PUT DATA (instead of
-	 * GENERATE ASYMMETRIC KEYPAIR).
+	 * GENERATE ASYMMETRIC KEY PAIR).
 	 */
 
 	/* MANAGE SECURITY ENVIRONMENT (SET). Set the algorithm and key references. */

--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -443,7 +443,7 @@ static const int ef_acl[9] = {
 	/* XXX: ADMIN should be an ACL type of its own, or mapped
 	 * to erase */
 	SC_AC_OP_ERASE,		/* ADMIN EF (modify meta information?) */
-	-1,			/* INC (-> cylic fixed files) */
+	-1,			/* INC (-> cyclic fixed files) */
 	-1			/* DEC */
 };
 

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2193,7 +2193,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 		LOG_TEST_GOTO_ERR(card->ctx, r, "No support for random data");
 	}
 
-	/* NIST 800-73-3 says use 9B, previous verisons used 00 */
+	/* NIST 800-73-3 says use 9B, previous versions used 00 */
 	r = piv_general_io(card, 0x87, 0x00, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
 	/*
 	 * piv_get_challenge is called in a loop.
@@ -2619,7 +2619,7 @@ err:
 
 /*
  * parse a CCC to test  if this is a Dual CAC/PIV
- * We read teh CCC using the PIV API.
+ * We read the CCC using the PIV API.
  * Look for CAC RID=A0 00 00 00 79
  */
  static int piv_parse_ccc(sc_card_t *card, u8* rbuf, size_t rbuflen)
@@ -3161,7 +3161,7 @@ static int piv_match_card_continued(sc_card_t *card)
 	 * Discovery Object introduced in 800-73-3 so will return 0 if found and PIV applet active.
 	 * Will fail with SC_ERROR_FILE_NOT_FOUND if 800-73-3 and no Discovery object.
 	 * But some other card could also return SC_ERROR_FILE_NOT_FOUND.
-	 * Will fail for other reasons if wrong applet is selected, or bad PIV implimentation. 
+	 * Will fail for other reasons if wrong applet is selected, or bad PIV implementation.
 	 */
 	
 	sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d CI:%08x r:%d\n", card->type,  priv->card_issues, r);
@@ -3753,7 +3753,7 @@ static int piv_card_reader_lock_obtained(sc_card_t *card, int was_reset)
 			r = piv_select_aid(card, piv_aids[0].value, piv_aids[0].len_short, temp, &templen);
 			sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH piv_select_aid card->type:%d r:%d\n", card->type, r);
 		} else {
-			r = 0; /* cant do anything with this card, hope there was no interference */
+			r = 0; /* can't do anything with this card, hope there was no interference */
 		}
 	}
 

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -322,14 +322,14 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 		sc_card_t uninitialized = *card;
 		sc_log(ctx, "matching built-in ATRs");
 		for (i = 0; ctx->card_drivers[i] != NULL; i++) {
-			/* FIXME If we had a clean API description, we'd propably get a
+			/* FIXME If we had a clean API description, we'd probably get a
 			 * cleaner implementation of the driver's match_card and init,
 			 * which should normally *not* modify the card object if
 			 * unsuccessful. However, after years of relentless hacking, reality
 			 * is different: The card object is changed in virtually every card
 			 * driver so in order to prevent unwanted interaction, we reset the
 			 * card object here and hope that the card driver at least doesn't
-			 * allocate any internal ressources that need to be freed. If we
+			 * allocate any internal resources that need to be freed. If we
 			 * had more time, we should refactor the existing code to not
 			 * modify sc_card_t until complete success (possibly by combining
 			 * `match_card()` and `init()`) */

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -57,7 +57,7 @@
  */
 typedef struct cwa_tlv_st {
         u8 *buf;                /** local copy of TLV byte array */
-        size_t buflen;          /** lengt of buffer */
+        size_t buflen;          /** length of buffer */
         unsigned int tag;       /** tag ID */
         size_t len;             /** length of data field */
         u8 *data;               /** pointer to start of data in buf buffer */

--- a/src/libopensc/muscle.c
+++ b/src/libopensc/muscle.c
@@ -506,7 +506,7 @@ int msc_get_challenge(sc_card_t *card, unsigned short dataLength, unsigned short
 int msc_generate_keypair(sc_card_t *card, int privateKey, int publicKey, int algorithm, int keySize, int options)
 {
 	sc_apdu_t apdu;
-	u8 buffer[16]; /* Keypair payload length */
+	u8 buffer[16]; /* Key pair payload length */
 	u8 *ptr = buffer;
 	int r;
 	unsigned short prRead = 0xFFFF, prWrite = 0x0002, prCompute = 0x0002,

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -685,7 +685,7 @@ struct sc_card_operations {
 	int (*update_binary)(struct sc_card *card, unsigned int idx,
 			     const u8 * buf, size_t count, unsigned long flags);
 	/**
-	 * @brief Sets (part of) the content fo an EF to its logical erased state
+	 * @brief Sets (part of) the content of an EF to its logical erased state
 	 *
 	 * Implementation of this call back is optional and may be NULL.
 	 *
@@ -915,7 +915,7 @@ int sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
  *  @param  apdu    APDU to be encoded as an octet string
  *  @param  proto   protocol version to be used
  *  @param  out     output buffer of size outlen.
- *  @param  outlen  size of hte output buffer
+ *  @param  outlen  size of the output buffer
  *  @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_apdu2bytes(sc_context_t *ctx, const sc_apdu_t *apdu,
@@ -1243,7 +1243,7 @@ int sc_update_binary(struct sc_card *card, unsigned int idx, const u8 * buf,
 		     size_t count, unsigned long flags);
 
 /**
- * Sets (part of) the content fo an EF to its logical erased state
+ * Sets (part of) the content of an EF to its logical erased state
  * @param  card   struct sc_card object on which to issue the command
  * @param  idx    index within the file for the data to be erased
  * @param  count  number of bytes to erase

--- a/src/libopensc/pkcs15-cardos.c
+++ b/src/libopensc/pkcs15-cardos.c
@@ -77,7 +77,7 @@ static int cardos_fix_token_info(sc_pkcs15_card_t *p15card)
 					&& sa->operations == 0 && sa->algo_ref == 0)
 				break;
 
-			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "supported_algos[%d] mechamism:0x%8.8x", i, sa->mechanism);
+			sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "supported_algos[%d] mechanism:0x%8.8x", i, sa->mechanism);
 			switch(sa->mechanism) {
 			case 0x01 :
 				/*
@@ -88,7 +88,7 @@ static int cardos_fix_token_info(sc_pkcs15_card_t *p15card)
 				 * correct the mechanism in tokenInfo
 				 */
 				if (sa->reference & 0x10) {
-					sc_log(card->ctx, "Changeing mechanism to CKM_RSA_X_509 based on reference");
+					sc_log(card->ctx, "Changing mechanism to CKM_RSA_X_509 based on reference");
 					passed->new_flags |= SC_ALGORITHM_RSA_RAW
 						| SC_ALGORITHM_RSA_PAD_NONE;
 					sa->mechanism = 0x03;

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -259,7 +259,7 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 		return SC_ERROR_OBJECT_NOT_VALID;
 	}
 
-	/* XXX: check if "halfkeys" can be stored with gpg2. If not, add keypairs in one loop */
+	/* XXX: check if "halfkeys" can be stored with gpg2. If not, add key pairs in one loop */
 	for (i = 0; i < 3; i++) {
 		sc_pkcs15_prkey_info_t prkey_info;
 		sc_pkcs15_object_t     prkey_obj;

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -760,7 +760,7 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 		dst->ecpointQ.len = buflen;
 
 		/*
-		 * In OpenSC the field_length is in bits. Not all curves are a mutiple of 8.
+		 * In OpenSC the field_length is in bits. Not all curves are a multiple of 8.
 		 * EC_POINT_point2oct handles this and returns octstrings that can handle
 		 * these curves. Get real field_length from OpenSSL. 
 		 */

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -352,7 +352,7 @@ int sc_pkcs15_derive(struct sc_pkcs15_card *p15card,
  * Unwrap a key into a key object on card.
  * in holds the wrapped key data
  * the target file that target_key points to must be created before calling this function
- * Use pkcs15init to peform the complete unwrapping operation and create the pkcs#15 object for the new key.
+ * Use pkcs15init to perform the complete unwrapping operation and create the pkcs#15 object for the new key.
  */
 int sc_pkcs15_unwrap(struct sc_pkcs15_card *p15card,
 		const struct sc_pkcs15_object *key,

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -694,7 +694,7 @@ static int pcsc_lock(sc_reader_t *reader)
 
 	switch (rv) {
 		case SCARD_E_INVALID_VALUE:
-			/* This is retuned in case of the same reader was re-attached */
+			/* This is returned in case of the same reader was re-attached */
 		case SCARD_E_INVALID_HANDLE:
 		case SCARD_E_READER_UNAVAILABLE:
 			r = pcsc_connect(reader);
@@ -1695,7 +1695,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 					/* Windows wants us to manually reset the changed state */
 					rsp->dwEventState &= ~SCARD_STATE_CHANGED;
 
-					/* By default, ignore a hotplug event as if a timout
+					/* By default, ignore a hotplug event as if a timeout
 					 * occurred, since it may be an unrequested removal or
 					 * false alarm. Just continue to loop and check at the end
 					 * of this function whether we need to return the attached

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -42,10 +42,10 @@ extern "C" {
  */
 
 /*
- * 1.1.0 depracated ERR_load_crypto_strings(), SSL_load_error_strings(), ERR_free_strings()
+ * 1.1.0 deprecated ERR_load_crypto_strings(), SSL_load_error_strings(), ERR_free_strings()
  * and ENGINE_load_dynamic.EVP_CIPHER_CTX_cleanup and EVP_CIPHER_CTX_init are replaced
  * by EVP_CIPHER_CTX_reset.
- * But for compatability with LibreSSL and older OpenSSL. OpenSC uses the older functions
+ * But for compatibility with LibreSSL and older OpenSSL. OpenSC uses the older functions
  */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L  && !defined(LIBRESSL_VERSION_NUMBER)
 # if defined(OPENSSL_API_COMPAT) && OPENSSL_API_COMPAT >= 0x10100000L

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4759,7 +4759,7 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 	if (0 == (CARD_PADDING_INFO_PRESENT & pInfo->dwSigningFlags))   {
 		/* When CARD_PADDING_INFO_PRESENT is not set in dwSigningFlags, this is
 		 * the basic version of the signing structure. (If this is not the
-		 * basic verison of the signing structure, the minidriver should return
+		 * basic version of the signing structure, the minidriver should return
 		 * ERROR_REVISION_MISMATCH.) The minidriver should only do PKCS1
 		 * padding and use the value in aiHashAlg. */
 		logprintf(pCardData, 3, "CARD_PADDING_INFO_PRESENT not set\n");

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1116,7 +1116,7 @@ pkcs15_init_slot(struct sc_pkcs15_card *p15card, struct sc_pkcs11_slot *slot,
 				if (p15card->tokeninfo)
 					tokeninfo_len = strlen(p15card->tokeninfo->label);
 				/* Print the possibly truncated token label with at least 4
-				 * characters followed by the PIN label in paranthesis */
+				 * characters followed by the PIN label in parenthesis */
 				if (tokeninfo_len == 0
 						|| pin_len + strlen("L... ()") > 32) {
 					/* There is no token label or it doesn't fit,
@@ -3011,7 +3011,7 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 	CK_RV rv = CKR_OK;
 	CK_BBOOL always_auth = CK_FALSE;
 
-	sc_log(context, "Keypair generation, mech = 0x%0lx",
+	sc_log(context, "Key pair generation, mech = 0x%0lx",
 		   pMechanism->mechanism);
 
 	if (pMechanism->mechanism != CKM_RSA_PKCS_KEY_PAIR_GEN
@@ -3984,9 +3984,9 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 		break;
 	case CKM_RSA_PKCS_PSS:
 		flags = SC_ALGORITHM_RSA_PAD_PSS;
-		/* The hash was done ouside of the module */
+		/* The hash was done outside of the module */
 		flags |= SC_ALGORITHM_RSA_HASH_NONE;
-		/* Omited parameter can use MGF1-SHA1 ? */
+		/* Omitted parameter can use MGF1-SHA1 ? */
 		if (pMechanism->pParameter == NULL) {
 			flags |= SC_ALGORITHM_MGF1_SHA1;
 			if (ulDataLen != SHA_DIGEST_LENGTH)
@@ -4013,7 +4013,7 @@ pkcs15_prkey_sign(struct sc_pkcs11_session *session, void *obj,
 	case CKM_SHA384_RSA_PKCS_PSS:
 	case CKM_SHA512_RSA_PKCS_PSS:
 		flags = SC_ALGORITHM_RSA_PAD_PSS;
-		/* Omited parameter can use MGF1-SHA1 and SHA1 hash ? */
+		/* Omitted parameter can use MGF1-SHA1 and SHA1 hash ? */
 		if (pMechanism->pParameter == NULL) {
 			flags |= SC_ALGORITHM_RSA_HASH_SHA1;
 			flags |= SC_ALGORITHM_MGF1_SHA1;
@@ -4207,7 +4207,7 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 	case CKM_RSA_PKCS_OAEP:
 		flags |= SC_ALGORITHM_RSA_PAD_OAEP;
 
-		/* Omited parameter can use MGF1-SHA1 and SHA1 hash ? */
+		/* Omitted parameter can use MGF1-SHA1 and SHA1 hash ? */
 		if (pMechanism->pParameter == NULL) {
 			flags |= SC_ALGORITHM_RSA_HASH_SHA1;
 			flags |= SC_ALGORITHM_MGF1_SHA1;

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -227,7 +227,7 @@ struct sc_pkcs11_slot {
 typedef struct sc_pkcs11_slot sc_pkcs11_slot_t;
 
 /* Debug virtual slots. S is slot to be highlighted or NULL
- * C is a comment format string and args It will be preceeded by "VSS " */
+ * C is a comment format string and args It will be preceded by "VSS " */
 #define DEBUG_VSS(S, ...) do { sc_log(context,"VSS " __VA_ARGS__); _debug_virtual_slots(S); } while (0)
 
 /* called by DEBUG_VSS to print table of virtual slots */

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -393,7 +393,7 @@ card_detect_all(void)
 			 * handle a shrinking slot list
 			 * https://bugzilla.mozilla.org/show_bug.cgi?id=1613632 */
 
-			/* Instead, remove the releation between reader and slot */
+			/* Instead, remove the relation between reader and slot */
 			for (j = 0; j<list_size(&virtual_slots); j++) {
 				sc_pkcs11_slot_t *slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, j);
 				if (slot->reader == reader) {

--- a/src/pkcs15init/pkcs15-asepcos.c
+++ b/src/pkcs15init/pkcs15-asepcos.c
@@ -226,7 +226,7 @@ static int asepcos_do_store_pin(sc_profile_t *profile, sc_card_t *card,
 	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;
 
-	/* outter tag */
+	/* outer tag */
 	*p++ = 0x85;
 	p++;
 	/* as a file id for pin with use 0x00:<key id> */

--- a/src/pkcs15init/pkcs15-entersafe.c
+++ b/src/pkcs15init/pkcs15-entersafe.c
@@ -382,7 +382,7 @@ static int entersafe_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 			  r = SC_ERROR_SECURITY_STATUS_NOT_SATISFIED;
 	}
 	sc_file_free(tfile);
-	LOG_TEST_RET(card->ctx, r, "cant verify pin");
+	LOG_TEST_RET(card->ctx, r, "can't verify pin");
 
 	data.key_id = (u8) kinfo->key_reference;
 	data.usage=0x22;
@@ -432,7 +432,7 @@ static int entersafe_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15ca
 			  r = SC_ERROR_SECURITY_STATUS_NOT_SATISFIED;
 	}
 	sc_file_free(tfile);
-	LOG_TEST_RET(card->ctx, r, "cant verify pin");
+	LOG_TEST_RET(card->ctx, r, "can't verify pin");
 
 	/* generate key pair */
 	gendat.key_id     = (u8) kinfo->key_reference;

--- a/src/pkcs15init/pkcs15-jcop.c
+++ b/src/pkcs15init/pkcs15-jcop.c
@@ -237,7 +237,7 @@ jcop_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 }
 
 /*
- * Generate a keypair
+ * Generate a key pair
  */
 static int
 jcop_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -828,7 +828,7 @@ myeid_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	r = sc_card_ctl(card, SC_CARDCTL_MYEID_GENERATE_STORE_KEY, &args);
 	LOG_TEST_RET(ctx, r, "Card control 'MYEID_GENERATE_STORE_KEY' failed");
 
-	/* Keypair generation -> collect public key info */
+	/* Key pair generation -> collect public key info */
 	if (pubkey != NULL) {
 		struct sc_cardctl_myeid_data_obj data_obj;
 

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -463,7 +463,7 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	r = sc_card_ctl(p15card->card, SC_CARDCTL_SETCOS_GENERATE_STORE_KEY, &args);
 	LOG_TEST_RET(ctx, r, "Card control 'GENERATE_STORE_KEY' failed");
 
-	/* Keypair generation -> collect public key info */
+	/* Key pair generation -> collect public key info */
 	if (pubkey != NULL) {
 		pubkey->algorithm		= SC_ALGORITHM_RSA;
 		pubkey->u.rsa.modulus.len	= (keybits + 7) / 8;

--- a/src/tests/p11test/p11test_case_ec_derive.c
+++ b/src/tests/p11test/p11test_case_ec_derive.c
@@ -50,7 +50,7 @@ unsigned long pkcs11_derive(test_cert_t *o, token_info_t * info,
 	unsigned char *pub = NULL;
 	size_t pub_len;
 
-	/* Conver the public key to the octet string */
+	/* Convert the public key to the octet string */
 	group = EC_KEY_get0_group(key);
 	publickey = EC_KEY_get0_public_key(key);
 	pub_len = EC_POINT_point2oct(group, publickey,

--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -689,7 +689,7 @@ int pss_sign_verify_test(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 }
 
 /* ignore the prefilled mechanisms and list all combinations of mechanisms
- * found, all resonable hash functions, MGFs and salt lengths
+ * found, all reasonable hash functions, MGFs and salt lengths
  */
 void fill_object_pss_mechanisms(token_info_t *info, test_cert_t *o)
 {

--- a/src/tests/unittests/asn1.c
+++ b/src/tests/unittests/asn1.c
@@ -61,7 +61,7 @@
 TORTURE_OID(small, "\x01\x02\x03\x04\x05\x06", 0, 1, 2, 3, 4, 5, 6, -1)
 /* Limit what we can fit into the first byte */
 TORTURE_OID(limit, "\x7F", 2, 47, -1)
-/* The second octet already oveflows to the second byte */
+/* The second octet already overflows to the second byte */
 TORTURE_OID(two_byte, "\x81\x00", 2, 48, -1)
 /* Existing OID ec publickey */
 TORTURE_OID(ecpubkey, "\x2A\x86\x48\xCE\x3D\x02\x01", 1, 2, 840, 10045, 2, 1, -1)
@@ -503,7 +503,7 @@ static void torture_asn1_put_tag_long_tag(void **state)
 	rv = sc_asn1_put_tag(tag, data, data_len, NULL, 0, NULL);
 	assert_int_equal(rv, SC_ERROR_INVALID_DATA);
 
-	/* Fisrt byte has bits 5-1 set to 1 */
+	/* First byte has bits 5-1 set to 1 */
 	tag = 0xE0FFFF7F;
 	rv = sc_asn1_put_tag(tag, data, data_len, NULL, 0, NULL);
 	assert_int_equal(rv, SC_ERROR_INVALID_DATA);

--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -162,18 +162,18 @@ static void show_initial_puk(sc_card_t *card)
 	u8 buf1[128], buf2[128];
 	int i;
 
-	printf("\nReading crypted Initial-PUK-file: ");
+	printf("\nReading encrypted Initial-PUK-file: ");
 	sc_format_path("3F004350",&p);
 	if((i=sc_select_file(card,&p,&f))<0){
-		printf("Cannot select crypted Initial-PUK-file, %s\n", sc_strerror(i));
+		printf("Cannot select encrypted Initial-PUK-file, %s\n", sc_strerror(i));
 		return;
 	}
 	if((i=sc_read_binary(card,0,buf1,128,0))!=128){
-		printf("Cannot read crypted Initial-PUK-file, %s\n", sc_strerror(i));
+		printf("Cannot read encrypted Initial-PUK-file, %s\n", sc_strerror(i));
 		return;
 	}
 
-	printf("OK\nDecrypting crypted Initial-PUK-file: ");
+	printf("OK\nDecrypting encrypted Initial-PUK-file: ");
 	sc_format_path("3F00DF01",&p);
 	if((i=sc_select_file(card,&p,&f))<0){
 		printf("Cannot select DF01, %s\n", sc_strerror(i));

--- a/src/tools/npa-tool.c
+++ b/src/tools/npa-tool.c
@@ -119,7 +119,7 @@ static void read_dg(sc_card_t *card, unsigned char sfid, const char *dg_str,
 {
 	int r = iso7816_read_binary_sfid(card, sfid, dg, dg_len);
 	if (r < 0)
-		fprintf(stderr, "Coult not read DG %02u %s (%s)\n",
+		fprintf(stderr, "Could not read DG %02u %s (%s)\n",
 				sfid, dg_str, sc_strerror(r));
 	else {
 		char buf[0x200];
@@ -161,7 +161,7 @@ static void verify(sc_card_t *card, const char *verify_str,
 
 	r = sc_transmit_apdu(card, &apdu);
 	if (r < 0)
-		fprintf(stderr, "Coult not verify %s (%s)\n",
+		fprintf(stderr, "Could not verify %s (%s)\n",
 				verify_str, sc_strerror(r));
 	else
 		printf("Verified %s\n", verify_str);

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1197,7 +1197,7 @@ static int do_pininfo(int argc, char **argv)
 			break;
 		case SC_PIN_STATE_UNKNOWN:
 		default:
-			printf("Login status unkwown.\n");
+			printf("Login status unknown.\n");
 	}
 	if (tries_left >= 0)
 		printf("%d tries left.\n", tries_left);

--- a/src/tools/opensc-notify.c
+++ b/src/tools/opensc-notify.c
@@ -142,7 +142,7 @@ DWORD WINAPI ThreadProc(_In_ LPVOID lpParameter)
 	return 0;
 }
 
-/* This application shall be executable without a console.  Therefor we're
+/* This application shall be executable without a console.  Therefore we're
  * creating a windows application that requires `WinMain()` rather than
  * `main()` as entry point. As benefit, we can properly handle `WM_CLOSE`. */
 int WINAPI

--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -614,7 +614,7 @@ static int list_algorithms(void)
 			if (card->algorithms[i].flags & alg_flag_names[j].id)
 				printf(" %s", alg_flag_names[j].str);
 
-		/* print RSA spcific flags */
+		/* print RSA specific flags */
 		if ( card->algorithms[i].algorithm == SC_ALGORITHM_RSA) {
 			int padding = card->algorithms[i].flags
 					& SC_ALGORITHM_RSA_PADS;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -300,7 +300,7 @@ static const char *option_help[] = {
 
 	"Test (best used with the --login or --pin option)",
 	"Test hotplug capabilities (C_GetSlotList + C_WaitForSlotEvent)",
-	"Test Mozilla-like keypair gen and cert req, <arg>=certfile",
+	"Test Mozilla-like key pair gen and cert req, <arg>=certfile",
 	"Verbose operation. (Set OPENSC_DEBUG to enable OpenSC specific debugging)",
 	"Set the CKA_PRIVATE attribute (object is only viewable after a login)",
 	"Set the CKA_SENSITIVE attribute (object cannot be revealed in plaintext)",
@@ -2082,7 +2082,7 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	else if (rv == CKR_SIGNATURE_INVALID)
 		printf("Invalid signature\n");
 	else
-		printf("Cryptoki returned erorr: %s\n", CKR2Str(rv));
+		printf("Cryptoki returned error: %s\n", CKR2Str(rv));
 }
 
 

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -1425,7 +1425,7 @@ static int wrap_key(sc_context_t *ctx, sc_card_t *card, int keyid, const char *o
 		ptr += ef_cert_len;
 	}
 
-	// Encode key, key decription and certificate object in sequence
+	// Encode key, key description and certificate object in sequence
 	r = wrap_with_tag(0x30, keyblob, ptr - keyblob, &key, &key_len);
 	LOG_TEST_RET(ctx, r, "Out of memory");
 

--- a/src/tools/sceac-example.c
+++ b/src/tools/sceac-example.c
@@ -83,7 +83,7 @@ main (int argc, char **argv)
 	EAC_init();
 
 
-	/* Now we try to change the PIN. Therefor we need to establish a SM channel
+	/* Now we try to change the PIN. Therefore we need to establish a SM channel
 	 * with PACE.
 	 *
 	 * You could set your PIN with pin=“123456”; or just leave it at NULL to be


### PR DESCRIPTION
Fix various spelling errors, mostly in comments but also in texts displayed.

Errors found & interactively fixed using `codespell`, with additional manual
checks after the fixes.

The changes should in no way affect OpenSC's functionality, but only improve
understandability of comments and messages.

Please consider merging them.

Thanks in advance
Peter