### PR TITLE
OpenPGP 3.4+: Enable ed25519/curve25519 support

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -98,6 +98,19 @@ static pgp_ec_curves_t	ec_curves_openpgp[] = {
 	{{{-1}}, 0} /* This entry must not be touched. */
 };
 
+/* v3.0+ supports: [RFC 4880 & 6637] 0x12 = ECDH, 0x13 = ECDSA */
+static pgp_ec_curves_t  ec_curves_openpgp34[] = {
+        {{{1, 2, 840, 10045, 3, 1, 7, -1}}, 256}, /* ansiX9p256r1 */
+        {{{1, 3, 132, 0, 34, -1}}, 384}, /* ansiX9p384r1 */
+        {{{1, 3, 132, 0, 35, -1}}, 521}, /* ansiX9p521r1 */
+        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 7, -1}}, 256}, /* brainpoolP256r1 */
+        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 11, -1}}, 384}, /* brainpoolP384r1 */
+        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 13, -1}}, 512}, /* brainpoolP512r1 */
+        {{{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}}, 256}, /* curve25519 for encryption => CKK_EC_MONTGOMERY */
+        {{{1, 3, 6, 1, 4, 1, 11591, 15, 1, -1}}, 256}, /* ed25519 for signatures => CKK_EC_EDWARDS */
+        {{{-1}}, 0} /* This entry must not be touched. */
+};
+
 struct sc_object_id curve25519_oid = {{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}};
 
 /* Gnuk supports NIST, SECG and Curve25519 since version 1.2 */
@@ -455,6 +468,8 @@ pgp_init(sc_card_t *card)
 	/* With gnuk, we use different curves */
 	if (card->type == SC_CARD_TYPE_OPENPGP_GNUK) {
 		priv->ec_curves = ec_curves_gnuk;
+	} else if (priv->bcd_version >= OPENPGP_CARD_3_4) {
+		priv->ec_curves = ec_curves_openpgp34;
 	} else {
 		priv->ec_curves = ec_curves_openpgp;
 	}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -87,8 +87,11 @@ static struct sc_card_driver pgp_drv = {
 };
 
 
-/* v3.0+ supports: [RFC 4880 & 6637] 0x12 = ECDH, 0x13 = ECDSA */
-static pgp_ec_curves_t	ec_curves_openpgp[] = {
+static pgp_ec_curves_t  ec_curves_openpgp34[] = {
+	/* OpenPGP 3.4+ Ed25519 and Curve25519 */
+	{{{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}}, 256}, /* curve25519 for encryption => CKK_EC_MONTGOMERY */
+	{{{1, 3, 6, 1, 4, 1, 11591, 15, 1, -1}}, 256}, /* ed25519 for signatures => CKK_EC_EDWARDS */
+	/* v3.0+ supports: [RFC 4880 & 6637] 0x12 = ECDH, 0x13 = ECDSA */
 	{{{1, 2, 840, 10045, 3, 1, 7, -1}}, 256}, /* ansiX9p256r1 */
 	{{{1, 3, 132, 0, 34, -1}}, 384}, /* ansiX9p384r1 */
 	{{{1, 3, 132, 0, 35, -1}}, 521}, /* ansiX9p521r1 */
@@ -98,18 +101,7 @@ static pgp_ec_curves_t	ec_curves_openpgp[] = {
 	{{{-1}}, 0} /* This entry must not be touched. */
 };
 
-/* v3.0+ supports: [RFC 4880 & 6637] 0x12 = ECDH, 0x13 = ECDSA */
-static pgp_ec_curves_t  ec_curves_openpgp34[] = {
-        {{{1, 2, 840, 10045, 3, 1, 7, -1}}, 256}, /* ansiX9p256r1 */
-        {{{1, 3, 132, 0, 34, -1}}, 384}, /* ansiX9p384r1 */
-        {{{1, 3, 132, 0, 35, -1}}, 521}, /* ansiX9p521r1 */
-        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 7, -1}}, 256}, /* brainpoolP256r1 */
-        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 11, -1}}, 384}, /* brainpoolP384r1 */
-        {{{1, 3, 36, 3, 3, 2, 8, 1, 1, 13, -1}}, 512}, /* brainpoolP512r1 */
-        {{{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}}, 256}, /* curve25519 for encryption => CKK_EC_MONTGOMERY */
-        {{{1, 3, 6, 1, 4, 1, 11591, 15, 1, -1}}, 256}, /* ed25519 for signatures => CKK_EC_EDWARDS */
-        {{{-1}}, 0} /* This entry must not be touched. */
-};
+static pgp_ec_curves_t *ec_curves_openpgp = ec_curves_openpgp34 + 2;
 
 struct sc_object_id curve25519_oid = {{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}};
 

