### PR TITLE
Fix 2340 pkcs15-sec.c wrong test

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -635,7 +635,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 * key is for signing and decryption, we need to emulate signing */
 
 	sc_log(ctx, "supported algorithm flags 0x%X, private key usage 0x%X", alg_info->flags, prkey->usage);
-	if (obj->type == SC_ALGORITHM_RSA) {
+	if (obj->type == SC_PKCS15_TYPE_PRKEY_RSA) {
 		if ((alg_info->flags & SC_ALGORITHM_NEED_USAGE) &&
 			((prkey->usage & USAGE_ANY_SIGN) &&
 			(prkey->usage & USAGE_ANY_DECIPHER)) ) {


### PR DESCRIPTION
if (obj->type == SC_PKCS15_TYPE_PRKEY_RSA) { is the correct test.

Fixes #2340 

Reported to work in:
https://github.com/OpenSC/OpenSC/issues/2340#issuecomment-841270527
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
