### PR TITLE
PKCS#11 C_FindObjectsInit can see private objects only when logged in as CKU_USER

### DIFF
--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -375,7 +375,7 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	/* Check whether we should hide private objects */
 	hide_private = 0;
-	if (slot->login_user != CKU_USER && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
+	if ((slot->login_user != CKU_SO) && (slot->login_user != CKU_USER) && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
 		hide_private = 1;
 
 	/* For each object in token do */

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -375,7 +375,7 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	/* Check whether we should hide private objects */
 	hide_private = 0;
-	if ((slot->login_user != CKU_SO) && (slot->login_user != CKU_USER) && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
+	if ((slot->login_user == -1) && (slot->token_info.flags & CKF_LOGIN_REQUIRED))
 		hide_private = 1;
 
 	/* For each object in token do */


### PR DESCRIPTION
PKCS#11 C_FindObjectsInit can see private objects only when logged in as CKU_USER.
In that case all private objects are visible, but we can't manage them (there are no permissions).
For example, when we want to remove stored key pair (using C_DestroyObject) and then re-create it with C_GenerateKeyPair, it is required to log in as SO, but we don't see private key then and can't destroy it, so the call fails.