### PR TITLE
Fix 'make check' when make --jobs= is used

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,6 +9,7 @@ dist_noinst_SCRIPTS = common.sh \
                       test-pkcs11-tool-sign-verify.sh \
                       test-pkcs11-tool-allowed-mechanisms.sh
 
+.NOTPARALLEL:
 TESTS = \
         test-manpage.sh \
         test-duplicate-symbols.sh \


### PR DESCRIPTION
The error was:
```
PASS: test-duplicate-symbols.sh
PASS: test-pkcs11-tool-allowed-mechanisms.sh
XFAIL: test-pkcs11-tool-test.sh
XFAIL: test-pkcs11-tool-test-threads.sh
PASS: test-manpage.sh
FAIL: test-pkcs11-tool-sign-verify.sh
============================================================================
Testsuite summary for OpenSC 0.22.0-rc1
============================================================================
============================================================================
See tests/test-suite.log
Please report to https://github.com/OpenSC/OpenSC/issues
============================================================================
```

This is because more than 1 test is executed at the same time. So
`card_cleanup()` is called at the end of one test while another test is
still running.

The problem is easy to replicate using `make --jobs=2`.
