### PR TITLE
Disable old card drivers and PKCS#15 emulators

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -837,12 +837,11 @@ app <em class="replaceable"><code>application</code></em> {
 						<code class="option">builtin_emulators = <em class="replaceable"><code>emulators</code></em>;</code>
 					</span></dt><dd><p>
 							List of the builtin pkcs15 emulators to test
-							(Default: <code class="literal">westcos, openpgp, 
-								starcert, tcos, esteid, itacns, 
-								PIV-II, cac, gemsafeGPK, gemsafeV1, actalis,
-								atrust-acos, tccardos, entersafe, pteid,
-								oberthur, sc-hsm, dnie, gids, iasecc, jpki,
-								coolkey, din66291</code>)
+							(Default: <code class="literal">internal</code>)
+						</p><p>
+							Special value <code class="literal">internal</code> will try all not disabled builtin pkcs15 emulators.
+						</p><p>
+							Special value of <code class="literal">old</code> will try all disabled pkcs15 emulators.
 					</p></dd><dt><span class="term">
 						<code class="option">pkcs11_enable_InitToken = <em class="replaceable"><code>bool</code></em>;</code>
 					</span></dt><dd><p>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1269,12 +1269,13 @@ app <replaceable>application</replaceable> {
 					</term>
 					<listitem><para>
 							List of the builtin pkcs15 emulators to test
-							(Default: <literal>westcos, openpgp, 
-								starcert, tcos, esteid, itacns, 
-								PIV-II, cac, gemsafeGPK, gemsafeV1, actalis,
-								atrust-acos, tccardos, entersafe, pteid,
-								oberthur, sc-hsm, dnie, gids, iasecc, jpki,
-								coolkey, din66291</literal>)
+							(Default: <literal>internal</literal>)
+						</para>
+						<para>
+							Special value of 'internal' will try all not disabled builtin pkcs15 emulators.
+						</para>
+						<para>
+							Special value of 'old' will try all disabled pkcs15 emulators.
 					</para></listitem>
 				</varlistentry>
 				<varlistentry>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1272,10 +1272,10 @@ app <replaceable>application</replaceable> {
 							(Default: <literal>internal</literal>)
 						</para>
 						<para>
-							Special value of 'internal' will try all not disabled builtin pkcs15 emulators.
+							Special value of <literal>internal</literal> will try all not disabled builtin pkcs15 emulators.
 						</para>
 						<para>
-							Special value of 'old' will try all disabled pkcs15 emulators.
+							Special value of <literal>old</literal> will try all disabled pkcs15 emulators.
 					</para></listitem>
 				</varlistentry>
 				<varlistentry>

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -929,8 +929,10 @@ app default {
 		# enable_builtin_emulation = no;
 		#
 		# List of the builtin pkcs15 emulators to test
-		# Default: esteid, openpgp, tcos, starcert, itacns, actalis, atrust-acos, gemsafeGPK, gemsafeV1, tccardos, PIV-II;
-		# builtin_emulators = openpgp;
+		# Special value of 'internal' will try all not disabled builtin pkcs15 emulators.
+		# Special value of 'old' will try all disabled pkcs15 emulators. 
+		# Default: internal;
+		# builtin_emulators = old, internal;
 
 		# additional settings per driver
 		#

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = Makefile.mak opensc.dll.manifest
 
 lib_LTLIBRARIES = libopensc.la
 noinst_HEADERS = cards.h ctbcs.h internal.h muscle.h muscle-filesystem.h \
-	internal-winscard.h p15card-helper.h pkcs15-syn.h \
+	internal-winscard.h p15card-helper.h pkcs15-syn.h pkcs15-emulator-filter.h \
 	opensc.h pkcs15.h gp.h \
 	cardctl.h asn1.h log.h simpletlv.h \
 	errors.h types.h compression.h itacns.h iso7816.h \
@@ -31,7 +31,7 @@ libopensc_la_SOURCES_BASE = \
 	\
 	pkcs15.c pkcs15-cert.c pkcs15-data.c pkcs15-pin.c \
 	pkcs15-prkey.c pkcs15-pubkey.c pkcs15-skey.c \
-	pkcs15-sec.c pkcs15-algo.c pkcs15-cache.c pkcs15-syn.c \
+	pkcs15-sec.c pkcs15-algo.c pkcs15-cache.c pkcs15-syn.c pkcs15-emulator-filter.c \
 	\
 	muscle.c muscle-filesystem.c \
 	\
@@ -114,7 +114,7 @@ TIDY_FILES = \
 	\
 	pkcs15-cert.c pkcs15-data.c pkcs15-pin.c \
 	pkcs15-prkey.c pkcs15-pubkey.c pkcs15-skey.c \
-	pkcs15-sec.c pkcs15-algo.c pkcs15-cache.c pkcs15-syn.c \
+	pkcs15-sec.c pkcs15-algo.c pkcs15-cache.c pkcs15-syn.c pkcs15-emulator-filter.c \
 	\
 	muscle.c muscle-filesystem.c \
 	\

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -8,7 +8,7 @@ OBJECTS			= \
 	\
 	pkcs15.obj pkcs15-cert.obj pkcs15-data.obj pkcs15-pin.obj \
 	pkcs15-prkey.obj pkcs15-pubkey.obj pkcs15-skey.obj \
-	pkcs15-sec.obj pkcs15-algo.obj pkcs15-cache.obj pkcs15-syn.obj \
+	pkcs15-sec.obj pkcs15-algo.obj pkcs15-cache.obj pkcs15-syn.obj pkcs15-emulator-filter.obj \
 	\
 	muscle.obj muscle-filesystem.obj \
 	\

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -95,13 +95,8 @@ struct _sc_driver_entry {
 
 static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "cardos",	(void *(*)(void)) sc_get_cardos_driver },
-	{ "flex",	(void *(*)(void)) sc_get_cryptoflex_driver },
 	{ "cyberflex",	(void *(*)(void)) sc_get_cyberflex_driver },
-#ifdef ENABLE_OPENSSL
-	{ "gpk",	(void *(*)(void)) sc_get_gpk_driver },
-#endif
 	{ "gemsafeV1",	(void *(*)(void)) sc_get_gemsafeV1_driver },
-	{ "asepcos",	(void *(*)(void)) sc_get_asepcos_driver },
 	{ "starcos",	(void *(*)(void)) sc_get_starcos_driver },
 	{ "tcos",	(void *(*)(void)) sc_get_tcos_driver },
 #ifdef ENABLE_OPENSSL
@@ -110,8 +105,6 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "iasecc",	(void *(*)(void)) sc_get_iasecc_driver },
 #endif
 	{ "belpic",	(void *(*)(void)) sc_get_belpic_driver },
-	{ "incrypto34", (void *(*)(void)) sc_get_incrypto34_driver },
-	{ "akis",	(void *(*)(void)) sc_get_akis_driver },
 #ifdef ENABLE_OPENSSL
 	{ "entersafe",(void *(*)(void)) sc_get_entersafe_driver },
 #ifdef ENABLE_SM
@@ -125,8 +118,6 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "dnie",       (void *(*)(void)) sc_get_dnie_driver },
 #endif
 	{ "masktech",	(void *(*)(void)) sc_get_masktech_driver },
-	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
-	{ "westcos",	(void *(*)(void)) sc_get_westcos_driver },
 	{ "esteid2018",	(void *(*)(void)) sc_get_esteid2018_driver },
 	{ "idprime",	(void *(*)(void)) sc_get_idprime_driver },
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
@@ -161,6 +152,15 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 };
 
 static const struct _sc_driver_entry old_card_drivers[] = {
+	{ "akis",       (void *(*)(void)) sc_get_akis_driver },
+	{ "asepcos",    (void *(*)(void)) sc_get_asepcos_driver },
+	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
+	{ "flex",       (void *(*)(void)) sc_get_cryptoflex_driver },
+#ifdef ENABLE_OPENSSL
+    { "gpk",        (void *(*)(void)) sc_get_gpk_driver },
+#endif
+	{ "incrypto34", (void *(*)(void)) sc_get_incrypto34_driver },
+	{ "westcos",    (void *(*)(void)) sc_get_westcos_driver },
 	{ NULL, NULL }
 };
 

--- a/src/libopensc/pkcs15-emulator-filter.c
+++ b/src/libopensc/pkcs15-emulator-filter.c
@@ -74,12 +74,14 @@ static int add_emul_list(struct _sc_pkcs15_emulators* filtered_emulators,
 	return SC_SUCCESS;
 }
 
-int set_emulators(struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list, 
+int set_emulators(sc_context_t *ctx, struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list,
 				  struct sc_pkcs15_emulator_handler* internal, struct sc_pkcs15_emulator_handler* old)
 {
 	const scconf_list *item;
 	int *cp, i, r, count;
 	
+	LOG_FUNC_CALLED(ctx);
+
 	if (!filtered_emulators || !list || !internal || !old)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
@@ -112,11 +114,15 @@ int set_emulators(struct _sc_pkcs15_emulators* filtered_emulators, const scconf_
 					break;
 				}
 			}
+			if (count == *cp)
+				sc_log(ctx, "Warning: Trying to add non-existing emulator '%s'.", item->data);
 		}
 	}
 out:
 	if (r == SC_SUCCESS || r == SC_ERROR_TOO_MANY_OBJECTS) {
 		filtered_emulators->list_of_handlers[*cp] = NULL;
+		if (r == SC_ERROR_TOO_MANY_OBJECTS)
+			sc_log(ctx, "Warning: Number of filtered emulators exceeded %d.", SC_MAX_PKCS15_EMULATORS);
 	}
