### PR TITLE
IASECC/CPX: Fix AlgoRefs

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -628,21 +628,23 @@ static int
 iasecc_init_cpx(struct sc_card *card)
 {
 	struct sc_context *ctx = card->ctx;
-	unsigned int flags; /* TBC it is not IASECC_CARD_DEFAULT_FLAGS */
+	unsigned int flags;
+	int rv = 0;
 
 	LOG_FUNC_CALLED(ctx);
 
-	card->caps = SC_CARD_CAP_RNG; /* TBC it is not IASECC_CARD_DEFAULT_CAPS */
+	card->caps = IASECC_CARD_DEFAULT_CAPS;
 
-	flags = SC_ALGORITHM_RSA_PAD_PKCS1;
-	flags |= SC_ALGORITHM_RSA_RAW;
-
-	flags |= SC_ALGORITHM_RSA_HASH_SHA1    |
-	         SC_ALGORITHM_RSA_HASH_SHA256;
+	flags = IASECC_CARD_DEFAULT_FLAGS;
 
 	_sc_card_add_rsa_alg(card, 512, flags, 0);
 	_sc_card_add_rsa_alg(card, 1024, flags, 0);
 	_sc_card_add_rsa_alg(card, 2048, flags, 0);
+
+	rv = iasecc_parse_ef_atr(card);
+	if (rv)
+		sc_invalidate_cache(card); /* avoid memory leakage */
+	LOG_TEST_RET(ctx, rv, "Parse EF.ATR");
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }

--- a/src/libopensc/iasecc.h
+++ b/src/libopensc/iasecc.h
@@ -133,4 +133,5 @@ struct iasecc_private_data {
 
 	struct iasecc_se_info *se_info;
 };
+
 #endif

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -34,6 +34,7 @@
 
 #include "internal.h"
 #include "pkcs15.h"
+#include "../pkcs15init/pkcs15-iasecc.h"
 #include "iasecc.h"
 #include "aux-data.h"
 

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -104,6 +104,38 @@ _iasecc_md_update_keyinfo(struct sc_pkcs15_card *p15card, struct sc_pkcs15_objec
 }
 
 
+/*
+ * CPx cards have an undocumented issue: they lack of
+ * Algorithm's reference into their PKCS's ASN1 encoding.
+ */
+static int
+_iasecc_cpx_fixup_prkdf(struct sc_pkcs15_card *p15card)
+{
+	struct sc_context * const ctx = p15card->card->ctx;
+	struct sc_pkcs15_object *pkobjs[32];
+	int ii, count;
+	int rv = SC_SUCCESS;
+
+	LOG_FUNC_CALLED(ctx);
+
+	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY, pkobjs, sizeof(pkobjs)/sizeof(pkobjs[0]));
+	LOG_TEST_RET(ctx, rv, "Cannot get PRKEY objects list");
+
+	count = rv;
+	for(ii=0; ii<count; ii++)   {
+		rv = iasecc_pkcs15_encode_supported_algos(p15card, pkobjs[ii]);
+		LOG_TEST_RET(ctx, rv, "Cannot fix suported_algos");
+	}
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+
+/*
+ * It is the entry point for 2 models of cards that need some hot patching
+ * - Gemalto cards
+ * - CPx: fixup algo_refs from the prkey
+ */
 static int
 _iasecc_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 {
@@ -123,13 +155,28 @@ _iasecc_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 	rv = sc_pkcs15_parse_df(p15card, df);
 	LOG_TEST_RET(ctx, rv, "DF parse error");
 
-	if (p15card->card->type != SC_CARD_TYPE_IASECC_GEMALTO)
-		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+	switch(p15card->card->type) {
+		/* enumerate the IASECC cards that need a fixup of the keyInfo */
+		case SC_CARD_TYPE_IASECC_GEMALTO:
+		case SC_CARD_TYPE_IASECC_CPX:
+		case SC_CARD_TYPE_IASECC_CPXCL:
+			sc_log(ctx, "Warning: the %d card has an invalid DF, hot patch to be applied",
+				p15card->card->type);
+			break;
+		default:
+			sc_log(ctx, "the %d card has a proper DF, no need for a hot patch",
+				p15card->card->type);
+			LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+			break;
+	}
 
 	if (df->type != SC_PKCS15_PRKDF)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
 	sc_log(ctx, "parse of SC_PKCS15_PRKDF");
+
+	rv = _iasecc_cpx_fixup_prkdf(p15card);
+	LOG_TEST_RET(ctx, rv, "Cannot fixup PrKDF");
 
 	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_DATA_OBJECT, dobjs, sizeof(dobjs)/sizeof(dobjs[0]));
 	LOG_TEST_RET(ctx, rv, "Cannot get DATA objects list");

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -91,6 +91,8 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DNIE_USER:
 		case SC_CARD_TYPE_DNIE_TERMINATED:
 		case SC_CARD_TYPE_IASECC_GEMALTO:
