### PR TITLE
pkcs11-tool: symmetric encrypt/decrypt

### DIFF
--- a/.github/test-oseid.sh
+++ b/.github/test-oseid.sh
@@ -40,6 +40,7 @@ echo | ./OsEID-tool INIT
 ./OsEID-tool EC-SIGN-TEST
 ./OsEID-tool EC-SIGN-PKCS11-TEST
 ./OsEID-tool EC-ECDH-TEST
+./OsEID-tool UNWRAP-WRAP-TEST
 popd
 
 # this does not work as we have random key IDs in here

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -387,6 +387,12 @@
 				</varlistentry>
 				<varlistentry>
 					<term>
+						<option>--wrap</option>,
+					</term>
+					<listitem><para>Wrap key.</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>--derive</option>,
 					</term>
 					<listitem><para>Derive a secret key using another key and some data.</para></listitem>

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -375,6 +375,12 @@
 
 				<varlistentry>
 					<term>
+						<option>--encrypt</option>,
+					</term>
+					<listitem><para>Encrypt some data.</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>--derive</option>,
 					</term>
 					<listitem><para>Derive a secret key using another key and some data.</para></listitem>
@@ -646,6 +652,15 @@
 					</para></listitem>
 				</varlistentry>
 
+				<varlistentry>
+					<term>
+						<option>--iv</option> <replaceable>data</replaceable>
+					</term>
+					<listitem><para>Initialization vector for symmetric ciphers.
+					The <replaceable>data</replaceable> is hexadecimal number, i.e. "000013aa7bffa0".
+					</para></listitem>
+				</varlistentry>
+
 			</variablelist>
 		</para>
 	</refsect1>
@@ -668,6 +683,13 @@
 			using the private key with ID <replaceable>ID</replaceable> and
 			using the RSA-PKCS mechanism:
 				<programlisting>pkcs11-tool --sign --id ID --mechanism RSA-PKCS --input-file data --output-file data.sig</programlisting>
+
+			To encrypt file using the AES key with ID 85 and using mechanism AES-CBC with padding:
+				<programlisting>
+pkcs11-tool --encrypt --id 85 -m AES-CBC-PAD \
+ --iv "00000000000000000000000000000000" \
+ -i file.txt -o encrypted_file.data
+				</programlisting>
 		</para>
 	</refsect1>
 

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -381,6 +381,12 @@
 				</varlistentry>
 				<varlistentry>
 					<term>
+						<option>--unwrap</option>,
+					</term>
+					<listitem><para>Unwrap key.</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>--derive</option>,
 					</term>
 					<listitem><para>Derive a secret key using another key and some data.</para></listitem>
@@ -689,6 +695,18 @@
 pkcs11-tool --encrypt --id 85 -m AES-CBC-PAD \
  --iv "00000000000000000000000000000000" \
  -i file.txt -o encrypted_file.data
