### PR TITLE
idprime: Fix RSA-PKCS mechanism with hashing on card

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -664,11 +664,11 @@ idprime_set_security_env(struct sc_card *card,
 				new_env.algorithm_ref = 0x65;
 			}
 		} else { /* RSA-PKCS */
-			if (env->algorithm_flags & SC_ALGORITHM_MGF1_SHA256) {
+			if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA256) {
 				new_env.algorithm_ref = 0x42;
-			} else if (env->algorithm_flags & SC_ALGORITHM_MGF1_SHA384) {
+			} else if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA384) {
 				new_env.algorithm_ref = 0x52;
-			} else if (env->algorithm_flags & SC_ALGORITHM_MGF1_SHA512) {
+			} else if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA512) {
 				new_env.algorithm_ref = 0x62;
 			} else { /* RSA-PKCS without hashing */
 				new_env.algorithm_ref = 0x02;


### PR DESCRIPTION
The RSA-PKCS mechanisms with hashing were broken for some time. Before the fix #2341 I did not see how to fix the issue, but with the above change applied, all works fine again.

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested