### PR TITLE
pkcs11-tool: disable wrap/unwrap test until #1796 is resolved

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5390,7 +5390,7 @@ static int test_verify(CK_SESSION_HANDLE sess)
 	return errors;
 }
 
-#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 20
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 21
 #else
 #ifdef ENABLE_OPENSSL
 static int wrap_unwrap(CK_SESSION_HANDLE session,
@@ -5514,7 +5514,7 @@ static int wrap_unwrap(CK_SESSION_HANDLE session,
  */
 static int test_unwrap(CK_SESSION_HANDLE sess)
 {
-#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 20
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 21
 	/* temporarily disable test, see https://github.com/OpenSC/OpenSC/issues/1796 */
 	return 0;
 #else


### PR DESCRIPTION

##### Checklist
- [ ] PKCS#11 module is tested
- [X] pkcs11-tool was tested

Same as done by @frankmorgner for release 0.20.0 in PR #1808, this now will prolong disabling the unwrap testing for upcoming release 0.21.0, as there was no activity so far to fix issue #1796.