### PR TITLE
idprime: Unbreak OS version 2 after key&cert renewal

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -196,8 +196,12 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 			&& (memcmp(&start[12], "mscp", 5) == 0)) {
 			new_object.fd++;
 			if (card->type == SC_CARD_TYPE_IDPRIME_V2) {
-				/* The key reference starts from 0x11 */
-				new_object.key_reference = 0x10 + new_object.fd;
+				/* The key reference starts from 0x11 and increments by the key id (ASCII) */
+				int key_id = 0;
+				if (start[8] >= '0' && start[8] <= '9') {
+					key_id = start[8] - '0';
+				}
+				new_object.key_reference = 0x11 + key_id;
 			} else {
 				/* The key reference is one bigger than the value found here for some reason */
 				new_object.key_reference = start[8] + 1;


### PR DESCRIPTION
Fix the IDPrime key reference for OS version 2.

One year later after implementing the initial support for IDPrime, I got contacted by an owner of another IDPrime card that it no longer works after certificate renewal. This card had only on certificate so there was quite a lot of guesswork. After some more digging, I updated the code to work also with renewed certificates (with different IDs), which is confirmed it works.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested