### PR TITLE
Enable CIFuzz to run fuzzers even before merging changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CIFuzz
+on:
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.h'
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'opensc'
+       dry-run: false
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'opensc'
+       fuzz-seconds: 600
+       dry-run: false
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
I stumbled upon the note about CIFuzz, which should allow us running fuzzers even before merging them in master and making sure some obvious issue is not introduced by the changes in short time of fuzzing (~10m by default)

https://google.github.io/oss-fuzz/getting-started/continuous-integration/

It integrates well with github actions so it should give reliable results quite fast.

On the other hand, I am not sure if it will not start spitting some oss-fuzz issues that are not fixed in master in unrelated pull requests.