### PR TITLE
Fix for running after build with gcc11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1091,7 +1091,7 @@ if test "${enable_pedantic}" = "yes"; then
 	CFLAGS="-pedantic ${CFLAGS}"
 fi
 if test "${enable_strict}" = "yes"; then
-	CFLAGS="-Wall -Wextra -Wno-unused-parameter -Werror ${CFLAGS}"
+	CFLAGS="-Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 ${CFLAGS}"
 fi
 
 AC_CONFIG_FILES([

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -124,18 +124,17 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 		struct sc_pkcs15_pubkey_info pubkey_info;
 		struct sc_pkcs15_object pubkey_obj;
 		struct sc_pkcs15_pubkey *pkey = NULL;
+		sc_pkcs15_cert_t *cert = NULL;
+
 		memset(&cert_info, 0, sizeof(cert_info));
 		memset(&cert_obj, 0, sizeof(cert_obj));
 		cert_info.id.len = 1;
 		cert_info.id.value[0] = 0x45;
 		cert_info.authority = 0;
 		cert_info.path = path;
-		r = sc_pkcs15_read_certificate(p15card, &cert_info,
-					       (sc_pkcs15_cert_t
-						**) (&cert_obj.data));
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert);
+		cert_obj.data = (void *) cert;
 		if (!r) {
-			sc_pkcs15_cert_t *cert =
-			    (sc_pkcs15_cert_t *) (cert_obj.data);
 			strlcpy(cert_obj.label, "User certificate",
 				sizeof(cert_obj.label));
 			cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1131,9 +1131,19 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	sc_context_t *ctx = reader->ctx;
 	struct pcsc_global_private_data *gpriv = (struct pcsc_global_private_data *) ctx->reader_drv_data;
 	struct pcsc_private_data *priv = reader->drv_data;
-	u8 feature_buf[256], rbuf[SC_MAX_APDU_BUFFER_SIZE];
 	DWORD rcount, feature_len, i;
 	PCSC_TLV_STRUCTURE *pcsc_tlv;
+	union {
+		PCSC_TLV_STRUCTURE msg;
+		u8 buf[256];
+	} feature_buf;
+	union {
+#ifdef PIN_PROPERTIES_v5
+		PIN_PROPERTIES_STRUCTURE_v5 capsv5;
+#endif
+		PIN_PROPERTIES_STRUCTURE caps;
+		u8 buf[SC_MAX_APDU_BUFFER_SIZE];
+	} rbuf;
 	LONG rv;
 	const char *log_disabled = "but it's disabled in configuration file";
 	int id_vendor = 0, id_product = 0;
@@ -1145,7 +1155,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	if (gpriv->SCardControl == NULL)
 		return;
 
-	rv = gpriv->SCardControl(card_handle, CM_IOCTL_GET_FEATURE_REQUEST, NULL, 0, feature_buf, sizeof(feature_buf), &feature_len);
+	rv = gpriv->SCardControl(card_handle, CM_IOCTL_GET_FEATURE_REQUEST, NULL, 0, feature_buf.buf, sizeof(feature_buf.buf), &feature_len);
 	if (rv != SCARD_S_SUCCESS) {
 		PCSC_TRACE(reader, "SCardControl failed", rv);
 		return;
@@ -1159,7 +1169,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	/* get the number of elements instead of the complete size */
 	feature_len /= sizeof(PCSC_TLV_STRUCTURE);
 
-	pcsc_tlv = (PCSC_TLV_STRUCTURE *)feature_buf;
+	pcsc_tlv = &feature_buf.msg;
 	for (i = 0; i < feature_len; i++) {
 		sc_log(ctx, "Reader feature %02x found", pcsc_tlv[i].tag);
 		if (pcsc_tlv[i].tag == FEATURE_VERIFY_PIN_DIRECT) {
@@ -1219,12 +1229,13 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 
 	/* Detect display */
 	if (priv->pin_properties_ioctl) {
-		rcount = sizeof(rbuf);
-		rv = gpriv->SCardControl(card_handle, priv->pin_properties_ioctl, NULL, 0, rbuf, sizeof(rbuf), &rcount);
+		rcount = sizeof(rbuf.buf);
+		rv = gpriv->SCardControl(card_handle, priv->pin_properties_ioctl,
+			NULL, 0, rbuf.buf, sizeof(rbuf.buf), &rcount);
 		if (rv == SCARD_S_SUCCESS) {
 #ifdef PIN_PROPERTIES_v5
 			if (rcount == sizeof(PIN_PROPERTIES_STRUCTURE_v5)) {
-				PIN_PROPERTIES_STRUCTURE_v5 *caps = (PIN_PROPERTIES_STRUCTURE_v5 *)rbuf;
+				PIN_PROPERTIES_STRUCTURE_v5 *caps = &rbuf.capsv5;
 				if (caps->wLcdLayout > 0) {
 					sc_log(ctx, "Reader has a display: %04X", caps->wLcdLayout);
 					reader->capabilities |= SC_READER_CAP_DISPLAY;
@@ -1233,7 +1244,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 			}
 #endif
 			if (rcount == sizeof(PIN_PROPERTIES_STRUCTURE)) {
-				PIN_PROPERTIES_STRUCTURE *caps = (PIN_PROPERTIES_STRUCTURE *)rbuf;
+				PIN_PROPERTIES_STRUCTURE *caps = &rbuf.caps;
 				if (caps->wLcdLayout > 0) {
 					sc_log(ctx, "Reader has a display: %04X", caps->wLcdLayout);
 					reader->capabilities |= SC_READER_CAP_DISPLAY;
@@ -1292,13 +1303,13 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	}
 
 	if(gpriv->SCardGetAttrib != NULL) {
-		rcount = sizeof(rbuf);
+		rcount = sizeof(rbuf.buf);
 		if (gpriv->SCardGetAttrib(card_handle, SCARD_ATTR_VENDOR_NAME,
-					rbuf, &rcount) == SCARD_S_SUCCESS
+					rbuf.buf, &rcount) == SCARD_S_SUCCESS
 				&& rcount > 0) {
 			/* add NUL termination, just in case... */
-			rbuf[(sizeof rbuf)-1] = '\0';
-			reader->vendor = strdup((char *) rbuf);
+			rbuf.buf[(sizeof rbuf.buf)-1] = '\0';
+			reader->vendor = strdup((char *) rbuf.buf);
 		}
 
 		rcount = sizeof i;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -670,6 +670,7 @@ __pkcs15_create_cert_object(struct pkcs15_fw_data *fw_data, struct sc_pkcs15_obj
 {
 	struct sc_pkcs15_cert_info *p15_info = NULL;
 	struct sc_pkcs15_cert *p15_cert = NULL;
+	struct pkcs15_any_object *any_object = NULL;
 	struct pkcs15_cert_object *object = NULL;
 	struct pkcs15_pubkey_object *obj2 = NULL;
 	int rv;
@@ -686,8 +687,9 @@ __pkcs15_create_cert_object(struct pkcs15_fw_data *fw_data, struct sc_pkcs15_obj
 	}
 
 	/* Certificate object */
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &object,
+	rv = __pkcs15_create_object(fw_data, &any_object,
 			cert, &pkcs15_cert_ops, sizeof(struct pkcs15_cert_object));
+	object = (struct pkcs15_cert_object *) any_object;
 	if (rv < 0) {
 		if (p15_cert != NULL)
 			sc_pkcs15_free_certificate(p15_cert);
@@ -720,7 +722,7 @@ __pkcs15_create_cert_object(struct pkcs15_fw_data *fw_data, struct sc_pkcs15_obj
 	pkcs15_cert_extract_label(object);
 
 	if (cert_object != NULL)
-		*cert_object = (struct pkcs15_any_object *) object;
+		*cert_object = any_object;
 
 	return 0;
 }
@@ -730,6 +732,7 @@ static int
 __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 	struct sc_pkcs15_object *pubkey, struct pkcs15_any_object **pubkey_object)
 {
+	struct pkcs15_any_object *any_object = NULL;
 	struct pkcs15_pubkey_object *object = NULL;
 	struct sc_pkcs15_pubkey *p15_key = NULL;
 	int rv;
@@ -758,8 +761,9 @@ __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 	}
 
 	/* Public key object */
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &object,
+	rv = __pkcs15_create_object(fw_data, &any_object,
 			pubkey, &pkcs15_pubkey_ops, sizeof(struct pkcs15_pubkey_object));
+	object = (struct pkcs15_pubkey_object *) any_object;
 	if (rv >= 0) {
 		object->pub_info = (struct sc_pkcs15_pubkey_info *) pubkey->data;
 		object->pub_data = p15_key;
@@ -773,7 +777,7 @@ __pkcs15_create_pubkey_object(struct pkcs15_fw_data *fw_data,
 			object->pub_data->alg_id->params = &((object->pub_data->u).gostr3410.params);
 	}
 	if (pubkey_object != NULL)
-		*pubkey_object = (struct pkcs15_any_object *) object;
+		*pubkey_object = any_object;
 
 	return rv;
 }
@@ -783,16 +787,18 @@ static int
 __pkcs15_create_prkey_object(struct pkcs15_fw_data *fw_data,
 	struct sc_pkcs15_object *prkey, struct pkcs15_any_object **prkey_object)
 {
+	struct pkcs15_any_object *any_object = NULL;
 	struct pkcs15_prkey_object *object = NULL;
 	int rv;
 
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &object,
+	rv = __pkcs15_create_object(fw_data, &any_object,
 			prkey, &pkcs15_prkey_ops, sizeof(struct pkcs15_prkey_object));
+	object = (struct pkcs15_prkey_object *) any_object;
 	if (rv >= 0)
 		object->prv_info = (struct sc_pkcs15_prkey_info *) prkey->data;
 
 	if (prkey_object != NULL)
-		*prkey_object = (struct pkcs15_any_object *) object;
+		*prkey_object = any_object;
 
 	return rv;
 }
@@ -802,18 +808,20 @@ static int
 __pkcs15_create_data_object(struct pkcs15_fw_data *fw_data,
 		struct sc_pkcs15_object *object, struct pkcs15_any_object **data_object)
 {
+	struct pkcs15_any_object *any_object = NULL;
 	struct pkcs15_data_object *dobj = NULL;
 	int rv;
 
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &dobj,
+	rv = __pkcs15_create_object(fw_data, &any_object,
 			object, &pkcs15_dobj_ops, sizeof(struct pkcs15_data_object));
+        dobj = (struct pkcs15_data_object *) any_object;
 	if (rv >= 0)   {
 		dobj->info = (struct sc_pkcs15_data_info *) object->data;
 		dobj->value = NULL;
 	}
 
 	if (data_object != NULL)
-		*data_object = (struct pkcs15_any_object *) dobj;
+		*data_object = any_object;
 
 	return rv;
 }
@@ -853,16 +861,18 @@ static int
 __pkcs15_create_secret_key_object(struct pkcs15_fw_data *fw_data,
 		struct sc_pkcs15_object *object, struct pkcs15_any_object **skey_object)
 {
+	struct pkcs15_any_object *any_object = NULL;
 	struct pkcs15_skey_object *skey = NULL;
 	int rv;
 
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &skey,
+	rv = __pkcs15_create_object(fw_data, &any_object,
 			object, &pkcs15_skey_ops, sizeof(struct pkcs15_skey_object));
+        skey = (struct pkcs15_skey_object *) any_object;
 	if (rv >= 0)
 		skey->info = (struct sc_pkcs15_skey_info *) object->data;
 
 	if (skey_object != NULL)
-		*skey_object = (struct pkcs15_any_object *) skey;
+		*skey_object = any_object;
 
 	return rv;
 }

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -347,6 +347,7 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	struct sc_pkcs11_object *object;
 	struct sc_pkcs11_find_operation *operation;
 	struct sc_pkcs11_slot *slot;
+	struct sc_pkcs11_operation *op = NULL;
 
 	if (pTemplate == NULL_PTR && ulCount > 0)
 		return CKR_ARGUMENTS_BAD;
@@ -363,7 +364,8 @@ C_FindObjectsInit(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	dump_template(SC_LOG_DEBUG_NORMAL, "C_FindObjectsInit()", pTemplate, ulCount);
 
 	rv = session_start_operation(session, SC_PKCS11_OPERATION_FIND,
-				     &find_mechanism, (struct sc_pkcs11_operation **)&operation);
+				     &find_mechanism, &op);
+	operation = (struct sc_pkcs11_find_operation *) op;
 	if (rv != CKR_OK)
 		goto out;
 
@@ -451,6 +453,7 @@ C_FindObjects(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	CK_ULONG to_return;
 	struct sc_pkcs11_session *session;
 	struct sc_pkcs11_find_operation *operation;
+	struct sc_pkcs11_operation *op = NULL;
 
 	if (phObject == NULL_PTR || ulMaxObjectCount == 0 || pulObjectCount == NULL_PTR)
 		return CKR_ARGUMENTS_BAD;
@@ -463,7 +466,8 @@ C_FindObjects(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	if (rv != CKR_OK)
 		goto out;
 
-	rv = session_get_operation(session, SC_PKCS11_OPERATION_FIND, (sc_pkcs11_operation_t **) & operation);
+	rv = session_get_operation(session, SC_PKCS11_OPERATION_FIND, &op);
+	operation = (struct sc_pkcs11_find_operation *) op;
 	if (rv != CKR_OK)
 		goto out;
 

--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -876,11 +876,11 @@ typedef unsigned long ck_rv_t;
 typedef ck_rv_t (*ck_notify_t) (ck_session_handle_t session,
 				ck_notification_t event, void *application);
 
-typedef struct ck_interface {
+struct ck_interface {
   char * pInterfaceName;
   void * pFunctionList;
   ck_flags_t flags;
-} ck_interface;
+};
 
 #define CKF_INTERFACE_FORK_SAFE	(0x00000001UL)
 
@@ -1169,12 +1169,12 @@ _CK_DECLARE_FUNCTION (C_GetFunctionStatus, (ck_session_handle_t session));
 _CK_DECLARE_FUNCTION (C_CancelFunction, (ck_session_handle_t session));
 
 _CK_DECLARE_FUNCTION (C_GetInterfaceList,
-		      (ck_interface *interfaces_list,
+		      (struct ck_interface *interfaces_list,
 		       unsigned long *count));
 _CK_DECLARE_FUNCTION (C_GetInterface,
 		      (unsigned char *interface_name,
 		       struct ck_version *version,
-		       ck_interface **interface,
+		       struct ck_interface **interface,
 		       ck_flags_t flags));
 
 _CK_DECLARE_FUNCTION (C_LoginUser,

--- a/src/tools/pkcs11-register.c
+++ b/src/tools/pkcs11-register.c
@@ -123,13 +123,15 @@ add_module_pkcs11_txt(const char *profile_dir,
 	char pkcs11_txt_path[PATH_MAX];
 	char *pkcs11_txt = NULL;
 	size_t pkcs11_txt_len = 0;
+	unsigned char *txt = NULL;
+
 	if (!profile_dir
 			|| snprintf(pkcs11_txt_path, sizeof pkcs11_txt_path,
 				"%s%c%s", profile_dir, path_sep, "pkcs11.txt") < 0
-			|| !fread_to_eof(pkcs11_txt_path,
-				(unsigned char **) &pkcs11_txt, &pkcs11_txt_len)) {
+			|| !fread_to_eof(pkcs11_txt_path, &txt, &pkcs11_txt_len)) {
 		goto err;
 	}
+	pkcs11_txt = (char *)txt;
 	char *p = realloc(pkcs11_txt, pkcs11_txt_len+1);
 	if (!p)
 		goto err;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -6303,11 +6303,12 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 		return session;
 	}
 
-	tmp = getID(session, priv_key, (CK_ULONG *) &opt_object_id_len);
-	if (opt_object_id_len == 0) {
+	tmp = getID(session, priv_key, &i);
+	if (i == 0) {
 		fprintf(stderr, "ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return session;
 	}
+	opt_object_id_len = (size_t) i;
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */
@@ -6485,11 +6486,12 @@ static void test_ec(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 	if (!gen_keypair(slot, session, &pub_key, &priv_key, opt_key_type))
 		return;
 
-	tmp = getID(session, priv_key, (CK_ULONG *) &opt_object_id_len);
-	if (opt_object_id_len == 0) {
+	tmp = getID(session, priv_key, &i);
+	if (i == 0) {
 		printf("ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return;
 	}
+	i = (size_t) opt_object_id_len;
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */


### PR DESCRIPTION
This made most of the applications crashing in Fedora 34 when
smart card was plugged in.

The suggested patch makes the code path more obvious for gcc to
handle.

https://bugzilla.redhat.com/show_bug.cgi?id=1930652

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested (roughly)
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
