### PR TITLE
prompt for env vars in bash completion for PIN/password options

### DIFF
--- a/doc/tools/Makefile.am
+++ b/doc/tools/Makefile.am
@@ -32,6 +32,9 @@ tools.html: $(srcdir)/tools.xml $(wildcard $(srcdir)/*.1.xml)
 		| sed "s,FILEOPTS,\
 			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*filename.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,' | grep ^ || echo "!*"),"  \
+		| sed "s,PINOPTS,\
+			$(shell sed -En 's,.*<option>([^<]*)</option>.*<replaceable>\s*(newpin|pin|puk|sopin|sopuk)\s*<.*,\1,pg' $< \
+				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,' | grep ^ || echo "!*"),"  \
 		| sed "s,MODULEOPTS,\
 			$(shell sed -n 's,.*<option>\([^<]*\)</option>.*<replaceable>.*mod.*,\1,pg' $< \
 				| sort -u | grep -- '^\-' | tr '\n' '|' | sed 's,|$$,,' | grep ^ || echo "!*")," \

--- a/doc/tools/completion-template
+++ b/doc/tools/completion-template
@@ -3,7 +3,7 @@ _FUNCTION_NAME()
 {
     COMPREPLY=()
     local cur prev split=false
-    _get_comp_words_by_ref cur prev
+    _get_comp_words_by_ref -n : cur prev
 
     _split_longopt && split=true
 
@@ -21,6 +21,11 @@ _FUNCTION_NAME()
             ;;
         FILEOPTS)
             _filedir
+            return 0
+            ;;
+        PINOPTS|--password)
+            COMPREPLY=( $( compgen -W "$(printenv | cut -d = -f 1 | xargs printf 'env:%s ')" -- $cur ) )
+            __ltrim_colon_completions "$cur"
             return 0
             ;;
         OPTSWITHARGS)

--- a/doc/tools/netkey-tool.1.xml
+++ b/doc/tools/netkey-tool.1.xml
@@ -43,29 +43,29 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>--pin</option> <replaceable>pin-value</replaceable>,
-            <option>-p</option> <replaceable>pin-value</replaceable>
+            <option>--pin</option> <replaceable>pin</replaceable>,
+            <option>-p</option> <replaceable>pin</replaceable>
           </term>
           <listitem><para>Specifies the current value of the global PIN.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>--puk</option> <replaceable>pin-value</replaceable>,
-            <option>-u</option> <replaceable>pin-value</replaceable>
+            <option>--puk</option> <replaceable>pin</replaceable>,
+            <option>-u</option> <replaceable>pin</replaceable>
           </term>
           <listitem><para>Specifies the current value of the global PUK.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>--pin0</option> <replaceable>pin-value</replaceable>,
-            <option>-0</option> <replaceable>pin-value</replaceable>
+            <option>--pin0</option> <replaceable>pin</replaceable>,
+            <option>-0</option> <replaceable>pin</replaceable>
           </term>
           <listitem><para>Specifies the current value of the local PIN0 (aka local PIN).</para></listitem>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>--pin1</option> <replaceable>pin-value</replaceable>,
-            <option>-1</option> <replaceable>pin-value</replaceable>
+            <option>--pin1</option> <replaceable>pin</replaceable>,
+            <option>-1</option> <replaceable>pin</replaceable>
           </term>
           <listitem><para>Specifies the current value of the local PIN1 (aka local PUK).</para></listitem>
         </varlistentry>

--- a/doc/tools/pkcs15-tool.1.xml
+++ b/doc/tools/pkcs15-tool.1.xml
@@ -52,8 +52,8 @@
 
 				<varlistentry>
 					<term>
-						<option>--auth-id</option> <replaceable>pin</replaceable>,
-						<option>-a</option> <replaceable>pin</replaceable>
+						<option>--auth-id</option> <replaceable>id</replaceable>,
+						<option>-a</option> <replaceable>id</replaceable>
 					</term>
 					<listitem><para>Specifies the auth id of the PIN to use for the
 					operation. This is useful with the --change-pin operation.</para></listitem>
@@ -335,7 +335,7 @@
 
 				<varlistentry>
 					<term>
-						<option>--new-pin</option> <replaceable>PIN</replaceable>
+						<option>--new-pin</option> <replaceable>pin</replaceable>
 					</term>
 					<listitem><para>Specify New PIN (when changing or unblocking)</para></listitem>
 				</varlistentry>


### PR DESCRIPTION
This adds a new case of options in the bash completion and normalized the docs regarding the PIN options.  I tested this on Debian/buster.  I wrote these files originally in #238

##### Checklist

- [X] Documentation is added or updated
- [X] New files have a LGPL 2.1 license statement
