### PR TITLE
Use more standard location for file cache

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -724,9 +724,11 @@ app <em class="replaceable"><code>application</code></em> {
 					</span></dt><dd><p>
 							Where to cache the card's files. The default values are:
 							</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem"><p>
-										<code class="filename"><code class="envar">HOME</code>/.eid/cache/</code> (Unix)
+										<code class="filename"><code class="envar">$XDG_CACHE_HOME</code>/opensc/</code> (if defined)
 									</p></li><li class="listitem"><p>
-										<code class="filename"><code class="envar">USERPROFILE</code>\.eid-cache\</code> (Windows)
+										<code class="filename"><code class="envar">$HOME</code>/.cache/opensc/</code> (Unix)
+									</p></li><li class="listitem"><p>
+										<code class="filename"><code class="envar">$USERPROFILE</code>\.eid-cache\</code> (Windows)
 									</p></li></ul></div><p>
 						</p><p>
 							If caching is done by a system process, the

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1116,12 +1116,17 @@ app <replaceable>application</replaceable> {
 							<itemizedlist>
 								<listitem>
 									<para>
-										<filename><envar>HOME</envar>/.eid/cache/</filename> (Unix)
+										<filename><envar>$XDG_CACHE_HOME</envar>/opensc/</filename> (If <envar>$XDG_CACHE_HOME</envar> is defined)
 									</para>
 								</listitem>
 								<listitem>
 									<para>
-										<filename><envar>USERPROFILE</envar>\.eid-cache\</filename> (Windows)
+										<filename><envar>$HOME</envar>/.cache/opensc/</filename> (Unix)
+									</para>
+								</listitem>
+								<listitem>
+									<para>
+										<filename><envar>$USERPROFILE</envar>\.eid-cache\</filename> (Windows)
 									</para>
 								</listitem>
 							</itemizedlist>

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -1008,7 +1008,12 @@ int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize)
 	}
 
 #ifndef _WIN32
-	cache_dir = ".eid/cache";
+	cache_dir = getenv("XDG_CACHE_HOME");
+	if (cache_dir != NULL && cache_dir[0] != '\0') {
+		snprintf(buf, bufsize, "%s/%s", cache_dir, "opensc");
+		return SC_SUCCESS;
+	}
+	cache_dir = ".cache/opensc";
 	homedir = getenv("HOME");
 #else
 	cache_dir = "eid-cache";
@@ -1020,7 +1025,7 @@ int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize)
 		homedir = temp_path;
 	}
 #endif
-	if (homedir == NULL)
+	if (homedir == NULL || homedir[0] == '\0')
 		return SC_ERROR_INTERNAL;
 	if (snprintf(buf, bufsize, "%s/%s", homedir, cache_dir) < 0)
 		return SC_ERROR_BUFFER_TOO_SMALL;

--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -6,8 +6,8 @@ include $(top_srcdir)/aminclude_static.am
 clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
 
-noinst_PROGRAMS = asn1 simpletlv
-TESTS = asn1 simpletlv
+noinst_PROGRAMS = asn1 simpletlv cachedir
+TESTS = asn1 simpletlv cachedir
 
 noinst_HEADERS = torture.h
 
@@ -22,6 +22,7 @@ LDADD = $(top_builddir)/src/libopensc/libopensc.la \
 
 asn1_SOURCES = asn1.c
 simpletlv_SOURCES = simpletlv.c
+cachedir_SOURCES = cachedir.c
 
 if ENABLE_ZLIB
 noinst_PROGRAMS += compression

--- a/src/tests/unittests/cachedir.c
+++ b/src/tests/unittests/cachedir.c
@@ -1,0 +1,107 @@
+/*
+ * cachedir.c: Test various options how cache dir is evaluated
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Author: Jakub Jelen <jjelen@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <limits.h>
+
+#include "torture.h"
+#include "libopensc/opensc.h"
+
+static void torture_cachedir_default_empty_home(void **state)
+{
+	sc_context_t *ctx = NULL;
+	char buf[PATH_MAX] = {0};
+	size_t buflen = sizeof(buf);
+	int rv;
+
+	rv = sc_establish_context(&ctx, "cachedir");
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_non_null(ctx);
+
+	/* Keep configuration empty */
+	setenv("OPENSC_CONF", "/nonexistent", 1);
+	setenv("XDG_CACHE_HOME", "", 1);
+	setenv("HOME", "", 1);
+
+	rv = sc_get_cache_dir(ctx, buf, buflen);
+	assert_int_equal(rv, SC_ERROR_INTERNAL);
+
+	sc_release_context(ctx);
+}
+
+static void torture_cachedir_default_empty(void **state)
+{
+	sc_context_t *ctx = NULL;
+	char buf[PATH_MAX] = {0};
+	size_t buflen = sizeof(buf);
+	int rv;
+
+	rv = sc_establish_context(&ctx, "cachedir");
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_non_null(ctx);
+
+	/* Keep configuration empty */
+	setenv("OPENSC_CONF", "/nonexistent", 1);
+	setenv("XDG_CACHE_HOME", "", 1);
+	setenv("HOME", "/home/test", 1);
+
+	rv = sc_get_cache_dir(ctx, buf, buflen);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_string_equal(buf, "/home/test/.cache/opensc");
+
+	sc_release_context(ctx);
+}
+
+static void torture_cachedir_default_cache_home(void **state)
+{
+	sc_context_t *ctx = NULL;
+	char buf[PATH_MAX] = {0};
+	size_t buflen = sizeof(buf);
+	int rv;
+
+	rv = sc_establish_context(&ctx, "cachedir");
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_non_null(ctx);
+
+	/* Keep configuration empty */
+	setenv("OPENSC_CONF", "/nonexistent", 1);
+	setenv("XDG_CACHE_HOME", "/home/test2/.cache", 1);
+	setenv("HOME", "/home/test", 1);
+
+	rv = sc_get_cache_dir(ctx, buf, buflen);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_string_equal(buf, "/home/test2/.cache/opensc");
+
+	sc_release_context(ctx);
+}
+
+
+int main(void)
+{
+	int rc;
+	struct CMUnitTest tests[] = {
+		cmocka_unit_test(torture_cachedir_default_empty_home),
+		cmocka_unit_test(torture_cachedir_default_empty),
+		cmocka_unit_test(torture_cachedir_default_cache_home),
+	};
+
+	rc = cmocka_run_group_tests(tests, NULL, NULL);
+	return rc;
+}


### PR DESCRIPTION
Currently, opensc uses non-standard `~/.eid/cache` directory to cache files. These days, there is a bit more standardization around the places which should be used for these things and from my reading of [1], `XDG_CACHE_HOME` is a place where we should place our cache by default.

The location is still possible to adjust in the configuration file (but it makes it hard as it does not support any replacement characters/environment variables, especially in multi-user systems.

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation is added or updated
- [X] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested