### PR TITLE
Support for itacns key length 2048

### DIFF
--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -104,7 +104,7 @@ static int itacns_match_cns_card(sc_card_t *card, unsigned int i)
 	if(card->driver) {
 		DRVDATA(card)->cns_version = atr[i];
 	}
-	/* Warn if the version is not 1.0. */
+	/* Warn if version is not 1.X. */
 	if(atr[i] != 0x10 && atr[i] != 0x11) {
 		char version[8];
 		snprintf(version, sizeof(version), "%d.%d", (atr[i] >> 4) & 0x0f, atr[i] & 0x0f);

--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -105,7 +105,7 @@ static int itacns_match_cns_card(sc_card_t *card, unsigned int i)
 		DRVDATA(card)->cns_version = atr[i];
 	}
 	/* Warn if the version is not 1.0. */
-	if(atr[i] != 0x10) {
+	if(atr[i] != 0x10 && atr[i] != 0x11) {
 		char version[8];
 		snprintf(version, sizeof(version), "%d.%d", (atr[i] >> 4) & 0x0f, atr[i] & 0x0f);
 		sc_log(card->ctx, "CNS card version %s; no official specifications "
@@ -219,8 +219,13 @@ static int itacns_init(sc_card_t *card)
 		| SC_ALGORITHM_RSA_RAW
 		| SC_ALGORITHM_RSA_HASHES
 		;
+
 	_sc_card_add_rsa_alg(card, 1024, flags, 0);
 
+	if (DRVDATA(card)->cns_version == 0x11) {
+		card->caps |= SC_CARD_CAP_APDU_EXT;
+		_sc_card_add_rsa_alg(card, 2048, flags, 0);
+	}
 	return SC_SUCCESS;
 }
 

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -283,7 +283,16 @@ static int itacns_add_pubkey(sc_pkcs15_card_t *p15card,
 	 * This is hard-coded, unless unforeseen versions of the CNS
 	 * turn up sometime.
 	 */
-	info.modulus_length = 1024;
+
+	/* This is the unforseen version :D */
+	if (((itacns_drv_data_t *) p15card->card->drv_data)->cns_version == 0x11) {
+		info.modulus_length = 2048;
+	}
+	else {
+		info.modulus_length = 1024;
+	}
+
+	
 
 	*modulus_len_out = info.modulus_length;
 	r = sc_pkcs15emu_add_rsa_pubkey(p15card, &obj, &info);
@@ -590,6 +599,10 @@ static int itacns_add_keyset(sc_pkcs15_card_t *p15card,
 
 	/* This is hard-coded, for the time being. */
 	int modulus_length = 1024;
+	/* it's a ST2021? */
+	if (((itacns_drv_data_t *) p15card->card->drv_data)->cns_version == 0x11) {
+		modulus_length = 2048;
+	}
 
 	/* Public key; not really needed */
 	/* FIXME: set usage according to the certificate. */


### PR DESCRIPTION
This PR should add support for itacns v1.1 (key lenght 2048) 
Italian gov documentation can be found here -> https://www.agid.gov.it/it/piattaforme/carta-nazionale-servizi
I check codebase against my new cns (marked ST2021) and my old one (marked ac2014).

As suggested by dengert I used card version to switch from 1024/2048 key length.

##### Checklist
- [x ] PKCS#11 module is tested
