### PR TITLE
Fix minidriver tests

### DIFF
--- a/src/tests/opensc-minidriver-test.c
+++ b/src/tests/opensc-minidriver-test.c
@@ -635,8 +635,11 @@ int apiTests(char *reader)
 	atrlen = sizeof(atr);
 
 	if (SCardConnect(cardData.hSCardCtx, reader, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T1, &cardData.hScard, &protocol) != SCARD_S_SUCCESS) {
-		printf("SCardStatus() failed\n");
-		exit(1);
+		printf("SCardStatus(T1) failed, retry with T0\n");
+		if (SCardConnect(cardData.hSCardCtx, reader, SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0, &cardData.hScard, &protocol) != SCARD_S_SUCCESS) {
+			printf("SCardStatus() failed\n");
+			exit(1);
+		}
 	}
 
 	if (SCardStatus(cardData.hScard, NULL, &readernamelen, &state, &protocol, atr, &atrlen) != SCARD_S_SUCCESS) {

--- a/src/tests/opensc-minidriver-test.c
+++ b/src/tests/opensc-minidriver-test.c
@@ -602,7 +602,12 @@ int apiTests(char *reader)
 	unsigned char atr[36], cardid[16];
 	DWORD dwrc,dwlen,dwparam;
 	BOOL flag;
+	char *pinEnv = getenv("MINIDRIVER_PIN");
 
+	if (pinEnv)
+		printf("Running tests using PIN=%s/len=%zd\n", pinEnv, strlen(pinEnv));
+	else
+		printf("Running tests wihtout any PIN\n");
 	memset(&cardData, 0, sizeof(cardData));
 	cardData.dwVersion = 7;
 	cardData.pwszCardName = L"TestCard";
@@ -703,14 +708,17 @@ int apiTests(char *reader)
 	
 	printf("Calling CardGetProperty(CP_CARD_LIST_PINS)");
 	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_LIST_PINS, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == CREATE_PIN_SET(ROLE_USER))));
+	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (IS_PIN_SET(dwparam, ROLE_USER))));
+	/* let's continue the tests only for the ROLE_USER */
+	dwparam = 0;
+	SET_PIN(dwparam, ROLE_USER);
 
 	printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
 	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
 	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 0)));
 
 	printf("Calling CardGetProperty(CP_CARD_PIN_STRENGTH_VERIFY)");
-	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_PIN_STRENGTH_VERIFY, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
+	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_PIN_STRENGTH_VERIFY, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, ROLE_USER);
 	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == CARD_PIN_STRENGTH_PLAINTEXT)));
 
 	printf("Calling CardGetProperty(CP_KEY_IMPORT_SUPPORT)");
@@ -756,36 +764,40 @@ int apiTests(char *reader)
 	printf(" - %x : %s\n", dwrc, verdict(dwrc == SCARD_S_SUCCESS));
 
 	printf("Calling CardAuthenticatePin(wszCARD_USER_USER)");
-	dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, "648219", 6, &dwparam);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 3)));
+	if (pinEnv) {
+		dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, pinEnv, (DWORD)strlen(pinEnv), &dwparam);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == -1)));
 
-	printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
-	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 2)));
+		printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
+		dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 2)));
 
-	printf("Calling CardAuthenticatePin(wszCARD_USER_USER) - Wrong PIN");
-	dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, "123456", 6, &dwparam);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_W_WRONG_CHV) && (dwparam == 2)));
+		printf("Calling CardAuthenticatePin(wszCARD_USER_USER) - Wrong PIN");
+		dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, "3456", 4, &dwparam);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_W_WRONG_CHV) && (dwparam == 2)));
 
-	printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
-	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 0)));
+		printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
+		dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 0)));
 
-	printf("Calling CardAuthenticatePin(wszCARD_USER_USER)");
-	dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, "648219", 6, &dwparam);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 3)));
+		printf("Calling CardAuthenticatePin(wszCARD_USER_USER)");
+		dwrc = (*cardData.pfnCardAuthenticatePin)(&cardData, wszCARD_USER_USER, pinEnv, (DWORD)strlen(pinEnv), &dwparam);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == -1)));
 
-	printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
-	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 2)));
+		printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
+		dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 2)));
 
