### PR TITLE
Friday fuzzing and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ addons:
     - ant
     - socat
     - cmake
+    - clang-tidy
 
 before_install:
   # homebrew is dead slow in older images due to the many updates it would need to download and build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -246,7 +246,7 @@ script:
       fi;
     fi
   - if [ -z "$HOST" -a "${DO_COVERITY_SCAN}" != "yes" -a -z "$DO_SIMULATION" ]; then
-      make check && make dist;
+      make check && make dist || cat tests/*log;
     fi
   - if [ ! -z "$HOST" -a "${DO_COVERITY_SCAN}" != "yes" ]; then
       make install;

--- a/configure.ac
+++ b/configure.ac
@@ -953,6 +953,7 @@ AC_PATH_PROG(GENGETOPT, gengetopt, not found)
 AC_ARG_VAR([CLANGTIDY],
            [absolute path to clang-tidy used for static code analysis])
 AC_PATH_PROG(CLANGTIDY, clang-tidy, not found)
+TIDY_CHECKS="-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling"
 
 AX_FUNC_GETOPT_LONG
 #AH_BOTTOM([#include "common/compat_getopt.h"])
@@ -1060,6 +1061,7 @@ AC_SUBST([PROFILE_DIR])
 AC_SUBST([PROFILE_DIR_DEFAULT])
 AC_SUBST([OPTIONAL_NOTIFY_CFLAGS])
 AC_SUBST([OPTIONAL_NOTIFY_LIBS])
+AC_SUBST([TIDY_CHECKS])
 
 AM_CONDITIONAL([ENABLE_MAN], [test "${enable_man}" = "yes"])
 AM_CONDITIONAL([ENABLE_THREAD_LOCKING], [test "${enable_thread_locking}" = "yes"])

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -43,4 +43,4 @@ TIDY_FILES = \
 	libpkcs11.c libscdl.c
 
 check-local:
-	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' --checks='$(TIDY_CHECKS)' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -147,4 +147,4 @@ TIDY_FILES = \
 	#$(SOURCES)
 
 check-local:
-	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' --checks='$(TIDY_CHECKS)' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1558,6 +1558,7 @@ authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 	pin_cmd.pin_type = data->pin_type;
 	pin_cmd.pin1.tries_left = -1;
 
+	memset(&acls, 0, sizeof(acls));
 	rv = authentic_pin_get_policy(card, &pin_cmd, acls);
 	LOG_TEST_RET(ctx, rv, "Get 'PIN policy' error");
 

--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -215,7 +215,6 @@ static int belpic_match_card(sc_card_t *card)
 static int belpic_init(sc_card_t *card)
 {
 	int key_size = 1024;
-	int r;
 
 	sc_log(card->ctx,  "Belpic V%s\n", BELPIC_VERSION);
 
@@ -227,7 +226,7 @@ static int belpic_init(sc_card_t *card)
 		u8 carddata[BELPIC_CARDDATA_RESP_LEN];
 		memset(carddata, 0, sizeof(carddata));
 
-		if((r = get_carddata(card, carddata, sizeof(carddata))) < 0) {
+		if(get_carddata(card, carddata, sizeof(carddata)) < 0) {
 			return SC_ERROR_INVALID_CARD;
 		}
 		if (carddata[BELPIC_CARDDATA_OFF_APPLETVERS] >= 0x17) {

--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -503,6 +503,7 @@ static int itacns_get_serialnr(sc_card_t *card, sc_serial_number_t *serial)
 		return SC_ERROR_WRONG_CARD;
 	}
 	len = file->size;
+	sc_file_free(file);
 
 	//Returned file->size should be 16. 
 	//We choose to not consider it as critical, because some cards 

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -114,7 +114,6 @@ sc_bytes2apdu
 sc_format_asn1_entry
 sc_format_oid
 sc_init_oid
-sc_compare_oid
 sc_valid_oid
 sc_format_path
 sc_free_apps
@@ -150,8 +149,6 @@ sc_pkcs15_cache_file
 sc_pkcs15_card_clear
 sc_pkcs15_card_free
 sc_pkcs15_card_new
-sc_pkcs15_tokeninfo_new
-sc_pkcs15_free_tokeninfo
 sc_pkcs15_change_pin
 sc_pkcs15_compare_id
 sc_pkcs15_compute_signature

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1171,6 +1171,7 @@ sc_pkcs15_bind_internal(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 		goto end;
 	}
 
+	sc_pkcs15_clear_tokeninfo(p15card->tokeninfo);
 	*(p15card->tokeninfo) = tokeninfo;
 
 	if (!p15card->tokeninfo->serial_number && 0 == card->serialnr.len) {

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -87,4 +87,4 @@ TIDY_FILES = \
 			 framework-pkcs15init.c debug.c
 
 check-local:
-	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi
+	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' --checks='$(TIDY_CHECKS)' -header-filter=.* $(TIDY_FILES) -- $(TIDY_FLAGS); fi

--- a/src/pkcs11/pkcs11.exports
+++ b/src/pkcs11/pkcs11.exports
@@ -66,5 +66,3 @@ C_GenerateRandom
 C_GetFunctionStatus
 C_CancelFunction
 C_WaitForSlotEvent
-C_Initialize
-C_Finalize

--- a/src/pkcs15init/pkcs15-authentic.c
+++ b/src/pkcs15init/pkcs15-authentic.c
@@ -862,7 +862,7 @@ authentic_emu_update_tokeninfo(struct sc_profile *profile, struct sc_pkcs15_card
 
 		len = file->size > sizeof(buffer) ? sizeof(buffer) : file->size;
 	        rv = sc_update_binary(p15card->card, 0, buffer, len, 0);
-		LOG_TEST_RET(ctx, rv, "Get challenge error");
+		LOG_TEST_RET(ctx, rv, "Update binary error");
 
 		sc_file_free(file);
 	}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,8 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh
 
 TESTS = \
-	test-manpage.sh \
+        test-manpage.sh \
+        test-duplicate-symbols.sh \
         test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-test.sh \
         test-pkcs11-tool-allowed-mechanisms.sh

--- a/tests/test-duplicate-symbols.sh
+++ b/tests/test-duplicate-symbols.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+SOURCE_PATH=../
+
+EXPORTS=`find "${SOURCE_PATH}" -name "*exports"`
+
+ERRORS=0
+for E in $EXPORTS; do
+	NUM_DUPES=`sort $E | uniq -D | wc -l`
+	if [[ "$NUM_DUPES" != 0 ]]; then
+		echo "There are duplicate symbols in '$E'"
+		ERRORS=1
+	fi
+done
+
+if [[ "$ERRORS" = 1 ]]; then
+	echo "There are duplicate symbols"
+	exit 1
+fi
+
+exit $ERRORS


### PR DESCRIPTION
Fixing couple of more fuzzing issues.

On the way, I tried to make working the clang-tidy, which is in place for quite some time, but really does not report much useful results (because configuration yields many warnings as memcpy and memset is used all over the place) and it was actually not installed in the CI machines.

I noticed also couple of duplicate symbols in `.exports`, which probably did not cause any issues, but my pedantic mind wanted to clear it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
