### PR TITLE
Fix dist build because of missing pkcs15-iasecc.h

### DIFF
--- a/src/pkcs15init/Makefile.am
+++ b/src/pkcs15init/Makefile.am
@@ -4,7 +4,7 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 EXTRA_DIST = Makefile.mak
 
 noinst_LTLIBRARIES = libpkcs15init.la
-noinst_HEADERS = profile.h pkcs15-init.h pkcs15-oberthur.h
+noinst_HEADERS = profile.h pkcs15-init.h pkcs15-oberthur.h pkcs15-iasecc.h
 dist_pkgdata_DATA = \
 	cyberflex.profile \
 	flex.profile \


### PR DESCRIPTION
This file should be enclosed with the packages.
When we run 'make distcheck', we can notice that it is missing.

This fix is required for the release 0.22

Fix: #2315
