### PR TITLE
Skip authentication if card access control mechanism is not active.

### DIFF
--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -257,6 +257,7 @@ typedef struct sc_file {
 	int id;		/* file identifier (2 bytes) */
 	int sid;	/* short EF identifier (1 byte) */
 	struct sc_acl_entry *acl[SC_MAX_AC_OPS]; /* Access Control List */
+	int acl_inactive;                        /* if set, the card access control mechanism is not active */
 
 	size_t record_length; /* max. length in case of record-oriented EF */
 	size_t record_count;  /* Valid, if not transparent EF or DF */

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3851,6 +3851,11 @@ sc_pkcs15init_authenticate(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	assert(file != NULL);
 	sc_log(ctx, "path '%s', op=%u", sc_print_path(&file->path), op);
 
+	if (file->acl_inactive) {
+		sc_log(ctx, "access control mechanism is not active (always allowed)");
+		LOG_FUNC_RETURN(ctx, r);
+	}
+
 	if (p15card->card->caps & SC_CARD_CAP_USE_FCI_AC) {
 		r = sc_select_file(p15card->card, &file->path, &file_tmp);
 		LOG_TEST_RET(ctx, r, "Authentication failed: cannot select file.");


### PR DESCRIPTION
Depending on the "lifecycle" of the file, we may omit the authentication
operation.  Typically if the card is in initialization or creation state,
the access control mechanism is inactive.  If authentification can be
skiped, the card driver is responsible for setting the "acl_inactive"
variable in sc_file structure.

Fixes #1737 

Tested: MyEID driver, card version 4.5.5 
