### PR TITLE
pkcs11-tool: disable wrap/unwrap test until OpenSC#1796 is resolved

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5746,7 +5746,7 @@ static int test_verify(CK_SESSION_HANDLE sess)
 	return errors;
 }
 
-#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 21
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 22
 #else
 #ifdef ENABLE_OPENSSL
 static int wrap_unwrap(CK_SESSION_HANDLE session,
@@ -5870,7 +5870,7 @@ static int wrap_unwrap(CK_SESSION_HANDLE session,
  */
 static int test_unwrap(CK_SESSION_HANDLE sess)
 {
-#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 21
+#if OPENSC_VERSION_MAJOR == 0 && OPENSC_VERSION_MINOR <= 22
 	/* temporarily disable test, see https://github.com/OpenSC/OpenSC/issues/1796 */
 	return 0;
 #else
@@ -7520,7 +7520,7 @@ static void * test_threads_run(void * pttd)
 			pctest ++;
 		if (*pctest == ':')
 			pctest++;
-		
+
 
 		if (rv != CKR_OK && rv != CKR_CRYPTOKI_ALREADY_INITIALIZED)
 		/* IN C_Initialize with NULL args */
@@ -7562,7 +7562,7 @@ static int test_threads_cleanup()
 		if (ended == test_threads_num) {
 			fprintf(stderr,"test_threads all threads have ended %s\n",
 					(ended_ok == test_threads_num)? "with CKR_OK": "some errors");
-			break; 
+			break;
 		} else {
 			fprintf(stderr,"test_threads threads stills active:%d\n", (test_threads_num - ended));
 			for (i = 0; i < test_threads_num; i++) {
@@ -7577,7 +7577,7 @@ static int test_threads_cleanup()
 #endif
 		}
 	}
-	
+
 	for (i = 0; i < test_threads_num; i++) {
 		fprintf(stderr,"test_threads thread:%d state:%d, rv:%s\n",
 			i, test_threads_datas[i].state, CKR2Str(test_threads_datas[i].rv));
@@ -7595,11 +7595,11 @@ static int test_threads_cleanup()
 	fprintf(stderr,"test_threads cleanup finished\n");
 	return 0;
 }
- 
+
 static int test_threads_start(int tnum)
 {
 	int r = 0;
-	
+
 #ifdef _WIN32
 	test_threads_handles[tnum] = CreateThread(NULL, 0, test_threads_run, (LPVOID) &test_threads_datas[tnum],
 		0, NULL);
@@ -7632,4 +7632,3 @@ static void test_threads()
 	}
 }
 #endif /* defined(_WIN32) || defiend(HAVE_PTHREAD) */
-


### PR DESCRIPTION
Ref. preparation for 0.22.0:
Again, as before for 0.20.0 and 0.21.0, the issue #1796 hasn't yet been solved, so this avoids errors from
pkcs11-tool --test

##### Checklist
- [ X] PKCS#11 module is tested


Using external driver from https://github.com/carblue/acos5 with ACS ACOS5 USB token CryptoMate64:
$ opensc-tool -i
OpenSC 0.22.0-rc1 [gcc  9.3.0]
Enabled features: locking zlib readline openssl pcsc(libpcsclite.so.1)

$ pkcs11-tool --test --login -p ********
Using slot 0 with a present token (0x0)
C_SeedRandom() and C_GenerateRandom():
  seeding (C_SeedRandom) not supported
  seems to be OK
Digests:
  all 4 digest functions seem to work
  MD5: OK
  SHA-1: OK
  RIPEMD160: OK
Signatures (currently only for RSA)
  testing key 0 (CAroot)  -- can't be used for signature, skipping
  testing key 1 (CAinter)  -- can't be used for signature, skipping
  testing key 2 (cb@posteo.de) 
  all 4 signature functions seem to work
  testing signature mechanisms:
    RSA-PKCS: OK
    SHA1-RSA-PKCS: OK
    MD5-RSA-PKCS: OK
    RIPEMD160-RSA-PKCS: OK
    SHA256-RSA-PKCS: OK
  testing key 1 (CAinter) with 1 mechanism -- can't be used to sign/verify, skipping
  testing key 2 (cb@posteo.de) with 1 mechanism
    RSA-PKCS: OK
  testing key 3 (arcor) with 1 mechanism
    RSA-PKCS: OK
  testing key 4 (dummy) with 1 mechanism
    RSA-PKCS: OK
Verify (currently only for RSA)
  testing key 0 (CAroot) -- can't be used to sign/verify, skipping
  testing key 1 (CAinter) with 1 mechanism -- can't be used to sign/verify, skipping
  testing key 2 (cb@posteo.de) with 1 mechanism
    RSA-PKCS: OK
  testing key 3 (arcor) with 1 mechanism
    RSA-PKCS: OK
  testing key 4 (dummy) with 1 mechanism
    RSA-PKCS: OK
Decryption (currently only for RSA)
  testing key 0 (CAroot) -- can't be used to decrypt, skipping
  testing key 1 (CAinter) -- can't be used to decrypt, skipping
  testing key 2 (cb@posteo.de)
    RSA-PKCS: OK
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
  testing key 3 (arcor)
    RSA-PKCS: OK
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
  testing key 4 (dummy)
    RSA-PKCS: OK
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
 -- mechanism can't be used to decrypt, skipping
No errors