### PR TITLE
Remove the SC_SEC_ENV_FILE_REF_PRESENT flag for Rutoken ECP cards

### DIFF
--- a/src/libopensc/card-rtecp.c
+++ b/src/libopensc/card-rtecp.c
@@ -366,6 +366,19 @@ static int rtecp_logout(sc_card_t *card)
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
 }
 
+static int rtecp_set_security_env(	struct sc_card *card,
+									const struct sc_security_env *env,
+									int se_num)
+{
+	struct sc_security_env se_env;
+	if(!env)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	se_env= *env;
+	se_env.flags &= ~SC_SEC_ENV_FILE_REF_PRESENT;
+	return iso_ops->set_security_env(card, &se_env, se_num);
+}
+
 static int rtecp_cipher(sc_card_t *card, const u8 *data, size_t data_len,
 		u8 *out, size_t out_len, int sign)
 {
@@ -824,7 +837,7 @@ struct sc_card_driver * sc_get_rtecp_driver(void)
 	rtecp_ops.verify = rtecp_verify;
 	rtecp_ops.logout = rtecp_logout;
 	/* restore_security_env */
-	/* set_security_env */
+	rtecp_ops.set_security_env = rtecp_set_security_env;
 	rtecp_ops.decipher = rtecp_decipher;
 	rtecp_ops.compute_signature = rtecp_compute_signature;
 	rtecp_ops.change_reference_data = rtecp_change_reference_data;


### PR DESCRIPTION
Rutoken ECP cards have no default SE file. Previous cards ignored
MSE with restoring default SE, but new cards don't. This requires
SC_SEC_ENV_FILE_REF_PRESENT to be removed from env flags.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
