### PR TITLE
Allow signing more than 512 bytes of data

### DIFF
--- a/src/libopensc/log.h
+++ b/src/libopensc/log.h
@@ -59,9 +59,15 @@ enum {
 #define __FUNCTION__ NULL
 #endif
 
+#ifdef __FILE_NAME__
+#define FILENAME __FILE_NAME__
+#else
+#define FILENAME __FILE__
+#endif
+
 #if defined(__GNUC__)
-#define sc_debug(ctx, level, format, args...)	sc_do_log(ctx, level, __FILE__, __LINE__, __FUNCTION__, format , ## args)
-#define sc_log(ctx, format, args...)   sc_do_log(ctx, SC_LOG_DEBUG_NORMAL, __FILE__, __LINE__, __FUNCTION__, format , ## args)
+#define sc_debug(ctx, level, format, args...)	sc_do_log(ctx, level, FILENAME, __LINE__, __FUNCTION__, format , ## args)
+#define sc_log(ctx, format, args...)   sc_do_log(ctx, SC_LOG_DEBUG_NORMAL, FILENAME, __LINE__, __FUNCTION__, format , ## args)
 #else
 #define sc_debug _sc_debug
 #define sc_log _sc_log
@@ -109,7 +115,7 @@ int sc_color_fprintf(int colors, struct sc_context *ctx, FILE * stream, const ch
  * @param[in] len   Length of \a data
  */
 #define sc_debug_hex(ctx, level, label, data, len) \
-    _sc_debug_hex(ctx, level, __FILE__, __LINE__, __FUNCTION__, label, data, len)
+    _sc_debug_hex(ctx, level, FILENAME, __LINE__, __FUNCTION__, label, data, len)
 #define sc_log_hex(ctx, label, data, len) \
     sc_debug_hex(ctx, SC_LOG_DEBUG_NORMAL, label, data, len)
 /** 
@@ -131,17 +137,17 @@ void sc_hex_dump(const u8 *buf, size_t len, char *out, size_t outlen);
 const char * sc_dump_hex(const u8 * in, size_t count);
 const char * sc_dump_oid(const struct sc_object_id *oid);
 #define SC_FUNC_CALLED(ctx, level) do { \
-	 sc_do_log(ctx, level, __FILE__, __LINE__, __FUNCTION__, "called\n"); \
+	 sc_do_log(ctx, level, FILENAME, __LINE__, __FUNCTION__, "called\n"); \
 } while (0)
 #define LOG_FUNC_CALLED(ctx) SC_FUNC_CALLED((ctx), SC_LOG_DEBUG_NORMAL)
 
 #define SC_FUNC_RETURN(ctx, level, r) do { \
 	int _ret = r; \
 	if (_ret <= 0) { \
-		sc_do_log_color(ctx, level, __FILE__, __LINE__, __FUNCTION__, _ret ? SC_COLOR_FG_RED : 0, \
+		sc_do_log_color(ctx, level, FILENAME, __LINE__, __FUNCTION__, _ret ? SC_COLOR_FG_RED : 0, \
 			"returning with: %d (%s)\n", _ret, sc_strerror(_ret)); \
 	} else { \
-		sc_do_log(ctx, level, __FILE__, __LINE__, __FUNCTION__, \
+		sc_do_log(ctx, level, FILENAME, __LINE__, __FUNCTION__, \
 			"returning with: %d\n", _ret); \
 	} \
 	return _ret; \
@@ -151,7 +157,7 @@ const char * sc_dump_oid(const struct sc_object_id *oid);
 #define SC_TEST_RET(ctx, level, r, text) do { \
 	int _ret = (r); \
 	if (_ret < 0) { \
-		sc_do_log_color(ctx, level, __FILE__, __LINE__, __FUNCTION__, SC_COLOR_FG_RED, \
+		sc_do_log_color(ctx, level, FILENAME, __LINE__, __FUNCTION__, SC_COLOR_FG_RED, \
 			"%s: %d (%s)\n", (text), _ret, sc_strerror(_ret)); \
 		return _ret; \
 	} \
@@ -161,7 +167,7 @@ const char * sc_dump_oid(const struct sc_object_id *oid);
 #define SC_TEST_GOTO_ERR(ctx, level, r, text) do { \
 	int _ret = (r); \
 	if (_ret < 0) { \
-		sc_do_log_color(ctx, level, __FILE__, __LINE__, __FUNCTION__, SC_COLOR_FG_RED, \
+		sc_do_log_color(ctx, level, FILENAME, __LINE__, __FUNCTION__, SC_COLOR_FG_RED, \
 			"%s: %d (%s)\n", (text), _ret, sc_strerror(_ret)); \
 		goto err; \
 	} \

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1539,6 +1539,10 @@ int sc_base64_decode(const char *in, u8 *out, size_t outlen);
 void sc_mem_clear(void *ptr, size_t len);
 void *sc_mem_secure_alloc(size_t len);
 void sc_mem_secure_free(void *ptr, size_t len);
+#define sc_mem_secure_clear_free(ptr, len) do { \
+	sc_mem_clear(ptr, len); \
+	sc_mem_secure_free(ptr, len); \
+} while (0);
 int sc_mem_reverse(unsigned char *buf, size_t len);
 
 int sc_get_cache_dir(sc_context_t *ctx, char *buf, size_t bufsize);

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -758,7 +758,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	}
 
 err:
-	sc_mem_secure_free(buf, buflen);
+	sc_mem_secure_clear_free(buf, buflen);
 
 	LOG_FUNC_RETURN(ctx, r);
 }

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -726,8 +726,10 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	          (flags & SC_ALGORITHM_RSA_PADS) == SC_ALGORITHM_RSA_PAD_NONE) {
 		/* Add zero-padding if input is shorter than the modulus */
 		if (inlen < modlen) {
-			if (modlen > buflen)
-				return SC_ERROR_BUFFER_TOO_SMALL;
+			if (modlen > buflen) {
+				r = SC_ERROR_BUFFER_TOO_SMALL;
+				goto err;
+			}
 			memmove(tmp+modlen-inlen, tmp, inlen);
 			memset(tmp, 0, modlen-inlen);
 		}

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2557,8 +2557,7 @@ void sc_pkcs15_free_object_content(struct sc_pkcs15_object *obj)
 			|| SC_PKCS15_TYPE_SKEY & obj->type
 			|| SC_PKCS15_TYPE_PRKEY & obj->type) {
 			/* clean everything that potentially contains a secret */
-			sc_mem_clear(obj->content.value, obj->content.len);
-			sc_mem_secure_free(obj->content.value, obj->content.len);
+			sc_mem_secure_clear_free(obj->content.value, obj->content.len);
 		} else {
 			free(obj->content.value);
 		}

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -55,7 +55,7 @@ signature_data_release(struct signature_data *data)
 	if (!data)
 		return;
 	sc_pkcs11_release_operation(&data->md);
-	sc_mem_secure_free(data->buffer, data->buffer_len);
+	sc_mem_secure_clear_free(data->buffer, data->buffer_len);
 	free(data);
 }
 
