### PR TITLE
Fix EOL for pkcs11-tool --test

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -6255,8 +6255,6 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 			continue;
 		}
 
-		printf("\n");
-
 #ifndef ENABLE_OPENSSL
 		printf("No OpenSSL support, unable to validate decryption\n");
 #else
@@ -6271,6 +6269,7 @@ static int test_decrypt(CK_SESSION_HANDLE sess)
 				continue;
 			}
 
+			/* each display will end with a \n */
 			errors += encrypt_decrypt(sess, mechs[n], privKeyObject);
 		}
 #endif


### PR DESCRIPTION
The \n is not required since all the previous displays already
include an EOL.

For instance, without this fix, we were getting:
```
[...]
Decryption (currently only for RSA)
  testing key 0 (CPS_PRIV_SIG) -- can't be used to decrypt, skipping
  testing key 1 (CPS_PRIV_AUT)
 -- mechanism can't be used to decrypt, skipping
    RSA-PKCS: OK
No errors
```
instead of
```
[...]
Decryption (currently only for RSA)
  testing key 0 (CPS_PRIV_SIG) -- can't be used to decrypt, skipping
  testing key 1 (CPS_PRIV_AUT) -- mechanism can't be used to decrypt, skipping
    RSA-PKCS: OK
No errors
```