### PR TITLE
Do not use EVP_PKEY_get0() for EC_KEY handling

### DIFF
--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -728,13 +728,13 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 		}
 	case EVP_PKEY_EC: {
 		struct sc_pkcs15_prkey_ec *dst = &pkcs15_key->u.ec;
-		EC_KEY *src = NULL;
+		const EC_KEY *src = NULL;
 		const EC_GROUP *grp = NULL;
 		unsigned char buf[255];
 		size_t buflen = 255;
 		int nid;
 
-		src = EVP_PKEY_get0(pk);
+		src = EVP_PKEY_get0_EC_KEY(pk);
 		assert(src);
 		assert(EC_KEY_get0_private_key(src));
 		assert(EC_KEY_get0_public_key(src));

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1783,13 +1783,13 @@ sc_pkcs15_convert_pubkey(struct sc_pkcs15_pubkey *pkcs15_key, void *evp_key)
 	}
 	case EVP_PKEY_EC: {
 		struct sc_pkcs15_pubkey_ec *dst = &pkcs15_key->u.ec;
-		EC_KEY *src = NULL;
+		const EC_KEY *src = NULL;
 		const EC_GROUP *grp = NULL;
 		unsigned char buf[255];
 		size_t buflen = 255;
 		int nid;
 
-		src = EVP_PKEY_get0(pk);
+		src = EVP_PKEY_get0_EC_KEY(pk);
 		assert(src);
 		assert(EC_KEY_get0_public_key(src));
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3143,18 +3143,18 @@ parse_gost_pkey(EVP_PKEY *pkey, int private, struct gostkey_info *gost)
 static int
 parse_ec_pkey(EVP_PKEY *pkey, int private, struct gostkey_info *gost)
 {
-	EC_KEY *src = EVP_PKEY_get0(pkey);
+	const EC_KEY *src = EVP_PKEY_get0_EC_KEY(pkey);
 	const BIGNUM *bignum;
 
 	if (!src)
 		return -1;
 
-	gost->param_oid.len = i2d_ECParameters(src, &gost->param_oid.value);
+	gost->param_oid.len = i2d_ECParameters((EC_KEY *)src, &gost->param_oid.value);
 	if (gost->param_oid.len <= 0)
 		return -1;
 
 	if (private) {
-		bignum = EC_KEY_get0_private_key(EVP_PKEY_get0(pkey));
+		bignum = EC_KEY_get0_private_key(src);
 
 		gost->private.len = BN_num_bytes(bignum);
 		gost->private.value = malloc(gost->private.len);


### PR DESCRIPTION
The function is intentionally broken in OpenSSL 3.0 for provided keys
and returning NULL. But it should still work for the legacy gost engine
implementation (but I do not have a good way to check).

Discussed in openssl upstream issue:

https://github.com/openssl/openssl/issues/16081
