### PR TITLE
Gemalto (Safenet) IDBridge K30 (Fina QSCD) support

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -287,9 +287,11 @@ static int idprime_pubfile_get_keyinfo(sc_card_t *card, u8 *pubfile_df, idprime_
 	/* select file */
 	memcpy(tinfo_path.value, pubfile_df, 2);
 	r = iso_ops->select_file(card, &tinfo_path, &file);
+	if (r != SC_SUCCESS)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 	const size_t file_size = file->size;
 	sc_file_free(file);
-	if (r != SC_SUCCESS || file->size == 0)
+	if (file_size == 0)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	/* read whole file */

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -378,7 +378,9 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 					new_object.key_reference = 0x11 + key_id;
 					break;
 				case SC_CARD_TYPE_IDPRIME_V3:
-					new_object.key_reference = 0xF7 + key_id;
+					//new_object.key_reference = 0xF7 + key_id; // how it was
+					//new_object.key_reference = 0xF5 + key_id; // mine IDBridge K30
+					new_object.key_reference = 0xF0 + start[2];
 					break;
 				case SC_CARD_TYPE_IDPRIME_V4:
 					new_object.key_reference = 0x56 + key_id;

--- a/src/libopensc/pkcs15-idprime.c
+++ b/src/libopensc/pkcs15-idprime.c
@@ -168,9 +168,17 @@ static int sc_pkcs15emu_idprime_init(sc_pkcs15_card_t *p15card)
 		pubkey_info.native        = 1;
 		prkey_info.native        = 1;
 
-		snprintf(cert_obj.label, SC_PKCS15_MAX_LABEL_SIZE, CERT_LABEL_TEMPLATE, i+1);
-		snprintf(pubkey_obj.label, SC_PKCS15_MAX_LABEL_SIZE, PUBKEY_LABEL_TEMPLATE, i+1);
-		snprintf(prkey_obj.label, SC_PKCS15_MAX_LABEL_SIZE, PRIVKEY_LABEL_TEMPLATE, i+1);
+		if (prkey_info.aux_data != NULL) {
+			/* note: xxx_obj.label are all zeroed thus null terminated */
+			strncpy(cert_obj.label, (const char *)prkey_info.aux_data, SC_PKCS15_MAX_LABEL_SIZE - 1);
+			strncpy(pubkey_obj.label, (const char *)prkey_info.aux_data, SC_PKCS15_MAX_LABEL_SIZE - 1);
+			strncpy(prkey_obj.label, (const char *)prkey_info.aux_data, SC_PKCS15_MAX_LABEL_SIZE - 1);
+			prkey_info.aux_data = NULL;
+		} else {
+			snprintf(cert_obj.label, SC_PKCS15_MAX_LABEL_SIZE, CERT_LABEL_TEMPLATE, i+1);
+			snprintf(pubkey_obj.label, SC_PKCS15_MAX_LABEL_SIZE, PUBKEY_LABEL_TEMPLATE, i+1);
+			snprintf(prkey_obj.label, SC_PKCS15_MAX_LABEL_SIZE, PRIVKEY_LABEL_TEMPLATE, i+1);
+		}
 		prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
 		sc_pkcs15_format_id(pin_id, &prkey_obj.auth_id);
 


### PR DESCRIPTION
This is first of series of patches to support my Gemalto USB eToken.
I'm not sure of exact model as it's distributed by croatian finance agency under the name Fina QCSD.

On google I found image of Gemalto (Safenet) IDBridge K30 that looks exactly like my token.

I have it working correctly under linux with opensc and official closed source binary driver (libeToken.so.10.7.77, libIDPrimePKCS11.so.10.7.77) - installed from safenetauthenticationclient_10.7.77_amd64.deb

I've managed to get wireshark captures with official driver. I have zero/minimal knowledge/experience of OpenSC and tokens so any help recommendations would be helpful.

I'm patching card-idprime.c code, I don't think I need to create completely separate driver for this?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

```bash
# output of: opensc-tool -n
Using reader with a card: Gemalto USB Shell Token V2 (xxxxxxxx) 00 00
Gemalto IDPrime (generic)

# output of: lsusb -d 08e6:3438 -v
Bus 003 Device 031: ID 08e6:3438 Gemalto (was Gemplus) GemPC Key SmartCard Reader
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0 
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x08e6 Gemalto (was Gemplus)
  idProduct          0x3438 GemPC Key SmartCard Reader
  bcdDevice            2.00
  iManufacturer           1 Gemalto
  iProduct                2 USB SmartCard Reader
  iSerial                 3 XhiddenX
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x005d
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0x80
      (Bus Powered)
    MaxPower               50mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           3
      bInterfaceClass        11 Chip/SmartCard
      bInterfaceSubClass      0 
      bInterfaceProtocol      0 
      iInterface              0 
      ChipCard Interface Descriptor:
        bLength                54
        bDescriptorType        33
        bcdCCID              1.01  (Warning: Only accurate for version 1.0)
        nMaxSlotIndex           0
        bVoltageSupport         7  5.0V 3.0V 1.8V 
        dwProtocols             3  T=0 T=1
        dwDefaultClock       4800
        dwMaxiumumClock      4800
        bNumClockSupported      0
        dwDataRate          12903 bps
        dwMaxDataRate      825806 bps
        bNumDataRatesSupp.     50
        dwMaxIFSD             254
        dwSyncProtocols  00000000 
        dwMechanical     00000000 
        dwFeatures       00010230
          Auto clock change
          Auto baud rate change
          NAD value other than 0x00 accepted
          TPDU level exchange
        dwMaxCCIDMsgLen       271
        bClassGetResponse      00
        bClassEnvelope         00
        wlcdLayout           none
        bPINSupport             0 
        bMaxCCIDBusySlots       1
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x01  EP 1 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x82  EP 2 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x83  EP 3 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0008  1x 8 bytes
        bInterval              16
can't get device qualifier: Resource temporarily unavailable
can't get debug descriptor: Resource temporarily unavailable
Device Status:     0x0000
  (Bus Powered)

```