-	return r;
+	LOG_FUNC_RETURN(ctx, r);
 }

--- a/src/libopensc/pkcs15-emulator-filter.c
+++ b/src/libopensc/pkcs15-emulator-filter.c
@@ -1,0 +1,122 @@
+/*
+ * pkcs15-emulator-filter.c: PKCS #15 emulator filter
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Author: Veronika Hanulikova <vhanulik@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "internal.h"
+#include "pkcs15-syn.h"
+#include "pkcs15-emulator-filter.h"
+
+static int add_emul(struct _sc_pkcs15_emulators* filtered_emulators,
+					struct sc_pkcs15_emulator_handler* emul_handler)
+{
+	struct sc_pkcs15_emulator_handler** lst;
+	int *cp, max, i;
+
+	if (!filtered_emulators || !emul_handler || !emul_handler->name || !emul_handler->handler)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	
+	lst = filtered_emulators->list_of_handlers;
+	cp = &filtered_emulators->ccount;
+	max = SC_MAX_PKCS15_EMULATORS;
+
+	if (*cp > max)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	if (*cp == max)
+		return SC_ERROR_TOO_MANY_OBJECTS;
+
+	for (i = 0; i < *cp; i++) {
+		if (!lst[i])
+			return SC_ERROR_OBJECT_NOT_VALID;
+		if (!strcmp(lst[i]->name, emul_handler->name))
+			return SC_SUCCESS;
+	}
+
+	lst[*cp] = emul_handler;
+	(*cp)++;
+	return SC_SUCCESS;
+}
+
+static int add_emul_list(struct _sc_pkcs15_emulators* filtered_emulators,
+						 struct sc_pkcs15_emulator_handler* emulators)
+{
+	struct sc_pkcs15_emulator_handler* lst;
+	int i, r;
+
+	if (!filtered_emulators || !emulators)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	lst = emulators;
+	for(i = 0; lst[i].name; i++) {
+		if ((r = add_emul(filtered_emulators, &lst[i])))
+			return r;
+	}
+	return SC_SUCCESS;
+}
+
+int set_emulators(struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list, 
+				  struct sc_pkcs15_emulator_handler* internal, struct sc_pkcs15_emulator_handler* old)
+{
+	const scconf_list *item;
+	int *cp, i, r, count;
+	
+	if (!filtered_emulators || !list || !internal || !old)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	cp = &filtered_emulators->ccount;
+	r = SC_SUCCESS;
+
+	for (item = list; item; item = item->next) {
+		if (!item->data)
+			continue;
+
+		if (!strcmp(item->data, "internal")) {
+			if ((r = add_emul_list(filtered_emulators, internal)))
+				goto out;
+		} else if (!strcmp(item->data, "old")) {
+			if ((r = add_emul_list(filtered_emulators, old)))
+				goto out;
+		} else {
+			count = *cp;
+			for (i = 0; internal[i].name; i++) {
+				if (!strcmp(internal[i].name, item->data)) {
+					if ((r = add_emul(filtered_emulators, &internal[i])))
+						goto out;
+					break;
+				}
+			}
+			for (i = 0; old[i].name && count == *cp; i++) {
+				if (!strcmp(old[i].name, item->data)) {
+					if ((r = add_emul(filtered_emulators, &old[i])))
+						goto out;
+					break;
+				}
+			}
+		}
+	}
+out:
+	if (r == SC_SUCCESS || r == SC_ERROR_TOO_MANY_OBJECTS) {
+		filtered_emulators->list_of_handlers[*cp] = NULL;
+	}
+	return r;
+}

--- a/src/libopensc/pkcs15-emulator-filter.h
+++ b/src/libopensc/pkcs15-emulator-filter.h
@@ -1,0 +1,28 @@
+/*
+ * pkcs15-emulator-filter.h: PKCS #15 emulator filter
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Author: Veronika Hanulikova <vhanulik@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+struct _sc_pkcs15_emulators {
+	struct sc_pkcs15_emulator_handler *list_of_handlers[SC_MAX_PKCS15_EMULATORS + 1];
+	int ccount;
+};
+
+int set_emulators(struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list, 
+					struct sc_pkcs15_emulator_handler* builtin, struct sc_pkcs15_emulator_handler* old);

--- a/src/libopensc/pkcs15-emulator-filter.h
+++ b/src/libopensc/pkcs15-emulator-filter.h
@@ -24,5 +24,5 @@ struct _sc_pkcs15_emulators {
 	int ccount;
 };
 
-int set_emulators(struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list, 
+int set_emulators(sc_context_t *ctx, struct _sc_pkcs15_emulators* filtered_emulators, const scconf_list *list,
 					struct sc_pkcs15_emulator_handler* builtin, struct sc_pkcs15_emulator_handler* old);

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -148,12 +148,12 @@ sc_pkcs15_bind_synthetic(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 			int ret;
 
 			filtered_emulators.ccount = 0;
-			ret = set_emulators(&filtered_emulators, list, builtin_emulators, old_emulators);
+			ret = set_emulators(ctx, &filtered_emulators, list, builtin_emulators, old_emulators);
 			if (ret == SC_SUCCESS || ret == SC_ERROR_TOO_MANY_OBJECTS) {
 				lst = filtered_emulators.list_of_handlers;
 
 				if (ret == SC_ERROR_TOO_MANY_OBJECTS)
-					sc_log(ctx, "number of filtered emulators exceeded %d", SC_MAX_PKCS15_EMULATORS);
+					sc_log(ctx, "trying first %d emulators from conf file", SC_MAX_PKCS15_EMULATORS);
 
 				for (i = 0; lst[i]; i++) {
 					sc_log(ctx, "trying %s", lst[i]->name);

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -33,9 +33,9 @@
 #include "asn1.h"
 #include "pkcs15.h"
 #include "pkcs15-syn.h"
+#include "pkcs15-emulator-filter.h"
 
 struct sc_pkcs15_emulator_handler builtin_emulators[] = {
-	{ "westcos",	sc_pkcs15emu_westcos_init_ex	},
 	{ "openpgp",	sc_pkcs15emu_openpgp_init_ex	},
 	{ "starcert",	sc_pkcs15emu_starcert_init_ex	},
 	{ "tcos",	sc_pkcs15emu_tcos_init_ex	},
@@ -44,10 +44,8 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "PIV-II",     sc_pkcs15emu_piv_init_ex	},
 	{ "cac",        sc_pkcs15emu_cac_init_ex	},
 	{ "idprime",    sc_pkcs15emu_idprime_init_ex	},
-	{ "gemsafeGPK",	sc_pkcs15emu_gemsafeGPK_init_ex	},
 	{ "gemsafeV1",	sc_pkcs15emu_gemsafeV1_init_ex	},
 	{ "actalis",	sc_pkcs15emu_actalis_init_ex	},
-	{ "atrust-acos",sc_pkcs15emu_atrust_acos_init_ex},
 	{ "tccardos",	sc_pkcs15emu_tccardos_init_ex	},
 	{ "entersafe",  sc_pkcs15emu_entersafe_init_ex	},
 	{ "pteid",	sc_pkcs15emu_pteid_init_ex	},
@@ -61,9 +59,15 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "din66291",   sc_pkcs15emu_din_66291_init_ex	},
 	{ "esteid2018", sc_pkcs15emu_esteid2018_init_ex	},
 	{ "cardos",     sc_pkcs15emu_cardos_init_ex	},
-
 	{ NULL, NULL }
 };
+
+struct sc_pkcs15_emulator_handler old_emulators[] = {
+	{ "westcos",	sc_pkcs15emu_westcos_init_ex	},
+	{ "gemsafeGPK",	sc_pkcs15emu_gemsafeGPK_init_ex	},
+	{ "atrust-acos",sc_pkcs15emu_atrust_acos_init_ex},
+	{ NULL, NULL }
+};	
 
 static int parse_emu_block(sc_pkcs15_card_t *, struct sc_aid *, scconf_block *);
 static sc_pkcs15_df_t * sc_pkcs15emu_get_df(sc_pkcs15_card_t *p15card,
@@ -132,25 +136,34 @@ sc_pkcs15_bind_synthetic(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 	} else {
 		/* we have a conf file => let's use it */
 		int builtin_enabled;
