### PR TITLE
Fix piv-tool on windows

### DIFF
--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -118,7 +118,7 @@ static int load_object(const char * object_id, const char * object_file)
 	int r = -1;
 	struct stat stat_buf;
 
-    if(!object_file || (fp=fopen(object_file, "r")) == NULL){
+    if(!object_file || (fp=fopen(object_file, "rb")) == NULL){
         printf("Cannot open object file, %s %s\n",
 			(object_file)?object_file:"", strerror(errno));
 		goto err;
@@ -184,7 +184,7 @@ static int load_cert(const char * cert_id, const char * cert_file,
 		goto err;
 	}
 
-    if((fp=fopen(cert_file, "r"))==NULL){
+    if((fp=fopen(cert_file, "rb"))==NULL){
         printf("Cannot open cert file, %s %s\n",
 				cert_file, strerror(errno));
         goto err;


### PR DESCRIPTION
fopen needs "rb" for fopen in two places

fixes #2338

 On branch piv-tool-windows
 Changes to be committed:
	modified:   piv-tool.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
