### PR TITLE
Small memory leak fix in main() of src/tests/p15dump.c

### DIFF
--- a/src/tests/p15dump.c
+++ b/src/tests/p15dump.c
@@ -123,6 +123,7 @@ int main(int argc, char *argv[])
 	/* Keep card locked to prevent useless calls to sc_logout */
 	if (i) {
 		fprintf(stderr, "failed: %s\n", sc_strerror(i));
+		sc_test_cleanup();
 		return 1;
 	}
 	printf("found.\n");


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