-		const scconf_list *list, *item;
+		const scconf_list *list;
 
 		builtin_enabled = scconf_get_bool(conf_block, "enable_builtin_emulation", 1);
 		list = scconf_find_list(conf_block, "builtin_emulators"); /* FIXME: rename to enabled_emulators */
 
 		if (builtin_enabled && list) {
-			/* get the list of enabled emulation drivers */
-			for (item = list; item; item = item->next) {
-				/* go through the list of builtin drivers */
-				const char *name = item->data;
+			/* filter enabled emulation drivers from conf file */
+			struct _sc_pkcs15_emulators filtered_emulators;
+			struct sc_pkcs15_emulator_handler** lst;
+			int ret;
 
-				sc_log(ctx, "trying %s", name);
-				for (i = 0; builtin_emulators[i].name; i++)
-					if (!strcmp(builtin_emulators[i].name, name)) {
-						r = builtin_emulators[i].handler(p15card, aid);
-						if (r == SC_SUCCESS)
-							/* we got a hit */
-							goto out;
-					}
+			filtered_emulators.ccount = 0;
+			ret = set_emulators(&filtered_emulators, list, builtin_emulators, old_emulators);
+			if (ret == SC_SUCCESS || ret == SC_ERROR_TOO_MANY_OBJECTS) {
+				lst = filtered_emulators.list_of_handlers;
+
+				if (ret == SC_ERROR_TOO_MANY_OBJECTS)
+					sc_log(ctx, "number of filtered emulators exceeded %d", SC_MAX_PKCS15_EMULATORS);
+
+				for (i = 0; lst[i]; i++) {
+					sc_log(ctx, "trying %s", lst[i]->name);
+					r = lst[i]->handler(p15card, aid);
+					if (r == SC_SUCCESS)
+						/* we got a hit */
+						goto out;
+				}
+			} else {
+				sc_log(ctx, "failed to filter enabled card emulators: %s", sc_strerror(ret));
 			}
 		}
 		else if (builtin_enabled) {
@@ -220,6 +233,14 @@ static int parse_emu_block(sc_pkcs15_card_t *p15card, struct sc_aid *aid, scconf
 			if (!strcmp(builtin_emulators[i].name, module_name)) {
 				init_func_ex = builtin_emulators[i].handler;
 				break;
+			}
+		}
+		if (init_func_ex == NULL) {
+			for (i = 0; old_emulators[i].name; i++) {
+				if (!strcmp(old_emulators[i].name, module_name)) {
+					init_func_ex = old_emulators[i].handler;
+					break;
+				}
 			}
 		}
 	} else {

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -45,8 +45,6 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "cac",        sc_pkcs15emu_cac_init_ex	},
 	{ "idprime",    sc_pkcs15emu_idprime_init_ex	},
 	{ "gemsafeV1",	sc_pkcs15emu_gemsafeV1_init_ex	},
-	{ "actalis",	sc_pkcs15emu_actalis_init_ex	},
-	{ "tccardos",	sc_pkcs15emu_tccardos_init_ex	},
 	{ "entersafe",  sc_pkcs15emu_entersafe_init_ex	},
 	{ "pteid",	sc_pkcs15emu_pteid_init_ex	},
 	{ "oberthur",   sc_pkcs15emu_oberthur_init_ex	},
@@ -66,6 +64,8 @@ struct sc_pkcs15_emulator_handler old_emulators[] = {
 	{ "westcos",	sc_pkcs15emu_westcos_init_ex	},
 	{ "gemsafeGPK",	sc_pkcs15emu_gemsafeGPK_init_ex	},
 	{ "atrust-acos",sc_pkcs15emu_atrust_acos_init_ex},
+	{ "actalis",	sc_pkcs15emu_actalis_init_ex	},
+	{ "tccardos",	sc_pkcs15emu_tccardos_init_ex	},
 	{ NULL, NULL }
 };	
 

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -49,6 +49,7 @@ typedef unsigned char u8;
 #define SC_MAX_SDO_ACLS			8
 #define SC_MAX_CRTS_IN_SE		12
 #define SC_MAX_SE_NUM			8
+#define SC_MAX_PKCS15_EMULATORS	48
 
 /* When changing this value, pay attention to the initialization of the ASN1
  * static variables that use this macro, like, for example,

--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -6,8 +6,8 @@ include $(top_srcdir)/aminclude_static.am
 clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
 
-noinst_PROGRAMS = asn1 simpletlv cachedir
-TESTS = asn1 simpletlv cachedir
+noinst_PROGRAMS = asn1 simpletlv cachedir pkcs15filter
+TESTS = asn1 simpletlv cachedir pkcs15filter
 
 noinst_HEADERS = torture.h
 
@@ -23,6 +23,7 @@ LDADD = $(top_builddir)/src/libopensc/libopensc.la \
 asn1_SOURCES = asn1.c
 simpletlv_SOURCES = simpletlv.c
 cachedir_SOURCES = cachedir.c
+pkcs15filter_SOURCES = pkcs15-emulator-filter.c
 
 if ENABLE_ZLIB
 noinst_PROGRAMS += compression

--- a/src/tests/unittests/Makefile.mak
+++ b/src/tests/unittests/Makefile.mak
@@ -1,9 +1,10 @@
 TOPDIR = ..\..\..
 
-TARGETS = asn1 compression
+TARGETS = asn1 compression pkcs15filter
 
 OBJECTS = asn1.obj \
-	compression.obj
+	compression.obj \
+	pkcs15-emulator-filter.obj
 	$(TOPDIR)\win32\versioninfo.res
 
 all: $(TARGETS)

--- a/src/tests/unittests/pkcs15-emulator-filter.c
+++ b/src/tests/unittests/pkcs15-emulator-filter.c
@@ -1,0 +1,490 @@
+/*
+ * pkcs15-emulator-filter.c: Unit tests for PKCS15 emulator filter
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Author: Veronika Hanulikova <vhanulik@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "torture.h"
+#include "libopensc/pkcs15-emulator-filter.c"
+
+int func(sc_pkcs15_card_t *card, struct sc_aid *aid) {
+	(void) card;
+	(void) aid;
+	return SC_SUCCESS;
+}
+
+struct sc_pkcs15_emulator_handler builtin[] = {
+	{ "openpgp",	&func },
+	{ "starcert",	&func },
+	{ NULL,	NULL }
+};
+struct sc_pkcs15_emulator_handler old[] = {
+	{ "westcos",	&func },
+	{ "cardos",		&func },
+	{ "jcop",		&func },
+	{ NULL, NULL }
+};
+
+/* add_emul */
+static void torture_null_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &builtin[0] }, 1 };
+	int rv;
+
+	rv = add_emul(NULL, &builtin[0]);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	rv = add_emul(&filtered_emulators, NULL);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+static void torture_name_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int rv;
+	filtered_emulators.ccount = 0;
+
+	rv = add_emul(&filtered_emulators, &builtin[0]);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_int_equal(filtered_emulators.ccount, 1);
+}
+
+static void torture_name_already_in_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &builtin[0] }, 1 };
+	int rv;
+
+	rv = add_emul(&filtered_emulators, &builtin[0]);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_int_equal(filtered_emulators.ccount, 1);
+}
+
+static void torture_full_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS;
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = add_emul(&filtered_emulators, &old[0]);
+	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &builtin[0]);
+}
+
+static void torture_overfilled_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS + 1;
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS + 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = add_emul(&filtered_emulators, &old[0]);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS + 1);
+}
+
+static void torture_invalid_handler_name_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	struct sc_pkcs15_emulator_handler handler = { NULL, &func };
+	int rv;
+	filtered_emulators.ccount = 0;
+
+	rv = add_emul(&filtered_emulators, &handler);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+static void torture_invalid_handler_func_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	struct sc_pkcs15_emulator_handler handler = { "name", NULL };
+	int rv;
+	filtered_emulators.ccount = 0;
+
+	rv = add_emul(&filtered_emulators, &handler);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+static void torture_invalid_emulator_list_add_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { NULL }, 1 };
+	struct sc_pkcs15_emulator_handler handler = { "name", &func };
+	int rv;
+
+	rv = add_emul(&filtered_emulators, &handler);
+	assert_int_equal(rv, SC_ERROR_OBJECT_NOT_VALID);
+}
+
+/* add_emul_list */
+static void torture_null_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &builtin[0] }, 1 };
+	int rv;
+
+	rv = add_emul_list(NULL, builtin);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	rv = add_emul_list(&filtered_emulators, NULL);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+static void torture_internal_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = 0;
+
+	rv = add_emul_list(&filtered_emulators, builtin);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_int_equal(filtered_emulators.ccount, i);
+}
+
+static void torture_internal_already_name_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &builtin[0] }, 1 };
+	int i, rv;
+
+	rv = add_emul_list(&filtered_emulators, builtin);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_int_equal(filtered_emulators.ccount, i);
+}
+
+static void torture_internal_already_name2_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &old[0] }, 1 };
+	int i, rv;
+
+	rv = add_emul_list(&filtered_emulators, builtin);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i + 1]);
+	}
+	assert_int_equal(filtered_emulators.ccount, i + 1);
+}
+
+static void torture_full_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS;
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[1];
+	}
+
+	rv = add_emul_list(&filtered_emulators, builtin);
+	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+}
+
+static void torture_one_to_full_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS - 1;
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS - 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = add_emul_list(&filtered_emulators, old);
+	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
+	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &old[0]);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+	assert_ptr_not_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS], &old[0]);
+}
+
+static void torture_overfilled_add_emul_list(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS + 1;
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS + 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = add_emul_list(&filtered_emulators, old);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &builtin[0]);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS + 1);
+}
+
+/* set_emulators */
+static void torture_non_existing(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int rv;
+	scconf_list list =  { NULL, "non" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_null(filtered_emulators.list_of_handlers[0]);
+}
+
+static void torture_internal_only(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	scconf_list list =  { NULL, "internal" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_int_equal(filtered_emulators.ccount, 2);
+	assert_null(filtered_emulators.list_of_handlers[2]);
+	assert_null(builtin[i].name);
+}
+
+static void torture_old_only(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	scconf_list list =  { NULL, "old" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; old[i].name; i++) {
+		assert_ptr_equal(&old[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_null(filtered_emulators.list_of_handlers[i]);
+	assert_null(old[i].name);
+}
+
+static void torture_internal_name(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int rv;
+	scconf_list list =  { NULL, strdup(builtin[0].name) };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_ptr_equal(&builtin[0], filtered_emulators.list_of_handlers[0]);
+	assert_null(filtered_emulators.list_of_handlers[1]);
+}
+
+static void torture_old_name(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int rv;
+	scconf_list list =  { NULL, strdup(old[0].name) };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_ptr_equal(&old[0], filtered_emulators.list_of_handlers[0]);
+	assert_null(filtered_emulators.list_of_handlers[1]);
+}
+
+static void torture_internal_and_name(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	scconf_list list2 =  { NULL, "cardos" };
+	scconf_list list1 =  { &list2, "internal" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_ptr_equal(&old[1], filtered_emulators.list_of_handlers[i]);
+	assert_null(filtered_emulators.list_of_handlers[i + 1]);
+}
+
+static void torture_name_and_internal(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int rv;
+	scconf_list list2 =  { NULL, "internal" };
+	scconf_list list1 =  { &list2, "starcert" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_ptr_equal(&builtin[1], filtered_emulators.list_of_handlers[0]);
+	assert_ptr_equal(&builtin[0], filtered_emulators.list_of_handlers[1]);
+	assert_null(filtered_emulators.list_of_handlers[2]);
+}
+
+static void torture_internal_and_nonexisting(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;;
+	scconf_list list2 =  { NULL, "non" };
+	scconf_list list1 =  { &list2, "internal" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_null(filtered_emulators.list_of_handlers[i]);
+	assert_null(builtin[i].name);
+}
+
+static void torture_nonexisting_and_internal(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	scconf_list list2 =  { NULL, "internal" };
+	scconf_list list1 =  { &list2, "non" };
+	filtered_emulators.ccount = 0;
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	for (i = 0; builtin[i].name; i++) {
+		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
+	}
+	assert_null(filtered_emulators.list_of_handlers[i]);
+	assert_null(builtin[i].name);
+}
+
+static void torture_null_set_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators = { { &builtin[0] }, 1 };
+	int rv;
+	scconf_list list1 = { NULL, "internal" };
+
+	rv = set_emulators(NULL, &list1, builtin, old);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	rv = set_emulators(&filtered_emulators, NULL, builtin, old);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	rv = set_emulators(&filtered_emulators, &list1, NULL, old);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+	rv = set_emulators(&filtered_emulators, &list1, builtin, NULL);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+static void torture_full_set_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS;
+	scconf_list list1 = { NULL, "old" };
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
+	assert_non_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1]);
+	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+}
+
+static void torture_one_to_full_set_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS - 1;
+	scconf_list list1 = { NULL, "old" };
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS - 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
+	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &old[0]);
+	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+}
+
+static void torture_one_to_full2_set_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS - 1;
+	scconf_list list1 = { NULL, strdup(old[1].name) };
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS - 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &old[1]);
+	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
+	assert_int_equal(filtered_emulators.ccount, SC_MAX_PKCS15_EMULATORS);
+}
+
+static void torture_overfilled_set_emul(void **state)
+{
+	struct _sc_pkcs15_emulators filtered_emulators;
+	int i, rv;
+	filtered_emulators.ccount = SC_MAX_PKCS15_EMULATORS + 1;
+	scconf_list list1 = { NULL, strdup(old[1].name) };
+	for (i = 0; i < SC_MAX_PKCS15_EMULATORS + 1; i++) {
+		filtered_emulators.list_of_handlers[i] = &builtin[0];
+	}
+
+	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		/* add_emul */
+		cmocka_unit_test(torture_null_add_emul),
+		cmocka_unit_test(torture_name_add_emul),
+		cmocka_unit_test(torture_name_already_in_add_emul),
+		cmocka_unit_test(torture_full_add_emul),
+		cmocka_unit_test(torture_overfilled_add_emul),
+		cmocka_unit_test(torture_invalid_handler_name_add_emul),
+		cmocka_unit_test(torture_invalid_handler_func_add_emul),
+		cmocka_unit_test(torture_invalid_emulator_list_add_emul),
+		/* add_emul_list */
+		cmocka_unit_test(torture_null_add_emul_list),
+		cmocka_unit_test(torture_internal_add_emul_list),
+		cmocka_unit_test(torture_internal_already_name_add_emul_list),
+		cmocka_unit_test(torture_internal_already_name2_add_emul_list),
+		cmocka_unit_test(torture_full_add_emul_list),
+		cmocka_unit_test(torture_one_to_full_add_emul_list),
+		cmocka_unit_test(torture_overfilled_add_emul_list),
+		/* set_emulators */
+		cmocka_unit_test(torture_non_existing),
+		cmocka_unit_test(torture_internal_only),
+		cmocka_unit_test(torture_old_only),
+		cmocka_unit_test(torture_internal_name),
+		cmocka_unit_test(torture_old_name),
+		cmocka_unit_test(torture_internal_and_name),
+		cmocka_unit_test(torture_name_and_internal),
+		cmocka_unit_test(torture_internal_and_nonexisting),
+		cmocka_unit_test(torture_nonexisting_and_internal),
+		cmocka_unit_test(torture_null_set_emul),
+		cmocka_unit_test(torture_full_set_emul),
+		cmocka_unit_test(torture_one_to_full_set_emul),
+		cmocka_unit_test(torture_one_to_full2_set_emul),
+		cmocka_unit_test(torture_overfilled_set_emul),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/unittests/pkcs15-emulator-filter.c
+++ b/src/tests/unittests/pkcs15-emulator-filter.c
@@ -239,7 +239,7 @@ static void torture_non_existing(void **state)
 	scconf_list list =  { NULL, "non" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	assert_null(filtered_emulators.list_of_handlers[0]);
 }
@@ -251,7 +251,7 @@ static void torture_internal_only(void **state)
 	scconf_list list =  { NULL, "internal" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	for (i = 0; builtin[i].name; i++) {
 		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
@@ -268,7 +268,7 @@ static void torture_old_only(void **state)
 	scconf_list list =  { NULL, "old" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	for (i = 0; old[i].name; i++) {
 		assert_ptr_equal(&old[i], filtered_emulators.list_of_handlers[i]);
@@ -284,7 +284,7 @@ static void torture_internal_name(void **state)
 	scconf_list list =  { NULL, strdup(builtin[0].name) };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	assert_ptr_equal(&builtin[0], filtered_emulators.list_of_handlers[0]);
 	assert_null(filtered_emulators.list_of_handlers[1]);
@@ -297,7 +297,7 @@ static void torture_old_name(void **state)
 	scconf_list list =  { NULL, strdup(old[0].name) };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	assert_ptr_equal(&old[0], filtered_emulators.list_of_handlers[0]);
 	assert_null(filtered_emulators.list_of_handlers[1]);
@@ -311,7 +311,7 @@ static void torture_internal_and_name(void **state)
 	scconf_list list1 =  { &list2, "internal" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	for (i = 0; builtin[i].name; i++) {
 		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
@@ -328,7 +328,7 @@ static void torture_name_and_internal(void **state)
 	scconf_list list1 =  { &list2, "starcert" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	assert_ptr_equal(&builtin[1], filtered_emulators.list_of_handlers[0]);
 	assert_ptr_equal(&builtin[0], filtered_emulators.list_of_handlers[1]);
@@ -343,7 +343,7 @@ static void torture_internal_and_nonexisting(void **state)
 	scconf_list list1 =  { &list2, "internal" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	for (i = 0; builtin[i].name; i++) {
 		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
@@ -360,7 +360,7 @@ static void torture_nonexisting_and_internal(void **state)
 	scconf_list list1 =  { &list2, "non" };
 	filtered_emulators.ccount = 0;
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	for (i = 0; builtin[i].name; i++) {
 		assert_ptr_equal(&builtin[i], filtered_emulators.list_of_handlers[i]);
@@ -375,13 +375,13 @@ static void torture_null_set_emul(void **state)
 	int rv;
 	scconf_list list1 = { NULL, "internal" };
 
-	rv = set_emulators(NULL, &list1, builtin, old);
+	rv = set_emulators(NULL, NULL, &list1, builtin, old);
 	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
-	rv = set_emulators(&filtered_emulators, NULL, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, NULL, builtin, old);
 	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
-	rv = set_emulators(&filtered_emulators, &list1, NULL, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, NULL, old);
 	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
-	rv = set_emulators(&filtered_emulators, &list1, builtin, NULL);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, NULL);
 	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
 }
 
@@ -395,7 +395,7 @@ static void torture_full_set_emul(void **state)
 		filtered_emulators.list_of_handlers[i] = &builtin[0];
 	}
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
 	assert_non_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1]);
 	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
@@ -412,7 +412,7 @@ static void torture_one_to_full_set_emul(void **state)
 		filtered_emulators.list_of_handlers[i] = &builtin[0];
 	}
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_ERROR_TOO_MANY_OBJECTS);
 	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &old[0]);
 	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
@@ -429,7 +429,7 @@ static void torture_one_to_full2_set_emul(void **state)
 		filtered_emulators.list_of_handlers[i] = &builtin[0];
 	}
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_SUCCESS);
 	assert_ptr_equal(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS - 1], &old[1]);
 	assert_null(filtered_emulators.list_of_handlers[SC_MAX_PKCS15_EMULATORS]);
@@ -446,7 +446,7 @@ static void torture_overfilled_set_emul(void **state)
 		filtered_emulators.list_of_handlers[i] = &builtin[0];
 	}
 
