### PR TITLE
openpgp: fix DO deletion

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1769,9 +1769,8 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	/* check if the tag is writable */
-	if (priv->current->id != tag)
-		affected_blob = pgp_find_blob(card, tag);
+	/* Check if there is a blob for the given tag */
+	affected_blob = pgp_find_blob(card, tag);
 
 	/* Non-readable DOs have no represented blob, we have to check from pgp_get_info_by_tag */
 	if (affected_blob == NULL)
@@ -1779,6 +1778,7 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 	else
 		dinfo = affected_blob->info;
 
+	/* Make sure the DO exists and is writeable */
 	if (dinfo == NULL) {
 		sc_log(card->ctx, "The DO %04X does not exist.", tag);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);


### PR DESCRIPTION
This fixes a problem reported in Nitrokey forum at

https://support.nitrokey.com/t/veracrypt-encryption-with-nitrokey-error/2872

as inability to save the VeraCrypt's keyfile onto the token
after deleting an existing one, unless the PKCS11 is reinitialized.

Reason: commit cbc53b9 "OpenPGP: Support write certificate for Gnuk"
introduced a condition on getting the blob handle, which is surplus
(the pgp_find_blob() function actually does that) and prevents
the blob refresh upon deletion, breaking the logic introduced
earlier in commit 9e04ae4 and causing the higher-level effect reported.

While at it, corrected comments to actually reflect the flow logic.

Tested on Fedora 33 using the repro steps from the forum and Nitrokey Pro.

Signed-off-by: alt3r 3go <alt3r.3go@protonmail.com>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
