### PR TITLE
iasecc: use proper printf format specifiers for size_t

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -421,7 +421,9 @@ static int iasecc_parse_ef_atr(struct sc_card *card)
 	sizes->recv =	 card->ef_atr->issuer_data[10] * 0x100 + card->ef_atr->issuer_data[11];
 	sizes->recv_sc = card->ef_atr->issuer_data[14] * 0x100 + card->ef_atr->issuer_data[15];
 
-	sc_log(ctx, "EF.ATR: IO Buffer Size send/sc %ld/%ld recv/sc %ld/%ld",
+	sc_log(ctx,
+		"EF.ATR: IO Buffer Size send/sc %"SC_FORMAT_LEN_SIZE_T"d/%"SC_FORMAT_LEN_SIZE_T"d "
+		"recv/sc %"SC_FORMAT_LEN_SIZE_T"d/%"SC_FORMAT_LEN_SIZE_T"d",
 		sizes->send, sizes->send_sc, sizes->recv, sizes->recv_sc);
 
 	card->max_send_size = sizes->send;


### PR DESCRIPTION
Do not hard-code the printf format specifier for size_t: use the macro instead.

This fixes compilation on 32-bit architectures.

