### PR TITLE
Small memory leak fix in sc_pkcs15_decode_skdf_entry()

### DIFF
--- a/src/libopensc/pkcs15-skey.c
+++ b/src/libopensc/pkcs15-skey.c
@@ -154,6 +154,8 @@ sc_pkcs15_decode_skdf_entry(struct sc_pkcs15_card *p15card, struct sc_pkcs15_obj
 	info.native = 1;
 
 	r = sc_asn1_decode(ctx, asn1_skey, *buf, *buflen, buf, buflen);
+	if (r < 0)
+		sc_pkcs15_free_key_params(&info.params);
 	if (r == SC_ERROR_ASN1_END_OF_CONTENTS)
 		return r;
 	LOG_TEST_RET(ctx, r, "ASN.1 decoding failed");
@@ -191,6 +193,7 @@ sc_pkcs15_decode_skdf_entry(struct sc_pkcs15_card *p15card, struct sc_pkcs15_obj
 		LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 	memcpy(obj->data, &info, sizeof(info));
 
+	sc_pkcs15_free_key_params(&info.params);
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
