### PR TITLE
OpenPGP: Fix read of certs with Ed25519 key

### DIFF
--- a/src/libopensc/pkcs15-algo.c
+++ b/src/libopensc/pkcs15-algo.c
@@ -451,6 +451,8 @@ static struct sc_asn1_pkcs15_algorithm_info algorithm_table[] = {
 #ifdef SC_ALGORITHM_EDDSA
 	/* aka Ed25519 */
 	{ SC_ALGORITHM_EDDSA, {{1, 3, 6, 1, 4, 1, 11591, 15, 1, -1}}, NULL, NULL, NULL },
+	/* RFC 8410, needed to parse X509 certs */
+	{ SC_ALGORITHM_EDDSA, {{1, 3, 101, 112, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_XEDDSA
 	/* aka curve25519 */

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1507,6 +1507,11 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 		}
 		memcpy(pubkey->u.ec.ecpointQ.value, pk.value, pk.len);
 		pubkey->u.ec.ecpointQ.len = pk.len;
+	} else if (pk_alg.algorithm == SC_ALGORITHM_EDDSA) {
+		/* EDDSA public key is not encapsulated into BIT STRING -- it's a BIT STRING */
+		pubkey->u.eddsa.pubkey.value = malloc(pk.len);
+		memcpy(pubkey->u.eddsa.pubkey.value, pk.value, pk.len);
+		pubkey->u.eddsa.pubkey.len = pk.len;
 	} else {
 		/* Public key is expected to be encapsulated into BIT STRING */
 		r = sc_pkcs15_decode_pubkey(ctx, pubkey, pk.value, pk.len);


### PR DESCRIPTION
Proper Ed25519 certs have pubkey algo with OID 1.3.101.112, according to
RFC8410. This commit add this OID, and also fixes pubkey parsing - according
to the same RFC, it's just a bytestring, without ASN.1 wrapping.
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
