### PR TITLE
First draft of migration to new OpenSSL 3.0 API

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1318,9 +1318,9 @@ authentic_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 	}
 
 	if (pin_cmd->pin1.data)
-		SHA1(pin_cmd->pin1.data, pin_cmd->pin1.len, pin_sha1);
+		EVP_Digest(pin_cmd->pin1.data, pin_cmd->pin1.len, pin_sha1, NULL, EVP_sha1(), NULL);
 	else
-		SHA1((unsigned char *)"", 0, pin_sha1);
+		EVP_Digest((unsigned char *)"", 0, pin_sha1, NULL, EVP_sha1(), NULL);
 
 	if (!memcmp(pin_sha1, prv_data->pins_sha1[pin_cmd->pin_reference], SHA_DIGEST_LENGTH))   {
 		sc_log(ctx, "Already verified");

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -44,6 +44,7 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif /* ENABLE_OPENSSL */
 
 #include "internal.h"
@@ -1707,7 +1708,7 @@ static int cac_populate_cac_alt(sc_card_t *card, int index, cac_private_data_t *
 		if (priv->cac_id == NULL) {
 			return SC_ERROR_OUT_OF_MEMORY;
 		}
-		SHA1(val, val_len, priv->cac_id);
+		EVP_Digest(val, val_len, priv->cac_id, NULL, EVP_sha1(), NULL);
 		priv->cac_id_len = 20;
 		sc_debug_hex(card->ctx, SC_LOG_DEBUG_VERBOSE,
 		    "cuid", priv->cac_id, priv->cac_id_len);

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -44,6 +44,7 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif /* ENABLE_OPENSSL */
 
 #include "internal.h"
@@ -441,7 +442,7 @@ static int cac_populate_cac1(sc_card_t *card, int index, cac_private_data_t *pri
 			return SC_ERROR_OUT_OF_MEMORY;
 		}
 #ifdef ENABLE_OPENSSL
-		SHA1(val, val_len, priv->cac_id);
+		EVP_Digest(val, val_len, priv->cac_id, NULL, EVP_sha1(), NULL);
 		priv->cac_id_len = 20;
 		sc_debug_hex(card->ctx, SC_LOG_DEBUG_VERBOSE,
 			"cuid", priv->cac_id, priv->cac_id_len);

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -183,7 +183,7 @@ iasecc_chv_cache_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 
 	pin_status->reference = pin_cmd->pin_reference;
 	if (pin_cmd->pin1.data)
-		SHA1(pin_cmd->pin1.data, pin_cmd->pin1.len, pin_status->sha1);
+		EVP_Digest(pin_cmd->pin1.data, pin_cmd->pin1.len, pin_status->sha1, NULL, EVP_sha1(), NULL);
 	else
 		memset(pin_status->sha1, 0, SHA_DIGEST_LENGTH);
 
@@ -246,7 +246,7 @@ iasecc_chv_cache_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_c
 	LOG_FUNC_CALLED(ctx);
 
 	if (pin_cmd->pin1.data)
-		SHA1(pin_cmd->pin1.data, pin_cmd->pin1.len, data_sha1);
+		EVP_Digest(pin_cmd->pin1.data, pin_cmd->pin1.len, data_sha1, NULL, EVP_sha1(), NULL);
 	else
 		memset(data_sha1, 0, SHA_DIGEST_LENGTH);
 	sc_log_hex(ctx, "data_sha1: %s", data_sha1, SHA_DIGEST_LENGTH);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -50,6 +50,7 @@
 #include "errors.h"
 #ifdef ENABLE_OPENSSL
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif /* ENABLE_OPENSSL */
 
 #include "card-openpgp.h"
@@ -2647,7 +2648,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 	p = NULL;
 
 	/* hash with SHA-1 */
-	SHA1(fp_buffer, fp_buffer_len, fingerprint);
+	EVP_Digest(fp_buffer, fp_buffer_len, fingerprint, NULL, EVP_sha1(), NULL);
 	free(fp_buffer);
 
 	/* store to DO */

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -36,6 +36,7 @@
 
 #ifdef ENABLE_OPENSSL
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif
 
 #ifdef HAVE_SYS_TIME_H
@@ -2860,7 +2861,7 @@ sc_pkcs15_get_object_guid(struct sc_pkcs15_card *p15card, const struct sc_pkcs15
 	 * - this also protects against data being too short
 	 */
 #ifdef ENABLE_OPENSSL
-	SHA1(guid_bin, guid_bin_size, guid_bin);
+	EVP_Digest(guid_bin, guid_bin_size, guid_bin, NULL, EVP_sha1(), NULL);
 	guid_bin_size = SHA_DIGEST_LENGTH;
 #else
 	/* If guid_bin has a size larger than 16 bytes

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -2685,13 +2685,16 @@ sc_pkcs15init_select_intrinsic_id(struct sc_pkcs15_card *p15card, struct sc_prof
 	switch (id_style)  {
 	case SC_PKCS15INIT_ID_STYLE_MOZILLA:
 		if (pubkey->algorithm == SC_ALGORITHM_RSA)
-			SHA1(pubkey->u.rsa.modulus.data, pubkey->u.rsa.modulus.len, id.value);
+			EVP_Digest(pubkey->u.rsa.modulus.data, pubkey->u.rsa.modulus.len,
+				id.value, NULL, EVP_sha1(), NULL);
 		else if (pubkey->algorithm == SC_ALGORITHM_DSA)
-			SHA1(pubkey->u.dsa.pub.data, pubkey->u.dsa.pub.len, id.value);
+			EVP_Digest(pubkey->u.dsa.pub.data, pubkey->u.dsa.pub.len,
+				id.value, NULL, EVP_sha1(), NULL);
 		else if (pubkey->algorithm == SC_ALGORITHM_EC)
 			/* ID should be SHA1 of the X coordinate according to PKCS#15 v1.1 */
 			/* skip the 04 tag and get the X component */
-			SHA1(pubkey->u.ec.ecpointQ.value+1, (pubkey->u.ec.ecpointQ.len - 1) / 2, id.value);
+			EVP_Digest(pubkey->u.ec.ecpointQ.value+1, (pubkey->u.ec.ecpointQ.len - 1) / 2,
+				id.value, NULL, EVP_sha1(), NULL);
 		else
 			goto done;
 
@@ -2706,7 +2709,7 @@ sc_pkcs15init_select_intrinsic_id(struct sc_pkcs15_card *p15card, struct sc_prof
 			LOG_TEST_GOTO_ERR(ctx, rv, "Encoding public key error");
 		}
 
-		SHA1(id_data, id_data_len, id.value);
+		EVP_Digest(id_data, id_data_len, id.value, NULL, EVP_sha1(), NULL);
 		id.len = SHA_DIGEST_LENGTH;
 
 		break;

--- a/src/smm/sm-cwa14890.c
+++ b/src/smm/sm-cwa14890.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 
 #include <openssl/des.h>
+#include <openssl/evp.h>
 
 #include "libopensc/opensc.h"
 #include "libopensc/sm.h"
@@ -191,21 +192,21 @@ sm_cwa_init_session_keys(struct sc_context *ctx, struct sm_cwa_session *session_
 	if (mechanism == IASECC_ALGORITHM_SYMMETRIC_SHA1)   {
 		xored[35] = 0x01;
 		sc_debug(ctx, SC_LOG_DEBUG_SM, "XOR for SkEnc %s", sc_dump_hex(xored, 36));
-		SHA1(xored, 36, buff);
+		EVP_Digest(xored, 36, buff, NULL, EVP_sha1(), NULL);
 		memcpy(&session_data->session_enc[0], buff, sizeof(session_data->session_enc));
 
 		xored[35] = 0x02;
 		sc_debug(ctx, SC_LOG_DEBUG_SM, "XOR for SkMac %s", sc_dump_hex(xored, 36));
-		SHA1(xored, 36, buff);
+		EVP_Digest(xored, 36, buff, NULL, EVP_sha1(), NULL);
 		memcpy(&session_data->session_mac[0], buff, sizeof(session_data->session_mac));
 	}
 	else if (mechanism == IASECC_ALGORITHM_SYMMETRIC_SHA256)   {
 		xored[35] = 0x01;
-		SHA256(xored, 36, buff);
+		EVP_Digest(xored, 36, buff, NULL, EVP_sha256(), NULL);
 		memcpy(&session_data->session_enc[0], buff, sizeof(session_data->session_enc));
 
 		xored[35] = 0x02;
-		SHA256(xored, 36, buff);
+		EVP_Digest(xored, 36, buff, NULL, EVP_sha256(), NULL);
 		memcpy(&session_data->session_mac[0], buff, sizeof(session_data->session_mac));
 	}
 	else   {

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -74,8 +74,7 @@ add_object(test_certs_t *objects, CK_ATTRIBUTE key_id, CK_ATTRIBUTE label)
 	o->derive_pub = 0;
 	o->key_type = -1;
 	o->x509 = NULL; /* The "reuse" capability of d2i_X509() is strongly discouraged */
-	o->key.rsa = NULL;
-	o->key.ec = NULL;
+	o->key = NULL;
 
 	/* Store the passed CKA_ID and CKA_LABEL */
 	o->key_id = malloc(key_id.ulValueLen);
@@ -208,30 +207,20 @@ int callback_certificates(test_certs_t *objects,
 	}
 
 	if (EVP_PKEY_base_id(evp) == EVP_PKEY_RSA) {
-		/* Extract public RSA key */
-		const RSA *rsa = EVP_PKEY_get0_RSA(evp);
-		if ((o->key.rsa = RSAPublicKey_dup((RSA *)rsa)) == NULL) {
-			fail_msg("RSAPublicKey_dup failed");
-			return -1;
-		}
+		o->key = evp;
 		o->type = EVP_PK_RSA;
 		o->bits = EVP_PKEY_bits(evp);
 
 	} else if (EVP_PKEY_base_id(evp) == EVP_PKEY_EC) {
-		/* Extract public EC key */
-		const EC_KEY *ec = EVP_PKEY_get0_EC_KEY(evp);
-		if ((o->key.ec = EC_KEY_dup(ec)) == NULL) {
-			fail_msg("EC_KEY_dup failed");
-			return -1;
-		}
+		o->key = evp;
 		o->type = EVP_PK_EC;
 		o->bits = EVP_PKEY_bits(evp);
 
 	} else {
+		EVP_PKEY_free(evp);
 		fprintf(stderr, "[WARN %s ]evp->type = 0x%.4X (not RSA, EC)\n",
 			o->id_str, EVP_PKEY_id(evp));
 	}
-	EVP_PKEY_free(evp);
 
 	debug_print(" [  OK %s ] Certificate with label %s loaded successfully",
 		o->id_str, o->label);
@@ -328,28 +317,66 @@ int callback_public_keys(test_certs_t *objects,
 		BIGNUM *n = NULL, *e = NULL;
 		n = BN_bin2bn(template[4].pValue, template[4].ulValueLen, NULL);
 		e = BN_bin2bn(template[5].pValue, template[5].ulValueLen, NULL);
-		if (o->key.rsa != NULL) {
+		if (o->key != NULL) {
+			int rv;
+#if 1
+// OPENSSL_VERSION_NUMBER < 0x30000000L
 			const BIGNUM *cert_n = NULL, *cert_e = NULL;
-			RSA_get0_key(o->key.rsa, &cert_n, &cert_e, NULL);
-			if (BN_cmp(cert_n, n) != 0 ||
-				BN_cmp(cert_e, e) != 0) {
-				debug_print(" [WARN %s ] Got different public key then from the certificate",
+			RSA *rsa = EVP_PKEY_get0_RSA(o->key);
+			RSA_get0_key(rsa, &cert_n, &cert_e, NULL);
+#else
+//TODO This looks broken in in current OpenSSL 3.0
+			BIGNUM *cert_n = NULL, *cert_e = NULL;
+			if ((EVP_PKEY_get_bn_param(o->key, OSSL_PKEY_PARAM_RSA_N, &cert_n) != 1) ||
+			    (EVP_PKEY_get_bn_param(o->key, OSSL_PKEY_PARAM_RSA_E, &cert_e) != 1)) {
+				debug_print(" [WARN %s ] Failed to get RSA key parameters",
 					o->id_str);
+				BN_free(cert_n);
 				BN_free(n);
 				BN_free(e);
 				return -1;
 			}
+#endif
+			rv = BN_cmp(cert_n, n) != 0 || BN_cmp(cert_e, e) != 0;
+			if (rv != 0) {
+				o->verify_public = 1;
+			} else {
+				debug_print(" [WARN %s ] Got different public key then from the certificate",
+					o->id_str);
+			}
+#if 0
+// OPENSSL_VERSION_NUMBER >= 0x30000000L
+			BN_free(cert_n);
+			BN_free(cert_e);
+#endif
 			BN_free(n);
 			BN_free(e);
-			o->verify_public = 1;
 		} else { /* store the public key for future use */
 			o->type = EVP_PK_RSA;
-			o->key.rsa = RSA_new();
-			if (RSA_set0_key(o->key.rsa, n, e, NULL) != 1) {
+			o->key = EVP_PKEY_new();
+#if 1
+// OPENSSL_VERSION_NUMBER < 0x30000000L
+			RSA *rsa = RSA_new();
+			if (RSA_set0_key(rsa, n, e, NULL) != 1 ||
+			    EVP_PKEY_set1_RSA(o->key, rsa))
+#else
+//TODO This looks broken in in current OpenSSL 3.0
+			if ((EVP_PKEY_set_bn_param(o->key, OSSL_PKEY_PARAM_RSA_N, n) != 1) ||
+			    (EVP_PKEY_set_bn_param(o->key, OSSL_PKEY_PARAM_RSA_E, e) != 1))
+#endif
+			{
 				fail_msg("Unable to set key params");
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+				BN_free(n);
+				BN_free(e);
+#endif
 				return -1;
 			}
-			o->bits = RSA_bits(o->key.rsa);
+			o->bits = EVP_PKEY_bits(o->key);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+			BN_free(n);
+			BN_free(e);
+#endif
 			n = NULL;
 			e = NULL;
 		}
@@ -407,9 +434,10 @@ int callback_public_keys(test_certs_t *objects,
 			return -1;
 		}
 
-		if (o->key.ec != NULL) {
-			const EC_GROUP *cert_group = EC_KEY_get0_group(o->key.ec);
-			const EC_POINT *cert_point = EC_KEY_get0_public_key(o->key.ec);
+		if (o->key != NULL) {
+			EC_KEY *ec = EVP_PKEY_get0_EC_KEY(o->key);
+			const EC_GROUP *cert_group = EC_KEY_get0_group(ec);
+			const EC_POINT *cert_point = EC_KEY_get0_public_key(ec);
 			int cert_nid = EC_GROUP_get_curve_name(cert_group);
 
 			if (cert_nid != nid ||
@@ -427,10 +455,12 @@ int callback_public_keys(test_certs_t *objects,
 			o->verify_public = 1;
 		} else { /* store the public key for future use */
 			o->type = EVP_PK_EC;
-			o->key.ec = EC_KEY_new_by_curve_name(nid);
-			EC_KEY_set_public_key(o->key.ec, ecpoint);
-			EC_KEY_set_group(o->key.ec, ecgroup);
+			o->key = EVP_PKEY_new();
+			EC_KEY *ec = EC_KEY_new_by_curve_name(nid);
+			EC_KEY_set_public_key(ec, ecpoint);
+			EC_KEY_set_group(ec, ecgroup);
 			o->bits = EC_GROUP_get_degree(ecgroup);
+			EVP_PKEY_set1_EC_KEY(o->key, ec);
 		}
 	} else if (o->key_type == CKK_EC_EDWARDS
 		|| o->key_type == CKK_EC_MONTGOMERY) {
@@ -511,13 +541,13 @@ int callback_public_keys(test_certs_t *objects,
 			ASN1_STRING_free(os);
 			return -1;
 		}
-		if (o->key.pkey != NULL) {
+		if (o->key != NULL) {
 			unsigned char *pub = NULL;
 			size_t publen = 0;
 
 			/* TODO check EVP_PKEY type */
 
-			if (EVP_PKEY_get_raw_public_key(o->key.pkey, NULL, &publen) != 1) {
+			if (EVP_PKEY_get_raw_public_key(o->key, NULL, &publen) != 1) {
 				debug_print(" [WARN %s ] Can not get size of the key", o->id_str);
 				ASN1_STRING_free(os);
 				return -1;
@@ -529,7 +559,7 @@ int callback_public_keys(test_certs_t *objects,
 				return -1;
 			}
 
-			if (EVP_PKEY_get_raw_public_key(o->key.pkey, pub, &publen) != 1 ||
+			if (EVP_PKEY_get_raw_public_key(o->key, pub, &publen) != 1 ||
 				publen != (size_t)os->length ||
 				memcmp(pub, os->data, publen) != 0) {
 				debug_print(" [WARN %s ] Got different public"
@@ -544,7 +574,7 @@ int callback_public_keys(test_certs_t *objects,
 			o->verify_public = 1;
 		} else { /* store the public key for future use */
 			o->type = evp_type;
-			o->key.pkey = key;
+			o->key = key;
 			o->bits = 255;
 		}
 		ASN1_STRING_free(os);
@@ -725,15 +755,8 @@ void clean_all_objects(test_certs_t *objects) {
 		free(objects->data[i].id_str);
 		free(objects->data[i].label);
 		X509_free(objects->data[i].x509);
-		if (objects->data[i].key_type == CKK_RSA &&
-		    objects->data[i].key.rsa != NULL) {
-			RSA_free(objects->data[i].key.rsa);
-		} else if (objects->data[i].key_type == CKK_EC &&
-			objects->data[i].key.ec != NULL) {
-			EC_KEY_free(objects->data[i].key.ec);
-		} else if (objects->data[i].key_type == CKK_EC_EDWARDS &&
-			objects->data[i].key.pkey != NULL) {
-			EVP_PKEY_free(objects->data[i].key.pkey);
+		if (objects->data[i].key != NULL) {
+			EVP_PKEY_free(objects->data[i].key);
 		}
 	}
 	free(objects->data);

--- a/src/tests/p11test/p11test_case_common.h
+++ b/src/tests/p11test/p11test_case_common.h
@@ -25,6 +25,9 @@
 #include <openssl/x509.h>
 #include <openssl/rsa.h>
 #include <openssl/err.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+# include <openssl/core_names.h>
+#endif
 #include "p11test_common.h"
 
 typedef struct {
@@ -33,11 +36,7 @@ typedef struct {
 	char		*id_str;
 	X509		*x509;
 	int		 type;
-	union {
-		RSA		*rsa;
-		EC_KEY	*ec;
-		EVP_PKEY	*pkey;
-	} key;
+	EVP_PKEY	*key;
 	CK_OBJECT_HANDLE private_handle;
 	CK_OBJECT_HANDLE public_handle;
 	CK_BBOOL	sign;

--- a/src/tests/p11test/p11test_case_ec_derive.c
+++ b/src/tests/p11test/p11test_case_ec_derive.c
@@ -143,7 +143,7 @@ int test_derive_x25519(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 		return 1;
 	}
 
-	rc = EVP_PKEY_derive_set_peer(pctx, o->key.pkey);
+	rc = EVP_PKEY_derive_set_peer(pctx, o->key);
 	if (rc != 1) {
 		debug_print(" [ KEY %s ] EVP_PKEY_derive_set_peer failed", o->id_str);
 		EVP_PKEY_CTX_free(pctx);
@@ -215,7 +215,7 @@ int test_derive_x25519(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 int test_derive(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 {
 	int nid, field_size;
-	EC_KEY *key = NULL;
+	EC_KEY *key = NULL, *pkey = NULL;
 	const EC_POINT *publickey = NULL;
 	const EC_GROUP *group = NULL;
 	unsigned char *secret = NULL, *pkcs11_secret = NULL;
@@ -263,10 +263,10 @@ int test_derive(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 		EC_KEY_free(key);
 		return 1;
 	}
-
+	pkey = EVP_PKEY_get0_EC_KEY(o->key);
 	/* Derive the shared secret locally */
 	secret_len = ECDH_compute_key(secret, secret_len,
-		EC_KEY_get0_public_key(o->key.ec), key, NULL);
+		EC_KEY_get0_public_key(pkey), key, NULL);
 
 	/* Try to do the same with the card key */
 

--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -188,24 +188,47 @@ size_t get_hash_length(CK_MECHANISM_TYPE mech)
 CK_BYTE *hash_message(const CK_BYTE *message, size_t message_length,
     CK_MECHANISM_TYPE hash)
 {
+	CK_BYTE *out = NULL;
+
 	switch (hash) {
 	case CKM_SHA224:
-		return SHA224(message, message_length, NULL);
+		out = malloc(SHA224_DIGEST_LENGTH);
+		if (out == NULL)
+			return NULL;
+		EVP_Digest(message, message_length, out, NULL, EVP_sha224(), NULL);
+		break;
 
 	case CKM_SHA256:
-		return SHA256(message, message_length, NULL);
+		out = malloc(SHA256_DIGEST_LENGTH);
+		if (out == NULL)
+			return NULL;
+		EVP_Digest(message, message_length, out, NULL, EVP_sha256(), NULL);
+		break;
 
 	case CKM_SHA384:
-		return SHA384(message, message_length, NULL);
+		out = malloc(SHA384_DIGEST_LENGTH);
+		if (out == NULL)
+			return NULL;
+		EVP_Digest(message, message_length, out, NULL, EVP_sha384(), NULL);
+		break;
 
 	case CKM_SHA512:
-		return SHA512(message, message_length, NULL);
+		out = malloc(SHA512_DIGEST_LENGTH);
+		if (out == NULL)
+			return NULL;
+		EVP_Digest(message, message_length, out, NULL, EVP_sha512(), NULL);
+		break;
 
 	case CKM_SHA_1:
 	default:
-		return SHA1(message, message_length, NULL);
+		out = malloc(SHA_DIGEST_LENGTH);
+		if (out == NULL)
+			return NULL;
+		EVP_Digest(message, message_length, out, NULL, EVP_sha1(), NULL);
+		break;
 
 	}
+	return out;
 }
 
 int oaep_encrypt_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -71,9 +71,11 @@ rsa_x_509_pad_message(const unsigned char *message,
 int encrypt_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
     CK_ULONG message_length, test_mech_t *mech, unsigned char **enc_message)
 {
-	int rv, padding;
+	int rv = -1, padding;
+	size_t outlen = 0;
+	EVP_PKEY_CTX *ctx = NULL;
 
-	*enc_message = malloc(RSA_size(o->key.rsa));
+	*enc_message = malloc(EVP_PKEY_size(o->key));
 	if (*enc_message == NULL) {
 		debug_print("malloc returned null");
 		return -1;
@@ -81,15 +83,19 @@ int encrypt_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message
 
 	/* Prepare padding for RSA_X_509 */
 	padding = ((mech->mech == CKM_RSA_X_509) ? RSA_NO_PADDING : RSA_PKCS1_PADDING);
-	rv = RSA_public_encrypt(message_length, message,
-		*enc_message, o->key.rsa, padding);
-	if (rv < 0) {
+
+	ctx = EVP_PKEY_CTX_new(o->key, NULL);
+	if (!ctx || (rv = EVP_PKEY_encrypt_init(ctx)) <= 0 ||
+	    (rv = EVP_PKEY_CTX_set_rsa_padding(ctx, padding)) <= 0 ||
+	    (rv = EVP_PKEY_encrypt(ctx, *enc_message, &outlen, message, message_length)) <= 0) {
 		free(*enc_message);
 		*enc_message = NULL;
-		debug_print("RSA_public_encrypt: rv = 0x%.8X\n", rv);
+		EVP_PKEY_CTX_free(ctx);
+		debug_print("OpenSSL encrypt failed: rv = 0x%.8X\n", rv);
 		return -1;
 	}
-	return rv;
+	EVP_PKEY_CTX_free(ctx);
+	return outlen;
 }
 
 int encrypt_message(test_cert_t *o, token_info_t *info, CK_BYTE *message,
@@ -198,7 +204,7 @@ int encrypt_decrypt_test(test_cert_t *o, token_info_t *info, test_mech_t *mech,
 	}
 
 	if (o->type != EVP_PK_RSA) {
-		debug_print(" [ KEY %s ] Skip non-RSA key for encryption", o->id_str);
+		debug_print(" [SKIP %s ] Skip non-RSA key for encryption", o->id_str);
 		return 0;
 	}
 
@@ -349,106 +355,57 @@ int verify_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 	int cmp_message_length;
 
 	if (o->type == EVP_PK_RSA) {
-		int type;
-
-		/* raw RSA mechanism */
-		if (mech->mech == CKM_RSA_PKCS || mech->mech == CKM_RSA_X_509) {
-			CK_BYTE dec_message[BUFFER_SIZE];
-			int padding = ((mech->mech == CKM_RSA_X_509)
-				? RSA_NO_PADDING : RSA_PKCS1_PADDING);
-			int dec_message_length = RSA_public_decrypt(sign_length, sign,
-				dec_message, o->key.rsa, padding);
-			if (dec_message_length < 0) {
-				fprintf(stderr, "RSA_public_decrypt: rv = %d: %s\n", dec_message_length,
-					ERR_error_string(ERR_peek_last_error(), NULL));
-				return -1;
-			}
-			if (memcmp(dec_message, message, dec_message_length) == 0
-					&& dec_message_length == (int) message_length) {
-				debug_print(" [  OK %s ] Signature is valid.", o->id_str);
-				mech->result_flags |= FLAGS_SIGN_OPENSSL;
-				return 1;
-			} else {
-				fprintf(stderr, " [ ERROR %s ] Signature is not valid. Error: %s\n",
-					o->id_str, ERR_error_string(ERR_peek_last_error(), NULL));
-				return 0;
-			}
-		}
+		EVP_PKEY_CTX *ctx = NULL;
+		const EVP_MD *md = NULL;
+		int padding = RSA_PKCS1_PADDING;
 
 		/* Digest mechanisms */
 		switch (mech->mech) {
+		case CKM_RSA_X_509:
+			padding = RSA_NO_PADDING;
+			break;
 		case CKM_SHA1_RSA_PKCS:
-			cmp_message_length = SHA_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha1(), NULL);
-			type = NID_sha1;
+			md = EVP_sha1();
 			break;
 		case CKM_SHA224_RSA_PKCS:
-			cmp_message_length = SHA224_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha224(), NULL);
-			type = NID_sha224;
+			md = EVP_sha224();
 			break;
 		case CKM_SHA256_RSA_PKCS:
-			cmp_message_length = SHA256_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha256(), NULL);
-			type = NID_sha256;
+			md = EVP_sha256();
 			break;
 		case CKM_SHA384_RSA_PKCS:
-			cmp_message_length = SHA384_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha384(), NULL);
-			type = NID_sha384;
+			md = EVP_sha384();
 			break;
 		case CKM_SHA512_RSA_PKCS:
-			cmp_message_length = SHA512_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha512(), NULL);
-			type = NID_sha512;
+			md = EVP_sha512();
 			break;
 		case CKM_MD5_RSA_PKCS:
-			cmp_message_length = MD5_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_md5(), NULL);
-			type = NID_md5;
+			md = EVP_md5();
 			break;
 		case CKM_RIPEMD160_RSA_PKCS:
-			cmp_message_length = RIPEMD160_DIGEST_LENGTH;
-			cmp_message = malloc(cmp_message_length);
-			if (cmp_message == NULL)
-				return -1;
-			EVP_Digest(message, message_length, cmp_message, NULL, EVP_ripemd160(), NULL);
-			type = NID_ripemd160;
+			md = EVP_ripemd160();
 			break;
 		default:
 			debug_print(" [SKIP %s ] Skip verify of unknown mechanism", o->id_str);
 			return 0;
 		}
-		rv = RSA_verify(type, cmp_message, cmp_message_length,
-			sign, sign_length, o->key.rsa);
-		if (rv == 1) {
-			debug_print(" [  OK %s ] Signature is valid.", o->id_str);
-			mech->result_flags |= FLAGS_SIGN_OPENSSL;
-		 } else {
+
+		ctx = EVP_PKEY_CTX_new(o->key, NULL);
+		if (!ctx || (rv = EVP_PKEY_verify_init(ctx)) <= 0 ||
+		    (rv = EVP_PKEY_CTX_set_rsa_padding(ctx, padding)) <= 0 ||
+		    (md && (rv = EVP_PKEY_CTX_set_signature_md(ctx, md)) <= 0) ||
+		    (rv = EVP_PKEY_verify(ctx, sign, sign_length, message, message_length)) != 1) {
 			fprintf(stderr, " [ ERROR %s ] Signature is not valid. Error: %s\n",
 				o->id_str, ERR_error_string(ERR_peek_last_error(), NULL));
+			EVP_PKEY_CTX_free(ctx);
 			return -1;
 		}
+		EVP_PKEY_CTX_free(ctx);
+		debug_print(" [  OK %s ] Signature is valid.", o->id_str);
+		return 1;
 	} else if (o->type == EVP_PK_EC) {
 		unsigned int nlen;
+		EC_KEY *ec = NULL;
 		ECDSA_SIG *sig = ECDSA_SIG_new();
 		BIGNUM *r = NULL, *s = NULL;
 		if (sig == NULL) {
@@ -484,7 +441,8 @@ int verify_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 			debug_print(" [SKIP %s ] Skip verify of unknown mechanism", o->id_str);
 			return 0;
 		}
-		rv = ECDSA_do_verify(cmp_message, cmp_message_length, sig, o->key.ec);
+		ec = EVP_PKEY_get0_EC_KEY(o->key);
+		rv = ECDSA_do_verify(cmp_message, cmp_message_length, sig, ec);
 		if (rv == 1) {
 			ECDSA_SIG_free(sig);
 			debug_print(" [  OK %s ] EC Signature of length %lu is valid.",
@@ -501,7 +459,7 @@ int verify_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 		/* need to be created even though we do not do any MD */
 		EVP_MD_CTX *ctx = EVP_MD_CTX_create();
 
-		rv = EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, o->key.pkey);
+		rv = EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, o->key);
 		if (rv != 1) {
 			fprintf(stderr, " [FAIL %s ] EVP_DigestVerifyInit: rv = %lu: %s\n", o->id_str,
 				rv, ERR_error_string(ERR_peek_last_error(), NULL));

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -75,7 +75,8 @@ int encrypt_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message
 	size_t outlen = 0;
 	EVP_PKEY_CTX *ctx = NULL;
 
-	*enc_message = malloc(EVP_PKEY_size(o->key));
+	outlen = EVP_PKEY_size(o->key);
+	*enc_message = malloc(outlen);
 	if (*enc_message == NULL) {
 		debug_print("malloc returned null");
 		return -1;
@@ -91,7 +92,8 @@ int encrypt_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message
 		free(*enc_message);
 		*enc_message = NULL;
 		EVP_PKEY_CTX_free(ctx);
-		debug_print("OpenSSL encrypt failed: rv = 0x%.8X\n", rv);
+		fprintf(stderr, " [ ERROR %s ] OpenSSL encrypt failed: %s\n",
+			o->id_str, ERR_error_string(ERR_peek_last_error(), NULL));
 		return -1;
 	}
 	EVP_PKEY_CTX_free(ctx);

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -378,38 +378,59 @@ int verify_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 		/* Digest mechanisms */
 		switch (mech->mech) {
 		case CKM_SHA1_RSA_PKCS:
-			cmp_message = SHA1(message, message_length, NULL);
 			cmp_message_length = SHA_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha1(), NULL);
 			type = NID_sha1;
 			break;
 		case CKM_SHA224_RSA_PKCS:
-			cmp_message = SHA224(message, message_length, NULL);
 			cmp_message_length = SHA224_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha224(), NULL);
 			type = NID_sha224;
 			break;
 		case CKM_SHA256_RSA_PKCS:
-			cmp_message = SHA256(message, message_length, NULL);
 			cmp_message_length = SHA256_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha256(), NULL);
 			type = NID_sha256;
 			break;
 		case CKM_SHA384_RSA_PKCS:
-			cmp_message = SHA384(message, message_length, NULL);
 			cmp_message_length = SHA384_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha384(), NULL);
 			type = NID_sha384;
 			break;
 		case CKM_SHA512_RSA_PKCS:
-			cmp_message = SHA512(message, message_length, NULL);
 			cmp_message_length = SHA512_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha512(), NULL);
 			type = NID_sha512;
 			break;
 		case CKM_MD5_RSA_PKCS:
-			cmp_message = MD5(message, message_length, NULL);
 			cmp_message_length = MD5_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_md5(), NULL);
 			type = NID_md5;
 			break;
 		case CKM_RIPEMD160_RSA_PKCS:
-			cmp_message = RIPEMD160(message, message_length, NULL);
 			cmp_message_length = RIPEMD160_DIGEST_LENGTH;
+			cmp_message = malloc(cmp_message_length);
+			if (cmp_message == NULL)
+				return -1;
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_ripemd160(), NULL);
 			type = NID_ripemd160;
 			break;
 		default:
@@ -440,19 +461,19 @@ int verify_message_openssl(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 		ECDSA_SIG_set0(sig, r, s);
 		switch (mech->mech) {
 		case CKM_ECDSA_SHA512:
-			cmp_message = SHA512(message, message_length, NULL);
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha512(), NULL);
 			cmp_message_length = SHA512_DIGEST_LENGTH;
 			break;
 		case CKM_ECDSA_SHA384:
-			cmp_message = SHA384(message, message_length, NULL);
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha384(), NULL);
 			cmp_message_length = SHA384_DIGEST_LENGTH;
 			break;
 		case CKM_ECDSA_SHA256:
-			cmp_message = SHA256(message, message_length, NULL);
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha256(), NULL);
 			cmp_message_length = SHA256_DIGEST_LENGTH;
 			break;
 		case CKM_ECDSA_SHA1:
-			cmp_message = SHA1(message, message_length, NULL);
+			EVP_Digest(message, message_length, cmp_message, NULL, EVP_sha1(), NULL);
 			cmp_message_length = SHA_DIGEST_LENGTH;
 			break;
 		case CKM_ECDSA:

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -137,7 +137,6 @@ int encrypt_message(test_cert_t *o, token_info_t *info, CK_BYTE *message,
 	rv = fp->C_Encrypt(info->session_handle, message, message_length,
 		*enc_message, &enc_message_length);
 	if (rv == CKR_OK) {
-		mech->result_flags |= FLAGS_SIGN;
 		return enc_message_length;
 	}
 	debug_print("   C_Encrypt: rv = 0x%.8lX", rv);

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -36,6 +36,7 @@
 #ifdef ENABLE_OPENSSL
 #include <openssl/des.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif
 
 #include "libopensc/opensc.h"
@@ -944,7 +945,7 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 		printf("can't convert startkey apdu to binary format: aborting\n");
 		return 1;
 	}
-	SHA1(apdu_bin, apdu_len, checksum);
+	EVP_Digest(apdu_bin, apdu_len, checksum, NULL, EVP_sha1(), NULL);
 
 	if (cardos_version[0] == 0xc8 && cardos_version[1] == 0x08) {
 		if (memcmp(checksum, cardos_43b_checksum, SHA_DIGEST_LENGTH) != 0) {


### PR DESCRIPTION
Related: #2308

What works:
 * Digest are done using EVP_Digest. This is compatible with the old versions
 * Using EVP_* interface for 3DES encryption/decryption (not converted everywhere yet). Does not work with older OpenSSL.
 * Using EVP_* interface for DES encryption with legacy provider
 * Encoders and decoders for key structures should work (I did not change in in all places though yet

What does not:
 * Accessing key parameters from EVP_PKEY API (RSA keys -- fails for me with the first check `evp_pkey_is_provided()`)
 * Accessing key parameters from EVP_PKEY API for EC keys (I did not find a way how to get `EC_GROUP` structure from the `EVP_PKEY` or modify/get anything from the group structure
 * iasecc is doing some [weird stuff with SHA hashes](https://github.com/OpenSC/OpenSC/blob/f0c059ede81871e4d4e388d51e2b8353cfdd9182/src/libopensc/card-iasecc.c#L3195). @vjardin could you check what it is and if there is a way to write it in some sensible way without touching OpenSSL internal structures? 
 * gost card is using some deprecated engine calls, which I am not familiar with at all

The PR is indeed incomplete and more like a draft. It will require quite some work to get it into the shape, working with new API, probably also on the OpenSSL side as it looks like some things are not possible yet (or I do not know how to do them).

I tried to rewrite at least most of the bits of the `p11tests`, to identify the most common issues and verified them against softhsm. I also wanted to submit the PR to see how the (old) CI systems will handle it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
