### PR TITLE
PIV global pin bug

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2603,7 +2603,7 @@ static int piv_parse_discovery(sc_card_t *card, u8 * rbuf, size_t rbuflen, int a
 				if (pinp && pinplen == 2) {
 					sc_log(card->ctx, "Discovery pinp flags=0x%2.2x 0x%2.2x",*pinp, *(pinp+1));
 					r = SC_SUCCESS;
-					if (*pinp == 0x60 && *(pinp+1) == 0x20) { /* use Global pin */
+					if ((*pinp & 0x60) == 0x60 && *(pinp+1) == 0x20) { /* use Global pin */
 						sc_log(card->ctx, "Pin Preference - Global");
 						priv->pin_preference = 0x00;
 					}


### PR DESCRIPTION
Fixes #2141

NIST 800-73-3 based cards only had 2 bits set in first pin policy byte.
NIST 800-73-4 defines additions bits in first pin policy byte.
When one of these bit is set, and the policy prefers the Global pin,
it is not recognized and the local pin is used.

 On branch PIV-global-pin-bug
 Changes to be committed:
	modified:   src/libopensc/card-piv.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested  using IDEMIA test card with pin policy 6820 
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
