### PR TITLE
SC-HSM card capability check

### DIFF
--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -1026,7 +1026,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 		r = sc_pin_cmd(card, &pindata, NULL);
 	}
 
-	if ((r != SC_ERROR_DATA_OBJECT_NOT_FOUND) && (r != SC_ERROR_INCORRECT_PARAMETERS))
+	if ((r != SC_ERROR_DATA_OBJECT_NOT_FOUND) && (r != SC_ERROR_INCORRECT_PARAMETERS) && (r != SC_ERROR_REF_DATA_NOT_USABLE))
 		card->caps |= SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH;
 
 


### PR DESCRIPTION
Card used: SmartCard-HSM version 2.6

The code segment checks the ADPU response to determine if the
SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH is available.
From the APDU manual of the SC-HSM, there's one status word:
SC_ERROR_REF_DATA_NOT_USABLE(0x6984) that should also be taken into account.

modified: src/libopensc/pkcs15-sc-hsm.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
