### PR TITLE
There may be a memory leak in main in /src/tools/sceac-example.c

### DIFF
--- a/src/tools/sceac-example.c
+++ b/src/tools/sceac-example.c
@@ -68,6 +68,7 @@ main (int argc, char **argv)
 	reader = sc_ctx_get_reader(ctx, 0);
 	if (!reader) {
 		fprintf(stderr, "Failed to access reader 0");
+		sc_release_context(ctx);
 		exit(1);
 	}
 


### PR DESCRIPTION
Signed-off-by: Xiaohui Zhang ruc_zhangxiaohui@163.com

When failed to access reader, cxt needs to be released before
exiting the program. Like in the patch of CVE-2019-6502, a
sc_release_context(ctx) is needed before line 71, or a
memory leak may occur.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