@@ -77,7 +77,7 @@ signature_data_buffer_append(struct signature_data *data,
 		memcpy(new_buffer, data->buffer, data->buffer_len);
 	memcpy(new_buffer+data->buffer_len, in, in_len);
 
-	sc_mem_secure_free(data->buffer, data->buffer_len);
+	sc_mem_secure_clear_free(data->buffer, data->buffer_len);
 	data->buffer = new_buffer;
 	data->buffer_len = new_len;
 	return CKR_OK;

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -216,8 +216,7 @@ CK_RV push_login_state(struct sc_pkcs11_slot *slot,
 err:
 	if (login) {
 		if (login->pPin) {
-			sc_mem_clear(login->pPin, login->ulPinLen);
-			sc_mem_secure_free(login->pPin, login->ulPinLen);
+			sc_mem_secure_clear_free(login->pPin, login->ulPinLen);
 		}
 		free(login);
 	}
@@ -232,8 +231,7 @@ void pop_login_state(struct sc_pkcs11_slot *slot)
 		if (size > 0) {
 			struct sc_pkcs11_login *login = list_get_at(&slot->logins, size-1);
 			if (login) {
-				sc_mem_clear(login->pPin, login->ulPinLen);
-				sc_mem_secure_free(login->pPin, login->ulPinLen);
+				sc_mem_secure_clear_free(login->pPin, login->ulPinLen);
 				free(login);
 			}
 			if (0 > list_delete_at(&slot->logins, size-1))
@@ -247,8 +245,7 @@ void pop_all_login_states(struct sc_pkcs11_slot *slot)
 	if (sc_pkcs11_conf.atomic && slot) {
 		struct sc_pkcs11_login *login = list_fetch(&slot->logins);
 		while (login) {
-			sc_mem_clear(login->pPin, login->ulPinLen);
-			sc_mem_secure_free(login->pPin, login->ulPinLen);
+			sc_mem_secure_clear_free(login->pPin, login->ulPinLen);
 			free(login);
 			login = list_fetch(&slot->logins);
 		}

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -359,7 +359,7 @@ CK_RV sc_to_cryptoki_error(int rc, const char *ctx);
 void sc_pkcs11_print_attrs(int level, const char *file, unsigned int line, const char *function,
 		const char *info, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);
 #define dump_template(level, info, pTemplate, ulCount) \
-		sc_pkcs11_print_attrs(level, __FILE__, __LINE__, __FUNCTION__, \
+		sc_pkcs11_print_attrs(level, FILENAME, __LINE__, __FUNCTION__, \
 				info, pTemplate, ulCount)
 
 /* Slot and card handling functions */


### PR DESCRIPTION
Fixes #2300

Note, that I've used `sc_mem_secure_alloc()` for saving the input data.

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [x] macOS tokend is tested
