### PR TITLE
p11test: Expect DERIVE to be set on both private and public key

### DIFF
--- a/src/tests/p11test/p11test_case_usage.c
+++ b/src/tests/p11test/p11test_case_usage.c
@@ -54,9 +54,9 @@ void usage_test(void **state) {
 			fprintf(stderr, " [ ERROR %s ] If Unwrap is set, Wrap should be set too.\n",
 			    objects.data[i].id_str);
 		}
-		if (objects.data[i].derive_pub) {
+		if (objects.data[i].derive_pub != objects.data[i].derive_priv) {
 			errors++;
-			fprintf(stderr, " [ ERROR %s ] Derive should not be set on public key\n",
+			fprintf(stderr, " [ ERROR %s ] Derive should be set on both private and public part.\n",
 			    objects.data[i].id_str);
 		}
 


### PR DESCRIPTION
Basically reverts part of 485b6cf, which turned out to be wrong.

Alternative to #2292