### PR TITLE
EC flags for EC mechanisms

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5748,7 +5748,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	/* ADD ECDH mechanisms */
 	/* The PIV uses curves where CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE produce the same results */
 	if(flags & SC_ALGORITHM_ECDH_CDH_RAW) {
-		mech_info.flags &= ~CKF_SIGN;
+		mech_info.flags &= ~(CKF_SIGN | CKF_VERIFY);
 		mech_info.flags |= CKF_DERIVE;
 
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL, NULL);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5022,9 +5022,15 @@ struct sc_pkcs11_object_ops pkcs15_dobj_ops = {
 
 /* PKCS#15 Data Object*/
 static void
-pkcs15_profile_release(void *object)
+pkcs15_profile_release(void *obj)
 {
-	__pkcs15_release_object((struct pkcs15_any_object *) object);
+	struct pkcs15_any_object *object = (struct pkcs15_any_object *) obj;
+	struct sc_pkcs15_object *p15_obj = object->p15_object;
+
+	if (__pkcs15_release_object((struct pkcs15_any_object *) obj) < 1) {
+		/* This is not a real pkcs15 object. We need to free it here */
+		free(p15_obj);
+	}
 }
 
 

--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -798,9 +798,11 @@ struct ck_mechanism_info
 #define CKF_EC_F_P			(1UL << 20)
 #define CKF_EC_F_2M			(1UL << 21)
 #define CKF_EC_ECPARAMETERS	(1UL << 22)
-#define CKF_EC_NAMEDCURVE	(1UL << 23)
+#define CKF_EC_OID		(1UL << 23)
+#define CKF_EC_NAMEDCURVE	CKF_EC_OID
 #define CKF_EC_UNCOMPRESS	(1UL << 24)
 #define CKF_EC_COMPRESS		(1UL << 25)
+#define CKF_EC_CURVENAME	(1UL << 26)
 
 /* Flags for C_WaitForSlotEvent.  */
 #define CKF_DONT_BLOCK				(1UL)

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -606,6 +606,8 @@ const char *get_mechanism_name(int mech_id)
 			return "ECDSA";
 		case CKM_ECDSA_SHA1:
 			return "ECDSA_SHA1";
+		case CKM_ECDSA_SHA224:
+			return "ECDSA_SHA224";
 		case CKM_ECDSA_SHA256:
 			return "ECDSA_SHA256";
 		case CKM_ECDSA_SHA384:

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1480,6 +1480,34 @@ static void list_mechs(CK_SLOT_ID slot)
 				printf(", derive");
 				info.flags &= ~CKF_DERIVE;
 			}
+			if (info.flags & CKF_EC_F_P) {
+				printf(", EC F_P");
+				info.flags &= ~CKF_EC_F_P;
+			}
+			if (info.flags & CKF_EC_F_2M) {
+				printf(", EC F_2M");
+				info.flags &= ~CKF_EC_F_2M;
+			}
+			if (info.flags & CKF_EC_ECPARAMETERS) {
+				printf(", EC parameters");
+				info.flags &= ~CKF_EC_ECPARAMETERS;
+			}
+			if (info.flags & CKF_EC_OID) {
+				printf(", EC OID");
+				info.flags &= ~CKF_EC_OID;
+			}
+			if (info.flags & CKF_EC_UNCOMPRESS) {
+				printf(", EC uncompressed");
+				info.flags &= ~CKF_EC_UNCOMPRESS;
+			}
+			if (info.flags & CKF_EC_COMPRESS) {
+				printf(", EC compressed");
+				info.flags &= ~CKF_EC_COMPRESS;
+			}
+			if (info.flags & CKF_EC_CURVENAME) {
+				printf(", EC curve name");
+				info.flags &= ~CKF_EC_CURVENAME;
+			}
 			if (info.flags)
 				printf(", other flags=0x%x", (unsigned int) info.flags);
 		}


### PR DESCRIPTION
This amends #2190 which introduced VERIFY flags to Derive mechanisms, which is invalid.

Additionally, it ads also missing flags in pkcs11 header files and into pkcs11-tool. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