+				</programlisting>
+
+			Use the key with ID 22 and mechanism RSA-PKCS to unwrap key from file
+			<replaceable>aes_wrapped.key</replaceable>. After a successful unwrap operation,
+			a new AES key is created on token. ID of this key is set to 90 and label of this
+			key is set to <replaceable>unwrapped-key</replaceable>
+			Note: for the MyEID card, the AES key size must be present in key
+			specification i.e. AES:16
+				<programlisting>
+pkcs11-tool --unwrap --mechanism RSA-PKCS --id 22 \
+  -i aes_wrapped.key --key-type AES: \
+  --application-id 90 --applicatin-label unwrapped-key
 				</programlisting>
 		</para>
 	</refsect1>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -165,6 +165,7 @@ enum {
 	OPT_DERIVE_PASS_DER,
 	OPT_DECRYPT,
 	OPT_ENCRYPT,
+	OPT_UNWRAP,
 	OPT_TEST_FORK,
 #if defined(_WIN32) || defined(HAVE_PTHREAD)
 	OPT_TEST_THREADS,
@@ -199,6 +200,7 @@ static const struct option options[] = {
 	{ "verify",		0, NULL,		OPT_VERIFY },
 	{ "decrypt",		0, NULL,		OPT_DECRYPT },
 	{ "encrypt",		0, NULL,		OPT_ENCRYPT },
+	{ "unwrap",		0, NULL,		OPT_UNWRAP },
 	{ "hash",		0, NULL,		'h' },
 	{ "derive",		0, NULL,		OPT_DERIVE },
 	{ "derive-pass-der",	0, NULL,		OPT_DERIVE_PASS_DER },
@@ -283,6 +285,7 @@ static const char *option_help[] = {
 	"Verify a signature of some data",
 	"Decrypt some data",
 	"Encrypt some data",
+	"Unwrap key",
 	"Hash some data",
 	"Derive a secret key using another key and some data",
 	"Derive ECDHpass DER encoded pubkey for compatibility with some PKCS#11 implementations",
@@ -522,6 +525,7 @@ static void		derive_key(CK_SLOT_ID, CK_SESSION_HANDLE, CK_OBJECT_HANDLE);
 static int		gen_keypair(CK_SLOT_ID slot, CK_SESSION_HANDLE,
 				CK_OBJECT_HANDLE *, CK_OBJECT_HANDLE *, const char *);
 static int		gen_key(CK_SLOT_ID slot, CK_SESSION_HANDLE, CK_OBJECT_HANDLE *, const char *, char *);
+static int		unwrap_key(CK_SESSION_HANDLE session);
 
 static int		write_object(CK_SESSION_HANDLE session);
 static int		read_object(CK_SESSION_HANDLE session);
@@ -679,6 +683,7 @@ int main(int argc, char * argv[])
 	int do_verify = 0;
 	int do_decrypt = 0;
 	int do_encrypt = 0;
+	int do_unwrap = 0;
 	int do_hash = 0;
 	int do_derive = 0;
 	int do_gen_keypair = 0;
@@ -884,6 +889,11 @@ int main(int argc, char * argv[])
 		case OPT_ENCRYPT:
 			need_session |= NEED_SESSION_RW;
 			do_encrypt = 1;
+			action_count++;
+			break;
+		case OPT_UNWRAP:
+			need_session |= NEED_SESSION_RW;
+			do_unwrap = 1;
 			action_count++;
 			break;
 		case 'f':
@@ -1211,7 +1221,7 @@ int main(int argc, char * argv[])
 	if (do_list_mechs)
 		list_mechs(opt_slot);
 
-	if (do_sign || do_decrypt || do_encrypt) {
+	if (do_sign || do_decrypt || do_encrypt || do_unwrap) {
 		CK_TOKEN_INFO info;
 
 		get_token_info(opt_slot, &info);
@@ -1344,6 +1354,9 @@ int main(int argc, char * argv[])
 		        opt_object_id_len, 0))
 			util_fatal("Public key nor certificate not found");
 	}
+
+	if (do_unwrap)
+		unwrap_key(session);
 
 	/* before list objects, so we can see a derived key */
 	if (do_derive)
@@ -3124,6 +3137,149 @@ gen_key(CK_SLOT_ID slot, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE *hSecretKey
 
 	printf("Key generated:\n");
 	show_object(session, *hSecretKey);
+	return 1;
+}
+
+static int
+unwrap_key(CK_SESSION_HANDLE session)
+{
+	CK_MECHANISM mechanism;
+	CK_OBJECT_CLASS secret_key_class = CKO_SECRET_KEY;
+	CK_BBOOL _true = TRUE;
+	CK_BBOOL _false = FALSE;
+	CK_KEY_TYPE key_type = CKK_AES;
+	CK_ULONG key_length;
+	const char *length;
+	CK_ATTRIBUTE keyTemplate[20] = {
+		{CKA_CLASS, &secret_key_class, sizeof(secret_key_class)},
+		{CKA_TOKEN, &_true, sizeof(_true)},
+	};
+	CK_OBJECT_HANDLE hSecretKey;
+	int n_attr = 2;
+	CK_RV rv;
+	int r, fd;
+	unsigned char in_buffer[1024];
+	CK_ULONG wrapped_key_length;
+	CK_BYTE_PTR pWrappedKey;
+	CK_BYTE_PTR iv = NULL;
+	size_t iv_size = 0;
+	CK_OBJECT_HANDLE hUnwrappingKey;
+
+	if (!find_object(session, CKO_PRIVATE_KEY, &hUnwrappingKey,
+			 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, 0))
+		if (!find_object(session, CKO_SECRET_KEY, &hUnwrappingKey,
+				 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, 0))
+			util_fatal("Private/secret key not found");
+
+	if (!opt_mechanism_used)
+		util_fatal("Unable to unwrap, no mechanism specified\n");
+
+	mechanism.mechanism = opt_mechanism;
+	mechanism.pParameter = NULL_PTR;
+	mechanism.ulParameterLen = 0;
+
+	if (opt_input == NULL)
+		fd = 0;
+	else if ((fd = open(opt_input, O_RDONLY | O_BINARY)) < 0)
+		util_fatal("Cannot open %s: %m", opt_input);
+
+	r = read(fd, in_buffer, sizeof(in_buffer));
+	if (r < 0)
+		util_fatal("Cannot read from %s: %m", opt_input);
+	wrapped_key_length = r;
+	if (fd != 0)
+		close(fd);
+	pWrappedKey = in_buffer;
+
+	if (opt_mechanism == CKM_AES_CBC || opt_mechanism == CKM_AES_CBC_PAD) {
+		iv_size = 16;
+		iv = get_iv(opt_iv, &iv_size);
+		mechanism.pParameter = iv;
+		mechanism.ulParameterLen = iv_size;
+	}
+
+	if (opt_key_type != NULL) {
+		if (strncasecmp(opt_key_type, "AES:", strlen("AES:")) == 0) {
+			length = opt_key_type + strlen("AES:");
+			key_type = CKK_AES;
+
+		} else if (strncasecmp(opt_key_type, "GENERIC:", strlen("GENERIC:")) == 0) {
+			length = opt_key_type + strlen("GENERIC:");
+			key_type = CKK_GENERIC_SECRET;
+
+		} else {
+			util_fatal("Unsupported key type %s", opt_key_type);
+		}
+
+		FILL_ATTR(keyTemplate[n_attr], CKA_KEY_TYPE, &key_type, sizeof(key_type));
+		n_attr++;
+
+		if (opt_is_sensitive != 0) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_SENSITIVE, &_true, sizeof(_true));
+			n_attr++;
+		} else {
+			FILL_ATTR(keyTemplate[n_attr], CKA_SENSITIVE, &_false, sizeof(_false));
+			n_attr++;
+		}
+
+		if (opt_key_usage_default || opt_key_usage_decrypt) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_ENCRYPT, &_true, sizeof(_true));
+			n_attr++;
+			FILL_ATTR(keyTemplate[n_attr], CKA_DECRYPT, &_true, sizeof(_true));
+			n_attr++;
+		}
+		if (opt_key_usage_wrap) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_WRAP, &_true, sizeof(_true));
+			n_attr++;
+			FILL_ATTR(keyTemplate[n_attr], CKA_UNWRAP, &_true, sizeof(_true));
+			n_attr++;
+		}
+
+		if (opt_is_extractable != 0) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_EXTRACTABLE, &_true, sizeof(_true));
+			n_attr++;
+		} else {
+			FILL_ATTR(keyTemplate[n_attr], CKA_EXTRACTABLE, &_false, sizeof(_true));
+			n_attr++;
+		}
+		/* softhsm2 does not allow to attribute CKA_VALUE_LEN, but MyEID card must have this attribute
+                   specified. We set CKA_VALUE_LEN only if the user sets it in the key specification. */
+		key_length = (unsigned long)atol(length);
+		if (key_length != 0) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_VALUE_LEN, &key_length, sizeof(key_length));
+			n_attr++;
+		}
+	}
+
+	if (opt_application_label != NULL) {
+		FILL_ATTR(keyTemplate[n_attr], CKA_LABEL, opt_application_label, strlen(opt_application_label));
+		n_attr++;
+	}
+
+	if (opt_application_id != NULL) {
+		CK_BYTE object_id[100];
+		size_t id_len;
+
+		id_len = sizeof(object_id);
+		if (hex_to_bin(opt_application_id, object_id, &id_len)) {
+			FILL_ATTR(keyTemplate[n_attr], CKA_ID, object_id, id_len);
+			n_attr++;
+		}
+	}
+
+	if (opt_allowed_mechanisms_len > 0) {
+		FILL_ATTR(keyTemplate[n_attr], CKA_ALLOWED_MECHANISMS, opt_allowed_mechanisms,
+			  sizeof(CK_MECHANISM_TYPE) * opt_allowed_mechanisms_len);
+		n_attr++;
+	}
+	rv = p11->C_UnwrapKey(session, &mechanism, hUnwrappingKey,
+			      pWrappedKey, wrapped_key_length, keyTemplate, n_attr, &hSecretKey);
+	if (rv != CKR_OK)
+		p11_fatal("C_UnwrapKey", rv);
+
+	free(iv);
+	printf("Key unwrapped\n");
+	show_object(session, hSecretKey);
 	return 1;
 }
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2403,7 +2403,6 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		printf("Cryptoki returned error: %s\n", CKR2Str(rv));
 }
 
