### PR TITLE
pkcs11-tool: Avoid calloc with 0 argument

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1270,15 +1270,18 @@ static void list_slots(int tokens, int refresh, int print)
 		if (rv != CKR_OK)
 			p11_fatal("C_GetSlotList(NULL)", rv);
 		free(p11_slots);
-		p11_slots = calloc(p11_num_slots, sizeof(CK_SLOT_ID));
-		if (p11_slots == NULL) {
-			perror("calloc failed");
-			exit(1);
+		p11_slots = NULL;
+		if (p11_num_slots > 0) {
+			p11_slots = calloc(p11_num_slots, sizeof(CK_SLOT_ID));
+			if (p11_slots == NULL) {
+				perror("calloc failed");
+				exit(1);
+			}
+			rv = p11->C_GetSlotList(tokens, p11_slots, &p11_num_slots);
+			if (rv != CKR_OK)
+				p11_fatal("C_GetSlotList()", rv);
 		}
 
-		rv = p11->C_GetSlotList(tokens, p11_slots, &p11_num_slots);
-		if (rv != CKR_OK)
-			p11_fatal("C_GetSlotList()", rv);
 	}
 
 	if (!print)


### PR DESCRIPTION
Even though the behavior of calloc with 0 argument is quite safe (from `man calloc`):

> If nmemb or size is 0, then calloc() returns either NULL, or a unique pointer value that can later be successfully passed to free().

It can cause various issues with memory sanitizers as previously reported in #1978. This is another occurrence where the similar pattern is happening. If we do not have any slots, it does not make sense to allocate anything in pkcs11-tool if I am right.

##### Checklist
- [-] PKCS#11 module is tested
- [-] Windows minidriver is tested
- [-] macOS tokend is tested
