### PR TITLE
opensc-explorer, command "info" - added information about LCS

### DIFF
--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -815,7 +815,7 @@ cryptoflex_construct_file_attrs(sc_card_t *card, const sc_file_t *file,
 		r = acl_to_keynum_nibble(entry);
 		p[13 + i/2] |= (r & 0x0F) << (((i+1) % 2) * 4);
 	}
-	p[11] = (file->status & SC_FILE_STATUS_INVALIDATED) ? 0x00 : 0x01;
+	p[11] = (file->status == SC_FILE_STATUS_INVALIDATED) ? 0x00 : 0x01;
 	if (file->type != SC_FILE_TYPE_DF &&
 	    (file->ef_structure == SC_FILE_EF_LINEAR_FIXED ||
 	    file->ef_structure == SC_FILE_EF_CYCLIC))

--- a/src/libopensc/card-miocos.c
+++ b/src/libopensc/card-miocos.c
@@ -187,7 +187,7 @@ static int encode_file_structure(sc_card_t *card, const sc_file_t *file,
                 *p++ = file->record_length;
 	else
 		*p++ = 0;
-	if (file->status & SC_FILE_STATUS_INVALIDATED)
+	if (file->status == SC_FILE_STATUS_INVALIDATED)
 		*p++ = 0;
 	else
 		*p++ = 0x01;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -331,6 +331,8 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 	size_t length;
 	int size;
 
+	file->status = SC_FILE_STATUS_UNKNOWN;
+
 	for (p = buf, length = buflen, end = buf + buflen;
 			p < end;
 			p += length, length = end - p) {
@@ -451,12 +453,48 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 
 			case 0x8A:
 				if (length == 1) {
-					if (p[0] == 0x01)
-						file->status = SC_FILE_STATUS_CREATION;
-					else if (p[0] == 0x07 || p[0] == 0x05)
-						file->status = SC_FILE_STATUS_ACTIVATED;
-					else if (p[0] == 0x06 || p[0] == 0x04)
-						file->status = SC_FILE_STATUS_INVALIDATED;
+					switch (p[0]) {
+						case 0:
+							file->status =SC_FILE_STATUS_NO_INFO;
+							break;
+						case 1:
+							file->status = SC_FILE_STATUS_CREATION;
+							break;
+						case 3:
+							file->status = SC_FILE_STATUS_INITIALISATION;
+							break;
+						case 4:
+						case 6:
+							file->status = SC_FILE_STATUS_INVALIDATED;
+							break;
+						case 5:
+						case 7:
+							file->status = SC_FILE_STATUS_ACTIVATED;
+							break;
+						case 12:
+						case 13:
+						case 14:
+						case 15:
+							file->status = SC_FILE_STATUS_TERMINATION;
+							break;
+						case 2:
+							file->status = SC_FILE_STATUS_RFU_2;
+							break;
+						case 8:
+							file->status = SC_FILE_STATUS_RFU_8;
+							break;
+						case 9:
+							file->status = SC_FILE_STATUS_RFU_9;
+							break;
+						case 10:
+							file->status = SC_FILE_STATUS_RFU_10;
+							break;
+						case 11:
+							file->status = SC_FILE_STATUS_RFU_11;
+							break;
+						default:
+							file->status = SC_FILE_STATUS_PROPRIETARY;
+					}
 				}
 				break;
 

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -225,10 +225,27 @@ typedef struct sc_acl_entry {
 #define SC_FILE_EF_CYCLIC_TLV		0x07
 
 /* File status flags */
-#define SC_FILE_STATUS_ACTIVATED	0x00
-#define SC_FILE_STATUS_INVALIDATED	0x01
-#define SC_FILE_STATUS_CREATION		0x02 /* Full access in this state,
-						(at least for SetCOS 4.4 */
+/* ISO7816-4: Unless otherwise specified, the security attributes are valid for the operational state.*/
+#define SC_FILE_STATUS_ACTIVATED	0x00 /* ISO7816-4: Operational state (activated)   (5, 7) */
+#define SC_FILE_STATUS_INVALIDATED	0x01 /* ISO7816-4: Operational state (deactivated) (4, 6) */
+
+/* Full access in this state, (at least for SetCOS 4.4 ) */
+#define SC_FILE_STATUS_CREATION		0x02 /* ISO7816-4: Creation state, (1) */
+
+#define SC_FILE_STATUS_INITIALISATION	0x03 /* ISO7816-4: Initialisation state, (3) */
+#define SC_FILE_STATUS_NO_INFO		0x04 /* ISO7816-4: No information given, (0) */
+#define SC_FILE_STATUS_TERMINATION	0x0c /* ISO7816-4: Termination state (12,13,14,15) */
+#define SC_FILE_STATUS_PROPRIETARY	0xf0 /* ISO7816-4: codes > 15 */
+
+/* reserved for future use by ISO/IEC */
+#define SC_FILE_STATUS_RFU_2		0x07 /* ISO7816-4: (0x02) */
+#define SC_FILE_STATUS_RFU_8		0x08 /* ISO7816-4: (0x08) */
+#define SC_FILE_STATUS_RFU_9		0x09 /* ISO7816-4: (0x09) */
+#define SC_FILE_STATUS_RFU_10		0x0a /* ISO7816-4: (0x0a) */
+#define SC_FILE_STATUS_RFU_11		0x0b /* ISO7816-4: (0x0b) */
+
+#define SC_FILE_STATUS_UNKNOWN		0xff /* if tag 0x8A is missing, there is no information about LCSB */
+
 typedef struct sc_file {
 	struct sc_path path;
 	unsigned char name[16];	/* DF name */

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -906,6 +906,25 @@ static int do_info(int argc, char **argv)
 	int r, not_current = 1;
 	const id2str_t *ac_ops = NULL;
 
+	const char *lifecycle = "unknown value";
+
+	static const id2str_t lc[] = {
+		{ SC_FILE_STATUS_NO_INFO,		"No information given"		},
+		{ SC_FILE_STATUS_CREATION,		"Creation state"		},
+		{ SC_FILE_STATUS_RFU_2,			"RFU (2)"			},
+		{ SC_FILE_STATUS_INITIALISATION,	"Initialisation state"		},
+		{ SC_FILE_STATUS_INVALIDATED,		"Operational, deactivated"	},
+		{ SC_FILE_STATUS_ACTIVATED,		"Operational, activated"	},
+		{ SC_FILE_STATUS_RFU_8,			"RFU (8)"			},
+		{ SC_FILE_STATUS_RFU_9,			"RFU (9)"			},
+		{ SC_FILE_STATUS_RFU_10,		"RFU (10)"			},
+		{ SC_FILE_STATUS_RFU_11,		"RFU (11)"			},
+		{ SC_FILE_STATUS_TERMINATION,		"Termination state"		},
+		{ SC_FILE_STATUS_PROPRIETARY,		"Proprietary state"		},
+		{ SC_FILE_STATUS_UNKNOWN,		"LCSB is not present"		},
+		{  0, NULL }
+	};
+
 	if (!argc) {
 		path = current_path;
 		file = current_file;
@@ -1033,6 +1052,10 @@ static int do_info(int argc, char **argv)
 		util_hex_dump(stdout, file->sec_attr, file->sec_attr_len, " ");
 		printf("\n");
 	}
+	for (i = 0; lc[i].str != NULL; i++)
+		if (file->status == lc[i].id)
+			lifecycle = lc[i].str;
+	printf("%-25s%s\n", "Life cycle: ", lifecycle);
 	printf("\n");
 	if (not_current) {
 		sc_file_free(file);


### PR DESCRIPTION
Information about "Life cycle status byte" is now available in listing.
Also src/libopensc/types.h update - added more LCSB definitions.


