### PR TITLE
Fix pkcs11-tool and test-pkcs11-tool-test-threads.sh

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -7506,10 +7506,12 @@ static void * test_threads_run(void * pttd)
 		/* Tn Get token from slot_index n C_GetTokenInfo, where n is 0 to 9 */
 		else if (*pctest == 'T' && *(pctest + 1) >= '0' && *(pctest + 1) <= '9') {
 			fprintf(stderr, "Test thread %d C_GetTokenInfo from slot_index %d using show_token\n", ttd->tnum, (*(pctest + 1) - '0'));
-			if (l_slots) {
+			if (l_slots && (CK_ULONG)(*(pctest + 1) - '0') < l_p11_num_slots) {
 				show_token(l_p11_slots[(*(pctest + 1) - '0')]);
 			} else {
-				show_token(p11_slots[(*(pctest + 1) - '0')]);
+				fprintf(stderr, "Test thread %d slot not available, unable to call C_GetTokenInfo\n", ttd->tnum);
+				rv = CKR_TOKEN_NOT_PRESENT;
+				break;
 			}
 		}
 

--- a/tests/test-pkcs11-tool-test-threads.sh
+++ b/tests/test-pkcs11-tool-test-threads.sh
@@ -14,16 +14,16 @@ fi
 card_setup
 
 echo "======================================================="
-echo "Test pkcs11 threads OSILGISLT0 "
+echo "Test pkcs11 threads IN "
 echo "======================================================="
 $PKCS11_TOOL --test-threads IN -L
 assert $? "Failed running tests"
 
 
 echo "======================================================="
-echo "Test pkcs11 threads OSILGISLT0 "
+echo "Test pkcs11 threads ILGISLT0 "
 echo "======================================================="
-$PKCS11_TOOL --test-threads OSILGISLT0 -L
+$PKCS11_TOOL --test-threads ILGISLT0 -L
 assert $? "Failed running tests"
 
 echo "======================================================="


### PR DESCRIPTION
test-pkcs11-tool-test-threads.sh had the wrong parameters
for one of the tests. And extra "OS" was left in the parameter.

pkcs11-tool when testing threads could segfault if no reader present.
Error checking for slot index improved.

Fixes:#2381

 On branch pkcs11-tool-and-test
 Changes to be committed:
	modified:   pkcs11-tool.c
	modified:   ../../tests/test-pkcs11-tool-test-threads.sh

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist

- [X] PKCS#11 module is tested

