### PR TITLE
PKCS#11 C_FindObjectsInit does not see private objects when logged in as CKU_SO

### DIFF
--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -375,7 +375,7 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	/* Check whether we should hide private objects */
 	hide_private = 0;
-	if (slot->login_user != CKU_USER && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
+	if ((slot->login_user != CKU_SO) && (slot->login_user != CKU_USER) && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
 		hide_private = 1;
 
 	/* For each object in token do */


### PR DESCRIPTION
PKCS#11 C_FindObjectsInit does not see private objects when logged in as CKU_SO.
However in case CKU_USER all private objects are visible, but we can't manage them.
For example, when we want to remove stored key pair (using C_DestroyObject) and then re-create it with C_GenerateKeyPair, it is required to log in as SO, but we don't see private key then and can't destroy it, so the call fails.