-
 static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE key)
 {
@@ -2412,7 +2411,8 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	CK_RV		rv;
 	CK_RSA_PKCS_OAEP_PARAMS oaep_params;
 	CK_ULONG	in_len, out_len;
-	int		fd, r;
+	int		fd_in, fd_out;
+	int		r;
 	CK_BYTE_PTR	iv = NULL;
 	size_t		iv_size = 0;
 
@@ -2429,15 +2429,6 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		util_fatal("The hash-algorithm is applicable only to "
                "RSA-PKCS-OAEP mechanism");
 
-	if (opt_input == NULL)
-		fd = 0;
-	else if ((fd = open(opt_input, O_RDONLY|O_BINARY)) < 0)
-		util_fatal("Cannot open %s: %m", opt_input);
-
-	r = read(fd, in_buffer, sizeof(in_buffer));
-	if (r < 0)
-		util_fatal("Cannot read from %s: %m", opt_input);
-	in_len = r;
 
 	/* set "default" MGF and hash algorithms. We can overwrite MGF later */
 	switch (opt_mechanism) {
@@ -2504,33 +2495,66 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 
 	}
 
-	rv = p11->C_DecryptInit(session, &mech, key);
-	if (rv != CKR_OK)
-		p11_fatal("C_DecryptInit", rv);
-	if (getALWAYS_AUTHENTICATE(session, key))
-		login(session,CKU_CONTEXT_SPECIFIC);
+	if (opt_input == NULL)
+		fd_in = 0;
+	else if ((fd_in = open(opt_input, O_RDONLY | O_BINARY)) < 0)
+		util_fatal("Cannot open %s: %m", opt_input);
 
-	out_len = sizeof(out_buffer);
-	rv = p11->C_Decrypt(session, in_buffer, in_len, out_buffer, &out_len);
-	if (rv != CKR_OK)
-		p11_fatal("C_Decrypt", rv);
-
-	if (fd != 0)
-		close(fd);
-
-	if (opt_output == NULL)   {
-		fd = 1;
-	}
-	else  {
-		fd = open(opt_output, O_CREAT|O_TRUNC|O_WRONLY|O_BINARY, S_IRUSR|S_IWUSR);
-		if (fd < 0)
+	if (opt_output == NULL) {
+		fd_out = 1;
+	} else {
+		fd_out = open(opt_output, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, S_IRUSR | S_IWUSR);
+		if (fd_out < 0)
 			util_fatal("failed to open %s: %m", opt_output);
 	}
-	r = write(fd, out_buffer, out_len);
+
+	r = read(fd_in, in_buffer, sizeof(in_buffer));
+	in_len = r;
+
 	if (r < 0)
-		util_fatal("Failed to write to %s: %m", opt_output);
-	if (fd != 1)
-		close(fd);
+		util_fatal("Cannot read from %s: %m", opt_input);
+
+	rv = CKR_CANCEL;
+	if (r < (int) sizeof(in_buffer)) {
+		out_len = sizeof(out_buffer);
+		rv = p11->C_DecryptInit(session, &mech, key);
+		if (rv != CKR_OK)
+			p11_fatal("C_DecryptInit", rv);
+		if (getALWAYS_AUTHENTICATE(session, key))
+			login(session, CKU_CONTEXT_SPECIFIC);
+		rv = p11->C_Decrypt(session, in_buffer, in_len, out_buffer, &out_len);
+	}
+	if (rv != CKR_OK) {
+		rv = p11->C_DecryptInit(session, &mech, key);
+		if (rv != CKR_OK)
+			p11_fatal("C_DecryptInit", rv);
+		if (getALWAYS_AUTHENTICATE(session, key))
+			login(session, CKU_CONTEXT_SPECIFIC);
+		do {
+			out_len = sizeof(out_buffer);
+			rv = p11->C_DecryptUpdate(session, in_buffer, in_len, out_buffer, &out_len);
+			if (rv != CKR_OK)
+				p11_fatal("C_DecryptUpdate", rv);
+			r = write(fd_out, out_buffer, out_len);
+			if (r != (int) out_len)
+				util_fatal("Cannot write to %s: %m", opt_output);
+			r = read(fd_in, in_buffer, sizeof(in_buffer));
+			in_len = r;
+		} while (r > 0);
+		out_len = sizeof(out_buffer);
+		rv = p11->C_DecryptFinal(session, out_buffer, &out_len);
+		if (rv != CKR_OK)
+			p11_fatal("C_DecryptFinal", rv);
+	}
+	if (out_len) {
+		r = write(fd_out, out_buffer, out_len);
+		if (r != (int) out_len)
+			util_fatal("Cannot write to %s: %m", opt_output);
+	}
+	if (fd_in != 0)
+		close(fd_in);
+	if (fd_out != 1)
+		close(fd_out);
 
 	free(iv);
 }
@@ -2542,7 +2566,8 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	CK_MECHANISM	mech;
 	CK_RV		rv;
 	CK_ULONG	in_len, out_len;
-	int		fd, r;
+	int		fd_in, fd_out;
+	int		r;
 	CK_BYTE_PTR	iv = NULL;
 	size_t		iv_size = 0;
 
@@ -2553,16 +2578,6 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	fprintf(stderr, "Using encrypt algorithm %s\n", p11_mechanism_to_name(opt_mechanism));
 	memset(&mech, 0, sizeof(mech));
 	mech.mechanism = opt_mechanism;
-
-	if (opt_input == NULL)
-		fd = 0;
-	else if ((fd = open(opt_input, O_RDONLY | O_BINARY)) < 0)
-		util_fatal("Cannot open %s: %m", opt_input);
-
-	r = read(fd, in_buffer, sizeof(in_buffer));
-	if (r < 0)
-		util_fatal("Cannot read from %s: %m", opt_input);
-	in_len = r;
 
 	switch (opt_mechanism) {
 	case CKM_AES_ECB:
@@ -2580,36 +2595,71 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		util_fatal("Mechanism %s illegal or not supported\n", p11_mechanism_to_name(opt_mechanism));
 	}
 
-	rv = p11->C_EncryptInit(session, &mech, key);
-	if (rv != CKR_OK)
-		p11_fatal("C_EncryptInit", rv);
-	if (getALWAYS_AUTHENTICATE(session, key))
-		login(session, CKU_CONTEXT_SPECIFIC);
-
-	out_len = sizeof(out_buffer);
-	rv = p11->C_Encrypt(session, in_buffer, in_len, out_buffer, &out_len);
-	if (rv != CKR_OK)
-		p11_fatal("C_Encrypt", rv);
-
-	if (fd != 0)
-		close(fd);
+	if (opt_input == NULL)
+		fd_in = 0;
+	else if ((fd_in = open(opt_input, O_RDONLY | O_BINARY)) < 0)
+		util_fatal("Cannot open %s: %m", opt_input);
 
 	if (opt_output == NULL) {
-		fd = 1;
+		fd_out = 1;
 	} else {
-		fd = open(opt_output, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, S_IRUSR | S_IWUSR);
-		if (fd < 0)
+		fd_out = open(opt_output, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, S_IRUSR | S_IWUSR);
+		if (fd_out < 0)
 			util_fatal("failed to open %s: %m", opt_output);
 	}
 
-	r = write(fd, out_buffer, out_len);
+	r = read(fd_in, in_buffer, sizeof(in_buffer));
+	in_len = r;
+
 	if (r < 0)
-		util_fatal("Failed to write to %s: %m", opt_output);
-	if (fd != 1)
-		close(fd);
+		util_fatal("Cannot read from %s: %m", opt_input);
+
+	rv = CKR_CANCEL;
+	if (r < (int) sizeof(in_buffer)) {
+		out_len = sizeof(out_buffer);
+		rv = p11->C_EncryptInit(session, &mech, key);
+		if (rv != CKR_OK)
+			p11_fatal("C_EncryptInit", rv);
+		if (getALWAYS_AUTHENTICATE(session, key))
+			login(session, CKU_CONTEXT_SPECIFIC);
+		out_len = sizeof(out_buffer);
+		rv = p11->C_Encrypt(session, in_buffer, in_len, out_buffer, &out_len);
+	}
+	if (rv != CKR_OK) {
+		rv = p11->C_EncryptInit(session, &mech, key);
+		if (rv != CKR_OK)
+			p11_fatal("C_EncryptInit", rv);
+		if (getALWAYS_AUTHENTICATE(session, key))
+			login(session, CKU_CONTEXT_SPECIFIC);
+		do {
+			out_len = sizeof(out_buffer);
+			rv = p11->C_EncryptUpdate(session, in_buffer, in_len, out_buffer, &out_len);
+			if (rv != CKR_OK)
+				p11_fatal("C_EncryptUpdate", rv);
+			r = write(fd_out, out_buffer, out_len);
+			if (r != (int) out_len)
+				util_fatal("Cannot write to %s: %m", opt_output);
+			r = read(fd_in, in_buffer, sizeof(in_buffer));
+			in_len = r;
+		} while (r > 0);
+		out_len = sizeof(out_buffer);
+		rv = p11->C_EncryptFinal(session, out_buffer, &out_len);
+		if (rv != CKR_OK)
+			p11_fatal("C_EncryptFinal", rv);
+	}
+	if (out_len) {
+		r = write(fd_out, out_buffer, out_len);
+		if (r != (int) out_len)
+			util_fatal("Cannot write to %s: %m", opt_output);
+	}
+	if (fd_in != 0)
+		close(fd_in);
+	if (fd_out != 1)
+		close(fd_out);
 
 	free(iv);
 }
