### PR TITLE
configure: disable "autostart-items" by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,9 +273,9 @@ AC_ARG_ENABLE(
 
 AC_ARG_ENABLE(
 	[autostart-items],
-	[AS_HELP_STRING([--enable-autostart-items],[enable autostart items @<:@enabled@:>@])],
+	[AS_HELP_STRING([--enable-autostart-items],[enable autostart items @<:@disabled@:>@])],
 	,
-	[enable_autostart="yes"]
+	[enable_autostart="no"]
 )
 
 AC_ARG_ENABLE(


### PR DESCRIPTION
Related-to: https://github.com/OpenSC/OpenSC/issues/2060
Signed-off-by: Henning Schild <henning@hennsch.de>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [x] macOS tokend is tested
