### PR TITLE
pkcs11-tool: allow setting CKA_EXTRACTABLE during keypair generation

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2745,6 +2745,12 @@ static int gen_keypair(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		n_privkey_attr++;
 	}
 
+	if (opt_is_extractable != 0) {
+		FILL_ATTR(privateKeyTemplate[n_privkey_attr], CKA_EXTRACTABLE,
+				&_true, sizeof(_true));
+		n_privkey_attr++;
+	}
+
 	if (opt_allowed_mechanisms_len > 0) {
 		FILL_ATTR(privateKeyTemplate[n_privkey_attr],
 			CKA_ALLOWED_MECHANISMS, opt_allowed_mechanisms,


### PR DESCRIPTION
Section 4.9 of the PKCS#11 v2.40 specification [1], mentions
CKA_EXTRACTABLE as a valid attribute for Private Key objects. However,
when calling `pkcs11-tool` with the `--exportable` option, the
attribute is not set as part of the private key template.

[1]: http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/pkcs11-base-v2.40-errata01-os-complete.html

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

Tested using a YubiHSM.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