+
 
 static void hash_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,7 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-sign-verify.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh \
                       test-pkcs11-tool-sym-crypt-test.sh\
-                      test-pkcs11-tool-unwrap-test.sh
+                      test-pkcs11-tool-unwrap-wrap-test.sh
 
 .NOTPARALLEL:
 TESTS = \
@@ -26,7 +26,7 @@ TESTS = \
         test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-allowed-mechanisms.sh \
         test-pkcs11-tool-sym-crypt-test.sh\
-        test-pkcs11-tool-unwrap-test.sh
+        test-pkcs11-tool-unwrap-wrap-test.sh
 XFAIL_TESTS = \
         test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-test.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,8 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-test-threads.sh \
                       test-pkcs11-tool-sign-verify.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh \
-                      test-pkcs11-tool-sym-crypt-test.sh
+                      test-pkcs11-tool-sym-crypt-test.sh\
+                      test-pkcs11-tool-unwrap-test.sh
 
 .NOTPARALLEL:
 TESTS = \
@@ -24,7 +25,8 @@ TESTS = \
         test-pkcs11-tool-test.sh \
         test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-allowed-mechanisms.sh \
-        test-pkcs11-tool-sym-crypt-test.sh
+        test-pkcs11-tool-sym-crypt-test.sh\
+        test-pkcs11-tool-unwrap-test.sh
 XFAIL_TESTS = \
         test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-test.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,8 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-test.sh \
                       test-pkcs11-tool-test-threads.sh \
                       test-pkcs11-tool-sign-verify.sh \
