### PR TITLE
pkcs11-spy: Fix more crashes with NULL arguments

### DIFF
--- a/src/pkcs11/pkcs11-display.c
+++ b/src/pkcs11/pkcs11-display.c
@@ -1035,6 +1035,9 @@ print_attribute_list(FILE *f, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG  ulCount)
 	CK_ULONG j, k;
 	int found;
 
+	if (!pTemplate)
+		return;
+
 	for(j = 0; j < ulCount ; j++) {
 		found = 0;
 		for(k = 0; k < ck_attribute_num; k++) {
@@ -1065,6 +1068,9 @@ print_attribute_list_req(FILE *f, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG  ulCount)
 {
 	CK_ULONG j, k;
 	int found;
+
+	if (!pTemplate)
+		return;
 
 	for(j = 0; j < ulCount ; j++) {
 		found = 0;

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -416,6 +416,8 @@ CK_RV C_GetFunctionList
 	}
 
 	enter("C_GetFunctionList");
+	if (ppFunctionList == NULL)
+		return retne(CKR_ARGUMENTS_BAD);
 	*ppFunctionList = pkcs11_spy;
 	return retne(CKR_OK);
 }

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -611,7 +611,10 @@ C_OpenSession(CK_SLOT_ID  slotID, CK_FLAGS  flags, CK_VOID_PTR  pApplication,
 	fprintf(spy_output, "[in] pApplication = %p\n", pApplication);
 	fprintf(spy_output, "[in] Notify = %p\n", (void *)Notify);
 	rv = po->C_OpenSession(slotID, flags, pApplication, Notify, phSession);
-	spy_dump_ulong_out("*phSession", *phSession);
+	if (phSession)
+		spy_dump_ulong_out("*phSession", *phSession);
+	else
+		fprintf(spy_output, "[out] phSession = %p\n", phSession);
 	return retne(rv);
 }
 

--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -608,8 +608,8 @@ C_OpenSession(CK_SLOT_ID  slotID, CK_FLAGS  flags, CK_VOID_PTR  pApplication,
 	enter("C_OpenSession");
 	spy_dump_ulong_in("slotID", slotID);
 	spy_dump_ulong_in("flags", flags);
-	fprintf(spy_output, "pApplication=%p\n", pApplication);
-	fprintf(spy_output, "Notify=%p\n", (void *)Notify);
+	fprintf(spy_output, "[in] pApplication = %p\n", pApplication);
+	fprintf(spy_output, "[in] Notify = %p\n", (void *)Notify);
 	rv = po->C_OpenSession(slotID, flags, pApplication, Notify, phSession);
 	spy_dump_ulong_out("*phSession", *phSession);
 	return retne(rv);


### PR DESCRIPTION
This PR fixes last crashes noticed with [Google's pkcs11test](https://github.com/google/pkcs11test).

Now it works with SoftHSMv2 (v2.6.1) and with OP-TEE PKCS#11 (devel) without crashing.

Following PRs are also needed:
- https://github.com/OpenSC/OpenSC/pull/2368
- https://github.com/OpenSC/OpenSC/pull/2375

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
