### PR TITLE
Use more portable switch for uniq to unbreak osx build

### DIFF
--- a/tests/test-duplicate-symbols.sh
+++ b/tests/test-duplicate-symbols.sh
@@ -5,7 +5,7 @@ EXPORTS=`find "${SOURCE_PATH}" -name "*exports"`
 
 ERRORS=0
 for E in $EXPORTS; do
-	NUM_DUPES=`sort $E | uniq -D | wc -l`
+	NUM_DUPES=`sort $E | uniq -d | wc -l`
 	if [[ "$NUM_DUPES" != 0 ]]; then
 		echo "There are duplicate symbols in '$E'"
 		ERRORS=1


### PR DESCRIPTION
The travis task for osx was failing like this:
```
FAIL: test-duplicate-symbols.sh
===============================
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//src/libopensc/libopensc.exports'
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//src/minidriver/minidriver.exports'
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//src/pkcs11/pkcs11.exports'
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//src/smm/sm-common.exports'
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//src/smm/smm-local.exports'
uniq: illegal option -- D
usage: uniq [-c | -d | -u] [-i] [-f fields] [-s chars] [input [output]]
There are duplicate symbols in '..//win32/customactions.exports'
There are duplicate symbols
FAIL test-duplicate-symbols.sh (exit status: 1)
```
For example here https://travis-ci.org/github/OpenSC/OpenSC/jobs/760924430