-                      test-pkcs11-tool-allowed-mechanisms.sh
+                      test-pkcs11-tool-allowed-mechanisms.sh \
+                      test-pkcs11-tool-sym-crypt-test.sh
 
 .NOTPARALLEL:
 TESTS = \
@@ -22,7 +23,8 @@ TESTS = \
         test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-test.sh \
         test-pkcs11-tool-test-threads.sh \
-        test-pkcs11-tool-allowed-mechanisms.sh
+        test-pkcs11-tool-allowed-mechanisms.sh \
+        test-pkcs11-tool-sym-crypt-test.sh
 XFAIL_TESTS = \
         test-pkcs11-tool-test-threads.sh \
         test-pkcs11-tool-test.sh

--- a/tests/test-pkcs11-tool-sym-crypt-test.sh
+++ b/tests/test-pkcs11-tool-sym-crypt-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+source common.sh
+
+echo "======================================================="
+echo "Setup SoftHSM"
+echo "======================================================="
+if [[ ! -f $P11LIB ]]; then
+    echo "WARNINIG: The SoftHSM is not installed. Can not run this test"
+    exit 77;
+fi
+# The Ubuntu has old softhsm version not supporting this feature
+grep "Ubuntu 18.04" /etc/issue && echo "WARNING: Not supported on Ubuntu 18.04" && exit 77
+
+softhsm_initialize
+
+#echo "======================================================="
+#echo "Generate AES key"
+#echo "======================================================="
+#ID1="85"
+# Generate key
+#$PKCS11_TOOL --keygen --key-type="aes:32" --login --pin=$PIN \
+#	--module="$P11LIB" --label="gen_aes256" --id="$ID1"
+#assert $? "Failed to Generate AES key"
+
+echo "======================================================="
+echo "import AES key"
+echo "======================================================="
+ID2="86"
+echo -n "pppppppppppppppp" > aes_128.key
+# import key
+softhsm2-util --import aes_128.key --aes --token "SC test" --pin "$PIN" --label import_aes_128 --id "$ID2"
+assert $? "Fail, unable to import key"
+
+$PKCS11_TOOL --module="$P11LIB" --list-objects -l --pin=$PIN  2>/dev/null |tee > objects.list
+assert $? "Failed to list objects"
+
+VECTOR="00000000000000000000000000000000"
+echo "======================================================="
+echo " AES-CBC-PAD"
+echo " OpenSSL encrypt, pkcs11-tool decrypt"
+echo " pkcs11-tool encrypt, compare to openssl encrypt"
+echo "======================================================="
+
+echo -n "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU" > aes_plain.data
+openssl enc -aes-128-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+assert $? "Fail, OpenSSL"
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --decrypt --id "$ID2" -m AES-CBC-PAD --iv "${VECTOR}" \
+	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
+assert $? "Fail/pkcs11-tool decrypt"
+cmp aes_plain.data aes_plain_test.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC-PAD - wrong decrypt"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CBC-PAD --iv "${VECTOR}" \
+	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC-PAD - wrong encrypt"
+
+
+echo "======================================================="
+echo " AES-ECB, AES-CBC - must fail, because the length of   "
+echo " the input is not multiple od block size               "
+echo "======================================================="
+! $PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-ECB --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail, AES-ECB must not work if the input is not a multiple of the block size"
+! $PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail, AES-CBC must not work if the input is not a multiple of the block size"
+
+echo -n "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU" > aes_plain.data
+
+echo "======================================================="
+echo " AES-ECB"
+echo " OpenSSL encrypt, pkcs11-tool decrypt"
+echo " pkcs11-tool encrypt, compare to openssl encrypt"
+echo "======================================================="
+
+openssl enc -aes-128-ecb -nopad -in aes_plain.data -out aes_ciphertext_openssl.data  -K "70707070707070707070707070707070"
+assert $? "Fail/OpenSSL"
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --decrypt --id "$ID2" -m AES-ECB --input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
+assert $? "Fail/pkcs11-tool decrypt"
+cmp aes_plain.data aes_plain_test.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-ECB - wrong decrypt"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-ECB --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-ECB - wrong encrypt"
+
+echo "======================================================="
+echo " AES-CBC"
+echo " OpenSSL encrypt, pkcs11-tool decrypt"
+echo " pkcs11-tool encrypt, compare to openssl encrypt"
+echo "======================================================="
+
+openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+assert $? "Fail/OpenSSL"
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --decrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
+assert $? "Fail/pkcs11-tool decrypt"
+cmp aes_plain.data aes_plain_test.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC - wrong decrypt"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp  aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC - wrong encrypt"
+
+VECTOR="000102030405060708090a0b0c0d0e0f"
+echo "======================================================="
+echo " AES-CBC, another IV"
+echo " OpenSSL encrypt, pkcs11-tool decrypt"
+echo " pkcs11-tool encrypt, compare to openssl encrypt"
+echo "======================================================="
+
+openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+assert $? "Fail/Openssl"
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --decrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
+assert $? "Fail/pkcs11-tool decrypt"
+cmp aes_plain.data aes_plain_test.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC - wrong decrypt"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp  aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC - wrong encrypt"
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+softhsm_cleanup
+
+rm objects.list
+rm aes_128.key aes_plain.data aes_plain_test.data  aes_ciphertext_openssl.data aes_ciphertext_pkcs11.data
+exit $ERRORS

