### PR TITLE
pkcs11-spy: Fix crash for pMechanism=NULL

### DIFF
--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -403,23 +403,28 @@ spy_attribute_list_out(const char *name, CK_ATTRIBUTE_PTR pTemplate,
 static void
 spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 {
+	char param_name[64];
+
 	if (!pMechanism) {
-		fprintf(spy_output, "[in] %s=(null)\n", name);
+		fprintf(spy_output, "[in] %s = NULL\n", name);
 		return;
 	}
 
-	fprintf(spy_output, "[in] %s->type=%s\n", name, lookup_enum(MEC_T, pMechanism->mechanism));
+	fprintf(spy_output, "[in] %s->type = %s\n", name, lookup_enum(MEC_T, pMechanism->mechanism));
 	switch (pMechanism->mechanism) {
 	case CKM_AES_GCM:
 		if (pMechanism->pParameter != NULL) {
 			CK_GCM_PARAMS *param =
 				(CK_GCM_PARAMS *) pMechanism->pParameter;
-			spy_dump_string_in("pIv[ulIvLen]",
+			snprintf(param_name, sizeof(param_name), "%s->pParameter->pIv[ulIvLen]", name);
+			spy_dump_string_in(param_name,
 				param->pIv, param->ulIvLen);
-			spy_dump_ulong_in("ulIvBits", param->ulIvBits);
-			spy_dump_string_in("pAAD[ulAADLen]",
+			snprintf(param_name, sizeof(param_name), "%s->pParameter->ulIvBits", name);
+			spy_dump_ulong_in(param_name, param->ulIvBits);
+			snprintf(param_name, sizeof(param_name), "%s->pParameter->pAAD[ulAADLen]", name);
+			spy_dump_string_in(param_name,
 				param->pAAD, param->ulAADLen);
-			fprintf(spy_output, "[in] %s->pParameter->ulTagBits=%lu\n", name, param->ulTagBits);
+			fprintf(spy_output, "[in] %s->pParameter->ulTagBits = %lu\n", name, param->ulTagBits);
 		} else {
 			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
 			break;
@@ -430,15 +435,14 @@ spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 		if (pMechanism->pParameter != NULL) {
 			CK_ECDH1_DERIVE_PARAMS *param =
 				(CK_ECDH1_DERIVE_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "[in] %s->pParameter = {\n\tkdf=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->kdf = %s\n", name,
 				lookup_enum(CKD_T, param->kdf));
-			fprintf(spy_output, "\tpSharedData[ulSharedDataLen] = ");
+			fprintf(spy_output, "[in] %s->pParameter->pSharedData[ulSharedDataLen] = ", name);
 			print_generic(spy_output, 0, param->pSharedData,
 				param->ulSharedDataLen, NULL);
-			fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
+			fprintf(spy_output, "[in] %s->pParameter->pPublicData[ulPublicDataLen] = ", name);
 			print_generic(spy_output, 0, param->pPublicData,
 				param->ulPublicDataLen, NULL);
-			fprintf(spy_output, "}\n");
 		} else {
 			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
 			break;
@@ -448,22 +452,21 @@ spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 		if (pMechanism->pParameter != NULL) {
 			CK_ECMQV_DERIVE_PARAMS *param =
 				(CK_ECMQV_DERIVE_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "[in] %s->pParameter = {\n\tkdf=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->kdf = %s\n", name,
 				lookup_enum(CKD_T, param->kdf));
-			fprintf(spy_output, "\tpSharedData[ulSharedDataLen] =");
+			fprintf(spy_output, "%s->pParameter->pSharedData[ulSharedDataLen] = ", name);
 			print_generic(spy_output, 0, param->pSharedData,
 				param->ulSharedDataLen, NULL);
-			fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
+			fprintf(spy_output, "%s->pParameter->pPublicData[ulPublicDataLen] = ", name);
 			print_generic(spy_output, 0, param->pPublicData,
 				param->ulPublicDataLen, NULL);
-			fprintf(spy_output, "\tulPrivateDataLen = %lu",
+			fprintf(spy_output, "%s->pParameter->ulPrivateDataLen = %lu", name,
 				param->ulPrivateDataLen);
-			fprintf(spy_output, "\thPrivateData = %lu", param->hPrivateData);
-			fprintf(spy_output, "\tpPublicData2[ulPublicDataLen2] = ");
+			fprintf(spy_output, "%s->pParameter->hPrivateData = %lu", name, param->hPrivateData);
+			fprintf(spy_output, "%s->pParameter->pPublicData2[ulPublicDataLen2] = ", name);
 			print_generic(spy_output, 0, param->pPublicData2,
 				param->ulPublicDataLen2, NULL);
-			fprintf(spy_output, "\tpublicKey = %lu", param->publicKey);
-			fprintf(spy_output, "}\n");
+			fprintf(spy_output, "%s->pParameter->publicKey = %lu", name, param->publicKey);
 		} else {
 			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
 			break;
@@ -473,12 +476,13 @@ spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 		if (pMechanism->pParameter != NULL) {
 			CK_RSA_PKCS_OAEP_PARAMS *param =
 				(CK_RSA_PKCS_OAEP_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "[in] %s->pParameter->hashAlg=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->hashAlg = %s\n", name,
 				lookup_enum(MEC_T, param->hashAlg));
-			fprintf(spy_output, "[in] %s->pParameter->mgf=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->mgf = %s\n", name,
 				lookup_enum(MGF_T, param->mgf));
-			fprintf(spy_output, "[in] %s->pParameter->source=%lu\n", name, param->source);
-			spy_dump_string_out("pSourceData[ulSourceDalaLen]",
+			fprintf(spy_output, "[in] %s->pParameter->source = %lu\n", name, param->source);
+			snprintf(param_name, sizeof(param_name), "%s->pParameter->pSourceData[ulSourceDalaLen]", name);
+			spy_dump_string_in(param_name,
 				param->pSourceData, param->ulSourceDataLen);
 		} else {
 			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
@@ -493,11 +497,11 @@ spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 		if (pMechanism->pParameter != NULL) {
 			CK_RSA_PKCS_PSS_PARAMS *param =
 				(CK_RSA_PKCS_PSS_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "[in] %s->pParameter->hashAlg=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->hashAlg = %s\n", name,
 				lookup_enum(MEC_T, param->hashAlg));
-			fprintf(spy_output, "[in] %s->pParameter->mgf=%s\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->mgf = %s\n", name,
 				lookup_enum(MGF_T, param->mgf));
-			fprintf(spy_output, "[in] %s->pParameter->sLen=%lu\n", name,
+			fprintf(spy_output, "[in] %s->pParameter->sLen = %lu\n", name,
 				param->sLen);
 		} else {
 			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
@@ -505,7 +509,8 @@ spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
 		}
 		break;
 	default:
-		spy_dump_string_in("pParameter[ulParameterLen]", pMechanism->pParameter, pMechanism->ulParameterLen);
+		snprintf(param_name, sizeof(param_name), "%s->pParameter[ulParameterLen]", name);
+		spy_dump_string_in(param_name, pMechanism->pParameter, pMechanism->ulParameterLen);
 		break;
 	}
 }

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -401,6 +401,116 @@ spy_attribute_list_out(const char *name, CK_ATTRIBUTE_PTR pTemplate,
 }
 
 static void
+spy_dump_mechanism_in(const char *name, CK_MECHANISM_PTR pMechanism)
+{
+	if (!pMechanism) {
+		fprintf(spy_output, "[in] %s=(null)\n", name);
+		return;
+	}
+
+	fprintf(spy_output, "[in] %s->type=%s\n", name, lookup_enum(MEC_T, pMechanism->mechanism));
+	switch (pMechanism->mechanism) {
+	case CKM_AES_GCM:
+		if (pMechanism->pParameter != NULL) {
+			CK_GCM_PARAMS *param =
+				(CK_GCM_PARAMS *) pMechanism->pParameter;
+			spy_dump_string_in("pIv[ulIvLen]",
+				param->pIv, param->ulIvLen);
+			spy_dump_ulong_in("ulIvBits", param->ulIvBits);
+			spy_dump_string_in("pAAD[ulAADLen]",
+				param->pAAD, param->ulAADLen);
+			fprintf(spy_output, "[in] %s->pParameter->ulTagBits=%lu\n", name, param->ulTagBits);
+		} else {
+			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
+			break;
+		}
+		break;
+	case CKM_ECDH1_DERIVE:
+	case CKM_ECDH1_COFACTOR_DERIVE:
+		if (pMechanism->pParameter != NULL) {
+			CK_ECDH1_DERIVE_PARAMS *param =
+				(CK_ECDH1_DERIVE_PARAMS *) pMechanism->pParameter;
+			fprintf(spy_output, "[in] %s->pParameter = {\n\tkdf=%s\n", name,
+				lookup_enum(CKD_T, param->kdf));
+			fprintf(spy_output, "\tpSharedData[ulSharedDataLen] = ");
+			print_generic(spy_output, 0, param->pSharedData,
+				param->ulSharedDataLen, NULL);
+			fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
+			print_generic(spy_output, 0, param->pPublicData,
+				param->ulPublicDataLen, NULL);
+			fprintf(spy_output, "}\n");
+		} else {
+			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
+			break;
+		}
+		break;
+	case CKM_ECMQV_DERIVE:
+		if (pMechanism->pParameter != NULL) {
+			CK_ECMQV_DERIVE_PARAMS *param =
+				(CK_ECMQV_DERIVE_PARAMS *) pMechanism->pParameter;
+			fprintf(spy_output, "[in] %s->pParameter = {\n\tkdf=%s\n", name,
+				lookup_enum(CKD_T, param->kdf));
+			fprintf(spy_output, "\tpSharedData[ulSharedDataLen] =");
+			print_generic(spy_output, 0, param->pSharedData,
+				param->ulSharedDataLen, NULL);
+			fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
+			print_generic(spy_output, 0, param->pPublicData,
+				param->ulPublicDataLen, NULL);
+			fprintf(spy_output, "\tulPrivateDataLen = %lu",
+				param->ulPrivateDataLen);
+			fprintf(spy_output, "\thPrivateData = %lu", param->hPrivateData);
+			fprintf(spy_output, "\tpPublicData2[ulPublicDataLen2] = ");
+			print_generic(spy_output, 0, param->pPublicData2,
+				param->ulPublicDataLen2, NULL);
+			fprintf(spy_output, "\tpublicKey = %lu", param->publicKey);
+			fprintf(spy_output, "}\n");
+		} else {
+			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
+			break;
+		}
+		break;
+	case CKM_RSA_PKCS_OAEP:
+		if (pMechanism->pParameter != NULL) {
+			CK_RSA_PKCS_OAEP_PARAMS *param =
+				(CK_RSA_PKCS_OAEP_PARAMS *) pMechanism->pParameter;
+			fprintf(spy_output, "[in] %s->pParameter->hashAlg=%s\n", name,
+				lookup_enum(MEC_T, param->hashAlg));
+			fprintf(spy_output, "[in] %s->pParameter->mgf=%s\n", name,
+				lookup_enum(MGF_T, param->mgf));
+			fprintf(spy_output, "[in] %s->pParameter->source=%lu\n", name, param->source);
+			spy_dump_string_out("pSourceData[ulSourceDalaLen]",
+				param->pSourceData, param->ulSourceDataLen);
+		} else {
+			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
+			break;
+		}
+		break;
+	case CKM_RSA_PKCS_PSS:
+	case CKM_SHA1_RSA_PKCS_PSS:
+	case CKM_SHA256_RSA_PKCS_PSS:
+	case CKM_SHA384_RSA_PKCS_PSS:
+	case CKM_SHA512_RSA_PKCS_PSS:
+		if (pMechanism->pParameter != NULL) {
+			CK_RSA_PKCS_PSS_PARAMS *param =
+				(CK_RSA_PKCS_PSS_PARAMS *) pMechanism->pParameter;
+			fprintf(spy_output, "[in] %s->pParameter->hashAlg=%s\n", name,
+				lookup_enum(MEC_T, param->hashAlg));
+			fprintf(spy_output, "[in] %s->pParameter->mgf=%s\n", name,
+				lookup_enum(MGF_T, param->mgf));
+			fprintf(spy_output, "[in] %s->pParameter->sLen=%lu\n", name,
+				param->sLen);
+		} else {
+			fprintf(spy_output, "[in] %s->pParameter = NULL\n", name);
+			break;
+		}
+		break;
+	default:
+		spy_dump_string_in("pParameter[ulParameterLen]", pMechanism->pParameter, pMechanism->ulParameterLen);
+		break;
+	}
+}
+
+static void
 print_ptr_in(const char *name, CK_VOID_PTR ptr)
 {
  	fprintf(spy_output, "[in] %s = %p\n", name, ptr);
@@ -853,27 +963,7 @@ C_EncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT
 
 	enter("C_EncryptInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
-	switch (pMechanism->mechanism) {
-	case CKM_AES_GCM:
-		if (pMechanism->pParameter != NULL) {
-			CK_GCM_PARAMS *param =
-				(CK_GCM_PARAMS *) pMechanism->pParameter;
-			spy_dump_string_in("pIv[ulIvLen]",
-				param->pIv, param->ulIvLen);
-			spy_dump_ulong_in("ulIvBits", param->ulIvBits);
-			spy_dump_string_in("pAAD[ulAADLen]",
-				param->pAAD, param->ulAADLen);
-			fprintf(spy_output, "pMechanism->pParameter->ulTagBits=%lu\n", param->ulTagBits);
-		} else {
-			fprintf(spy_output, "Parameters block for %s is empty...\n",
-				lookup_enum(MEC_T, pMechanism->mechanism));
-		}
-		break;
-	default:
-		spy_dump_string_in("pParameter[ulParameterLen]", pMechanism->pParameter, pMechanism->ulParameterLen);
-		break;
-	}
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_EncryptInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -931,28 +1021,7 @@ C_DecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT
 
 	enter("C_DecryptInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
-	switch (pMechanism->mechanism) {
-	case CKM_RSA_PKCS_OAEP:
-		if (pMechanism->pParameter != NULL) {
- 			CK_RSA_PKCS_OAEP_PARAMS *param =
-				(CK_RSA_PKCS_OAEP_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "pMechanism->pParameter->hashAlg=%s\n",
-				lookup_enum(MEC_T, param->hashAlg));
-			fprintf(spy_output, "pMechanism->pParameter->mgf=%s\n",
-				lookup_enum(MGF_T, param->mgf));
-			fprintf(spy_output, "pMechanism->pParameter->source=%lu\n", param->source);
-			spy_dump_string_out("pSourceData[ulSourceDalaLen]", 
-				param->pSourceData, param->ulSourceDataLen);
-		} else {
-			fprintf(spy_output, "Parameters block for %s is empty...\n",
-				lookup_enum(MEC_T, pMechanism->mechanism));
-		}
-		break;
-	default:
-		spy_dump_string_in("pParameter[ulParameterLen]", pMechanism->pParameter, pMechanism->ulParameterLen);
-		break;
-	}
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_DecryptInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1011,7 +1080,7 @@ C_DigestInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism)
 
 	enter("C_DigestInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	rv = po->C_DigestInit(hSession, pMechanism);
 	return retne(rv);
 }
@@ -1077,28 +1146,7 @@ C_SignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HA
 
 	enter("C_SignInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
-	switch (pMechanism->mechanism) {
-	case CKM_RSA_PKCS_PSS:
-	case CKM_SHA1_RSA_PKCS_PSS:
-	case CKM_SHA256_RSA_PKCS_PSS:
-	case CKM_SHA384_RSA_PKCS_PSS:
-	case CKM_SHA512_RSA_PKCS_PSS:
-		if (pMechanism->pParameter != NULL) {
-			CK_RSA_PKCS_PSS_PARAMS *param =
-				(CK_RSA_PKCS_PSS_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "pMechanism->pParameter->hashAlg=%s\n",
-				lookup_enum(MEC_T, param->hashAlg));
-			fprintf(spy_output, "pMechanism->pParameter->mgf=%s\n",
-				lookup_enum(MGF_T, param->mgf));
-			fprintf(spy_output, "pMechanism->pParameter->sLen=%lu\n",
-				param->sLen);
-		} else {
-			fprintf(spy_output, "Parameters block for %s is empty...\n",
-				lookup_enum(MEC_T, pMechanism->mechanism));
-		}
-		break;
-	}
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_SignInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1153,8 +1201,7 @@ C_SignRecoverInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OB
 
 	enter("C_SignRecoverInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n",
-			lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_SignRecoverInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1182,28 +1229,7 @@ C_VerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_
 
 	enter("C_VerifyInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
-	switch (pMechanism->mechanism) {
-	case CKM_RSA_PKCS_PSS:
-	case CKM_SHA1_RSA_PKCS_PSS:
-	case CKM_SHA256_RSA_PKCS_PSS:
-	case CKM_SHA384_RSA_PKCS_PSS:
-	case CKM_SHA512_RSA_PKCS_PSS:
-		if (pMechanism->pParameter != NULL) {
-			CK_RSA_PKCS_PSS_PARAMS *param =
-				(CK_RSA_PKCS_PSS_PARAMS *) pMechanism->pParameter;
-			fprintf(spy_output, "pMechanism->pParameter->hashAlg=%s\n",
-				lookup_enum(MEC_T, param->hashAlg));
-			fprintf(spy_output, "pMechanism->pParameter->mgf=%s\n",
-				lookup_enum(MGF_T, param->mgf));
-			fprintf(spy_output, "pMechanism->pParameter->sLen=%lu\n",
-				param->sLen);
-		} else {
-			fprintf(spy_output, "Parameters block for %s is empty...\n",
-				lookup_enum(MEC_T, pMechanism->mechanism));
-		}
-		break;
-	}
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_VerifyInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1256,7 +1282,7 @@ C_VerifyRecoverInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
 
 	enter("C_VerifyRecoverInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_VerifyRecoverInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1349,7 +1375,7 @@ C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
 
 	enter("C_GenerateKey");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_attribute_list_in("pTemplate", pTemplate, ulCount);
 	rv = po->C_GenerateKey(hSession, pMechanism, pTemplate, ulCount, phKey);
 	if (rv == CKR_OK)
@@ -1368,7 +1394,7 @@ C_GenerateKeyPair(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
 
 	enter("C_GenerateKeyPair");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_attribute_list_in("pPublicKeyTemplate", pPublicKeyTemplate, ulPublicKeyAttributeCount);
 	spy_attribute_list_in("pPrivateKeyTemplate", pPrivateKeyTemplate, ulPrivateKeyAttributeCount);
 	rv = po->C_GenerateKeyPair(hSession, pMechanism,
@@ -1391,7 +1417,7 @@ C_WrapKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
 
 	enter("C_WrapKey");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hWrappingKey", hWrappingKey);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_WrapKey(hSession, pMechanism, hWrappingKey, hKey, pWrappedKey, pulWrappedKeyLen);
@@ -1411,7 +1437,7 @@ C_UnwrapKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
 
 	enter("C_UnwrapKey");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hUnwrappingKey", hUnwrappingKey);
 	spy_dump_string_in("pWrappedKey[ulWrappedKeyLen]", pWrappedKey, ulWrappedKeyLen);
 	spy_attribute_list_in("pTemplate", pTemplate, ulAttributeCount);
@@ -1430,52 +1456,7 @@ C_DeriveKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_H
 
 	enter("C_DeriveKey");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "[in] pMechanism->type=%s\n",
-		lookup_enum(MEC_T, pMechanism->mechanism));
-	switch (pMechanism->mechanism) {
-	case CKM_ECDH1_DERIVE:
-	case CKM_ECDH1_COFACTOR_DERIVE:
-		if (pMechanism->pParameter == NULL) {
-			fprintf(spy_output, "[in] pMechanism->pParameter = NULL\n");
-			break;
-		}
-		CK_ECDH1_DERIVE_PARAMS *param =
-			(CK_ECDH1_DERIVE_PARAMS *) pMechanism->pParameter;
-		fprintf(spy_output, "[in] pMechanism->pParameter = {\n\tkdf=%s\n",
-			lookup_enum(CKD_T, param->kdf));
-		fprintf(spy_output, "\tpSharedData[ulSharedDataLen] = ");
-		print_generic(spy_output, 0, param->pSharedData,
-			param->ulSharedDataLen, NULL);
-		fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
-		print_generic(spy_output, 0, param->pPublicData,
-			param->ulPublicDataLen, NULL);
-		fprintf(spy_output, "}\n");
-		break;
-	case CKM_ECMQV_DERIVE:
-		if (pMechanism->pParameter == NULL) {
-			fprintf(spy_output, "[in] pMechanism->pParameter = NULL\n");
-			break;
-		}
-		CK_ECMQV_DERIVE_PARAMS *param2 =
-			(CK_ECMQV_DERIVE_PARAMS *) pMechanism->pParameter;
-		fprintf(spy_output, "[in] pMechanism->pParameter = {\n\tkdf=%s\n",
-			lookup_enum(CKD_T, param2->kdf));
-		fprintf(spy_output, "\tpSharedData[ulSharedDataLen] =");
-		print_generic(spy_output, 0, param2->pSharedData,
-			param2->ulSharedDataLen, NULL);
-		fprintf(spy_output, "\tpPublicData[ulPublicDataLen] = ");
-		print_generic(spy_output, 0, param2->pPublicData,
-			param2->ulPublicDataLen, NULL);
-		fprintf(spy_output, "\tulPrivateDataLen = %lu",
-			param2->ulPrivateDataLen);
-		fprintf(spy_output, "\thPrivateData = %lu", param2->hPrivateData);
-		fprintf(spy_output, "\tpPublicData2[ulPublicDataLen2] = ");
-		print_generic(spy_output, 0, param2->pPublicData2,
-			param2->ulPublicDataLen2, NULL);
-		fprintf(spy_output, "\tpublicKey = %lu", param2->publicKey);
-		fprintf(spy_output, "}\n");
-		break;
-	}
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hBaseKey", hBaseKey);
 	spy_attribute_list_in("pTemplate", pTemplate, ulAttributeCount);
 	rv = po->C_DeriveKey(hSession, pMechanism, hBaseKey, pTemplate, ulAttributeCount, phKey);
@@ -1696,7 +1677,7 @@ C_MessageEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK
 
 	enter("C_MessageEncryptInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_MessageEncryptInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1779,7 +1760,7 @@ C_MessageDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK
 
 	enter("C_MessageDecryptInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_MessageDecryptInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1862,7 +1843,7 @@ C_MessageSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OB
 
 	enter("C_MessageSignInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_MessageSignInit(hSession, pMechanism, hKey);
 	return retne(rv);
@@ -1934,7 +1915,7 @@ C_MessageVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_
 
 	enter("C_MessageVerifyInit");
 	spy_dump_ulong_in("hSession", hSession);
-	fprintf(spy_output, "pMechanism->type=%s\n", lookup_enum(MEC_T, pMechanism->mechanism));
+	spy_dump_mechanism_in("pMechanism", pMechanism);
 	spy_dump_ulong_in("hKey", hKey);
 	rv = po->C_MessageVerifyInit(hSession, pMechanism, hKey);
 	return retne(rv);


### PR DESCRIPTION
Some test suites are excercising pMechanism==NULL case and this causes
crash when using pkcs11-spy for logging in between.

Centralize logging for pMechanism and handle NULL case.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