-	rv = set_emulators(&filtered_emulators, &list1, builtin, old);
+	rv = set_emulators(NULL, &filtered_emulators, &list1, builtin, old);
 	assert_int_equal(rv, SC_ERROR_INVALID_ARGUMENTS);
 }
 


### PR DESCRIPTION
This PR disables old and recently unmodified card drivers (`card-*.c`) and their counterpart PKCS#15 emulators (`pkcs15-*.c`), and adds boilerplate for disabling old emulators.

Developer activity below tracks active developing and maintaining a card driver/emulator, excluding generic changes and fuzzing/static analysis fixes:
- `card-akis.c`: modified [2007](https://github.com/OpenSC/OpenSC/commit/f9476144182dcc1568518f436ec8e5368841902a)
- `card-asepcos.c`: modified [2010](https://github.com/OpenSC/OpenSC/commit/02c35be138d67b290e0a3fe239a1db739c1c6fe3)
- `card-atrust-acos.c` (`pkcs15-atrust-acos.c`): modified [2008](https://github.com/OpenSC/OpenSC/commit/a4bad4452e7d6acdb75c129fa28c5291f4606b79)
- `card-flex.c`: modified [2010](https://github.com/OpenSC/OpenSC/commit/7d935df1bc65022ef80a40f8721f0fa8e3709289)
- `card-gpk.c` (`pkcs15-gemsafeGPK.c`): modified [2007](https://github.com/OpenSC/OpenSC/commit/a8908b8548e02d320376844b3d9668f0f89b3c29)
- `card-incrypto34.c`: modified [2007](https://github.com/OpenSC/OpenSC/commit/a2f622a21521cb350541894d80e3266b5f2f5612)
- `card-westcos.c` (`pkcs15-westcos.c`): modified [2010](https://github.com/OpenSC/OpenSC/commit/c3de15d2d08061cd6b2a0fabbdaaa7b8a6ede1fa)
- `pkcs15-actalis.c` and `pkcs15-tccardos.c`: Emulators detect card according to card name, which was changed in `card-cardos.c` in eee4964 (2017) and they were not updated since this change accordingly, which implies no latest use.

There was no recent user activity (issues, bug reports) related to the mentioned cards.
Disabled drivers and emulators can be enabled in `opensc.conf`.
Filtering of PKCS#15 emulators in `pkcs15-emulator-filter.c` enables emulators according to `opensc.conf` file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
