### PR TITLE
PIV Improved parsing of data from the card

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2372,7 +2372,7 @@ static int piv_validate_general_authentication(sc_card_t *card,
 	r = sc_asn1_read_tag(&p2, r, &cla, &tag, &bodylen);
 	if (p2 == NULL || r < 0 || bodylen == 0 || (cla|tag) != 0x7C) {
 		LOG_TEST_GOTO_ERR(card->ctx, SC_ERROR_INVALID_DATA, "Can't find 0x7C");
-        }
+	}
 
 	r = sc_asn1_read_tag(&p2, bodylen, &cla, &tag, &taglen);
 	if (p2 == NULL || r < 0 || taglen == 0 || (cla|tag) != 0x82) {
@@ -2453,7 +2453,7 @@ piv_compute_signature(sc_card_t *card, const u8 * data, size_t datalen,
 				ptemp++;
 				templen--;
 			}
-			memcpy(out + nLen*i + nLen - templen , ptemp, templen);
+			memcpy(out + nLen*i + nLen - templen, ptemp, templen);
 			pint += intlen; /* next integer */
 			
 		}

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2449,8 +2449,6 @@ piv_compute_signature(sc_card_t *card, const u8 * data, size_t datalen,
 			if (intlen > nLen) { /* drop leading 00 if present */
 				if (*ptemp != 0x00) {
 					LOG_TEST_GOTO_ERR(card->ctx, SC_ERROR_INVALID_DATA,"Signature too long");
-					r = SC_ERROR_INVALID_DATA;
-					goto err;
 				}
 				ptemp++;
 				templen--;


### PR DESCRIPTION
Based on Fuzz testing, many of the calls to sc_asn1_find_tag were replaced
with sc_asn1_read_tag. The input is also tested that the
expected tag is the first byte. Additional tests are also add.

sc_asn1_find_tag will skip 0X00 or 0Xff if found. NIST sp800-73-x specs
do not allow these extra bytes.

 On branch PIV-improved-parsing
 Changes to be committed:
	modified:   card-piv.c


##### Checklist
- [X] PKCS#11 module is tested