-	printf("Calling CardDeAuthenticate(wszCARD_USER_USER)");
-	dwrc = (*cardData.pfnCardDeauthenticate)(&cardData, wszCARD_USER_USER, 0);
-	printf(" - %x : %s\n", dwrc, verdict(dwrc == SCARD_S_SUCCESS));
+		printf("Calling CardDeAuthenticate(wszCARD_USER_USER)");
+		dwrc = (*cardData.pfnCardDeauthenticate)(&cardData, wszCARD_USER_USER, 0);
+		printf(" - %x : %s\n", dwrc, verdict(dwrc == SCARD_S_SUCCESS));
 
-	printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
-	dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
-	printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 0)));
+		printf("Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE)");
+		dwrc = (*cardData.pfnCardGetProperty)(&cardData, CP_CARD_AUTHENTICATED_STATE, (PBYTE)&dwparam, sizeof(dwparam), &dwlen, 0);
+		printf(" - %x : %s\n", dwrc, verdict((dwrc == SCARD_S_SUCCESS) && (dwparam == 0)));
+	} else {
+		printf(" - skip: missing set MINIDRIVER_PIN=abcd\n");
+	}
 
 	printf("Calling CardDeleteContext()");
 	dwrc = (*cardData.pfnCardDeleteContext)(&cardData);


### PR DESCRIPTION
Prior to this commit, 12 tests were failed. If fixes 5 tests.

Usage:
```
cd minidriver
set MINIDRIVER_PIN=1234
..\tests\opensc-minidriver-test.exe -r "Gemalto USB SmartCard Reader 0" -a
Running tests using PIN=1234/len=4
SCardStatus(T1) failed, retry with T0
Calling CardAcquireContext() - 0 : Passed
Calling CardQueryFreeSpace() - 0 : Passed
Calling CardGetProperty(CP_CARD_FREE_SPACE) - 0 : Passed
Calling CardQueryCapabilities() - 0 : Passed
Calling CardGetProperty(CP_CARD_CAPABILITIES) - 0 : Passed
Calling CardQueryKeySizes() - 0 : Passed
Calling CardGetProperty(CP_CARD_KEYSIZES) - 0 : Passed
Calling CardGetProperty(CP_CARD_READ_ONLY) - 0 : Passed
Calling CardGetProperty(CP_CARD_CACHE_MODE) - 0 : Passed
Calling CardGetProperty(CP_SUPPORTS_WIN_X509_ENROLLMENT) - 0 : Passed
Calling CardGetProperty(CP_CARD_GUID) - 0 : Passed
Calling CardGetProperty(CP_CARD_SERIAL_NO) - 0 : Passed
Calling CardGetProperty(CP_CARD_PIN_INFO) - 0 : Passed
Calling CardGetProperty(CP_CARD_LIST_PINS) - 0 : Passed
Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE) - 80100004 : Failed
Calling CardGetProperty(CP_CARD_PIN_STRENGTH_VERIFY) - 0 : Passed
Calling CardGetProperty(CP_KEY_IMPORT_SUPPORT) - 0 : Passed
Calling CardReadFile(cardid) - 0 : Passed
Calling CardReadFile(cardcf) - 0 : Passed
Calling CardReadFile(cardapps) - 0 : Passed
Calling CardReadFile(mscp/cmapfile) - 0 : Passed
Calling CardReadFile(mscp/msroots) - 80100024 : Failed
Calling CardGetFileInfo(mscp/cmapfile) - 0 : Passed
Calling CardReadFile(mscp/kxc00) - 80100024 : Failed
Calling CardEnumFiles(root) - 0 : Passed
Calling CardGetContainerInfo(0) - 0 : Passed
Calling CardAuthenticatePin(wszCARD_USER_USER) - 0 : Passed
Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE) - 80100004 : Failed
Calling CardAuthenticatePin(wszCARD_USER_USER) - Wrong PIN - 8010006b : Passed
Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE) - 80100004 : Failed
Calling CardAuthenticatePin(wszCARD_USER_USER) - 0 : Passed
Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE) - 80100004 : Failed
Calling CardDeAuthenticate(wszCARD_USER_USER) - 0 : Passed
Calling CardGetProperty(CP_CARD_AUTHENTICATED_STATE) - 80100004 : Failed
Calling CardDeleteContext() - 0 : Passed
Unit test finished.
35 tests performed.
7 tests failed.
```