--- a/tests/test-pkcs11-tool-unwrap-test.sh
+++ b/tests/test-pkcs11-tool-unwrap-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+source common.sh
+
+echo "======================================================="
+echo "Setup SoftHSM"
+echo "======================================================="
+if [[ ! -f $P11LIB ]]; then
+    echo "WARNINIG: The SoftHSM is not installed. Can not run this test"
+    exit 77;
+fi
+# The Ubuntu has old softhsm version not supporting this feature
+grep "Ubuntu 18.04" /etc/issue && echo "WARNING: Not supported on Ubuntu 18.04" && exit 77
+softhsm_initialize
+
+#echo "======================================================="
+#echo "Generate RSA key"
+#echo "======================================================="
+ID1="85"
+ID2="95"
+ID3="96"
+# Generate key
+$PKCS11_TOOL --module="$P11LIB" --login --pin=$PIN --keypairgen --key-type="rsa:1024" --id "$ID1" --usage-wrap
+assert $? "Failed to Generate RSA key"
+# export public key
+$PKCS11_TOOL --module="$P11LIB" --login --pin=$PIN --read-object --type pubkey --id="$ID1" -o rsa_pub.key
+assert $? "Failed to export public key"
+# create AES key
+KEY="70707070707070707070707070707070"
+
+echo -n $KEY|xxd -p -r > aes_plain_key
+# wrap AES key
+openssl rsautl -encrypt -pubin --keyform der -inkey rsa_pub.key -in aes_plain_key -out aes_wrapped_key
+assert $? "Failed wrap AES key"
+
+# unwrap key by pkcs11 interface
+$PKCS11_TOOL --module="$P11LIB" --login --pin=$PIN --unwrap --mechanism RSA-PKCS --id "$ID1" -i aes_wrapped_key --key-type GENERIC: \
+	--extractable --application-id "$ID3" --application-label "unwrap-generic-ex" 2>/dev/null
+assert $? "Unwrap failed"
+# because key is extractable, there is no problem to compare key value with original key
+$PKCS11_TOOL --module="$P11LIB" --login --pin=$PIN --id "$ID3" --read-object --type secrkey --output-file generic_extracted_key
+assert $? "unable to read key value"
+cmp generic_extracted_key aes_plain_key >/dev/null 2>/dev/null
+assert $? "extracted key does not match the input key"
+
+# unwrap AES key, not extractable
+$PKCS11_TOOL --module="$P11LIB" --login --pin=$PIN --unwrap --mechanism RSA-PKCS --id "$ID1" -i aes_wrapped_key --key-type AES: \
+	--application-id "$ID2" --application-label "unwrap-aes" 2>/dev/null
+assert $? "Unwrap failed"
+
+# To check if AES key was correctly unwrapped (non extractable), we need to encrypt some data by pkcs11 interface and by openssl
+# (with same key). If result is same, key was correctly unwrapped.
+VECTOR="00000000000000000000000000000000"
+echo "======================================================="
+echo " AES-CBC"
+echo " OpenSSL encrypt, pkcs11-tool encrypt, compare"
+echo "======================================================="
+
+echo -n "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU" > aes_plain.data
+
+openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K $KEY
+assert $? "Fail/Openssl"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
+        --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CBC - wrong encrypt"
+
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+softhsm_cleanup
+
+rm rsa_pub.key aes_plain_key aes_wrapped_key aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data aes_plain.data generic_extracted_key
+
+exit $ERRORS


### PR DESCRIPTION
supported mechanisms: AES-ECB, AES-CBC, AES-CBC-PAD
support for initialization vector

Tested - softhsm2, (test-pkcs11-tool-sym-crypt-test.sh)

	modified:   doc/tools/pkcs11-tool.1.xml
	modified:   src/tools/pkcs11-tool.c
	modified:   tests/Makefile.am
	new file:   tests/test-pkcs11-tool-sym-crypt-test.sh


