### PR TITLE
Update piv-tool man pages for AES

### DIFF
--- a/doc/tools/piv-tool.1.xml
+++ b/doc/tools/piv-tool.1.xml
@@ -53,15 +53,18 @@
 						<option>--admin</option> <replaceable>argument</replaceable>,
 						<option>-A</option> <replaceable>argument</replaceable>
 					</term>
-					<listitem><para>Authenticate to the card using a 2DES or 3DES key.
+					<listitem><para>Authenticate to the card using a 2DES, 3DES or AES key.
 					The <replaceable>argument</replaceable> of the form
 					<synopsis> {<literal>A</literal>|<literal>M</literal>}<literal>:</literal><replaceable>ref</replaceable><literal>:</literal><replaceable>alg</replaceable></synopsis>
 					is required, were <literal>A</literal> uses "EXTERNAL AUTHENTICATION"
 					and <literal>M</literal> uses "MUTUAL AUTHENTICATION".
 					<replaceable>ref</replaceable> is normally <literal>9B</literal>,
-					and <replaceable>alg</replaceable> is <literal>03</literal> for 3DES.
-					The key is provided by the card vendor, and the environment variable
-					<varname>PIV_EXT_AUTH_KEY</varname> must point to a text file containing
+					and <replaceable>alg</replaceable> is <literal>03</literal> for 3DES,
+					<literal>01</literal> for 2DES, <literal>08</literal> for AES-128,
+					<literal>0A</literal> for AES-192 or <literal>0C</literal> for AES-256.
+					The key is provided by the card vendor. The environment variable
+					<varname>PIV_EXT_AUTH_KEY</varname> must point to either a binary file
+					matching the length of the key or a text file containing
 					the key in the format:
 					<code>XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX</code>
 					</para></listitem>


### PR DESCRIPTION
commit 295c523e4 (William Roberts     2014-07-08 13:52:48)
added support for AES keys to card-piv.c but the man page
for piv-tool that uses the code was never updated.

 On branch piv-tool-doc
 Changes to be committed:
	modified:   ../../doc/tools/piv-tool.1.xml

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation is added or updated
- [X] piv-tool was tested with piv card that uses AES-256 for 9B admin key.