### PR TITLE
pkcs11-spy: fix random crash in print_generic()

### DIFF
--- a/src/pkcs11/pkcs11-display.c
+++ b/src/pkcs11/pkcs11-display.c
@@ -141,7 +141,8 @@ print_generic(FILE *f, CK_LONG type, CK_VOID_PTR value, CK_ULONG size, CK_VOID_P
 	CK_ULONG i;
 
 	if((CK_LONG)size != -1 && value != NULL) {
-		char hex[16*3+1], ascii[16+1];
+		char hex[16*3+1] = {0};
+		char ascii[16+1];
 		char *hex_ptr = hex, *ascii_ptr = ascii;
 		int offset = 0;
 


### PR DESCRIPTION
Depending on stack state print_generic() could cause crash or spurious garbage
in logs.

Example crash:

*** buffer overflow detected ***: pkcs11test terminated

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
