### PR TITLE
pkcs11: Unbreak detection of unenrolled cards

### DIFF
--- a/.github/restart-pcscd.sh
+++ b/.github/restart-pcscd.sh
@@ -7,7 +7,7 @@
 function pcscd_cleanup {
 	echo "Process terminated: resetting pcscd"
 	sudo pkill pcscd
-	if which systemctl; then
+	if which systemctl && systemctl is-system-running; then
 		sudo systemctl start pcscd.socket
 	fi
 }
@@ -15,7 +15,7 @@ trap pcscd_cleanup EXIT
 
 
 # stop the pcscd service and run it from console to see possible errors
-if which systemctl; then
+if which systemctl && systemctl is-system-running; then
 	sudo systemctl stop pcscd.service pcscd.socket
 else
 	sudo pkill pcscd || echo "no pcscd process was running"

--- a/.github/setup-java.sh
+++ b/.github/setup-java.sh
@@ -27,5 +27,7 @@ fi
 pushd jcardsim
 env | grep -i openjdk
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
-mvn initialize && mvn clean install
+if [ ! -f target/jcardsim-3.0.5-SNAPSHOT.jar ]; then
+	mvn initialize && mvn clean install
+fi
 popd

--- a/.github/setup-java.sh
+++ b/.github/setup-java.sh
@@ -14,6 +14,7 @@ env | grep -i openjdk
 
 # Javacard SDKs
 if [ ! -d "oracle_javacard_sdks" ]; then
+	# https://github.com/licel/jcardsim/pull/174
 	git clone https://github.com/martinpaljak/oracle_javacard_sdks.git
 fi
 export JC_HOME=$PWD/oracle_javacard_sdks/jc222_kit

--- a/.github/setup-vsmartcard.sh
+++ b/.github/setup-vsmartcard.sh
@@ -6,6 +6,5 @@ if [ ! -d "vsmartcard" ]; then
 	git clone https://github.com/frankmorgner/vsmartcard.git
 fi
 pushd vsmartcard/virtualsmartcard
-git checkout -b  tag-0.8 virtualsmartcard-0.8
 autoreconf -vis && ./configure && make -j2 && sudo make install
 popd

--- a/.github/test-isoapplet.sh
+++ b/.github/test-isoapplet.sh
@@ -11,14 +11,14 @@ export LD_LIBRARY_PATH=/usr/local/lib
 
 # The ISO applet
 if [ ! -d IsoApplet ]; then
-	git clone https://github.com/philipWendland/IsoApplet.git;
+	git clone https://github.com/philipWendland/IsoApplet.git
 fi
