### PR TITLE
Use fresh data from FCI instead of FCP for sc_pkcs15init_authenticate()

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -4028,7 +4028,7 @@ sc_pkcs15init_update_file(struct sc_profile *profile,
 	}
 
 	/* Present authentication info needed */
-	r = sc_pkcs15init_authenticate(profile, p15card, file, SC_AC_OP_UPDATE);
+	r = sc_pkcs15init_authenticate(profile, p15card, selected_file, SC_AC_OP_UPDATE);
 	if (r >= 0 && datalen)
 		r = sc_update_binary(p15card->card, 0, (const unsigned char *) data, datalen, 0);
 


### PR DESCRIPTION
Function sc_pkcs15init_update_file(): we will try to select the file, if
file can not be selected, the file is created, and select operation is
repeated. In both cases, the "selected_file" variable contains the current
FCI of the selected file.

Then the sc_pkcs15init_authenticate () function is called, but not with
"selected_file" variable, but "file" variable where the FCP data is present
(from the file creation operation).

Difference between FCP and FCI  (pkcs15-init -C  / MyEID card).
62 17 80 02 00 FF 82 01 01 83 02 50 31 86 03 01 3F FF 85 02 00 00 8A 01 00
6F 17 80 02 00 FF 82 01 01 83 02 50 31 86 03 01 3F FF 85 02 00 00 8A 01 01

Here it is clear that the data from FCP are outdated.  The card changed the
TAG 0x8a from 0 to 1 ("no information given", "creation state".) We need to
respect the authority of the card, FCI is to be used in next code, not FCP.

	modified:   src/pkcs15init/pkcs15-lib.c
