### PR TITLE
westcos-tool.c:fix memory leaks in dst->modulus.data and dst->exponen…

### DIFF
--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -673,11 +673,16 @@ int main(int argc, char *argv[])
 
 			if (!do_convert_bignum(&dst->modulus, rsa_n)
 			 || !do_convert_bignum(&dst->exponent, rsa_e))
+			{
+				free(dst->modulus.data);
+				free(dst->exponent.data);
 				goto out;
-
+			}
 		}
 
 		r = sc_pkcs15_encode_pubkey(ctx, &key, &pdata, &lg);
+		free(dst->modulus.data);
+		free(dst->exponent.data);
 		if(r) goto out;
 
 		printf("Public key length %"SC_FORMAT_LEN_SIZE_T"d\n", lg);


### PR DESCRIPTION
…t.data

Signed-off-by: whzhe <wanghongzhe@huawei.com>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
