### PR TITLE
pkcs15-tool: Write data objects in binary mode

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -389,7 +389,7 @@ print_data_object(const char *kind, const u8*data, size_t data_len)
 
 	if (opt_outfile != NULL) {
 		FILE *outf;
-		outf = fopen(opt_outfile, "w");
+		outf = fopen(opt_outfile, "wb");
 		if (outf == NULL) {
 			fprintf(stderr, "Error opening file '%s': %s\n",
 				opt_outfile, strerror(errno));


### PR DESCRIPTION
Writing out data objects to a file in win32 results in all instances of 0x0a being replaced with 0x0d0a since the output file is opened in text mode.


