### PR TITLE
Avoid black/whitelist terms in documentation and comments

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -177,7 +177,7 @@ app <em class="replaceable"><code>application</code></em> {
 				</p></dd><dt><a name="card_drivers"></a><span class="term">
 					<code class="option">card_drivers =  <em class="replaceable"><code>name</code></em>... ;</code>
 				</span></dt><dd><p>
-						Whitelist of card drivers to load at start-up.
+						Allowlist of card drivers to load at start-up.
 						The special value <code class="literal">internal</code> (the
 						default) will load all statically linked drivers.
 					</p><p>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -209,7 +209,7 @@ app <replaceable>application</replaceable> {
 							rep="repeat"><replaceable>name</replaceable></arg>;</option>
 				</term>
 				<listitem><para>
-						Whitelist of card drivers to load at start-up.
+						Allowlist of card drivers to load at start-up.
 						The special value <literal>internal</literal> (the
 						default) will load all statically linked drivers.
 					</para>

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -133,7 +133,7 @@ app default {
 		# max_recv_size = 65536;
 	}
 
-	# Whitelist of card drivers to load at start-up
+	# Allowlist of card drivers to load at start-up
 	#
 	# The supported internal card driver names can be retrieved
 	# from the output of:

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1165,8 +1165,8 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 
 	/* Many cards do support PIN status queries, but some cards don't and
 	 * mistakenly count the command as a failed PIN attempt, so for now we
-	 * whitelist cards with this flag.  In future this may be reduced to a
-	 * blacklist, subject to testing more cards. */
+	 * allow cards with this flag.  In future this may be reduced to a
+	 * blocklist, subject to testing more cards. */
 	if (data->cmd == SC_PIN_CMD_GET_INFO &&
 	    !(card->caps & SC_CARD_CAP_ISO7816_PIN_INFO)) {
 		sc_log(card->ctx, "Card does not support PIN status queries");


### PR DESCRIPTION
As part of inclusive efforts, we try to eliminate some terms in the software we are using.

There are a lot of cases that we can not change, mostly PKCS#11 constants or terms as master file in several drivers or references to may git branches, but there are at least couple of changes that are not needed and can be quite safely changed as in this PR.

##### Checklist
- [X] Documentation is added or updated