### PR TITLE
Travis ci focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: DO_PUSH_ARTIFACT=yes
     - compiler: clang
       os: linux
-      dist: bionic
+      dist: focal
     - compiler: gcc
       os: linux
       dist: bionic
@@ -21,7 +21,7 @@ matrix:
         - ENABLE_DOC=--enable-doc
     - compiler: gcc
       os: linux
-      dist: bionic
+      dist: focal
       env:
         - DO_SIMULATION=oseid
     - env:
@@ -71,6 +71,7 @@ addons:
     - socat
     - cmake
     - clang-tidy
+    - softhsm2
 
 before_install:
   # homebrew is dead slow in older images due to the many updates it would need to download and build.

--- a/tests/test-pkcs11-tool-allowed-mechanisms.sh
+++ b/tests/test-pkcs11-tool-allowed-mechanisms.sh
@@ -22,7 +22,7 @@ MECHANISMS="RSA-PKCS,SHA1-RSA-PKCS,RSA-PKCS-PSS"
 # Generate key pair
 $PKCS11_TOOL --keypairgen --key-type="RSA:" --login --pin=$PIN \
 	--module="$P11LIB" --label="test" --id="$ID" \
-	--allowed-mechanisms="$MECHANISMS"
+	--allowed-mechanisms="$MECHANISMS,SHA384-RSA-PKCS"
 assert $? "Failed to Generate RSA key pair"
 
 # Check the attributes are visible


### PR DESCRIPTION
travis-ci: Try to run the tests on Ubuntu 20 (Focal Fossa)

travis CI: testsuite fix (tests/test-pkcs11-tool-allowed-mechanisms.sh)
Ubuntu (focal) softhsm2 workaround - mechanism listing incorrect