-javac -classpath jcardsim/target/jcardsim-3.0.5-SNAPSHOT.jar IsoApplet/src/net/pwendland/javacard/pki/isoapplet/*.java;
-echo "com.licel.jcardsim.card.applet.0.AID=F276A288BCFBA69D34F31001" > isoapplet_jcardsim.cfg;
-echo "com.licel.jcardsim.card.applet.0.Class=net.pwendland.javacard.pki.isoapplet.IsoApplet" >> isoapplet_jcardsim.cfg;
-echo "com.licel.jcardsim.card.ATR=3B80800101" >> isoapplet_jcardsim.cfg;
-echo "com.licel.jcardsim.vsmartcard.host=localhost" >> isoapplet_jcardsim.cfg;
-echo "com.licel.jcardsim.vsmartcard.port=35963" >> isoapplet_jcardsim.cfg;
+javac -classpath jcardsim/target/jcardsim-3.0.5-SNAPSHOT.jar IsoApplet/src/net/pwendland/javacard/pki/isoapplet/*.java
+echo "com.licel.jcardsim.card.applet.0.AID=F276A288BCFBA69D34F31001" > isoapplet_jcardsim.cfg
+echo "com.licel.jcardsim.card.applet.0.Class=net.pwendland.javacard.pki.isoapplet.IsoApplet" >> isoapplet_jcardsim.cfg
+echo "com.licel.jcardsim.card.ATR=3B80800101" >> isoapplet_jcardsim.cfg
+echo "com.licel.jcardsim.vsmartcard.host=localhost" >> isoapplet_jcardsim.cfg
+echo "com.licel.jcardsim.vsmartcard.port=35963" >> isoapplet_jcardsim.cfg
 
 
 # prepare pcscd
@@ -27,18 +27,18 @@ echo "com.licel.jcardsim.vsmartcard.port=35963" >> isoapplet_jcardsim.cfg;
 
 # start the applet and run couple of commands against that
 java -noverify -cp IsoApplet/src/:jcardsim/target/jcardsim-3.0.5-SNAPSHOT.jar com.licel.jcardsim.remote.VSmartCard isoapplet_jcardsim.cfg >/dev/null &
-PID=$!;
-sleep 5;
-opensc-tool --card-driver default --send-apdu 80b800001a0cf276a288bcfba69d34f310010cf276a288bcfba69d34f3100100;
-opensc-tool -n;
-pkcs15-init --create-pkcs15 --so-pin 123456 --so-puk 0123456789abcdef;
-pkcs15-tool --change-pin --pin 123456 --new-pin 654321;
-pkcs15-tool --unblock-pin --puk 0123456789abcdef --new-pin 123456;
-pkcs15-init --generate-key rsa/2048     --id 1 --key-usage decrypt,sign --auth-id FF --pin 123456;
-pkcs15-init --generate-key rsa/2048     --id 2 --key-usage decrypt      --auth-id FF --pin 123456;
-pkcs15-init --generate-key ec/secp256r1 --id 3 --key-usage sign         --auth-id FF --pin 123456;
-pkcs15-tool -D;
-pkcs11-tool -l -t -p 123456;
+PID=$!
+sleep 5
+opensc-tool --card-driver default --send-apdu 80b800001a0cf276a288bcfba69d34f310010cf276a288bcfba69d34f3100100
+opensc-tool -n
+pkcs15-init --create-pkcs15 --so-pin 123456 --so-puk 0123456789abcdef
+pkcs15-tool --change-pin --pin 123456 --new-pin 654321
+pkcs15-tool --unblock-pin --puk 0123456789abcdef --new-pin 123456
+pkcs15-init --generate-key rsa/2048     --id 1 --key-usage decrypt,sign --auth-id FF --pin 123456
+pkcs15-init --generate-key rsa/2048     --id 2 --key-usage decrypt      --auth-id FF --pin 123456
+pkcs15-init --generate-key ec/secp256r1 --id 3 --key-usage sign         --auth-id FF --pin 123456
+pkcs15-tool -D
+pkcs11-tool -l -t -p 123456
 
 # run the tests
 pushd src/tests/p11test/
@@ -46,6 +46,6 @@ sleep 5
 ./p11test -s 0 -p 123456 -o isoapplet.json || true # ec_sign_size_test is failing here
 popd
 
-kill -9 $PID;
+kill -9 $PID
 
 diff -u3 src/tests/p11test/isoapplet{_ref,}.json

--- a/.github/test-isoapplet.sh
+++ b/.github/test-isoapplet.sh
@@ -39,4 +39,13 @@ pkcs15-init --generate-key rsa/2048     --id 2 --key-usage decrypt      --auth-i
 pkcs15-init --generate-key ec/secp256r1 --id 3 --key-usage sign         --auth-id FF --pin 123456;
 pkcs15-tool -D;
 pkcs11-tool -l -t -p 123456;
+
+# run the tests
+pushd src/tests/p11test/
+sleep 5
+./p11test -s 0 -p 123456 -o isoapplet.json || true # ec_sign_size_test is failing here
+popd
+
 kill -9 $PID;
+
+diff -u3 src/tests/p11test/isoapplet{_ref,}.json

--- a/.github/test-isoapplet.sh
+++ b/.github/test-isoapplet.sh
@@ -10,7 +10,9 @@ export LD_LIBRARY_PATH=/usr/local/lib
 ./.github/setup-java.sh
 
 # The ISO applet
-git clone https://github.com/philipWendland/IsoApplet.git;
+if [ ! -d IsoApplet ]; then
+	git clone https://github.com/philipWendland/IsoApplet.git;
+fi
 javac -classpath jcardsim/target/jcardsim-3.0.5-SNAPSHOT.jar IsoApplet/src/net/pwendland/javacard/pki/isoapplet/*.java;
 echo "com.licel.jcardsim.card.applet.0.AID=F276A288BCFBA69D34F31001" > isoapplet_jcardsim.cfg;
 echo "com.licel.jcardsim.card.applet.0.Class=net.pwendland.javacard.pki.isoapplet.IsoApplet" >> isoapplet_jcardsim.cfg;

--- a/src/tests/p11test/isoapplet_ref.json
+++ b/src/tests/p11test/isoapplet_ref.json
@@ -1,0 +1,364 @@
+{
+"time": 0,
+"results": [
+{
+	"test_id": "wait_test",
+	"result": "skip"
+},
+{
+	"test_id": "supported_mechanisms_test",
+	"data": [
+	[
+		"MECHANISM",
+		"MIN KEY",
+		"MAX KEY",
+		"FLAGS"
+	],
+	[
+		"SHA_1",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"SHA224",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"SHA256",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"SHA384",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"SHA512",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"MD5",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"RIPEMD160",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"GOSTR3411",
+		"0",
+		"0",
+		"CKF_DIGEST"
+	],
+	[
+		"ECDSA_SHA224",
+		"192",
+		"384",
+		"0x00002800"
+	],
+	[
+		"ECDSA_SHA256",
+		"192",
+		"384",
+		"0x00002800"
+	],
+	[
+		"ECDSA_SHA384",
+		"192",
+		"384",
+		"0x00002800"
+	],
+	[
+		"ECDSA_SHA512",
+		"192",
+		"384",
+		"0x00002800"
+	],
+	[
+		"ECDSA_SHA1",
+		"192",
+		"384",
+		"0x01902801"
+	],
+	[
+		"EC_KEY_PAIR_GEN",
+		"192",
+		"384",
+		"0x01910001"
+	],
+	[
+		"RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002A01"
+	],
+	[
+		"SHA1_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"SHA224_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"SHA256_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"SHA384_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"SHA512_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"MD5_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"RIPEMD160_RSA_PKCS",
+		"2048",
+		"2048",
+		"0x00002800"
+	],
+	[
+		"RSA_PKCS_KEY_PAIR_GEN",
+		"2048",
+		"2048",
+		"CKF_GENERATE_KEY_PAIR"
+	]],
+	"result": "pass"
+},
+{
+	"test_id": "interface_test",
+	"result": "pass"
+},
+{
+	"test_id": "readonly_tests",
+	"data": [
+	[
+		"KEY ID",
+		"MECHANISM",
+		"SIGN&VERIFY WORKS",
+		"ENCRYPT&DECRYPT WORKS"
+	],
+	[
+		"01",
+		"RSA_PKCS",
+		"YES",
+		"YES"
+	],
+	[
+		"01",
+		"SHA1_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"SHA224_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"SHA256_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"SHA384_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"SHA512_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"MD5_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"01",
+		"RIPEMD160_RSA_PKCS",
+		"YES",
+		""
+	],
+	[
+		"02",
+		"RSA_PKCS",
+		"",
+		"YES"
+	]],
+	"result": "pass"
+},
+{
+	"test_id": "multipart_tests",
+	"data": [
+	[
+		"KEY ID",
+		"MECHANISM",
+		"MULTIPART SIGN&VERIFY WORKS"
+	],
+	[
+		"01",
+		"RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"SHA1_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"SHA224_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"SHA256_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"SHA384_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"SHA512_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"MD5_RSA_PKCS",
+		"YES"
+	],
+	[
+		"01",
+		"RIPEMD160_RSA_PKCS",
+		"YES"
+	]],
+	"result": "pass"
+},
+{
+	"test_id": "ec_sign_size_test",
+	"fail_reason": "Some signatures were not verified successfully. Please review the log",
+	"result": "fail"
+},
+{
+	"test_id": "usage_test",
+	"data": [
+	[
+		"KEY ID",
+		"LABEL",
+		"TYPE",
+		"BITS",
+		"VERIFY PUBKEY",
+		"SIGN",
+		"VERIFY",
+		"ENCRYPT",
+		"DECRYPT",
+		"WRAP",
+		"UNWRAP",
+		"DERIVE PUBLIC",
+		"DERIVE PRIVATE",
+		"ALWAYS AUTH"
+	],
+	[
+		"01",
+		"Private Key",
+		"RSA",
+		"2048",
+		"",
+		"YES",
+		"YES",
+		"YES",
+		"YES",
+		"YES",
+		"YES",
+		"",
+		"",
+		""
+	],
+	[
+		"02",
+		"Private Key",
+		"RSA",
+		"2048",
+		"",
+		"",
+		"",
+		"YES",
+		"YES",
+		"YES",
+		"YES",
+		"",
+		"",
+		""
+	],
+	[
+		"03",
+		"Private Key",
+		"EC",
+		"256",
+		"",
+		"YES",
+		"YES",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		""
+	]],
+	"result": "pass"
+},
+{
+	"test_id": "pss_oaep_test",
+	"result": "unknown"
+},
+{
+	"test_id": "derive_tests",
+	"data": [
+	[
+		"KEY ID",
+		"MECHANISM",
+		"DERIVE WORKS"
+	]],
+	"result": "pass"
+}]
+}


### PR DESCRIPTION
This was broken since 58b03b68, which tried to sanitize some states,
but caused C_GetTokenInfo returning CKR_TOKEN_NOT_RECOGNIZED instead
of empty token information.

Note, that this has effect only if the configuration options
enable_default_driver and pkcs11_enable_InitToken are turned on.
Otherwise it still returns CKR_TOKEN_NOT_RECOGNIZED.

I am still considering writing some tests for this as some applications depend on this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested