### PR TITLE
Fix read/write certs with Ed25519/X25519 public key

### DIFF
--- a/src/libopensc/pkcs15-algo.c
+++ b/src/libopensc/pkcs15-algo.c
@@ -450,11 +450,13 @@ static struct sc_asn1_pkcs15_algorithm_info algorithm_table[] = {
 #endif
 #ifdef SC_ALGORITHM_EDDSA
 	/* aka Ed25519 */
-	{ SC_ALGORITHM_EDDSA, {{1, 3, 6, 1, 4, 1, 11591, 15, 1, -1}}, NULL, NULL, NULL },
+	/* RFC 8410, needed to parse/create X509 certs/pubkeys */
+	{ SC_ALGORITHM_EDDSA, {{1, 3, 101, 112, -1}}, NULL, NULL, NULL },
 #endif
 #ifdef SC_ALGORITHM_XEDDSA
 	/* aka curve25519 */
-	{ SC_ALGORITHM_XEDDSA, {{1, 3, 6, 1, 4, 1, 3029, 1, 5, 1, -1}}, NULL, NULL, NULL },
+	/* RFC 8410, needed to parse/create X509 certs/pubkeys */
+	{ SC_ALGORITHM_XEDDSA, {{1, 3, 101, 110, -1}}, NULL, NULL, NULL },
 #endif
 	{ -1, {{ -1 }}, NULL, NULL, NULL }
 };
@@ -552,7 +554,11 @@ sc_asn1_encode_algorithm_id(struct sc_context *ctx, u8 **buf, size_t *len,
 	sc_format_asn1_entry(asn1_alg_id + 0, (void *) &id->oid, NULL, 1);
 
 	/* no parameters, write NULL tag */
-	if (!id->params || !alg_info->encode)
+	/* If it's EDDSA/XEDDSA, according to RFC8410, params
+	 * MUST be absent */
+	if (id->algorithm != SC_ALGORITHM_EDDSA &&
+	    id->algorithm != SC_ALGORITHM_XEDDSA &&
+	    (!id->params || !alg_info->encode))
 		asn1_alg_id[1].flags |= SC_ASN1_PRESENT;
 
 	r = _sc_asn1_encode(ctx, asn1_alg_id, buf, len, depth + 1);


### PR DESCRIPTION
Proper Ed25519/X25519 certs have pubkey algo with OID 1.3.101.112/110, according to
RFC8410. This commit add these OIDs, and also fixes pubkey parsing/creation - according
to the same RFC, it's just a bytestring, without ASN.1 wrapping.

Also, according to the same RFC, EDDSA/X25519 MUST not have params, even empty.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
