### PR TITLE
pkcs11-tool support key-gen for GENERIC secret key

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -146,7 +146,9 @@
 					<term>
 						<option>--key-type</option> <replaceable>specification</replaceable>
 					</term>
-					<listitem><para>Specify the type and length of the key to create, for example rsa:1024 or EC:prime256v1.</para></listitem>
+					<listitem><para>Specify the type and length (bytes if symmetric) of the key to create,
+					for example RSA:1024, EC:prime256v1, GOSTR3410-2012-256:B,
+					DES:8, DES3:24, AES:16 or GENERIC:64.</para></listitem>
 				</varlistentry>
 
 				<varlistentry>


### PR DESCRIPTION
Fixes #2139

Added code to support  mechanism GENERIC-SECRET-KEY-GEN.

Improved --help because key gen of symmetric keys pass
CKA_VALUE_LEN which is length of key in bytes.

Tested with:
```
./pkcs11-tool --module /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
 --login --label generic-64 --keygen --key-type GENERIC:64 \
 --mechanism GENERIC-SECRET-KEY-GEN

./pkcs11-tool --module /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so --login -O
```

 On branch pkcs11-tool-generic
 Changes to be committed:
	modified:   pkcs11-tool.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
- [X] PKCS#11 module is tested
