### PR TITLE
Detached reader macOS

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -415,7 +415,8 @@ static int refresh_attributes(sc_reader_t *reader)
 		 * XXX: We'll hit it again, as no readers are removed currently.
 		 */
 		reader->flags &= ~(SC_READER_CARD_PRESENT);
-		return SC_ERROR_READER_DETACHED;
+		sc_log(reader->ctx, "Reader unknown: %s", sc_strerror(SC_ERROR_READER_DETACHED));
+		SC_FUNC_RETURN(reader->ctx, SC_LOG_DEBUG_VERBOSE, SC_SUCCESS);
 	}
 
 	reader->flags &= ~(SC_READER_CARD_CHANGED|SC_READER_CARD_INUSE|SC_READER_CARD_EXCLUSIVE);

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -476,7 +476,12 @@ static int pcsc_detect_card_presence(sc_reader_t *reader)
 	rv = refresh_attributes(reader);
 	if (rv != SC_SUCCESS)
 		LOG_FUNC_RETURN(reader->ctx, rv);
-	LOG_FUNC_RETURN(reader->ctx, reader->flags);
+
+	// Return 0 if the card is not present
+	if (reader->flags & SC_READER_CARD_PRESENT)
+		LOG_FUNC_RETURN(reader->ctx, reader->flags);
+	else
+		LOG_FUNC_RETURN(reader->ctx, 0);
 }
 
 static int check_forced_protocol(sc_reader_t *reader, DWORD *protocol)

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -393,10 +393,7 @@ static int refresh_attributes(sc_reader_t *reader)
 				|| rv == (LONG)SCARD_E_NO_READERS_AVAILABLE
 #endif
 				|| rv == (LONG)SCARD_E_SERVICE_STOPPED) {
- 			if (old_flags & SC_READER_CARD_PRESENT) {
- 				reader->flags |= SC_READER_CARD_CHANGED;
- 			}
-			
+ 			reader->flags &= ~(SC_READER_CARD_PRESENT);
  			SC_FUNC_RETURN(reader->ctx, SC_LOG_DEBUG_VERBOSE, SC_SUCCESS);
  		}
 
@@ -459,8 +456,6 @@ static int refresh_attributes(sc_reader_t *reader)
 		}
 	} else {
 		reader->flags &= ~SC_READER_CARD_PRESENT;
-		if (old_flags & SC_READER_CARD_PRESENT)
-			reader->flags |= SC_READER_CARD_CHANGED;
 	}
 	sc_log(reader->ctx, "card %s%s",
 			reader->flags & SC_READER_CARD_PRESENT ? "present" : "absent",

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -337,6 +337,12 @@ int sc_detect_card_presence(sc_reader_t *reader)
 		LOG_FUNC_RETURN(reader->ctx, SC_ERROR_NOT_SUPPORTED);
 
 	r = reader->ops->detect_card_presence(reader);
+
+	// Check that we get sane return value from backend
+	// detect_card_presence should return 0 if no card is present.
+	if (r && !(r & SC_READER_CARD_PRESENT))
+		LOG_FUNC_RETURN(reader->ctx, SC_ERROR_INTERNAL);
+
 	LOG_FUNC_RETURN(reader->ctx, r);
 }
 


### PR DESCRIPTION
This fixes an issue where a detached reader wasn't noticed when running C_WaitForSlotEvent(CKF_DONT_BLOCK) on macOS 11.6. This was found when trying the work around mentioned in issue #2415:

(We're going to see if we can work around this by doing a more complex tango with OpenSC:

 1. `C_WaitForSlotEvent(CKF_DONT_BLOCK)`
 2. `C_GetSlotList(NULL)`
 3. `C_WaitForSlotEvent(CKF_DONT_BLOCK)`

_Originally posted by @CendioOssman in https://github.com/OpenSC/OpenSC/issues/2415#issuecomment-932120601_)


After my changes, I have tested that the following events are observed with the work around mentioned above: 
✓ Remove card
✓ Detach reader with card in
✓ Insert card
✓ Attach reader with card in
✓ Change to another card in the reader

Tested on both Fedora 34 and macOS 11.6. The last point about changing to another card did not work as expected on macOS. I have tested this before my changes and it didn't work then either.
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