--- a/src/libopensc/pkcs15-openpgp.c
+++ b/src/libopensc/pkcs15-openpgp.c
@@ -309,6 +309,11 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 			if (cxdata[0] == SC_OPENPGP_KEYALGO_ECDH ||
 				cxdata[0] == SC_OPENPGP_KEYALGO_ECDSA ||
 				cxdata[0] == SC_OPENPGP_KEYALGO_EDDSA) {
+				/* Last byte could be Import-Format of private key, let's ignore it,
+				 * as it is not part of OID */
+				if (cxdata[cxdata_len-1] == SC_OPENPGP_KEYFORMAT_EC_STD ||
+				    cxdata[cxdata_len-1] == SC_OPENPGP_KEYFORMAT_EC_STDPUB)
+					cxdata_len--;
 				r = sc_asn1_decode_object_id(&cxdata[1], cxdata_len-1, &oid);
 				if (r != SC_SUCCESS) {
 					sc_log(ctx, "Failed to parse OID for elliptic curve algorithm");
@@ -429,6 +434,11 @@ sc_pkcs15emu_openpgp_init(sc_pkcs15_card_t *p15card)
 			if (cxdata[0] == SC_OPENPGP_KEYALGO_ECDH ||
 				cxdata[0] == SC_OPENPGP_KEYALGO_ECDSA ||
 				cxdata[0] == SC_OPENPGP_KEYALGO_EDDSA) {
+				/* Last byte could be Import-Format of private key, let's ignore it,
+				 * as it is not part of OID */
+				if (cxdata[cxdata_len-1] == SC_OPENPGP_KEYFORMAT_EC_STD ||
+				    cxdata[cxdata_len-1] == SC_OPENPGP_KEYFORMAT_EC_STDPUB)
+					cxdata_len--;
 				r = sc_asn1_decode_object_id(&cxdata[1], cxdata_len-1, &oid);
 				if (r != SC_SUCCESS) {
 					sc_log(ctx, "Failed to parse OID for elliptic curve algorithm");

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -300,10 +300,10 @@ int sc_compare_oid(const struct sc_object_id *oid1, const struct sc_object_id *o
 	}
 
 	for (i = 0; i < SC_MAX_OBJECT_ID_OCTETS; i++)   {
+		if ((oid1->value[i] == -1) || (oid2->value[i] == -1))
+			break;
 		if (oid1->value[i] != oid2->value[i])
 			return 0;
-		if (oid1->value[i] == -1)
-			break;
 	}
 
 	return 1;

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -300,10 +300,10 @@ int sc_compare_oid(const struct sc_object_id *oid1, const struct sc_object_id *o
 	}
 
 	for (i = 0; i < SC_MAX_OBJECT_ID_OCTETS; i++)   {
-		if ((oid1->value[i] == -1) || (oid2->value[i] == -1))
-			break;
 		if (oid1->value[i] != oid2->value[i])
 			return 0;
+		if (oid1->value[i] == -1)
+			break;
 	}
 
 	return 1;


### PR DESCRIPTION
This MR add support of 25519-series of curves to OpenSC. It extends support added in https://github.com/OpenSC/OpenSC/pull/1960.

Tested with Yubikey 5 NFC, Firmware 5.2.4.

It includes fix for Yubikey, which returns extra 0 at the end of OID in Algorithm Attribute DO. I've changed sc_compare_oid to return in it found -1 in any OID. This way, all trailing bytes will be ignored for comparison, including Import-Format.

p11test works, the only issue is with test_usages, which complains that derive should not be set on public key. I think, this should be an issue for all ECDH supporting tokens, as it's set in https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/pkcs15-openpgp.c#L480 and https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/pkcs15-openpgp.c#L484.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

P.S. Right now I'm just checking if version of card is more or equal to 3.4, but it seems, that there is a better way to detect list of supported algorithms, via Algorithm Information DO added in spec version 3.4. I've addressed that in https://github.com/OpenSC/OpenSC/pull/2287