### PR TITLE
Add sc_release_context() before exit()

### DIFF
--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -542,17 +542,20 @@ int main(
 		if(!strcmp("tcos", ctx->card_drivers[i]->short_name)) break;
 	if(!ctx->card_drivers[i]){
 		fprintf(stderr,"Context does not support TCOS-cards\n");
+		sc_release_context(ctx);
 		exit(1);
 	}
 
 	printf("%d Readers detected\n", sc_ctx_get_reader_count(ctx));
 	if(reader < 0 || reader >= (int)sc_ctx_get_reader_count(ctx)){
 		fprintf(stderr,"Cannot open reader %d\n", reader);
+		sc_release_context(ctx);
 		exit(1);
 	}
 
 	if((r = sc_connect_card(sc_ctx_get_reader(ctx, 0), &card))<0){
 		fprintf(stderr,"Connect-Card failed: %s\n", sc_strerror(r));
+		sc_release_context(ctx);
 		exit(1);
 	}
 	printf("\nCard detected (driver: %s)\nATR:", card->driver->name);
@@ -562,6 +565,7 @@ int main(
 
 	if((r = sc_lock(card))<0){
 		fprintf(stderr,"Lock failed: %s\n", sc_strerror(r));
+		sc_release_context(ctx);
 		exit(1);
 	}
 

--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -437,9 +437,9 @@ int main(
 		{ "pin1",     1, NULL, '1' },
 		{ NULL, 0, NULL, 0 }
 	};
-	sc_context_t *ctx;
+	sc_context_t *ctx = NULL;
 	sc_context_param_t ctx_param;
-	sc_card_t *card;
+	sc_card_t *card = NULL;
 	int do_help=0, do_unblock=0, do_change=0, do_nullpin=0, do_readcert=0, do_writecert=0;
 	u8 newpin[32];
 	char *certfile=NULL, *p;
@@ -565,6 +565,7 @@ int main(
 
 	if((r = sc_lock(card))<0){
 		fprintf(stderr,"Lock failed: %s\n", sc_strerror(r));
+		sc_disconnect_card(card);
 		sc_release_context(ctx);
 		exit(1);
 	}


### PR DESCRIPTION
Fixes https://github.com/OpenSC/OpenSC/issues/2135
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
