### PR TITLE
pkcs11-global: Obey to the tokenPresent parameter on C_GetSlotList

### DIFF
--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -519,9 +519,10 @@ CK_RV C_GetSlotList(CK_BBOOL       tokenPresent,  /* only slots with token prese
 		 * - any slot with token;
 		 * - any slot that has already been seen;
 		 */
-		if ((!tokenPresent && slot->reader != prev_reader)
-				|| (slot->slot_info.flags & CKF_TOKEN_PRESENT)
-				|| (slot->flags & SC_PKCS11_SLOT_FLAG_SEEN)) {
+		if ((!tokenPresent &&
+				(slot->reader != prev_reader ||
+			 	 slot->flags & SC_PKCS11_SLOT_FLAG_SEEN))
+				|| slot->slot_info.flags & CKF_TOKEN_PRESENT) {
 			found[numMatches++] = slot->id;
 			slot->flags |= SC_PKCS11_SLOT_FLAG_SEEN;
 		}


### PR DESCRIPTION
Since commit dba0f56 the tokenPresent parameter is ignored in case the
slot has been already seen.

This breaks the API expectations as we may return a slot that has no
token inserted.

So, only consider the SC_PKCS11_SLOT_FLAG_SEEN if tokenPresent is false

---

Tested with:

Using reader with a card: Alcor Micro AU9560 00 00
CNS card

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
