### PR TITLE
Fix missing test-duplicate-symbols.sh

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-test.sh \
                       test-pkcs11-tool-test-threads.sh \
                       test-pkcs11-tool-sign-verify.sh \
+                      test-duplicate-symbols.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh
 
 TESTS = \


### PR DESCRIPTION
make distcheck fails because this script is missing from the package.

Fix: commit b486965, issue #2317
