### PR TITLE
More fixes related to strict aliasing with GCC 8

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -836,19 +836,20 @@ __pkcs15_create_profile_object(struct pkcs15_fw_data *fw_data,
 	int public_certificates, struct pkcs15_any_object **profile_object)
 {
 	struct pkcs15_profile_object *pobj = NULL;
+	struct pkcs15_any_object *any_pobj = NULL;
 	struct sc_pkcs15_object *obj = NULL;
 	int rv;
 
 	obj = calloc(1, sizeof(struct sc_pkcs15_object));
 
-	rv = __pkcs15_create_object(fw_data, (struct pkcs15_any_object **) &pobj,
+	rv = __pkcs15_create_object(fw_data, &any_pobj,
 			obj, &pkcs15_profile_ops, sizeof(struct pkcs15_profile_object));
 
 	if (rv != SC_SUCCESS) {
 		free(obj);
 		return rv;
 	}
-
+	pobj = (struct pkcs15_profile_object *) any_pobj;
 	pobj->profile_id = public_certificates ? CKP_PUBLIC_CERTIFICATES_TOKEN : CKP_AUTHENTICATION_TOKEN;
 
 	if (profile_object != NULL)

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -182,6 +182,7 @@ ck_interface compat_interfaces[NUM_INTERFACES] = {
 static CK_RV
 init_spy(void)
 {
+	CK_FUNCTION_LIST_PTR po_v2 = NULL;
 	const char *output, *module;
 	CK_RV rv = CKR_OK;
 #ifdef _WIN32
@@ -285,8 +286,8 @@ init_spy(void)
 		free(pkcs11_spy);
 		return CKR_DEVICE_ERROR;
 	}
-
-	modhandle = C_LoadModule(module, (CK_FUNCTION_LIST_PTR_PTR)&po);
+	modhandle = C_LoadModule(module, &po_v2);
+	po = (CK_FUNCTION_LIST_3_0_PTR) po_v2;
 	if (modhandle && po) {
 		fprintf(spy_output, "Loaded: \"%s\"\n", module);
 	}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1052,9 +1052,12 @@ int main(int argc, char * argv[])
 	else
 #endif
 	{
-		module = C_LoadModule(opt_module, (CK_FUNCTION_LIST_PTR_PTR)&p11);
+		CK_FUNCTION_LIST_PTR p11_v2 = NULL;
+
+		module = C_LoadModule(opt_module, &p11_v2);
 		if (module == NULL)
 			util_fatal("Failed to load pkcs11 module");
+		p11 = (CK_FUNCTION_LIST_3_0_PTR) p11_v2;
 	}
 
 	/* This can be done even before initialization */
@@ -6266,6 +6269,7 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 		{CKA_SUBJECT, (void *) "This won't be used in our lib", 29}
 	};
 	FILE			*f;
+	CK_FUNCTION_LIST_PTR	p11_v2 = NULL;
 
 	if (!opt_object_id_len) {
 		fprintf(stderr, "ERR: must give an ID, e.g.: --id 01\n");
@@ -6408,9 +6412,10 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 
 	printf("\n*** Loading the pkcs11 lib, opening a session and logging in ***\n");
 
-	module = C_LoadModule(opt_module, (CK_FUNCTION_LIST_PTR_PTR)&p11);
+	module = C_LoadModule(opt_module, &p11_v2);
 	if (module == NULL)
 		util_fatal("Failed to load pkcs11 module");
+	p11 = (CK_FUNCTION_LIST_3_0_PTR ) p11_v2;
 
 	rv = p11->C_Initialize(c_initialize_args_ptr);
 	if (rv == CKR_CRYPTOKI_ALREADY_INITIALIZED)

--- a/tests/test-duplicate-symbols.sh
+++ b/tests/test-duplicate-symbols.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-SOURCE_PATH=../
+SOURCE_PATH=..
 
 EXPORTS=`find "${SOURCE_PATH}" -name "*exports"`
 
 ERRORS=0
 for E in $EXPORTS; do
-	NUM_DUPES=`sort $E | uniq -d | wc -l`
+	DUPES=`sort $E | uniq -d`
+	NUM_DUPES=`echo -n "$DUPES" | wc -l`
 	if [[ "$NUM_DUPES" != 0 ]]; then
-		echo "There are duplicate symbols in '$E'"
+		echo "There are $NUM_DUPES duplicate symbols in '$E': $DUPES"
 		ERRORS=1
 	fi
 done


### PR DESCRIPTION
Thanks @popovec for reporting this. I took the liberty to use better naming for variables and slightly reorder the lines. Additionally, I would like to try to fix the osx test failure investigating what is going on there.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
