### PR TITLE
sm-common.c - missing semicolons

### DIFF
--- a/src/sm/sm-common.c
+++ b/src/sm/sm-common.c
@@ -534,21 +534,21 @@ sm_encrypt_des_cbc3(struct sc_context *ctx, unsigned char *key,
 #else
 	cctx = EVP_CIPHER_CTX_new();
 	if (!EVP_EncryptInit_ex2(cctx, EVP_des_ede_cbc(), key, icv, NULL)) {
-		free(*out)
+		free(*out);
 		EVP_CIPHER_CTX_free(cctx);
 		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_SM, SC_ERROR_INTERNAL);
 	}
 	/* Disable padding, otherwise it will fail to decrypt non-padded inputs */
 	EVP_CIPHER_CTX_set_padding(cctx, 0);
 	if (!EVP_EncryptUpdate(cctx, *out, &tmplen, data, data_len)) {
-		free(*out)
+		free(*out);
 		EVP_CIPHER_CTX_free(cctx);
 		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_SM, SC_ERROR_INTERNAL);
 	}
 	*out_len = tmplen;
 
 	if (!EVP_EncryptFinal_ex(cctx, *out + *out_len, &tmplen)) {
-		free(*out)
+		free(*out);
 		EVP_CIPHER_CTX_free(cctx);
 		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_SM, SC_ERROR_INTERNAL);
 	}


### PR DESCRIPTION
Add missing semicolons. Only needed with OpenSSL-3.0.0
Partially Fixes: #2411

 On branch sm-common-semicolons
 Changes to be committed:
	modified:   ../sm/sm-common.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
