### PR TITLE
Public keys can have CKA_DERIVE attribute

### DIFF
--- a/src/tests/p11test/p11test_case_usage.c
+++ b/src/tests/p11test/p11test_case_usage.c
@@ -54,11 +54,6 @@ void usage_test(void **state) {
 			fprintf(stderr, " [ ERROR %s ] If Unwrap is set, Wrap should be set too.\n",
 			    objects.data[i].id_str);
 		}
-		if (objects.data[i].derive_pub) {
-			errors++;
-			fprintf(stderr, " [ ERROR %s ] Derive should not be set on public key\n",
-			    objects.data[i].id_str);
-		}
 
 		/* We have at least one usage flag for every key group */
 		if (! objects.data[i].sign       && ! objects.data[i].verify &&


### PR DESCRIPTION
in response to https://github.com/OpenSC/OpenSC/pull/2286#issuecomment-814734597

This removes the error message:

fprintf(stderr, " [ ERROR %s ] Derive should not be set on public key\n",

PKCS11-base-v2.40 says:
Table 22, Common Key Attributes  Common key attributes:
    CKA_DERIVE  | CK_BBOOL | CK_TRUE if key supports key derivation (i.e., if other keys can be derived from this one (default CK_FALSE)

Table 24, Mapping of X.509 key usage flags to Cryptoki attributes for public keys:
   Key usage flags for public keys in X.509 public key certificates
      Corresponding cryptoki attributes for public keys.
         keyAgreement  CKA_DERIVE


NIST demo PIV card 4 with EC keys was used with p11test. The error message not shown.
```
[ RUN      ] usage_test
[KEY ID] [LABEL]
[ TYPE ] [ SIZE ] [PUBLIC] [SIGN&VERIFY] [ENC&DECRYPT] [WRAP&UNWR] [ DERIVE ] [ALWAYS_AUTH]

[07    ] [Retired Certificate for Key Management 3]
[ RSA  ] [  2048] [  ./  ] [[  ]  [  ] ] [[./]  [./] ] [[./] [./]] [[  ][  ]] [    [  ]   ]

[01    ] [Certificate for PIV Authentication]
[  EC  ] [   256] [  ./  ] [[./]  [./] ] [[  ]  [  ] ] [[  ] [  ]] [[  ][  ]] [    [  ]   ]

[02    ] [Certificate for Digital Signature]
[  EC  ] [   256] [  ./  ] [[./]  [./] ] [[  ]  [  ] ] [[  ] [  ]] [[  ][  ]] [    [./]   ]

[03    ] [Certificate for Key Management]
[  EC  ] [   256] [  ./  ] [[  ]  [  ] ] [[  ]  [  ] ] [[  ] [  ]] [[./][./]] [    [  ]   ]

[05    ] [Retired Certificate for Key Management 1]
[  EC  ] [   256] [  ./  ] [[  ]  [  ] ] [[  ]  [  ] ] [[  ] [  ]] [[./][./]] [    [  ]   ]

[06    ] [Retired Certificate for Key Management 2]
[  EC  ] [   256] [  ./  ] [[  ]  [  ] ] [[  ]  [  ] ] [[  ] [  ]] [[./][./]] [    [  ]   ]

[04    ] [Certificate for Card Authentication]
[  EC  ] [   256] [  ./  ] [[./]  [./] ] [[  ]  [  ] ] [[  ] [  ]] [[  ][  ]] [    [  ]   ]
 Public == Cert -----^       ^-----^       ^-----^       ^----^      ^---^
 Sign & Verify Attributes ------'             |            |           |
 Encrypt & Decrypt Attributes ----------------'            |           |
 Wrap & Unwrap Attributes ---------------------------------'           |
 Public and Private key Derive Attributes -----------------------------'
[       OK ] usage_test
```




