### PR TITLE
openpgp-tool: fix buffer overflow on serials with MSb set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ src/tests/unittests/*.trs
 src/tests/unittests/asn1
 src/tests/unittests/cachedir
 src/tests/unittests/compression
+src/tests/unittests/openpgp-tool
 src/tests/unittests/pkcs15filter
 src/tests/unittests/simpletlv
 src/tests/unittests/sm

--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,9 @@ tests/*.trs
 src/tests/unittests/*.log
 src/tests/unittests/*.trs
 src/tests/unittests/asn1
+src/tests/unittests/cachedir
 src/tests/unittests/compression
+src/tests/unittests/pkcs15filter
 src/tests/unittests/simpletlv
 src/tests/unittests/sm
 

--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -6,8 +6,8 @@ include $(top_srcdir)/aminclude_static.am
 clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
 
-noinst_PROGRAMS = asn1 simpletlv cachedir pkcs15filter
-TESTS = asn1 simpletlv cachedir pkcs15filter
+noinst_PROGRAMS = asn1 simpletlv cachedir pkcs15filter openpgp-tool
+TESTS = asn1 simpletlv cachedir pkcs15filter openpgp-tool
 
 noinst_HEADERS = torture.h
 
@@ -24,6 +24,7 @@ asn1_SOURCES = asn1.c
 simpletlv_SOURCES = simpletlv.c
 cachedir_SOURCES = cachedir.c
 pkcs15filter_SOURCES = pkcs15-emulator-filter.c
+openpgp_tool_SOURCES = openpgp-tool.c $(top_builddir)/src/tools/openpgp-tool-helpers.c
 
 if ENABLE_ZLIB
 noinst_PROGRAMS += compression

--- a/src/tests/unittests/openpgp-tool.c
+++ b/src/tests/unittests/openpgp-tool.c
@@ -1,0 +1,168 @@
+/*
+ * openpgp-tool.c: Test various functions of openpgp-tool
+ *
+ * Copyright (C) 2021  Vincent Pelletier <plr.vincent@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "torture.h"
+
+#include "tools/openpgp-tool-helpers.h"
+
+struct expectation {
+    const char *data;
+    size_t length;
+    const char *output;
+};
+
+static void torture_prettify(void **state, const struct expectation *cur, char *(prettify_func)(const u8 *data, size_t length))
+{
+	char *output;
+
+	while (cur->data != NULL) {
+		output = prettify_func((u8 *) cur->data, cur->length);
+		if (cur->output == NULL)
+			assert_null(output);
+		else {
+			assert_non_null(output);
+			assert_string_equal(output, cur->output);
+		}
+		cur++;
+	}
+}
+
+const struct expectation expectations_algorithm[] = {
+    { "", 0, NULL },
+    { "\x12\x2b\x06\x01\x04\x01\x97\x55\x01\x05\x01", 11, "ECDH" },
+    { "\x01\x08\x00\x00\x20\x00", 6, "RSA2048" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_algorithm(void **state)
+{
+	torture_prettify(state, expectations_algorithm, prettify_algorithm);
+}
+
+const struct expectation expectations_date[] = {
+    { "\x01\x02\x03", 3, NULL },
+    { "\x12\x34\x56\x78", 4, "1979-09-05 22:51:36" },
+    { "\x7f\xff\xff\xff", 4, "2038-01-19 03:14:07" },
+    /* XXX: probably not a feature */
+    { "\x80\x00\x00\x00", 4, "1901-12-13 20:45:52" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_date(void **state)
+{
+	torture_prettify(state, expectations_date, prettify_date);
+}
+
+const struct expectation expectations_version[] = {
+    { "\x01", 1, NULL },
+    { "\x03\x41", 2, "3.41" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_version(void **state)
+{
+	torture_prettify(state, expectations_version, prettify_version);
+}
+
+const struct expectation expectations_manufacturer[] = {
+    { "\x01", 1, NULL },
+    { "\xf5\x17", 2, "FSIJ" },
+    { "\xff\x00", 2, "unmanaged S/N range" },
+    { "\xff\x7f", 2, "unmanaged S/N range" },
+    { "\xff\xfe", 2, "unmanaged S/N range" },
+    { "\xff\xff", 2, "test card" },
+    /* Number picked by a fair dice roll among unregistered numbers */
+    { "\x81\x88", 2, "unknown" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_manufacturer(void **state)
+{
+	torture_prettify(state, expectations_manufacturer, prettify_manufacturer);
+}
+
+const struct expectation expectations_serialnumber[] = {
+    { "\x00\x00\x00", 3, NULL },
+    { "\x12\x34\x56\x78", 4, "12345678" },
+    { "\x80\x00\x00\x00", 4, "80000000" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_serialnumber(void **state)
+{
+	torture_prettify(state, expectations_serialnumber, prettify_serialnumber);
+}
+
+const struct expectation expectations_name[] = {
+    { "", 0, NULL },
+    { "John Doe", 8, "John Doe" },
+    { "John<Doe", 8, "John Doe" },
+    { "John<<Doe", 9, "John Doe" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_name(void **state)
+{
+	torture_prettify(state, expectations_name, prettify_name);
+}
+
+const struct expectation expectations_language[] = {
+    { "", 0, NULL },
+    { "en", 2, "en" },
+    { "end", 3, "en" },
+    { "deen", 4, "de,en" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_language(void **state)
+{
+	torture_prettify(state, expectations_language, prettify_language);
+}
+
+const struct expectation expectations_gender[] = {
+    { "", 0, NULL },
+    { "\x30", 1, "unknown" },
+    { "\x31", 1, "male" },
+    { "\x32", 1, "female" },
+    { "\x39", 1, "not announced" },
+    { NULL, 0, NULL }
+};
+
+static void torture_prettify_gender(void **state)
+{
+	torture_prettify(state, expectations_gender, prettify_gender);
+}
+
+int main(void)
+{
+	int rc;
+	struct CMUnitTest tests[] = {
+		cmocka_unit_test(torture_prettify_algorithm),
+		cmocka_unit_test(torture_prettify_date),
+		cmocka_unit_test(torture_prettify_version),
+		cmocka_unit_test(torture_prettify_manufacturer),
+		cmocka_unit_test(torture_prettify_serialnumber),
+		cmocka_unit_test(torture_prettify_name),
+		cmocka_unit_test(torture_prettify_language),
+		cmocka_unit_test(torture_prettify_gender),
+	};
+
+	rc = cmocka_run_group_tests(tests, NULL, NULL);
+	return rc;
+}

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -25,7 +25,8 @@ EXTRA_DIST = Makefile.mak versioninfo-tools.rc.in versioninfo-opensc-notify.rc.i
 
 noinst_HEADERS = util.h fread_to_eof.h \
 	egk-tool-cmdline.h goid-tool-cmdline.h npa-tool-cmdline.h \
-	opensc-asn1-cmdline.h opensc-notify-cmdline.h pkcs11-register-cmdline.h
+	opensc-asn1-cmdline.h opensc-notify-cmdline.h pkcs11-register-cmdline.h \
+	openpgp-tool-helpers.h
 noinst_PROGRAMS = sceac-example
 bin_PROGRAMS = opensc-tool opensc-explorer opensc-notify \
 	pkcs15-tool pkcs15-crypt pkcs11-tool pkcs11-register \
@@ -77,7 +78,7 @@ netkey_tool_SOURCES = netkey-tool.c
 netkey_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 westcos_tool_SOURCES = westcos-tool.c util.c
 westcos_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
-openpgp_tool_SOURCES = openpgp-tool.c util.c
+openpgp_tool_SOURCES = openpgp-tool.c util.c openpgp-tool-helpers.c
 openpgp_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 iasecc_tool_SOURCES = iasecc-tool.c util.c
 iasecc_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)

--- a/src/tools/Makefile.mak
+++ b/src/tools/Makefile.mak
@@ -57,6 +57,11 @@ pkcs15-tool.exe: pkcs15-tool.obj $(TOPDIR)\src\pkcs11\pkcs11-display.obj
 	link $(LINKFLAGS) /pdb:$*.pdb /out:$@ $*.obj $(TOPDIR)\src\pkcs11\pkcs11-display.obj $(OBJECTS) $(LIBS) $(OPENSSL_LIB) gdi32.lib shell32.lib User32.lib ws2_32.lib shlwapi.lib
 	mt -manifest exe.manifest -outputresource:$@;1
 
+openpgp-tool.exe: openpgp-tool-helpers.obj $(LIBS)
+	cl $(COPTS) /c $*.c
+	link $(LINKFLAGS) /pdb:$*.pdb /out:$@ $*.obj openpgp-tool-helpers.obj $(OBJECTS) $(LIBS) gdi32.lib shell32.lib User32.lib ws2_32.lib shlwapi.lib
+	mt -manifest exe.manifest -outputresource:$@;1
+
 .c.exe:
 	cl $(COPTS) /c $<
 	link $(LINKFLAGS) /pdb:$*.pdb /out:$@ $*.obj $(OBJECTS) $(LIBS) $(OPENSSL_LIB) gdi32.lib shell32.lib User32.lib ws2_32.lib shlwapi.lib

--- a/src/tools/openpgp-tool-helpers.c
+++ b/src/tools/openpgp-tool-helpers.c
@@ -1,0 +1,222 @@
+/*
+ * openpgp-tool-helpers.c: OpenPGP card utility
+ *
+ * Copyright (C) 2012-2020 Peter Marschall <peter@adpm.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <time.h>
+#include "openpgp-tool-helpers.h"
+#include "util.h"
+
+
+/* prettify hex */
+char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen)
+{
+	if (data != NULL) {
+		int r = sc_bin_to_hex(data, length, buffer, buflen, ':');
+
+		if (r == SC_SUCCESS)
+			return buffer;
+	}
+	return NULL;
+}
+
+
+/* prettify algorithm parameters */
+char *prettify_algorithm(u8 *data, size_t length)
+{
+	if (data != NULL && length >= 1) {
+		static char result[64];	/* large enough */
+
+		if (data[0] == 0x01 && length >= 5) {		/* RSA */
+			unsigned short modulus = (data[1] << 8) + data[2];
+			snprintf(result, sizeof(result), "RSA%u", modulus);
+			return result;
+		}
+		else if (data[0] == 0x12) {			/* ECDH */
+			strcpy(result, "ECDH");
+			return result;
+		}
+		else if (data[0] == 0x13) {			/* ECDSA */
+			strcpy(result, "ECDSA");
+			return result;
+		}
+	}
+	return NULL;
+}
+
+
+/* prettify date/time */
+char *prettify_date(u8 *data, size_t length)
+{
+	if (data != NULL && length == 4) {
+		time_t time = (time_t) (data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3]);
+		struct tm tm;
+		static char result[64];	/* large enough */
+
+#ifdef _WIN32
+		if (0 != gmtime_s(&tm, &time))
+			return NULL;
+#else
+		if (NULL == gmtime_r(&time, &tm))
+			return NULL;
+#endif
+		strftime(result, sizeof(result), "%Y-%m-%d %H:%M:%S", &tm);
+		return result;
+	}
+	return NULL;
+}
+
+
+#define BCD2CHAR(x) (((((x) & 0xF0) >> 4) * 10) + ((x) & 0x0F))
+
+/* prettify OpenPGP card version */
+char *prettify_version(u8 *data, size_t length)
+{
+	if (data != NULL && length >= 2) {
+		static char result[10];	/* large enough for even 2*3 digits + separator */
+		int major = BCD2CHAR(data[0]);
+		int minor = BCD2CHAR(data[1]);
+
+		sprintf(result, "%d.%d", major, minor);
+		return result;
+	}
+	return NULL;
+}
+
+
+/* prettify manufacturer */
+char *prettify_manufacturer(u8 *data, size_t length)
+{
+	if (data != NULL && length >= 2) {
+		unsigned int manuf = (data[0] << 8) + data[1];
+
+		switch (manuf) {
+			case 0x0001: return "PPC Card Systems";
+			case 0x0002: return "Prism";
+			case 0x0003: return "OpenFortress";
+			case 0x0004: return "Wewid";
+			case 0x0005: return "ZeitControl";
+			case 0x0006: return "Yubico";
+			case 0x0007: return "OpenKMS";
+			case 0x0008: return "LogoEmail";
+			case 0x0009: return "Fidesmo";
+			case 0x000A: return "Dangerous Things";
+			case 0x000B: return "Feitian Technologies";
+
+			case 0x002A: return "Magrathea";
+			case 0x0042: return "GnuPG e.V.";
+
+			case 0x1337: return "Warsaw Hackerspace";
+			case 0x2342: return "warpzone"; /* hackerspace Muenster.  */
+			case 0x4354: return "Confidential Technologies";   /* cotech.de */
+			case 0x5443: return "TIF-IT e.V.";
+			case 0x63AF: return "Trustica";
+			case 0xBA53: return "c-base e.V.";
+			case 0xBD0E: return "Paranoidlabs";
+			case 0xF517: return "FSIJ";
+			case 0xF5EC: return "F-Secure";
+
+			/* 0x0000 and 0xFFFF are defined as test cards per spec,
+			   0xFF00 to 0xFFFE are assigned for use with randomly created
+			   serial numbers.  */
+			case 0x0000:
+			case 0xffff: return "test card";
+			default: return (manuf & 0xff00) == 0xff00 ? "unmanaged S/N range" : "unknown";
+		}
+	}
+	return NULL;
+}
+
+
+/* prettify pure serial number */
+char *prettify_serialnumber(u8 *data, size_t length)
+{
+	if (data != NULL && length >= 4) {
+		static char result[15];	/* large enough for even 2*3 digits + separator */
+		sprintf(result, "%02X%02X%02X%02X", data[0], data[1], data[2], data[3]);
+		return result;
+	}
+	return NULL;
+}
+
+
+/* prettify card holder's name */
+char *prettify_name(u8 *data, size_t length)
+{
+	if (data != NULL && length > 0) {
+		char *src = (char *) data;
+		char *dst = (char *) data;
+
+		while (*src != '\0' && length > 0) {
+			*dst = *src++;
+			length--;
+			if (*dst == '<') {
+				if (length > 0 && *src == '<') {
+					src++;
+					length--;
+				}
+				*dst = ' ';
+			}
+			dst++;
+		}
+		*dst = '\0';
+		return (char *) data;
+	}
+	return NULL;
+}
+
+
+/* prettify language */
+char *prettify_language(u8 *data, size_t length)
+{
+	if (data != NULL && length > 0) {
+		char *str = (char *) data;
+
+		switch (strlen(str)) {
+			case 8: memmove(str+7, str+6, 1+strlen(str+6));
+				str[6] = ',';
+				/* fall through */
+			case 6: memmove(str+5, str+4, 1+strlen(str+4));
+				str[4] = ',';
+				/* fall through */
+			case 4: memmove(str+3, str+2, 1+strlen(str+2));
+				str[2] = ',';
+				/* fall through */
+			case 2: return str;
+		}
+	}
+	return NULL;
+}
+
+
+/* convert the raw ISO-5218 SEX value to an english word */
+char *prettify_gender(u8 *data, size_t length)
+{
+	if (data != NULL && length > 0) {
+		switch (*data) {
+			case '0': return "unknown";
+			case '1': return "male";
+			case '2': return "female";
+			case '9': return "not announced";
+		}
+	}
+	return NULL;
+}

--- a/src/tools/openpgp-tool-helpers.c
+++ b/src/tools/openpgp-tool-helpers.c
@@ -58,6 +58,10 @@ char *prettify_algorithm(const u8 *data, size_t length)
 			strcpy(result, "ECDSA");
 			return result;
 		}
+		else if (data[0] == 0x16) {			/* EDDSA */
+			strcpy(result, "EDDSA");
+			return result;
+		}
 	}
 	return NULL;
 }

--- a/src/tools/openpgp-tool-helpers.h
+++ b/src/tools/openpgp-tool-helpers.h
@@ -24,15 +24,15 @@
 #include "util.h"
 
 
-char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen);
-char *prettify_algorithm(u8 *data, size_t length);
-char *prettify_date(u8 *data, size_t length);
-char *prettify_version(u8 *data, size_t length);
-char *prettify_manufacturer(u8 *data, size_t length);
-char *prettify_serialnumber(u8 *data, size_t length);
-char *prettify_name(u8 *data, size_t length);
-char *prettify_language(u8 *data, size_t length);
-char *prettify_gender(u8 *data, size_t length);
+char *prettify_hex(const u8 *data, size_t length, char *buffer, size_t buflen);
+char *prettify_algorithm(const u8 *data, size_t length);
+char *prettify_date(const u8 *data, size_t length);
+char *prettify_version(const u8 *data, size_t length);
+char *prettify_manufacturer(const u8 *data, size_t length);
+char *prettify_serialnumber(const u8 *data, size_t length);
+char *prettify_name(const u8 *data, size_t length);
+char *prettify_language(const u8 *data, size_t length);
+char *prettify_gender(const u8 *data, size_t length);
 
 
 #endif /* OPENPGP_TOOL_HELPERS_H */

--- a/src/tools/openpgp-tool-helpers.h
+++ b/src/tools/openpgp-tool-helpers.h
@@ -1,0 +1,38 @@
+/*
+ * openpgp-tool-helpers.h: OpenPGP card utility
+ *
+ * Copyright (C) 2012-2020 Peter Marschall <peter@adpm.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef OPENPGP_TOOL_HELPERS_H
+#define OPENPGP_TOOL_HELPERS_H
+
+#include "util.h"
+
+
+char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen);
+char *prettify_algorithm(u8 *data, size_t length);
+char *prettify_date(u8 *data, size_t length);
+char *prettify_version(u8 *data, size_t length);
+char *prettify_manufacturer(u8 *data, size_t length);
+char *prettify_serialnumber(u8 *data, size_t length);
+char *prettify_name(u8 *data, size_t length);
+char *prettify_language(u8 *data, size_t length);
+char *prettify_gender(u8 *data, size_t length);
+
+
+#endif /* OPENPGP_TOOL_HELPERS_H */

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -49,6 +49,8 @@
 #include "libopensc/log.h"
 #include "libopensc/card-openpgp.h"
 
+#include "openpgp-tool-helpers.h"
+
 #define OPT_RAW     256
 #define OPT_PRETTY  257
 #define OPT_VERIFY  258
@@ -74,15 +76,6 @@ struct ef_name_map {
 
 /* declare functions */
 static void show_version(void);
-static char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen);
-static char *prettify_algorithm(u8 *data, size_t length);
-static char *prettify_date(u8 *data, size_t length);
-static char *prettify_version(u8 *data, size_t length);
-static char *prettify_manufacturer(u8 *data, size_t length);
-static char *prettify_serialnumber(u8 *data, size_t length);
-static char *prettify_name(u8 *data, size_t length);
-static char *prettify_language(u8 *data, size_t length);
-static char *prettify_gender(u8 *data, size_t length);
 static void display_data(const struct ef_name_map *mapping, u8 *data, size_t length);
 static int decode_options(int argc, char **argv);
 static int do_info(sc_card_t *card, const struct ef_name_map *map);
@@ -197,202 +190,6 @@ static void show_version(void)
 		"\n"
 		"Copyright (c) 2012-2020 Peter Marschall <peter@adpm.de>\n"
 		"Licensed under LGPL v2\n");
-}
-
-
-/* prettify hex */
-static char *prettify_hex(u8 *data, size_t length, char *buffer, size_t buflen)
-{
-	if (data != NULL) {
-		int r = sc_bin_to_hex(data, length, buffer, buflen, ':');
-
-		if (r == SC_SUCCESS)
-			return buffer;
-	}
-	return NULL;
-}
-
-
-/* prettify algorithm parameters */
-static char *prettify_algorithm(u8 *data, size_t length)
-{
-	if (data != NULL && length >= 1) {
-		static char result[64];	/* large enough */
-
-		if (data[0] == 0x01 && length >= 5) {		/* RSA */
-			unsigned short modulus = (data[1] << 8) + data[2];
-			snprintf(result, sizeof(result), "RSA%u", modulus);
-			return result;
-		}
-		else if (data[0] == 0x12) {			/* ECDH */
-			strcpy(result, "ECDH");
-			return result;
-		}
-		else if (data[0] == 0x13) {			/* ECDSA */
-			strcpy(result, "ECDSA");
-			return result;
-		}
-	}
-	return NULL;
-}
-
-
-/* prettify date/time */
-static char *prettify_date(u8 *data, size_t length)
-{
-	if (data != NULL && length == 4) {
-		time_t time = (time_t) (data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3]);
-		struct tm tm;
-		static char result[64];	/* large enough */
-
-#ifdef _WIN32
-		if (0 != gmtime_s(&tm, &time))
-			return NULL;
-#else
-		if (NULL == gmtime_r(&time, &tm))
-			return NULL;
-#endif
-		strftime(result, sizeof(result), "%Y-%m-%d %H:%M:%S", &tm);
-		return result;
-	}
-	return NULL;
-}
-
-
-#define BCD2CHAR(x) (((((x) & 0xF0) >> 4) * 10) + ((x) & 0x0F))
-
-/* prettify OpenPGP card version */
-static char *prettify_version(u8 *data, size_t length)
-{
-	if (data != NULL && length >= 2) {
-		static char result[10];	/* large enough for even 2*3 digits + separator */
-		int major = BCD2CHAR(data[0]);
-		int minor = BCD2CHAR(data[1]);
-
-		sprintf(result, "%d.%d", major, minor);
-		return result;
-	}
-	return NULL;
-}
-
-
-/* prettify manufacturer */
-static char *prettify_manufacturer(u8 *data, size_t length)
-{
-	if (data != NULL && length >= 2) {
-		unsigned int manuf = (data[0] << 8) + data[1];
-
-		switch (manuf) {
-			case 0x0001: return "PPC Card Systems";
-			case 0x0002: return "Prism";
-			case 0x0003: return "OpenFortress";
-			case 0x0004: return "Wewid";
-			case 0x0005: return "ZeitControl";
-			case 0x0006: return "Yubico";
-			case 0x0007: return "OpenKMS";
-			case 0x0008: return "LogoEmail";
-			case 0x0009: return "Fidesmo";
-			case 0x000A: return "Dangerous Things";
-			case 0x000B: return "Feitian Technologies";
-
-			case 0x002A: return "Magrathea";
-			case 0x0042: return "GnuPG e.V.";
-
-			case 0x1337: return "Warsaw Hackerspace";
-			case 0x2342: return "warpzone"; /* hackerspace Muenster.  */
-			case 0x4354: return "Confidential Technologies";   /* cotech.de */
-			case 0x5443: return "TIF-IT e.V.";
-			case 0x63AF: return "Trustica";
-			case 0xBA53: return "c-base e.V.";
-			case 0xBD0E: return "Paranoidlabs";
-			case 0xF517: return "FSIJ";
-			case 0xF5EC: return "F-Secure";
-
-			/* 0x0000 and 0xFFFF are defined as test cards per spec,
-			   0xFF00 to 0xFFFE are assigned for use with randomly created
-			   serial numbers.  */
-			case 0x0000:
-			case 0xffff: return "test card";
-			default: return (manuf & 0xff00) == 0xff00 ? "unmanaged S/N range" : "unknown";
-		}
-	}
-	return NULL;
-}
-
-
-/* prettify pure serial number */
-static char *prettify_serialnumber(u8 *data, size_t length)
-{
-	if (data != NULL && length >= 4) {
-		static char result[15];	/* large enough for even 2*3 digits + separator */
-		sprintf(result, "%02X%02X%02X%02X", data[0], data[1], data[2], data[3]);
-		return result;
-	}
-	return NULL;
-}
-
-
-/* prettify card holder's name */
-static char *prettify_name(u8 *data, size_t length)
-{
-	if (data != NULL && length > 0) {
-		char *src = (char *) data;
-		char *dst = (char *) data;
-
-		while (*src != '\0' && length > 0) {
-			*dst = *src++;
-			length--;
-			if (*dst == '<') {
-				if (length > 0 && *src == '<') {
-					src++;
-					length--;
-				}
-				*dst = ' ';
-			}
-			dst++;
-		}
-		*dst = '\0';
-		return (char *) data;
-	}
-	return NULL;
-}
-
-
-/* prettify language */
-static char *prettify_language(u8 *data, size_t length)
-{
-	if (data != NULL && length > 0) {
-		char *str = (char *) data;
-
-		switch (strlen(str)) {
-			case 8: memmove(str+7, str+6, 1+strlen(str+6));
-				str[6] = ',';
-				/* fall through */
-			case 6: memmove(str+5, str+4, 1+strlen(str+4));
-				str[4] = ',';
-				/* fall through */
-			case 4: memmove(str+3, str+2, 1+strlen(str+2));
-				str[2] = ',';
-				/* fall through */
-			case 2: return str;
-		}
-	}
-	return NULL;
-}
-
-
-/* convert the raw ISO-5218 SEX value to an english word */
-static char *prettify_gender(u8 *data, size_t length)
-{
-	if (data != NULL && length > 0) {
-		switch (*data) {
-			case '0': return "unknown";
-			case '1': return "male";
-			case '2': return "female";
-			case '9': return "not announced";
-		}
-	}
-	return NULL;
 }
 
 

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -325,9 +325,7 @@ static char *prettify_serialnumber(u8 *data, size_t length)
 {
 	if (data != NULL && length >= 4) {
 		static char result[15];	/* large enough for even 2*3 digits + separator */
-		unsigned long serial = (unsigned long) (data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3]);
-
-		sprintf(result, "%08lX", serial);
+		sprintf(result, "%02X%02X%02X%02X", data[0], data[1], data[2], data[3]);
 		return result;
 	}
 	return NULL;

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -71,7 +71,7 @@ struct ef_name_map {
 	enum code_types type;
 	size_t offset;
 	size_t length;	/* exact length: 0 <=> potentially infinite */
-	char *(*prettify_value)(u8 *, size_t);
+	char *(*prettify_value)(const u8 *, size_t);
 };
 
 /* declare functions */


### PR DESCRIPTION
Fixes the following crash:
  $ openpgp-tool --card-info
  Using reader with a card: Linux Foundation Multifunction Composite Gadget - vincent [python-usb-f-ccid] 00 00
  AID:             d2:76:00:01:24:01:03:41:ff:65:a4:9b:68:64:00:00
  Version:         3.41
  Manufacturer:    unmanaged S/N range
  *** buffer overflow detected ***: terminated
  Abandon (core dumped)
"a4:9b:68:64" from the AID being the serial, and:
  (gdb) print (data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3])
  $12 = -1533319068
but
  (gdb) print (unsigned long) (data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3])
  $13 = 18446744072176232548

Avoid the shifts and cast altogether.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
