### PR TITLE
test-actions-2 vsmartcard-0.8 

### DIFF
--- a/.github/setup-vsmartcard.sh
+++ b/.github/setup-vsmartcard.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-
+set -x
 if [ ! -d "vsmartcard" ]; then
 	git clone https://github.com/frankmorgner/vsmartcard.git
 fi
 pushd vsmartcard/virtualsmartcard
+git checkout -b  tag-0.8 virtualsmartcard-0.8
 autoreconf -vis && ./configure && make -j2 && sudo make install
 popd


### PR DESCRIPTION
[vsmartcard](https://github.com/frankmorgner/vsmartcard) was updated on 8/13 a few days before we start noticing Github actions failing for several tests.

This temporary change  checkout out vsmartcard-0.8  avoids this commit: https://github.com/frankmorgner/vsmartcard/commit/5a6b330b154a6b6b3ad30c4b69fae83a031d0f36 

All the action tests now run.
