### PR TITLE
Fix for #2283 C_Sign fails ECDSA when card can do HASH on card

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -737,7 +737,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 * But if card is going to do the hash, pass in all the data
 	 */
 	else if (senv.algorithm == SC_ALGORITHM_EC &&
-			(senv.flags & SC_ALGORITHM_ECDSA_HASHES) == 0) {
+			(senv.algorithm_flags & SC_ALGORITHM_ECDSA_HASHES) == 0) {
 		inlen = MIN(inlen, (prkey->field_length+7)/8);
 	}
 


### PR DESCRIPTION
Do not truncate ECDSA input to size of key if card or driver will do HASH.

Fixes: #2283

 On branch Fix_for_2283_ECDSA
 Changes to be committed:
	modified:   src/libopensc/pkcs15-sec.c

Tested with:

Slot 0 (0x0): SCM Microsystems Inc. SCR 355 [CCID Interface] 00 00
  token label        : SmartCard-HSM (UserPIN)
  token manufacturer : www.CardContact.de
  token model        : PKCS#15 emulated
  token flags        : login required, rng, token initialized, PIN initialized
  hardware version   : 24.13
  firmware version   : 1.2
  serial num         : DECC0100248
  pin min/max        : 6/15


