### PR TITLE
pkcs11-tool: allow using SW tokens

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -612,6 +612,15 @@
 					</para></listitem>
 				</varlistentry>
 
+				<varlistentry>
+					<term>
+						<option>--allow-sw</option>
+					</term>
+					<listitem><para>Allow using software mechanisms that do not have the CKF_HW flag set.
+					May be required when using software tokens and emulators.
+					</para></listitem>
+				</varlistentry>
+
 			</variablelist>
 		</para>
 	</refsect1>


### PR DESCRIPTION
I wanted to test SoftHSM with `pkcs11-tool --test` and had to remove `CKF_HW` from the mechanism filter, which is what this PR does.

I can't think of a reason for only allowing HW mechanisms, but let me know if I'm missing something.
