### PR TITLE
Avoid assigning local variables to function arguments on return 

### DIFF
--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1872,6 +1872,7 @@ static int cac_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries
 	sc_apdu_t apdu;
 	u8  sbuf[SC_MAX_APDU_BUFFER_SIZE];
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
+	int rv;
 
 	if (data->cmd == SC_PIN_CMD_CHANGE) {
 		int i = 0;
@@ -1897,7 +1898,10 @@ static int cac_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries
 		}
 	}
 
-	return  iso_drv->ops->pin_cmd(card, data, tries_left);
+	rv = iso_drv->ops->pin_cmd(card, data, tries_left);
+
+	data->apdu = NULL;
+	return rv;
 }
 
 static struct sc_card_operations cac_ops;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -2143,7 +2143,6 @@ static int dnie_pin_verify(struct sc_card *card,
 	res = cwa_create_secure_channel(card, GET_DNIE_PRIV_DATA(card)->cwa_provider, CWA_SM_ON);
 	LOG_TEST_RET(card->ctx, res, "Establish SM failed");
 
-	data->apdu = &apdu;	/* prepare apdu struct */
 	/* compose pin data to be inserted in apdu */
 	if (data->flags & SC_PIN_CMD_NEED_PADDING)
 		padding = 1;

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -1284,6 +1284,7 @@ static int flex_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 	r = iso_ops->pin_cmd(card, data, NULL);
 	if (old_cla != -1)
 		card->cla = old_cla;
+	data->apdu = NULL;
 	return r;
 }
 

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -1795,7 +1795,10 @@ gpk_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 
 	data->apdu = &apdu;
 
-	return iso_ops->pin_cmd(card, data, tries_left);
+	r = iso_ops->pin_cmd(card, data, tries_left);
+
+	data->apdu = NULL;
+	return r;
 }
 
 /*

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -718,6 +718,7 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		data->pin2.offset = 5;
 
 		r = (*iso_ops->pin_cmd)(card, data, tries_left);
+		data->apdu = NULL;
 	}
 	LOG_TEST_RET(card->ctx, r, "Verification failed");
 

--- a/src/libopensc/card-westcos.c
+++ b/src/libopensc/card-westcos.c
@@ -805,6 +805,7 @@ static int westcos_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
 			} else {
 				r = SC_ERROR_NOT_SUPPORTED;
 			}
+			data->apdu = NULL;
 		}
 		if (r)
 			return (r);


### PR DESCRIPTION
I got the following error from the local run of static analyzer with recent changes:
```
1. opensc-0.19.0/src/libopensc/card-cac.c:1893: error[autoVariables]: Address of local auto-variable assigned to a function parameter.
#  1891|   			/* it requires P1 = 0x01 completely against the ISO specs */
#  1892|   			apdu.p1 = 0x01;
#  1893|-> 			data->apdu = &apdu;
#  1894|   		}
#  1895|   	}
```
If I understand it right, the issue is that the data->apdu is a local variable and it is kept in the argument after it no longer exists (after return from this function). I think to fix this, resetting it back to NULL (it is empty when called in all cases if I am right) should be enough. I searched for the same issues in other drivers and it looks like common antipatern, but from my reading of the code, it is never used after returning from these functions so we did not see any crashes from this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
