### PR TITLE
Update minidriver.c

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -6871,7 +6871,7 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 	if ( pCardData->pwszCardName == NULL )
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	/* <2 length or >=0x22 are not ISO compliant */
-	if (pCardData->cbAtr >= 0x22 || pCardData->cbAtr <= 0x2)
+	if (pCardData->cbAtr >= 0x22 || pCardData->cbAtr < 0x2)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	/* ATR beginning by 0x00 or 0xFF are not ISO compliant */
 	if (pCardData->pbAtr[0] == 0xFF || pCardData->pbAtr[0] == 0x00)

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -6870,8 +6870,8 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	if ( pCardData->pwszCardName == NULL )
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
-	/* <2 length or >=0x22 are not ISO compliant */
-	if (pCardData->cbAtr >= 0x22 || pCardData->cbAtr < 0x2)
+	/* <2 length or >0x22 are not ISO compliant */
+	if (pCardData->cbAtr > 0x22 || pCardData->cbAtr < 0x2)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	/* ATR beginning by 0x00 or 0xFF are not ISO compliant */
 	if (pCardData->pbAtr[0] == 0xFF || pCardData->pbAtr[0] == 0x00)


### PR DESCRIPTION
Fix check of ATR length (2-to 33 characters inclusive).

Fixes #2145.
 
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
- [X] New files have a LGPL 2.1 license statement
- [x] Windows minidriver is tested
