### PR TITLE
OpenPGP 3.4+: Get list of supported algorithms from Algorithm Information

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1246,12 +1246,14 @@ pgp_enumerate_blob(sc_card_t *card, pgp_blob_t *blob)
 
 		r = sc_asn1_read_tag(&data, blob->len - (in - blob->data),
 					&cla, &tag, &len);
-		if (data == NULL) {
-			sc_log(card->ctx, "Unexpected end of contents");
-			return SC_ERROR_OBJECT_NOT_VALID;
-		}
 		if (r == SC_ERROR_INVALID_ASN1_OBJECT) {
 			sc_log(card->ctx, "Invalid ASN.1 object");
+			return SC_ERROR_OBJECT_NOT_VALID;
+		}
+		/* Check for unknown error, or empty data */
+		if (((r < 0) && (r != SC_ERROR_ASN1_END_OF_CONTENTS)) ||
+		    (data == NULL)) {
+			sc_log(card->ctx, "Unexpected end of contents");
 			return SC_ERROR_OBJECT_NOT_VALID;
 		}
 

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -707,7 +707,6 @@ int _pgp_add_algo(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t key_info, si
 		/* fall through */
 	case SC_OPENPGP_KEYALGO_ECDSA:
 		/* v3.0+: ECC [RFC 4880 & 6637] */
-		/* EdDSA from draft-ietf-openpgp-rfc4880bis-08 */
 
 		/* Allow curve to be used by both ECDH and ECDSA.
 		 * pgp_init set these flags the same way */
@@ -723,6 +722,7 @@ int _pgp_add_algo(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t key_info, si
 			do_num, key_info.algorithm, key_info.u.ec.key_length);
 		break;
 	case SC_OPENPGP_KEYALGO_EDDSA:
+		/* EdDSA from draft-ietf-openpgp-rfc4880bis-08 */
 		/* Handle Yubikey bug, that in DO FA curve25519 has EDDSA algo */
 		if (_pgp_handle_curve25519(card, key_info, do_num))
 			break;
@@ -812,7 +812,7 @@ pgp_get_card_features(sc_card_t *card)
 		if (pgp_get_blob(card, priv->mf, 0x00fa, &blobfa) >= 0) {
 			pgp_blob_t *child;
 			pgp_enumerate_blob(card, blobfa);
-			/* There will be multiple childs with the same ID, but
+			/* There will be multiple children with the same ID, but
 			 * different algos, so we need to iterate over all of them */
 			for (child = blobfa->files; child; child = child->next) {
 				if ((child->id < 0x00c1) || (child->id > 0x00c3))

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -907,9 +907,9 @@ pgp_get_card_features(sc_card_t *card)
 		}
 
 		/* if we found at least one usable algo, let's skip other ways to find them */
-		if (handled_algos > 0) {
+		if (handled_algos) {
 			sc_log(card->ctx, "Algo list populated from Algorithm Information DO");
-			LOG_FUNC_RETURN(card->ctx, 1);
+			LOG_FUNC_RETURN(card->ctx, handled_algos);
 		}
 
 		/* get _current_ algorithms & key lengths from "algorithm attributes" DOs
@@ -932,7 +932,7 @@ pgp_get_card_features(sc_card_t *card)
 
 	}
 
-	LOG_FUNC_RETURN(card->ctx, 0);
+	LOG_FUNC_RETURN(card->ctx, handled_algos);
 }
 
 

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -1154,16 +1154,13 @@ sc_algorithm_info_t * sc_card_find_alg(sc_card_t *card,
 
 		if (info->algorithm != algorithm)
 			continue;
-		if (param)   {
-			if (info->algorithm == SC_ALGORITHM_EC ||
-				info->algorithm == SC_ALGORITHM_EDDSA ||
-				info->algorithm == SC_ALGORITHM_XEDDSA)
-				if (sc_compare_oid((struct sc_object_id *)param, &info->u._ec.params.id))
-					return info;
-		}
-		if (info->key_length != key_length)
-			continue;
-		return info;
+		if (param && (info->algorithm == SC_ALGORITHM_EC ||
+			info->algorithm == SC_ALGORITHM_EDDSA ||
+			info->algorithm == SC_ALGORITHM_XEDDSA)) {
+			if (sc_compare_oid((struct sc_object_id *)param, &info->u._ec.params.id))
+				return info;
+		} else if (info->key_length == key_length)
+			return info;
 	}
 	return NULL;
 }

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -120,7 +120,7 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 				_update_mech_info(&existing_mt->mech_info, &mt->mech_info);
 				/* XXX Should be changed to loop over mt->key_types, if
 				 * we allow to register mechanism with multiple key types
-                                 * in one operation */
+				 * in one operation */
 				existing_mt->key_types[i] = mt->key_types[0];
 				if (i + 1 < MAX_KEY_TYPES) {
 					existing_mt->key_types[i + 1] = -1;
@@ -129,7 +129,7 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 				return CKR_OK;
 			}
 		}
-		sc_log(p11card->card->ctx, "Too much key types in mechanism 0x%lx, more than %d", mt->mech, MAX_KEY_TYPES);
+		sc_log(p11card->card->ctx, "Too many key types in mechanism 0x%lx, more than %d", mt->mech, MAX_KEY_TYPES);
 		free(mt);
 		return CKR_BUFFER_TOO_SMALL;
 	}

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -53,7 +53,7 @@ static void	sc_pkcs11_openssl_md_release(sc_pkcs11_operation_t *);
 static sc_pkcs11_mechanism_type_t openssl_sha1_mech = {
 	CKM_SHA_1,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -72,7 +72,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha1_mech = {
 static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
 	CKM_SHA224,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -91,7 +91,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
 static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
 	CKM_SHA256,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -110,7 +110,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
 static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
 	CKM_SHA384,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -129,7 +129,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
 static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 	CKM_SHA512,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -148,7 +148,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	CKM_GOSTR3411,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -167,7 +167,7 @@ static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 	CKM_MD5,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,
@@ -186,7 +186,7 @@ static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 static sc_pkcs11_mechanism_type_t openssl_ripemd160_mech = {
 	CKM_RIPEMD160,
 	{ 0, 0, CKF_DIGEST },
-	0,
+	{ -1 },
 	sizeof(struct sc_pkcs11_operation),
 	sc_pkcs11_openssl_md_release,
 	sc_pkcs11_openssl_md_init,

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -31,7 +31,7 @@ static void sc_find_release(sc_pkcs11_operation_t *operation);
 static sc_pkcs11_mechanism_type_t find_mechanism = {
 	0,		/* mech */
 	{0,0,0},	/* mech_info */
-	0,		/* key_type */
+	{ -1 },		/* key_types */
 	sizeof(struct sc_pkcs11_find_operation),	/* obj_size */
 	sc_find_release,				/* release */
 	NULL,		/* md_init */

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -264,11 +264,13 @@ enum {
 	SC_PKCS11_OPERATION_MAX
 };
 
+#define MAX_KEY_TYPES 2
+
 /* This describes a PKCS11 mechanism */
 struct sc_pkcs11_mechanism_type {
-	CK_MECHANISM_TYPE mech;		/* algorithm: md5, sha1, ... */
-	CK_MECHANISM_INFO mech_info;	/* mechanism info */
-	CK_MECHANISM_TYPE key_type;	/* for sign/decipher ops */
+	CK_MECHANISM_TYPE mech;				/* algorithm: md5, sha1, ... */
+	CK_MECHANISM_INFO mech_info;			/* mechanism info */
+	int 		  key_types[MAX_KEY_TYPES];	/* for sign/decipher ops */
 	unsigned int	  obj_size;
 
 	/* General management */
@@ -440,17 +442,17 @@ CK_RV sc_pkcs11_md_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR);
 CK_RV sc_pkcs11_md_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 CK_RV sc_pkcs11_md_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_sign_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR,
-				struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
+				struct sc_pkcs11_object *, CK_KEY_TYPE);
 CK_RV sc_pkcs11_sign_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 CK_RV sc_pkcs11_sign_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_sign_size(struct sc_pkcs11_session *, CK_ULONG_PTR);
 #ifdef ENABLE_OPENSSL
 CK_RV sc_pkcs11_verif_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR,
-				struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
+				struct sc_pkcs11_object *, CK_KEY_TYPE);
 CK_RV sc_pkcs11_verif_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 CK_RV sc_pkcs11_verif_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 #endif
-CK_RV sc_pkcs11_decr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
+CK_RV sc_pkcs11_decr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE);
 CK_RV sc_pkcs11_decr(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_wrap(struct sc_pkcs11_session *,CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE, struct sc_pkcs11_object *, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_unwrap(struct sc_pkcs11_session *,CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE, CK_BYTE_PTR, CK_ULONG, struct sc_pkcs11_object *);


### PR DESCRIPTION
OpenPGP Card 3.4+ supports getting list of algos from the new Algoritm Information DO
https://gnupg.org/ftp/specs/OpenPGP-smart-card-application-3.4.pdf, 4.4.3.11
If at least one algo is in this list, use it, and ignore hardcoded.

Tested on Yubikey 5 NFC with FW 5.2.4. Handled few problems with Yubikey not
following the spec.

Also, fixed problem with algorithm find, which will return EC algorithm with the same
key size, even if curve is not the same (e.g., curves 1.3.132.0.34 and 1.3.36.3.3.2.8.1.1.11 has
the same keysize of 384 bits, so it was possible that one returned in place of other)

This is needed for Yubikey to support more algorithms, than are used in Algorithm Attributes DO,
in case it was initialized with gpg, and not pkcs15-tool.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
