### PR TITLE
MyEID: enable more PKCS11 mechanisms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -318,6 +318,7 @@ script:
       ./OsEID-tool RSA-CREATE-KEYS;
       ./OsEID-tool RSA-UPLOAD-KEYS;
       ./OsEID-tool RSA-DECRYPT-TEST;
+      ./OsEID-tool RSA-SIGN-PKCS11-TEST;
       ./OsEID-tool EC-CREATE-KEYS;
       ./OsEID-tool EC-UPLOAD-KEYS;
       ./OsEID-tool EC-SIGN-TEST;

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -225,7 +225,7 @@ static int myeid_init(struct sc_card *card)
 	}
 
 	flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_ONBOARD_KEY_GEN;
-	flags |= SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_HASH_SHA1;
+	flags |= SC_ALGORITHM_RSA_HASH_NONE;
 
 	_sc_card_add_rsa_alg(card,  512, flags, 0);
 	_sc_card_add_rsa_alg(card,  768, flags, 0);


### PR DESCRIPTION
This patch enables using of: SHA224-RSA-PKCS, SHA256-RSA-PKCS,
SHA384-RSA-PKCS, SHA512-RSA-PKCS and PSS variants of these mechanism for
MyEID users. (This patch is related to issue #2173.)

CI tests for these mechanisms are also enabled (using OsEID emulation).

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
