### PR TITLE
pkcs15-oberthur.c:remove redundant code

### DIFF
--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -332,7 +332,7 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 			if (!rv)
 				rv = sc_oberthur_read_file(p15card, in_path, out, out_len, 0);
 		}
-	};
+	}
 
 	sc_file_free(file);
 


### PR DESCRIPTION
Signed-off-by: whzhe <wanghongzhe@huawei.com>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