+		case SC_CARD_TYPE_IASECC_CPX:
+		case SC_CARD_TYPE_IASECC_CPXCL:
 		case SC_CARD_TYPE_PIV_II_GENERIC:
 		case SC_CARD_TYPE_PIV_II_HIST:
 		case SC_CARD_TYPE_PIV_II_NEO:

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -801,7 +801,8 @@ iasecc_pkcs15_encode_supported_algos(struct sc_pkcs15_card *p15card, struct sc_p
 			LOG_TEST_RET(ctx, rv, "cannot add supported algorithm DECIPHER:CKM_RSA_PKCS");
 		}
 
-		if (prkey_info->usage & SC_PKCS15_PRKEY_USAGE_SIGN)   {
+		if (prkey_info->usage & (SC_PKCS15_PRKEY_USAGE_SIGN |
+		                         SC_PKCS15_PRKEY_USAGE_NONREPUDIATION))   {
 			if (prkey_info->usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)   {
 				algo = sc_pkcs15_get_supported_algo(p15card, SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE, CKM_SHA1_RSA_PKCS);
 				rv = sc_pkcs15_add_supported_algo_ref(object, algo);

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -24,6 +24,10 @@
 #include <config.h>
 #endif
 
+#ifndef FIX_UNUSED
+#define FIX_UNUSED(X) (void) (X) /* avoid warnings for unused params */
+#endif
+
 #ifdef ENABLE_OPENSSL   /* empty file without openssl */
 
 #include <stdlib.h>
@@ -778,7 +782,7 @@ iasecc_pkcs15_fix_file_access(struct sc_pkcs15_card *p15card, struct sc_file *fi
 }
 
 
-static int
+int
 iasecc_pkcs15_encode_supported_algos(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *object)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -1879,6 +1883,21 @@ struct sc_pkcs15init_operations *
 sc_pkcs15init_get_iasecc_ops(void)
 {
 	return &sc_pkcs15init_iasecc_operations;
+}
+
+#else /* ENABLE_OPENSSL */
+#include "../libopensc/log.h"
+#include "pkcs15-init.h"
+
+int
+iasecc_pkcs15_encode_supported_algos(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *object)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	FIX_UNUSED(object);
+
+	LOG_FUNC_CALLED(ctx);
+	sc_log(ctx, "OpenSC was built without OpenSSL support: skipping");
+	LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_IMPLEMENTED);
 }
 
 #endif /* ENABLE_OPENSSL */

--- a/src/pkcs15init/pkcs15-iasecc.h
+++ b/src/pkcs15init/pkcs15-iasecc.h
@@ -1,0 +1,25 @@
+/*
+ * pkcs15-iasecc.h Support for IAS/ECC smart cards
+ *
+ * Copyright (C) 2021  Vincent JARDIN <vjardin/AT\free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef pkcs15_iasecc_h
+#define pkcs15_iasecc_h
+
+extern int iasecc_pkcs15_encode_supported_algos(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *object);
+#endif /* #ifndef pkcs15_iasecc_h*/


### PR DESCRIPTION
Same than Gemalto's IASECC, the CPX cards need a workaround since
the PrKey does not have its Algo_regs.

Currently, it is a WIP in order to share the updates. Please, do not apply it yet.

We get:
```
pkcs15-tool -k --verify-pin --pin 1234
Using reader with a card: ACS ACR33U-A1 3SAM ICC Reader 00 00
Private RSA Key [CPS_PRIV_SIG]
	Object Flags   : [0x01], private
	Usage          : [0x200], nonRepudiation
	Access Flags   : [0x0D], sensitive, alwaysSensitive, neverExtract
	Algo_refs      : 0
	Access Rules   : pso_cds:01;
	ModLength      : 2048
	Key ref        : 129 (0x81)
	Native         : yes
	Path           : e828bd080f8025000001ff0010::
	Auth ID        : 01
	ID             : e828bd080f8025000001ff001001
	MD:guid        : e7aab727-f2af-e673-37bb-7d43867a6349

Private RSA Key [CPS_PRIV_AUT]
	Object Flags   : [0x07], private, modifiable
	Usage          : [0x06], decrypt, sign
	Access Flags   : [0x0D], sensitive, alwaysSensitive, neverExtract
	Algo_refs      : 0
	Access Rules   : pso_decrypt:01; int_auth:01;
	ModLength      : 2048
	Key ref        : 130 (0x82)
	Native         : yes
	Path           : e828bd080f8025000001ff0010::
	Auth ID        : 01
	ID             : e828bd080f8025000001ff001002
	MD:guid        : 2b6bf284-225c-80bc-8cbe-1c791db33543
```

We need to get `Algo_regs` to be set to something that is not 0.

Fix: issue #2267
