### PR TITLE
Jcop4 NQ-Applet

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -50,14 +50,14 @@ libopensc_la_SOURCES_BASE = \
 	card-dnie.c cwa14890.c cwa-dnie.c \
 	card-isoApplet.c card-masktech.c card-gids.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
-	card-edo.c \
+	card-edo.c card-nqApplet.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c \
 	pkcs15-tcos.c pkcs15-esteid.c pkcs15-gemsafeGPK.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
-	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c \
+	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	compression.c p15card-helper.c sm.c \
 	aux-data.c
@@ -133,14 +133,14 @@ TIDY_FILES = \
 	cwa14890.c cwa-dnie.c \
 	card-isoApplet.c card-masktech.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
-	card-edo.c \
+	card-edo.c card-nqApplet.c \
 	\
 	pkcs15-openpgp.c pkcs15-cardos.c \
 	pkcs15-tcos.c pkcs15-esteid.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-westcos.c pkcs15-pteid.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
-	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c \
+	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	compression.c p15card-helper.c sm.c \
 	aux-data.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -28,7 +28,7 @@ OBJECTS			= \
 	card-sc-hsm.obj card-dnie.obj card-isoApplet.obj pkcs15-coolkey.obj \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-idprime.obj \
-	card-edo.obj \
+	card-edo.obj card-nqApplet.obj \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj \
 	pkcs15-tcos.obj pkcs15-esteid.obj pkcs15-gemsafeGPK.obj \
@@ -36,7 +36,7 @@ OBJECTS			= \
 	pkcs15-cac.obj pkcs15-esinit.obj pkcs15-westcos.obj pkcs15-pteid.obj pkcs15-din-66291.obj \
 	pkcs15-oberthur.obj pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
 	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-jpki.obj \
-	pkcs15-esteid2018.obj pkcs15-idprime.obj \
+	pkcs15-esteid2018.obj pkcs15-idprime.obj pkcs15-nqApplet.obj \
 	compression.obj p15card-helper.obj sm.obj \
 	aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -1,0 +1,553 @@
+/*
+ * Support for the JCOP4 Cards with NQ-Applet
+ *
+ * Copyright (C) 2020 jozsefd <jozsef.dojcsak@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "asn1.h"
+#include "cardctl.h"
+#include "internal.h"
+#include "log.h"
+
+#define APPLET_VERSION_LEN 2
+#define APPLET_MEMTYPE_LEN 1
+#define APPLET_SERIALNR_LEN 8
+
+/* card constants */
+static const struct sc_atr_table nqapplet_atrs[] = 
+{
+	{ "3b:d5:18:ff:81:91:fe:1f:c3:80:73:c8:21:10:0a", NULL, NULL, SC_CARD_TYPE_NQ_APPLET, 0, NULL },
+	{ NULL, NULL, NULL, 0, 0, NULL }
+};
+
+static const u8 nqapplet_aid[] = {0xd2, 0x76, 0x00, 0x01, 0x80, 0xBA, 0x01, 0x44, 0x02, 0x01, 0x00};
+
+static struct sc_card_operations nqapplet_operations;
+static struct sc_card_operations *iso_operations = NULL;
+
+#define KEY_REFERENCE_NO_KEY	0x00
+#define KEY_REFERENCE_AUTH_KEY	0x01
+#define KEY_REFERENCE_ENCR_KEY	0x02
+
+struct nqapplet_driver_data
+{
+	u8 version_minor;
+	u8 version_major;
+	u8 key_reference;
+	u8 serial_nr[APPLET_SERIALNR_LEN];
+};
+typedef struct nqapplet_driver_data * nqapplet_driver_data_ptr;
+
+static struct sc_card_driver nqapplet_driver = 
+{
+	"NQ-Applet",      // name
+	"nqapplet",      // short name
+	&nqapplet_operations,	// operations
+	NULL,           // atr table
+    0,              // nr of atr
+    NULL            // dll?
+};
+
+static const struct sc_card_error nqapplet_errors[] = 
+{
+	{ 0x6700, SC_ERROR_WRONG_LENGTH, "Invalid LC or LE"}, 
+	{ 0x6982, SC_ERROR_SECURITY_STATUS_NOT_SATISFIED, "Security status not satisfied" }, //TODO MK/DK??
+	{ 0x6985, SC_ERROR_NOT_ALLOWED,	"Invalid PIN or key" },
+	{ 0x6986, SC_ERROR_NOT_ALLOWED,	"Conditions of use not satisfied" },
+	{ 0x6A80, SC_ERROR_INVALID_ARGUMENTS, "Invalid parameters" },
+	{ 0x6A82, SC_ERROR_OBJECT_NOT_FOUND, "Data object not found"},
+	{ 0x6A84, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory" },
+	{ 0x6A86, SC_ERROR_INCORRECT_PARAMETERS, "Invalid P1 or P2" }, 
+	{ 0x6A88, SC_ERROR_INVALID_ARGUMENTS, "Wrong key ID" },
+	{ 0x6D00, SC_ERROR_FILE_NOT_FOUND, "Applet not found" }
+};
+
+/* convenience functions */
+
+static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor, u8 * serial_nr, size_t cb_serial_nr)
+{
+	nqapplet_driver_data_ptr data = calloc(1, sizeof(struct nqapplet_driver_data));
+	if (data == NULL)
+	{
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+	}
+
+	data->version_major = version_major;
+	data->version_minor = version_minor;
+	data->key_reference = KEY_REFERENCE_NO_KEY;
+	memcpy(data->serial_nr, serial_nr, min(cb_serial_nr, sizeof(data->serial_nr)));
+	card->drv_data = (void*)data;
+	return SC_SUCCESS;
+}
+
+/**
+ * SELECT NQ-Applet, on success it returns the applet version and card serial nr.
+ *
+ * @param[in]     	card
+ * @param[out,opt]  version_major	Version major of the applet
+ * @param[out,opt]  version_minor	Version minor of the applet
+ * @param[out,opt]  serial_nr		Buffer to receive serial number octets
+ * @param[in]  		cb_serial_nr	Size of buffer in octets
+ * @param[out,opt]	serial_nr_len	The actual number of octet copied into serial_nr buffer
+ *
+ * @return SC_SUCCESS: The applet is present and selected.
+ * 
+ */
+static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor, u8 *serial_nr, size_t cb_serial_nr, size_t *serial_nr_len)
+{
+	int rv;
+	sc_context_t *ctx = card->ctx;
+	sc_apdu_t apdu;
+	u8 buffer[APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN+2];
+	size_t cb_buffer = sizeof(buffer);
+	size_t cb_aid = sizeof(nqapplet_aid);
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
+	apdu.lc = cb_aid;
+	apdu.data = nqapplet_aid;
+	apdu.datalen = cb_aid;
+	apdu.resp = buffer;
+	apdu.resplen = cb_buffer;
+	apdu.le = cb_buffer;
+
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, rv, "APDU transmit failure.");
+
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, rv, "Card returned error");
+
+	if ( version_major != NULL )
+	{
+		*version_major = buffer[0];
+	}
+	if ( version_minor != NULL )
+	{
+		*version_minor = buffer[1];
+	}
+	if ( serial_nr != NULL && cb_serial_nr > 0 && serial_nr_len != NULL )
+	{
+		size_t cb = MIN(APPLET_SERIALNR_LEN, cb_serial_nr);
+		memcpy(serial_nr, buffer+3, cb);
+		*serial_nr_len = cb;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+
+/* driver operations API */
+static int nqapplet_match_card(struct sc_card *card)
+{
+	int rv = _sc_match_atr(card, nqapplet_atrs, &card->type);
+	return (rv >= 0);
+}
+
+static int nqapplet_init(struct sc_card *card)
+{
+	u8 version_major;
+	u8 version_minor;
+	u8 serial_nr[APPLET_SERIALNR_LEN];
+	size_t cb_serial_nr = sizeof(serial_nr);
+	unsigned long rsa_flags = 0;
+
+	LOG_FUNC_CALLED(card->ctx);
+	int rv = select_nqapplet(card, &version_major, &version_minor, serial_nr, cb_serial_nr, &cb_serial_nr);
+	if ( rv != SC_SUCCESS )
+	{
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_CARD, "Cannot select NQ-Applet.");
+	}
+
+	rv = init_driver_data(card, version_major, version_minor, serial_nr, cb_serial_nr);
+	LOG_TEST_RET(card->ctx, rv, "Failed to initialize driver data.");
+
+	card->max_send_size = 255;
+	card->max_recv_size = 256;
+	card->caps |=  SC_CARD_CAP_RNG | SC_CARD_CAP_ISO7816_PIN_INFO;
+	rsa_flags |= SC_ALGORITHM_RSA_RAW;
+	_sc_card_add_rsa_alg(card, 3072, rsa_flags, 0);
+	
+	card->serialnr.len = MIN(sizeof(card->serialnr.value), cb_serial_nr);
+	memcpy(card->serialnr.value, serial_nr, card->serialnr.len);
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int nqapplet_finish(struct sc_card *card)
+{
+	nqapplet_driver_data_ptr data = (nqapplet_driver_data_ptr)card->drv_data;
+
+	LOG_FUNC_CALLED(card->ctx);
+	if (data != NULL)
+	{
+		free(data);
+		card->drv_data=NULL;
+	}
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int nqapplet_get_response(struct sc_card *card, size_t *cb_resp, u8 *resp)
+{
+	struct sc_apdu apdu;
+	int rv;
+	size_t resplen;
+
+	LOG_FUNC_CALLED(card->ctx);
+	resplen = MIN(sc_get_max_recv_size(card), *cb_resp);
+
+	sc_format_apdu_ex(&apdu, 0x80, 0xC0, 0x00, 0x00, NULL, 0, resp, resplen);
+	apdu.flags  |= SC_APDU_FLAGS_NO_GET_RESP;
+
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+	if (apdu.resplen == 0)
+	{
+		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+	}
+
+	*cb_resp = apdu.resplen;
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+	{
+		rv = SC_SUCCESS;
+	}
+	else if (apdu.sw1 == 0x61)
+	{
+		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
+	}
+	else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82)
+	{
+		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int nqapplet_get_challenge(struct sc_card *card, u8 * buf, size_t count)
+{
+	int r;
+	struct sc_apdu apdu;
+
+	LOG_FUNC_CALLED(card->ctx);
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0x84, 0x00, 0x00);
+	apdu.le = count;
+	apdu.resp = buf;
+	apdu.resplen = count;
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE failed");
+
+	if (count < apdu.resplen)
+	{
+		return (int) count;
+	}
+   
+	return (int) apdu.resplen;
+}
+
+static int nqapplet_logout(struct sc_card *card)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	int rv = select_nqapplet(card, NULL, NULL, NULL, 0, NULL);
+	if ( rv != SC_SUCCESS )
+	{
+		LOG_TEST_RET(card->ctx, rv, "Failed to logout");
+	}
+	
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env *env, int se_num)
+{
+	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV, this function only checks the intended parameters */
+	nqapplet_driver_data_ptr data;
+	
+	assert(card != NULL && env != NULL);
+	LOG_FUNC_CALLED(card->ctx);
+
+	data = (nqapplet_driver_data_ptr)card->drv_data;
+	data->key_reference = KEY_REFERENCE_NO_KEY;
+	u8 key_reference = KEY_REFERENCE_NO_KEY;
+
+	if(se_num != 0)
+	{
+		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "Storing of security environment is not supported");
+	}
+	if ( env->key_ref_len == 1 )
+	{
+		key_reference = env->key_ref[0];
+	}
+	
+	switch (env->operation)
+	{
+		case SC_SEC_OPERATION_DECIPHER:
+			if ( key_reference != KEY_REFERENCE_AUTH_KEY && key_reference != KEY_REFERENCE_ENCR_KEY ) {
+				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
+			}
+			data->key_reference = key_reference;
+			break;
+		case SC_SEC_OPERATION_SIGN:
+			if ( key_reference != KEY_REFERENCE_AUTH_KEY ) {
+				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
+			}
+			data->key_reference = key_reference;
+			break;
+		default:
+			LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "Unsupported sec. operation.");
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_data, u8 * out, size_t outlen)
+{
+	int rv;
+	struct sc_apdu apdu;
+	u8 p1 = 0x80;
+	u8 p2 = 0x86;
+	nqapplet_driver_data_ptr drv_data;
+
+	assert(card != NULL && data != NULL && out != NULL);
+	LOG_FUNC_CALLED(card->ctx);
+
+	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
+	
+	if ( drv_data->key_reference == KEY_REFERENCE_AUTH_KEY )
+	{
+		p1 = 0x9E;
+		p2 = 0x9A;
+	} 
+	else if ( drv_data->key_reference != KEY_REFERENCE_ENCR_KEY )
+	{
+		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
+	}
+
+	/* the applet supports only 3072 RAW RSA input must be 384 bytes out at least 384 octets */
+	sc_format_apdu_ex(&apdu, 0x80, 0x2A, p1, p2, data, cb_data, out, outlen);
+	apdu.le = 256;
+	apdu.flags |= SC_APDU_FLAGS_CHAINING;
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+	{
+		rv = apdu.resplen;
+	}
+	else if (apdu.sw1 == 0x61)
+	{
+		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
+	}
+	else
+	{
+		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, size_t cb_data, u8 * out, size_t outlen)
+{
+	int rv;
+	struct sc_apdu apdu;
+	nqapplet_driver_data_ptr drv_data;
+
+	assert(card != NULL && data != NULL && out != NULL);
+	LOG_FUNC_CALLED(card->ctx);
+	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
+	
+	if ( drv_data->key_reference != KEY_REFERENCE_AUTH_KEY )
+	{
+		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
+	}
+
+	/* the applet supports only 3072 RAW RSA input must be 384 bytes out at least 384 octets */
+	sc_format_apdu_ex(&apdu, 0x80, 0x2A, 0x9E, 0x9A, data, cb_data, out, outlen);
+	apdu.le = 256;
+	apdu.flags |= SC_APDU_FLAGS_CHAINING;
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+	{
+		rv = apdu.resplen;
+	}
+	else if (apdu.sw1 == 0x61)
+	{
+		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
+	}
+	else
+	{
+		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int nqapplet_check_sw(struct sc_card *card,unsigned int sw1,unsigned int sw2)
+{
+	const int nqapplet_error_count = sizeof(nqapplet_errors)/sizeof(struct sc_card_error);
+	int i;
+
+	LOG_FUNC_CALLED(card->ctx);
+	sc_log(card->ctx, "Checking sw1 = 0x%02x, sw2 = 0x%02x\n", sw1, sw2);
+  
+	for (i = 0; i < nqapplet_error_count; i++)
+	{
+		if (nqapplet_errors[i].SWs == ((sw1 << 8) | sw2))
+		{
+			LOG_TEST_RET(card->ctx, nqapplet_errors[i].errorno, nqapplet_errors[i].errorstr);
+		}
+	}
+
+	return iso_operations->check_sw(card, sw1, sw2);
+}
+
+static int nqapplet_get_data(struct sc_card *card, unsigned int id, u8 *resp, size_t cb_resp)
+{
+	struct sc_apdu apdu;
+	int rv;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	sc_format_apdu_ex(&apdu, 0x80, 0xB0, 0x00, (u8)id, NULL, 0, resp, cb_resp);
+	apdu.le = 256;
+
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+	{
+		rv = apdu.resplen;
+	}
+	else if (apdu.sw1 == 0x61)
+	{
+		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
+	}
+	else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82)
+	{
+		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int nqapplet_select_file(struct sc_card *card, const struct sc_path *in_path, struct sc_file **file_out)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	/* the applet does not support SELECT EF/DF except for SELECT APPLET.
+	In order to enable opensc-explorer add support for virtually selecting MF only */
+	if (in_path->type == SC_PATH_TYPE_PATH && in_path->len == 2 && memcmp(in_path->value, "\x3F\x00", 2) == 0 ) {
+		if ( file_out != NULL )   {
+			struct sc_file *file = sc_file_new();
+			if (file == NULL)
+			{
+				LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+			}
+			file->path = *in_path;
+			*file_out = file;
+			LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+		}
+	}
+	//TODO allow selecting Applet AID
+
+	LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+}
+
+static int nqapplet_card_ctl(sc_card_t* card, unsigned long cmd, void* ptr)
+{
+	switch (cmd)
+	{
+	case SC_CARDCTL_GET_SERIALNR:
+		if (card->serialnr.len) {
+			sc_serial_number_t* serial = (sc_serial_number_t*)ptr;
+			memcpy(serial->value, card->serialnr.value, card->serialnr.len);
+			serial->len = card->serialnr.len;
+			return SC_SUCCESS;
+		}
+	default:
+		return SC_ERROR_NOT_SUPPORTED;
+	}
+}
+
+
+struct sc_card_driver * sc_get_nqApplet_driver(void)
+{
+	sc_card_driver_t * iso_driver = sc_get_iso7816_driver();
+
+	if( iso_operations == NULL )
+	{
+		iso_operations = iso_driver->ops;
+	}
+
+	nqapplet_operations = *iso_driver->ops;
+
+	/* supported operations */
+	nqapplet_operations.match_card = nqapplet_match_card;
+	nqapplet_operations.init = nqapplet_init;
+	nqapplet_operations.finish = nqapplet_finish;
+	nqapplet_operations.get_response = nqapplet_get_response;
+	nqapplet_operations.get_challenge = nqapplet_get_challenge;
+	nqapplet_operations.logout = nqapplet_logout;
+	nqapplet_operations.set_security_env = nqapplet_set_security_env;
+	nqapplet_operations.decipher = nqapplet_decipher;
+	nqapplet_operations.compute_signature = nqapplet_compute_signature;
+	nqapplet_operations.check_sw = nqapplet_check_sw;
+	nqapplet_operations.get_data = nqapplet_get_data;
+	nqapplet_operations.select_file = nqapplet_select_file;
+
+	/* unsupported operations */
+	nqapplet_operations.read_binary = NULL;
+	nqapplet_operations.write_binary = NULL;
+	nqapplet_operations.update_binary = NULL;
+	nqapplet_operations.erase_binary = NULL;
+	nqapplet_operations.read_record = NULL;
+	nqapplet_operations.write_record = NULL;
+	nqapplet_operations.append_record = NULL;
+	nqapplet_operations.update_record = NULL;
+
+	nqapplet_operations.verify = NULL;
+	nqapplet_operations.restore_security_env = NULL;
+	nqapplet_operations.change_reference_data = NULL;
+	nqapplet_operations.reset_retry_counter = NULL;
+	nqapplet_operations.create_file = NULL;
+	nqapplet_operations.delete_file = NULL;
+	nqapplet_operations.list_files = NULL;
+	nqapplet_operations.process_fci = NULL;
+	nqapplet_operations.construct_fci = NULL;
+	nqapplet_operations.put_data = NULL;
+	nqapplet_operations.delete_record = NULL;
+	nqapplet_operations.read_public_key = NULL;
+	nqapplet_operations.card_ctl = nqapplet_card_ctl;
+
+	/* let iso driver handle these operations
+	nqapplet_operations.pin_cmd;
+	nqapplet_operations.card_reader_lock_obtained;
+	nqapplet_operations.wrap;
+	nqapplet_operations.unwrap;
+	*/
+
+	return &nqapplet_driver;
+}

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -121,13 +121,7 @@ static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
-	apdu.lc = cb_aid;
-	apdu.data = nqapplet_aid;
-	apdu.datalen = cb_aid;
-	apdu.resp = buffer;
-	apdu.resplen = cb_buffer;
-	apdu.le = cb_buffer;
+	sc_format_apdu_ex(&apdu, 0x00, 0xA4, 0x04, 0x00, nqapplet_aid, cb_aid, buffer, cb_buffer);
 
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(ctx, rv, "APDU transmit failure.");

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "opensc.h"
 #include "asn1.h"
 #include "cardctl.h"
 #include "internal.h"

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -1,7 +1,7 @@
 /*
  * Support for the JCOP4 Cards with NQ-Applet
  *
- * Copyright (C) 2020 jozsefd <jozsef.dojcsak@gmail.com>
+ * Copyright (C) 2021 jozsefd <jozsef.dojcsak@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -61,8 +61,8 @@ static struct sc_card_driver nqapplet_driver =
 	"nqapplet",      // short name
 	&nqapplet_operations,	// operations
 	NULL,           // atr table
-    0,              // nr of atr
-    NULL            // dll?
+	0,              // nr of atr
+	NULL            // dll?
 };
 
 static const struct sc_card_error nqapplet_errors[] = 
@@ -281,7 +281,8 @@ static int nqapplet_logout(struct sc_card *card)
 
 int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env *env, int se_num)
 {
-	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV, this function only checks the intended parameters */
+	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV, 
+	this function checks the intended parameters and sets card_data.key_reference */
 	nqapplet_driver_data_ptr data;
 	
 	assert(card != NULL && env != NULL);
@@ -344,7 +345,8 @@ static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_da
 		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
 	}
 
-	/* the applet supports only 3072 RAW RSA input must be 384 bytes out at least 384 octets */
+	/* the applet supports only 3072 RAW RSA, input buffer size must be 384 octets,
+	output buffer size must be at least 384 octets */
 	sc_format_apdu_ex(&apdu, 0x80, 0x2A, p1, p2, data, cb_data, out, outlen);
 	apdu.le = 256;
 	apdu.flags |= SC_APDU_FLAGS_CHAINING;
@@ -382,7 +384,8 @@ static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, siz
 		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
 	}
 
-	/* the applet supports only 3072 RAW RSA input must be 384 bytes out at least 384 octets */
+	/* the applet supports only 3072 RAW RSA, input buffer size must be 384 octets,
+	output buffer size must be at least 384 octets */
 	sc_format_apdu_ex(&apdu, 0x80, 0x2A, 0x9E, 0x9A, data, cb_data, out, outlen);
 	apdu.le = 256;
 	apdu.flags |= SC_APDU_FLAGS_CHAINING;

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -92,7 +92,7 @@ static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor,
 	data->version_major = version_major;
 	data->version_minor = version_minor;
 	data->key_reference = KEY_REFERENCE_NO_KEY;
-	memcpy(data->serial_nr, serial_nr, min(cb_serial_nr, sizeof(data->serial_nr)));
+	memcpy(data->serial_nr, serial_nr, MIN(cb_serial_nr, sizeof(data->serial_nr)));
 	card->drv_data = (void*)data;
 	return SC_SUCCESS;
 }
@@ -487,9 +487,9 @@ static int nqapplet_card_ctl(sc_card_t* card, unsigned long cmd, void* ptr)
 			serial->len = card->serialnr.len;
 			return SC_SUCCESS;
 		}
-	default:
-		return SC_ERROR_NOT_SUPPORTED;
+		break;
 	}
+	return SC_ERROR_NOT_SUPPORTED;
 }
 
 

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -129,6 +129,10 @@ static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, rv, "Card returned error");
 
+	if ( apdu.resplen < APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN ) {
+		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_WRONG_LENGTH);
+	}
+
 	if ( version_major != NULL )
 	{
 		*version_major = buffer[0];

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -51,7 +51,6 @@ struct nqapplet_driver_data
 	u8 version_minor;
 	u8 version_major;
 	u8 key_reference;
-	u8 serial_nr[APPLET_SERIALNR_LEN];
 };
 typedef struct nqapplet_driver_data * nqapplet_driver_data_ptr;
 
@@ -81,7 +80,7 @@ static const struct sc_card_error nqapplet_errors[] =
 
 /* convenience functions */
 
-static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor, u8 * serial_nr, size_t cb_serial_nr)
+static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor)
 {
 	nqapplet_driver_data_ptr data = calloc(1, sizeof(struct nqapplet_driver_data));
 	if (data == NULL)
@@ -92,7 +91,6 @@ static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor,
 	data->version_major = version_major;
 	data->version_minor = version_minor;
 	data->key_reference = KEY_REFERENCE_NO_KEY;
-	memcpy(data->serial_nr, serial_nr, MIN(cb_serial_nr, sizeof(data->serial_nr)));
 	card->drv_data = (void*)data;
 	return SC_SUCCESS;
 }
@@ -174,7 +172,7 @@ static int nqapplet_init(struct sc_card *card)
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_CARD, "Cannot select NQ-Applet.");
 	}
 
-	rv = init_driver_data(card, version_major, version_minor, serial_nr, cb_serial_nr);
+	rv = init_driver_data(card, version_major, version_minor);
 	LOG_TEST_RET(card->ctx, rv, "Failed to initialize driver data.");
 
 	card->max_send_size = 255;

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -266,7 +266,7 @@ static int nqapplet_get_challenge(struct sc_card *card, u8 * buf, size_t count)
 static int nqapplet_logout(struct sc_card *card)
 {
 	LOG_FUNC_CALLED(card->ctx);
-
+	/* selecting NQ-Applet again will reset the applet status and unauthorize PINs */
 	int rv = select_nqapplet(card, NULL, NULL, NULL, 0, NULL);
 	if ( rv != SC_SUCCESS )
 	{
@@ -281,12 +281,12 @@ int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env
 	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV, 
 	this function checks the intended parameters and sets card_data.key_reference */
 	nqapplet_driver_data_ptr data;
+	u8 key_reference = KEY_REFERENCE_NO_KEY;
 	
 	LOG_FUNC_CALLED(card->ctx);
 
 	data = (nqapplet_driver_data_ptr)card->drv_data;
 	data->key_reference = KEY_REFERENCE_NO_KEY;
-	u8 key_reference = KEY_REFERENCE_NO_KEY;
 
 	if(se_num != 0)
 	{
@@ -519,6 +519,7 @@ struct sc_card_driver * sc_get_nqApplet_driver(void)
 	nqapplet_operations.check_sw = nqapplet_check_sw;
 	nqapplet_operations.get_data = nqapplet_get_data;
 	nqapplet_operations.select_file = nqapplet_select_file;
+	nqapplet_operations.card_ctl = nqapplet_card_ctl;
 
 	/* unsupported operations */
 	nqapplet_operations.read_binary = NULL;
@@ -542,7 +543,6 @@ struct sc_card_driver * sc_get_nqApplet_driver(void)
 	nqapplet_operations.put_data = NULL;
 	nqapplet_operations.delete_record = NULL;
 	nqapplet_operations.read_public_key = NULL;
-	nqapplet_operations.card_ctl = nqapplet_card_ctl;
 
 	/* let iso driver handle these operations
 	nqapplet_operations.pin_cmd;

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -281,7 +281,6 @@ int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env
 	this function checks the intended parameters and sets card_data.key_reference */
 	nqapplet_driver_data_ptr data;
 	
-	assert(card != NULL && env != NULL);
 	LOG_FUNC_CALLED(card->ctx);
 
 	data = (nqapplet_driver_data_ptr)card->drv_data;
@@ -326,7 +325,6 @@ static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_da
 	u8 p2 = 0x86;
 	nqapplet_driver_data_ptr drv_data;
 
-	assert(card != NULL && data != NULL && out != NULL);
 	LOG_FUNC_CALLED(card->ctx);
 
 	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
@@ -371,7 +369,6 @@ static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, siz
 	struct sc_apdu apdu;
 	nqapplet_driver_data_ptr drv_data;
 
-	assert(card != NULL && data != NULL && out != NULL);
 	LOG_FUNC_CALLED(card->ctx);
 	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
 	

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -26,72 +26,65 @@
 #include "internal.h"
 #include "log.h"
 
-#define APPLET_VERSION_LEN 2
-#define APPLET_MEMTYPE_LEN 1
+#define APPLET_VERSION_LEN  2
+#define APPLET_MEMTYPE_LEN  1
 #define APPLET_SERIALNR_LEN 8
 
 /* card constants */
-static const struct sc_atr_table nqapplet_atrs[] = 
-{
-	{ "3b:d5:18:ff:81:91:fe:1f:c3:80:73:c8:21:10:0a", NULL, NULL, SC_CARD_TYPE_NQ_APPLET, 0, NULL },
-	{ NULL, NULL, NULL, 0, 0, NULL }
-};
+static const struct sc_atr_table nqapplet_atrs[] = {
+	{"3b:d5:18:ff:81:91:fe:1f:c3:80:73:c8:21:10:0a", NULL, NULL, SC_CARD_TYPE_NQ_APPLET, 0, NULL},
+	{NULL, NULL, NULL, 0, 0, NULL}};
 
 static const u8 nqapplet_aid[] = {0xd2, 0x76, 0x00, 0x01, 0x80, 0xBA, 0x01, 0x44, 0x02, 0x01, 0x00};
 
 static struct sc_card_operations nqapplet_operations;
 static struct sc_card_operations *iso_operations = NULL;
 
-#define KEY_REFERENCE_NO_KEY	0x00
-#define KEY_REFERENCE_AUTH_KEY	0x01
-#define KEY_REFERENCE_ENCR_KEY	0x02
+#define KEY_REFERENCE_NO_KEY   0x00
+#define KEY_REFERENCE_AUTH_KEY 0x01
+#define KEY_REFERENCE_ENCR_KEY 0x02
 
-struct nqapplet_driver_data
-{
+struct nqapplet_driver_data {
 	u8 version_minor;
 	u8 version_major;
 	u8 key_reference;
 };
-typedef struct nqapplet_driver_data * nqapplet_driver_data_ptr;
+typedef struct nqapplet_driver_data *nqapplet_driver_data_ptr;
 
-static struct sc_card_driver nqapplet_driver = 
-{
-	"NQ-Applet",      // name
-	"nqapplet",      // short name
-	&nqapplet_operations,	// operations
-	NULL,           // atr table
-	0,              // nr of atr
-	NULL            // dll?
+static struct sc_card_driver nqapplet_driver = {
+	"NQ-Applet",          // name
+	"nqapplet",           // short name
+	&nqapplet_operations, // operations
+	NULL,                 // atr table
+	0,                    // nr of atr
+	NULL                  // dll?
 };
 
-static const struct sc_card_error nqapplet_errors[] = 
-{
-	{ 0x6700, SC_ERROR_WRONG_LENGTH, "Invalid LC or LE"}, 
-	{ 0x6982, SC_ERROR_SECURITY_STATUS_NOT_SATISFIED, "Security status not satisfied" }, //TODO MK/DK??
-	{ 0x6985, SC_ERROR_NOT_ALLOWED,	"Invalid PIN or key" },
-	{ 0x6986, SC_ERROR_NOT_ALLOWED,	"Conditions of use not satisfied" },
-	{ 0x6A80, SC_ERROR_INVALID_ARGUMENTS, "Invalid parameters" },
-	{ 0x6A82, SC_ERROR_OBJECT_NOT_FOUND, "Data object not found"},
-	{ 0x6A84, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory" },
-	{ 0x6A86, SC_ERROR_INCORRECT_PARAMETERS, "Invalid P1 or P2" }, 
-	{ 0x6A88, SC_ERROR_INVALID_ARGUMENTS, "Wrong key ID" },
-	{ 0x6D00, SC_ERROR_FILE_NOT_FOUND, "Applet not found" }
-};
+static const struct sc_card_error nqapplet_errors[] = {
+	{0x6700, SC_ERROR_WRONG_LENGTH, "Invalid LC or LE"},
+	{0x6982, SC_ERROR_SECURITY_STATUS_NOT_SATISFIED, "Security status not satisfied"}, // TODO MK/DK??
+	{0x6985, SC_ERROR_NOT_ALLOWED, "Invalid PIN or key"},
+	{0x6986, SC_ERROR_NOT_ALLOWED, "Conditions of use not satisfied"},
+	{0x6A80, SC_ERROR_INVALID_ARGUMENTS, "Invalid parameters"},
+	{0x6A82, SC_ERROR_OBJECT_NOT_FOUND, "Data object not found"},
+	{0x6A84, SC_ERROR_NOT_ENOUGH_MEMORY, "Not enough memory"},
+	{0x6A86, SC_ERROR_INCORRECT_PARAMETERS, "Invalid P1 or P2"},
+	{0x6A88, SC_ERROR_INVALID_ARGUMENTS, "Wrong key ID"},
+	{0x6D00, SC_ERROR_FILE_NOT_FOUND, "Applet not found"}};
 
 /* convenience functions */
 
 static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor)
 {
 	nqapplet_driver_data_ptr data = calloc(1, sizeof(struct nqapplet_driver_data));
-	if (data == NULL)
-	{
+	if (data == NULL) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 	}
 
 	data->version_major = version_major;
 	data->version_minor = version_minor;
 	data->key_reference = KEY_REFERENCE_NO_KEY;
-	card->drv_data = (void*)data;
+	card->drv_data = (void *)data;
 	return SC_SUCCESS;
 }
 
@@ -106,14 +99,15 @@ static int init_driver_data(sc_card_t *card, u8 version_major, u8 version_minor)
  * @param[out,opt]	serial_nr_len	The actual number of octet copied into serial_nr buffer
  *
  * @return SC_SUCCESS: The applet is present and selected.
- * 
+ *
  */
-static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor, u8 *serial_nr, size_t cb_serial_nr, size_t *serial_nr_len)
+static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor, u8 *serial_nr,
+                           size_t cb_serial_nr, size_t *serial_nr_len)
 {
 	int rv;
 	sc_context_t *ctx = card->ctx;
 	sc_apdu_t apdu;
-	u8 buffer[APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN+2];
+	u8 buffer[APPLET_VERSION_LEN + APPLET_MEMTYPE_LEN + APPLET_SERIALNR_LEN + 2];
 	size_t cb_buffer = sizeof(buffer);
 	size_t cb_aid = sizeof(nqapplet_aid);
 
@@ -127,29 +121,24 @@ static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, rv, "Card returned error");
 
-	if ( apdu.resplen < APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN )
-	{
+	if (apdu.resplen < APPLET_VERSION_LEN + APPLET_MEMTYPE_LEN + APPLET_SERIALNR_LEN) {
 		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_WRONG_LENGTH);
 	}
 
-	if ( version_major != NULL )
-	{
+	if (version_major != NULL) {
 		*version_major = buffer[0];
 	}
-	if ( version_minor != NULL )
-	{
+	if (version_minor != NULL) {
 		*version_minor = buffer[1];
 	}
-	if ( serial_nr != NULL && cb_serial_nr > 0 && serial_nr_len != NULL )
-	{
+	if (serial_nr != NULL && cb_serial_nr > 0 && serial_nr_len != NULL) {
 		size_t cb = MIN(APPLET_SERIALNR_LEN, cb_serial_nr);
-		memcpy(serial_nr, buffer+3, cb);
+		memcpy(serial_nr, buffer + 3, cb);
 		*serial_nr_len = cb;
 	}
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
-
 
 /* driver operations API */
 static int nqapplet_match_card(struct sc_card *card)
@@ -167,9 +156,9 @@ static int nqapplet_init(struct sc_card *card)
 	unsigned long rsa_flags = 0;
 
 	LOG_FUNC_CALLED(card->ctx);
-	int rv = select_nqapplet(card, &version_major, &version_minor, serial_nr, cb_serial_nr, &cb_serial_nr);
-	if ( rv != SC_SUCCESS )
-	{
+	int rv =
+		select_nqapplet(card, &version_major, &version_minor, serial_nr, cb_serial_nr, &cb_serial_nr);
+	if (rv != SC_SUCCESS) {
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_CARD, "Cannot select NQ-Applet.");
 	}
 
@@ -178,10 +167,10 @@ static int nqapplet_init(struct sc_card *card)
 
 	card->max_send_size = 255;
 	card->max_recv_size = 256;
-	card->caps |=  SC_CARD_CAP_RNG | SC_CARD_CAP_ISO7816_PIN_INFO;
+	card->caps |= SC_CARD_CAP_RNG | SC_CARD_CAP_ISO7816_PIN_INFO;
 	rsa_flags |= SC_ALGORITHM_RSA_RAW;
 	_sc_card_add_rsa_alg(card, 3072, rsa_flags, 0);
-	
+
 	card->serialnr.len = MIN(sizeof(card->serialnr.value), cb_serial_nr);
 	memcpy(card->serialnr.value, serial_nr, card->serialnr.len);
 
@@ -193,10 +182,9 @@ static int nqapplet_finish(struct sc_card *card)
 	nqapplet_driver_data_ptr data = (nqapplet_driver_data_ptr)card->drv_data;
 
 	LOG_FUNC_CALLED(card->ctx);
-	if (data != NULL)
-	{
+	if (data != NULL) {
 		free(data);
-		card->drv_data=NULL;
+		card->drv_data = NULL;
 	}
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
@@ -211,34 +199,28 @@ static int nqapplet_get_response(struct sc_card *card, size_t *cb_resp, u8 *resp
 	resplen = MIN(sc_get_max_recv_size(card), *cb_resp);
 
 	sc_format_apdu_ex(&apdu, 0x80, 0xC0, 0x00, 0x00, NULL, 0, resp, resplen);
-	apdu.flags  |= SC_APDU_FLAGS_NO_GET_RESP;
+	apdu.flags |= SC_APDU_FLAGS_NO_GET_RESP;
 
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
-	if (apdu.resplen == 0)
-	{
+	if (apdu.resplen == 0) {
 		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
 	}
 
 	*cb_resp = apdu.resplen;
 
-	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
-	{
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
 		rv = SC_SUCCESS;
-	}
-	else if (apdu.sw1 == 0x61)
-	{
+	} else if (apdu.sw1 == 0x61) {
 		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
-	}
-	else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82)
-	{
+	} else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82) {
 		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	}
 
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
 
-static int nqapplet_get_challenge(struct sc_card *card, u8 * buf, size_t count)
+static int nqapplet_get_challenge(struct sc_card *card, u8 *buf, size_t count)
 {
 	int r;
 	struct sc_apdu apdu;
@@ -255,12 +237,11 @@ static int nqapplet_get_challenge(struct sc_card *card, u8 * buf, size_t count)
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE failed");
 
-	if (count < apdu.resplen)
-	{
-		return (int) count;
+	if (count < apdu.resplen) {
+		return (int)count;
 	}
-   
-	return (int) apdu.resplen;
+
+	return (int)apdu.resplen;
 }
 
 static int nqapplet_logout(struct sc_card *card)
@@ -268,59 +249,56 @@ static int nqapplet_logout(struct sc_card *card)
 	LOG_FUNC_CALLED(card->ctx);
 	/* selecting NQ-Applet again will reset the applet status and unauthorize PINs */
 	int rv = select_nqapplet(card, NULL, NULL, NULL, 0, NULL);
-	if ( rv != SC_SUCCESS )
-	{
+	if (rv != SC_SUCCESS) {
 		LOG_TEST_RET(card->ctx, rv, "Failed to logout");
 	}
-	
+
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
 int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env *env, int se_num)
 {
-	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV, 
+	/* Note: the NQ-Applet does not have APDU for SET SECURITY ENV,
 	this function checks the intended parameters and sets card_data.key_reference */
 	nqapplet_driver_data_ptr data;
 	u8 key_reference = KEY_REFERENCE_NO_KEY;
-	
+
 	LOG_FUNC_CALLED(card->ctx);
 
 	data = (nqapplet_driver_data_ptr)card->drv_data;
 	data->key_reference = KEY_REFERENCE_NO_KEY;
 
-	if(se_num != 0)
-	{
-		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "Storing of security environment is not supported");
+	if (se_num != 0) {
+		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED,
+		             "Storing of security environment is not supported");
 	}
-	if ( env->key_ref_len == 1 )
-	{
+	if (env->key_ref_len == 1) {
 		key_reference = env->key_ref[0];
 	}
-	
-	switch (env->operation)
-	{
-		case SC_SEC_OPERATION_DECIPHER:
-			if ( key_reference != KEY_REFERENCE_AUTH_KEY && key_reference != KEY_REFERENCE_ENCR_KEY )
-			{
-				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
-			}
-			data->key_reference = key_reference;
-			break;
-		case SC_SEC_OPERATION_SIGN:
-			if ( key_reference != KEY_REFERENCE_AUTH_KEY )
-			{
-				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
-			}
-			data->key_reference = key_reference;
-			break;
-		default:
-			LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "Unsupported sec. operation.");
+
+	switch (env->operation) {
+	case SC_SEC_OPERATION_DECIPHER:
+		if (key_reference != KEY_REFERENCE_AUTH_KEY && key_reference != KEY_REFERENCE_ENCR_KEY) {
+			LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY,
+			             "Decipher operation is only supported with AUTH and ENCR keys.");
+		}
+		data->key_reference = key_reference;
+		break;
+	case SC_SEC_OPERATION_SIGN:
+		if (key_reference != KEY_REFERENCE_AUTH_KEY) {
+			LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY,
+			             "Sign operation is only supported with AUTH key.");
+		}
+		data->key_reference = key_reference;
+		break;
+	default:
+		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "Unsupported sec. operation.");
 	}
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_data, u8 * out, size_t outlen)
+static int nqapplet_decipher(struct sc_card *card, const u8 *data, size_t cb_data, u8 *out, size_t outlen)
 {
 	int rv;
 	struct sc_apdu apdu;
@@ -331,15 +309,13 @@ static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_da
 	LOG_FUNC_CALLED(card->ctx);
 
 	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
-	
-	if ( drv_data->key_reference == KEY_REFERENCE_AUTH_KEY )
-	{
+
+	if (drv_data->key_reference == KEY_REFERENCE_AUTH_KEY) {
 		p1 = 0x9E;
 		p2 = 0x9A;
-	} 
-	else if ( drv_data->key_reference != KEY_REFERENCE_ENCR_KEY )
-	{
-		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
+	} else if (drv_data->key_reference != KEY_REFERENCE_ENCR_KEY) {
+		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY,
+		             "Decipher operation is only supported with AUTH and ENCR keys.");
 	}
 
 	/* the applet supports only 3072 RAW RSA, input buffer size must be 384 octets,
@@ -350,23 +326,19 @@ static int nqapplet_decipher(struct sc_card *card, const u8 * data, size_t cb_da
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
 
-	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
-	{
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
 		rv = apdu.resplen;
-	}
-	else if (apdu.sw1 == 0x61)
-	{
+	} else if (apdu.sw1 == 0x61) {
 		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
-	}
-	else
-	{
+	} else {
 		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	}
 
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
 
-static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, size_t cb_data, u8 * out, size_t outlen)
+static int nqapplet_compute_signature(struct sc_card *card, const u8 *data, size_t cb_data, u8 *out,
+                                      size_t outlen)
 {
 	int rv;
 	struct sc_apdu apdu;
@@ -374,10 +346,10 @@ static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, siz
 
 	LOG_FUNC_CALLED(card->ctx);
 	drv_data = (nqapplet_driver_data_ptr)card->drv_data;
-	
-	if ( drv_data->key_reference != KEY_REFERENCE_AUTH_KEY )
-	{
-		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
+
+	if (drv_data->key_reference != KEY_REFERENCE_AUTH_KEY) {
+		LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY,
+		             "Sign operation is only supported with AUTH key.");
 	}
 
 	/* the applet supports only 3072 RAW RSA, input buffer size must be 384 octets,
@@ -388,34 +360,27 @@ static int nqapplet_compute_signature(struct sc_card *card, const u8 * data, siz
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
 
-	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
-	{
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
 		rv = apdu.resplen;
-	}
-	else if (apdu.sw1 == 0x61)
-	{
+	} else if (apdu.sw1 == 0x61) {
 		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
-	}
-	else
-	{
+	} else {
 		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	}
 
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
 
-static int nqapplet_check_sw(struct sc_card *card,unsigned int sw1,unsigned int sw2)
+static int nqapplet_check_sw(struct sc_card *card, unsigned int sw1, unsigned int sw2)
 {
-	const int nqapplet_error_count = sizeof(nqapplet_errors)/sizeof(struct sc_card_error);
+	const int nqapplet_error_count = sizeof(nqapplet_errors) / sizeof(struct sc_card_error);
 	int i;
 
 	LOG_FUNC_CALLED(card->ctx);
 	sc_log(card->ctx, "Checking sw1 = 0x%02x, sw2 = 0x%02x\n", sw1, sw2);
-  
-	for (i = 0; i < nqapplet_error_count; i++)
-	{
-		if (nqapplet_errors[i].SWs == ((sw1 << 8) | sw2))
-		{
+
+	for (i = 0; i < nqapplet_error_count; i++) {
+		if (nqapplet_errors[i].SWs == ((sw1 << 8) | sw2)) {
 			LOG_TEST_RET(card->ctx, nqapplet_errors[i].errorno, nqapplet_errors[i].errorstr);
 		}
 	}
@@ -436,35 +401,29 @@ static int nqapplet_get_data(struct sc_card *card, unsigned int id, u8 *resp, si
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
 
-	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
-	{
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
 		rv = apdu.resplen;
-	}
-	else if (apdu.sw1 == 0x61)
-	{
+	} else if (apdu.sw1 == 0x61) {
 		rv = apdu.sw2 == 0 ? 256 : apdu.sw2;
-	}
-	else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82)
-	{
+	} else if (apdu.sw1 == 0x62 && apdu.sw2 == 0x82) {
 		rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	}
 
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
 
-static int nqapplet_select_file(struct sc_card *card, const struct sc_path *in_path, struct sc_file **file_out)
+static int nqapplet_select_file(struct sc_card *card, const struct sc_path *in_path,
+                                struct sc_file **file_out)
 {
 	LOG_FUNC_CALLED(card->ctx);
 
 	/* the applet does not support SELECT EF/DF except for SELECT APPLET.
 	In order to enable opensc-explorer add support for virtually selecting MF only */
-	if (in_path->type == SC_PATH_TYPE_PATH && in_path->len == 2 && memcmp(in_path->value, "\x3F\x00", 2) == 0 )
-	{
-		if ( file_out != NULL )
-		{
+	if (in_path->type == SC_PATH_TYPE_PATH && in_path->len == 2 &&
+	    memcmp(in_path->value, "\x3F\x00", 2) == 0) {
+		if (file_out != NULL) {
 			struct sc_file *file = sc_file_new();
-			if (file == NULL)
-			{
+			if (file == NULL) {
 				LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 			}
 			file->path = *in_path;
@@ -472,19 +431,17 @@ static int nqapplet_select_file(struct sc_card *card, const struct sc_path *in_p
 			LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 		}
 	}
-	//TODO allow selecting Applet AID
+	// TODO allow selecting Applet AID
 
 	LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 }
 
-static int nqapplet_card_ctl(sc_card_t* card, unsigned long cmd, void* ptr)
+static int nqapplet_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 {
-	switch (cmd)
-	{
+	switch (cmd) {
 	case SC_CARDCTL_GET_SERIALNR:
-		if (card->serialnr.len)
-		{
-			sc_serial_number_t* serial = (sc_serial_number_t*)ptr;
+		if (card->serialnr.len) {
+			sc_serial_number_t *serial = (sc_serial_number_t *)ptr;
 			memcpy(serial->value, card->serialnr.value, card->serialnr.len);
 			serial->len = card->serialnr.len;
 			return SC_SUCCESS;
@@ -494,13 +451,11 @@ static int nqapplet_card_ctl(sc_card_t* card, unsigned long cmd, void* ptr)
 	return SC_ERROR_NOT_SUPPORTED;
 }
 
-
-struct sc_card_driver * sc_get_nqApplet_driver(void)
+struct sc_card_driver *sc_get_nqApplet_driver(void)
 {
-	sc_card_driver_t * iso_driver = sc_get_iso7816_driver();
+	sc_card_driver_t *iso_driver = sc_get_iso7816_driver();
 
-	if( iso_operations == NULL )
-	{
+	if (iso_operations == NULL) {
 		iso_operations = iso_driver->ops;
 	}
 

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -127,7 +127,8 @@ static int select_nqapplet(sc_card_t *card, u8 *version_major, u8 *version_minor
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, rv, "Card returned error");
 
-	if ( apdu.resplen < APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN ) {
+	if ( apdu.resplen < APPLET_VERSION_LEN+APPLET_MEMTYPE_LEN+APPLET_SERIALNR_LEN )
+	{
 		SC_FUNC_RETURN(ctx, SC_LOG_DEBUG_NORMAL, SC_ERROR_WRONG_LENGTH);
 	}
 
@@ -299,13 +300,15 @@ int nqapplet_set_security_env(struct sc_card *card, const struct sc_security_env
 	switch (env->operation)
 	{
 		case SC_SEC_OPERATION_DECIPHER:
-			if ( key_reference != KEY_REFERENCE_AUTH_KEY && key_reference != KEY_REFERENCE_ENCR_KEY ) {
+			if ( key_reference != KEY_REFERENCE_AUTH_KEY && key_reference != KEY_REFERENCE_ENCR_KEY )
+			{
 				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Decipher operation is only supported with AUTH and ENCR keys.");
 			}
 			data->key_reference = key_reference;
 			break;
 		case SC_SEC_OPERATION_SIGN:
-			if ( key_reference != KEY_REFERENCE_AUTH_KEY ) {
+			if ( key_reference != KEY_REFERENCE_AUTH_KEY )
+			{
 				LOG_TEST_RET(card->ctx, SC_ERROR_INCOMPATIBLE_KEY, "Sign operation is only supported with AUTH key.");
 			}
 			data->key_reference = key_reference;
@@ -455,8 +458,10 @@ static int nqapplet_select_file(struct sc_card *card, const struct sc_path *in_p
 
 	/* the applet does not support SELECT EF/DF except for SELECT APPLET.
 	In order to enable opensc-explorer add support for virtually selecting MF only */
-	if (in_path->type == SC_PATH_TYPE_PATH && in_path->len == 2 && memcmp(in_path->value, "\x3F\x00", 2) == 0 ) {
-		if ( file_out != NULL )   {
+	if (in_path->type == SC_PATH_TYPE_PATH && in_path->len == 2 && memcmp(in_path->value, "\x3F\x00", 2) == 0 )
+	{
+		if ( file_out != NULL )
+		{
 			struct sc_file *file = sc_file_new();
 			if (file == NULL)
 			{
@@ -477,7 +482,8 @@ static int nqapplet_card_ctl(sc_card_t* card, unsigned long cmd, void* ptr)
 	switch (cmd)
 	{
 	case SC_CARDCTL_GET_SERIALNR:
-		if (card->serialnr.len) {
+		if (card->serialnr.len)
+		{
 			sc_serial_number_t* serial = (sc_serial_number_t*)ptr;
 			memcpy(serial->value, card->serialnr.value, card->serialnr.len);
 			serial->len = card->serialnr.len;

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -265,7 +265,10 @@ enum {
 	SC_CARD_TYPE_IDPRIME_GENERIC,
 
 	/* eDO cards */
-	SC_CARD_TYPE_EDO = 38000
+	SC_CARD_TYPE_EDO = 38000,
+
+	/* JCOP4 cards with NQ-Applet */
+	SC_CARD_TYPE_NQ_APPLET = 39000
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);
@@ -309,6 +312,7 @@ extern sc_card_driver_t *sc_get_npa_driver(void);
 extern sc_card_driver_t *sc_get_esteid2018_driver(void);
 extern sc_card_driver_t *sc_get_idprime_driver(void);
 extern sc_card_driver_t *sc_get_edo_driver(void);
+extern sc_card_driver_t *sc_get_nqApplet_driver(void);
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -145,6 +145,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "jpki",	(void *(*)(void)) sc_get_jpki_driver },
 	{ "npa",	(void *(*)(void)) sc_get_npa_driver },
 	{ "cac1",	(void *(*)(void)) sc_get_cac1_driver },
+	{ "nqapplet",	(void *(*)(void)) sc_get_nqApplet_driver },
 	/* The default driver should be last, as it handles all the
 	 * unrecognized cards. */
 	{ "default",	(void *(*)(void)) sc_get_default_driver },

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -1,0 +1,233 @@
+/*
+ * PKCS15 emulation for JCOP4 Cards with NQ-Applet
+ *
+ * Copyright (C) 2020 jozsefd <jozsef.dojcsak@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/compat_strlcpy.h"
+#include "log.h"
+#include "pkcs15.h"
+#include "cards.h"
+
+static const char name_Card[] = "NQ-Applet";
+static const char name_Vendor[] = "JCOP4";
+
+static int get_nqapplet_certificate(sc_card_t * card, u8 data_id, struct sc_pkcs15_der * cert_info)
+{
+    int rv;
+    u8 buffer[3072];
+    size_t cb_buffer = sizeof(buffer);
+	LOG_FUNC_CALLED(card->ctx);
+
+    rv = sc_get_data(card, data_id, buffer, cb_buffer);
+    LOG_TEST_RET(card->ctx, rv, "GET DATA failed");
+    if ( rv == 0 )
+    {
+        LOG_TEST_RET(card->ctx, SC_ERROR_FILE_NOT_FOUND, "No certificate data returned");
+    }
+
+    if ( cert_info != NULL )
+    {
+        if ( cert_info->value != NULL )
+        {
+            free(cert_info->value);
+        }
+        cert_info->value = malloc(rv);
+        if ( cert_info->value != NULL )
+        {
+            cert_info->len = rv;
+            memcpy(cert_info->value, buffer, rv);
+        }
+    }
+    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int add_nqapplet_pin(sc_pkcs15_card_t *p15card, const char * id, u8 reference)
+{
+    int rv;
+    struct sc_pkcs15_auth_info  pin_info;
+    struct sc_pkcs15_object     pin_obj;
+	sc_card_t * card = p15card->card;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+    memset(&pin_info, 0, sizeof(pin_info));
+    memset(&pin_obj, 0, sizeof(pin_obj));
+
+    sc_pkcs15_format_id(id, &pin_info.auth_id);
+    pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
+    pin_info.attrs.pin.reference = reference;
+    pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN;
+    pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_UTF8;
+    pin_info.attrs.pin.min_length = 6;
+    pin_info.attrs.pin.stored_length = 6;
+    pin_info.attrs.pin.max_length = 6;
+    pin_info.attrs.pin.pad_char = '\0';
+    pin_info.tries_left = -1; //TODO
+    pin_info.max_tries = 3;
+
+    strlcpy(pin_obj.label, "UserPIN", sizeof(pin_obj.label));
+    pin_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
+
+    rv = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
+    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_pin_obj failed");
+    
+    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int add_nqapplet_certificate(sc_pkcs15_card_t *p15card, const char * id, const char * name, u8 data_id)
+{
+    int rv;
+    struct sc_pkcs15_cert_info  cert_info;
+    struct sc_pkcs15_object     cert_obj;
+	sc_card_t * card = p15card->card;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+    memset(&cert_info, 0, sizeof(cert_info));
+    memset(&cert_obj,  0, sizeof(cert_obj));
+
+    sc_pkcs15_format_id(id, &cert_info.id);
+	cert_info.authority = 0;
+    rv = get_nqapplet_certificate(card, data_id, &cert_info.value);
+    LOG_TEST_RET(card->ctx, rv, "Failed to get certificate");
+
+    strlcpy(cert_obj.label, name, sizeof(cert_obj.label));
+	cert_obj.flags = 0;
+
+    rv = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_x509_cert failed");
+
+    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int add_nqapplet_private_key(sc_pkcs15_card_t *p15card, const char * id, int reference, const char * name, const char * pin_id, unsigned int usage)
+{
+    int rv;
+    struct sc_pkcs15_prkey_info prkey_info;
+    struct sc_pkcs15_object     prkey_obj;
+	sc_card_t * card = p15card->card;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+    memset(&prkey_info, 0, sizeof(prkey_info));
+    memset(&prkey_obj, 0, sizeof(prkey_obj));
+
+    sc_pkcs15_format_id(id, &prkey_info.id);
+    prkey_info.usage = usage;
+    prkey_info.native = 1;
+    prkey_info.key_reference = reference;
+    prkey_info.modulus_length = 3072;
+
+    strlcpy(prkey_obj.label, name, sizeof(prkey_obj.label));
+    prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
+    sc_pkcs15_format_id(pin_id, &prkey_obj.auth_id);
+
+    rv = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_rsa_prkey failed");
+
+    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int add_nqapplet_objects(sc_pkcs15_card_t *p15card)
+{
+    int rv;
+	sc_card_t * card = p15card->card;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+    // 1) User PIN
+    rv = add_nqapplet_pin(p15card, "1", 0x01);
+    LOG_TEST_RET(card->ctx, rv, "Failed to add PIN 1");
+
+    // 2.1) CH.Auth 
+    rv = add_nqapplet_certificate(p15card, "1", "C.CH.Auth", 0x00);
+    LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. certificate");
+
+    // 2.2) PrK.CH.Auth
+    rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_DECRYPT);
+    LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. private key");
+
+    // 2.1) CH.Auth 
+    rv = add_nqapplet_certificate(p15card, "2", "C.CH.Encr", 0x01);
+    LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. certificate");
+
+    // 2.2) PrK.CH.Auth
+    rv = add_nqapplet_private_key(p15card, "2", 0x02, "PrK.CH.Encr", "1", SC_PKCS15_PRKEY_USAGE_DECRYPT);
+    LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. private key");
+
+    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+
+int sc_pkcs15emu_nqapplet_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
+{
+	int rv = SC_ERROR_WRONG_CARD;
+    sc_context_t * ctx;
+	sc_card_t * card;
+
+    if (!p15card || ! p15card->card || !p15card->card->ctx) return SC_ERROR_INVALID_ARGUMENTS;
+
+	card = p15card->card;
+	ctx = card->ctx;
+	
+    SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
+
+	if (card->type!=SC_CARD_TYPE_NQ_APPLET) {
+        sc_log(p15card->card->ctx, "Unsupported card type: %d", card->type);
+        return SC_ERROR_WRONG_CARD;
+    }
+
+    rv = add_nqapplet_objects(p15card);
+    LOG_TEST_RET(ctx, rv, "Failed to add PKCS15");
+
+	if ( aid != NULL ) {
+        struct sc_file *file = sc_file_new();
+        if (file != NULL)
+        {
+            /* PKCS11 depends on the file_app object, provide MF */
+            sc_format_path("3f00", &file->path);
+            sc_file_free(p15card->file_app);
+            p15card->file_app = file;		
+        }
+	}
+
+    if ( p15card->tokeninfo != NULL ) {
+		sc_pkcs15_free_tokeninfo(p15card->tokeninfo);
+	}
+
+    p15card->tokeninfo = sc_pkcs15_tokeninfo_new();
+    if ( p15card->tokeninfo == NULL ) 
+    {
+		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "unable to create tokeninfo struct");
+	}
+    else 
+    {
+		char serial_hex[SC_MAX_SERIALNR*2+2];
+
+		sc_bin_to_hex(card->serialnr.value, card->serialnr.len , serial_hex, sizeof(serial_hex), 0);
+		p15card->tokeninfo->serial_number = strdup(serial_hex);
+		p15card->tokeninfo->label = strdup(name_Card);
+		p15card->tokeninfo->manufacturer_id = strdup(name_Vendor);
+		p15card->tokeninfo->flags = SC_PKCS15_TOKEN_READONLY;
+	}
+
+    return SC_SUCCESS;
+}

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -45,10 +45,7 @@ static int get_nqapplet_certificate(sc_card_t *card, u8 data_id, struct sc_pkcs1
 
 	if (cert_info != NULL)
 	{
-		if (cert_info->value != NULL)
-		{
-			free(cert_info->value);
-		}
+		free(cert_info->value);
 		cert_info->value = malloc(rv);
 		if (cert_info->value != NULL)
 		{

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "opensc.h"
 #include "cards.h"
 #include "common/compat_strlcpy.h"
 #include "log.h"

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -102,12 +102,10 @@ static int add_nqapplet_certificate(sc_pkcs15_card_t *p15card, const char *id, c
 	memset(&cert_obj, 0, sizeof(cert_obj));
 
 	sc_pkcs15_format_id(id, &cert_info.id);
-	cert_info.authority = 0;
 	rv = get_nqapplet_certificate(card, data_id, &cert_info.value);
 	LOG_TEST_RET(card->ctx, rv, "Failed to get certificate");
 
 	strlcpy(cert_obj.label, name, sizeof(cert_obj.label));
-	cert_obj.flags = 0;
 
 	rv = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
 	LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_x509_cert failed");
@@ -210,10 +208,7 @@ int sc_pkcs15emu_nqapplet_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 		}
 	}
 
-	if (p15card->tokeninfo != NULL)
-	{
-		sc_pkcs15_free_tokeninfo(p15card->tokeninfo);
-	}
+	sc_pkcs15_free_tokeninfo(p15card->tokeninfo);
 
 	p15card->tokeninfo = sc_pkcs15_tokeninfo_new();
 	if (p15card->tokeninfo == NULL)

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -154,7 +154,7 @@ static int add_nqapplet_objects(sc_pkcs15_card_t *p15card)
 	rv = add_nqapplet_pin(p15card, "1", 0x01);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add PIN 1");
 
-	// 2.1) CH.Auth
+	// 2.1) C.CH.Auth
 	rv = add_nqapplet_certificate(p15card, "1", "C.CH.Auth", 0x00);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. certificate");
 
@@ -162,11 +162,11 @@ static int add_nqapplet_objects(sc_pkcs15_card_t *p15card)
 	rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_DECRYPT);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. private key");
 
-	// 2.1) CH.Auth
+	// 3.1) C.CH.Encr
 	rv = add_nqapplet_certificate(p15card, "2", "C.CH.Encr", 0x01);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. certificate");
 
-	// 2.2) PrK.CH.Auth
+	// 3.2) PrK.CH.Encr
 	rv = add_nqapplet_private_key(p15card, "2", 0x02, "PrK.CH.Encr", "1", SC_PKCS15_PRKEY_USAGE_DECRYPT);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. private key");
 

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -159,7 +159,7 @@ static int add_nqapplet_objects(sc_pkcs15_card_t *p15card)
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. certificate");
 
 	// 2.2) PrK.CH.Auth
-	rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_DECRYPT);
+	rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_DECRYPT);
 	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. private key");
 
 	// 3.1) C.CH.Encr

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -27,7 +27,7 @@
 #include "cards.h"
 
 static const char name_Card[] = "NQ-Applet";
-static const char name_Vendor[] = "JCOP4";
+static const char name_Vendor[] = "NXP";
 
 static int get_nqapplet_certificate(sc_card_t *card, u8 data_id, struct sc_pkcs15_der *cert_info)
 {

--- a/src/libopensc/pkcs15-nqApplet.c
+++ b/src/libopensc/pkcs15-nqApplet.c
@@ -1,7 +1,7 @@
 /*
  * PKCS15 emulation for JCOP4 Cards with NQ-Applet
  *
- * Copyright (C) 2020 jozsefd <jozsef.dojcsak@gmail.com>
+ * Copyright (C) 2021 jozsefd <jozsef.dojcsak@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,205 +29,210 @@
 static const char name_Card[] = "NQ-Applet";
 static const char name_Vendor[] = "JCOP4";
 
-static int get_nqapplet_certificate(sc_card_t * card, u8 data_id, struct sc_pkcs15_der * cert_info)
+static int get_nqapplet_certificate(sc_card_t *card, u8 data_id, struct sc_pkcs15_der *cert_info)
 {
-    int rv;
-    u8 buffer[3072];
-    size_t cb_buffer = sizeof(buffer);
+	int rv;
+	u8 buffer[3072];
+	size_t cb_buffer = sizeof(buffer);
 	LOG_FUNC_CALLED(card->ctx);
 
-    rv = sc_get_data(card, data_id, buffer, cb_buffer);
-    LOG_TEST_RET(card->ctx, rv, "GET DATA failed");
-    if ( rv == 0 )
-    {
-        LOG_TEST_RET(card->ctx, SC_ERROR_FILE_NOT_FOUND, "No certificate data returned");
-    }
+	rv = sc_get_data(card, data_id, buffer, cb_buffer);
+	LOG_TEST_RET(card->ctx, rv, "GET DATA failed");
+	if (rv == 0)
+	{
+		LOG_TEST_RET(card->ctx, SC_ERROR_FILE_NOT_FOUND, "No certificate data returned");
+	}
 
-    if ( cert_info != NULL )
-    {
-        if ( cert_info->value != NULL )
-        {
-            free(cert_info->value);
-        }
-        cert_info->value = malloc(rv);
-        if ( cert_info->value != NULL )
-        {
-            cert_info->len = rv;
-            memcpy(cert_info->value, buffer, rv);
-        }
-    }
-    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	if (cert_info != NULL)
+	{
+		if (cert_info->value != NULL)
+		{
+			free(cert_info->value);
+		}
+		cert_info->value = malloc(rv);
+		if (cert_info->value != NULL)
+		{
+			cert_info->len = rv;
+			memcpy(cert_info->value, buffer, rv);
+		}
+	}
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-static int add_nqapplet_pin(sc_pkcs15_card_t *p15card, const char * id, u8 reference)
+static int add_nqapplet_pin(sc_pkcs15_card_t *p15card, const char *id, u8 reference)
 {
-    int rv;
-    struct sc_pkcs15_auth_info  pin_info;
-    struct sc_pkcs15_object     pin_obj;
-	sc_card_t * card = p15card->card;
+	int rv;
+	struct sc_pkcs15_auth_info pin_info;
+	struct sc_pkcs15_object pin_obj;
+	sc_card_t *card = p15card->card;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-    memset(&pin_info, 0, sizeof(pin_info));
-    memset(&pin_obj, 0, sizeof(pin_obj));
+	memset(&pin_info, 0, sizeof(pin_info));
+	memset(&pin_obj, 0, sizeof(pin_obj));
 
-    sc_pkcs15_format_id(id, &pin_info.auth_id);
-    pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
-    pin_info.attrs.pin.reference = reference;
-    pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN;
-    pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_UTF8;
-    pin_info.attrs.pin.min_length = 6;
-    pin_info.attrs.pin.stored_length = 6;
-    pin_info.attrs.pin.max_length = 6;
-    pin_info.attrs.pin.pad_char = '\0';
-    pin_info.tries_left = -1; //TODO
-    pin_info.max_tries = 3;
+	sc_pkcs15_format_id(id, &pin_info.auth_id);
+	pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
+	pin_info.attrs.pin.reference = reference;
+	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_TYPE_FLAGS_PIN_GLOBAL | SC_PKCS15_PIN_AUTH_TYPE_PIN;
+	pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_UTF8;
+	pin_info.attrs.pin.min_length = 6;
+	pin_info.attrs.pin.stored_length = 6;
+	pin_info.attrs.pin.max_length = 6;
+	pin_info.attrs.pin.pad_char = '\0';
+	pin_info.tries_left = -1; //TODO
+	pin_info.max_tries = 3;
 
-    strlcpy(pin_obj.label, "UserPIN", sizeof(pin_obj.label));
-    pin_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
+	strlcpy(pin_obj.label, "UserPIN", sizeof(pin_obj.label));
+	pin_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE | SC_PKCS15_CO_FLAG_PRIVATE;
 
-    rv = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
-    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_pin_obj failed");
-    
-    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	rv = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
+	LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_pin_obj failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-static int add_nqapplet_certificate(sc_pkcs15_card_t *p15card, const char * id, const char * name, u8 data_id)
+static int add_nqapplet_certificate(sc_pkcs15_card_t *p15card, const char *id, const char *name, u8 data_id)
 {
-    int rv;
-    struct sc_pkcs15_cert_info  cert_info;
-    struct sc_pkcs15_object     cert_obj;
-	sc_card_t * card = p15card->card;
+	int rv;
+	struct sc_pkcs15_cert_info cert_info;
+	struct sc_pkcs15_object cert_obj;
+	sc_card_t *card = p15card->card;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-    memset(&cert_info, 0, sizeof(cert_info));
-    memset(&cert_obj,  0, sizeof(cert_obj));
+	memset(&cert_info, 0, sizeof(cert_info));
+	memset(&cert_obj, 0, sizeof(cert_obj));
 
-    sc_pkcs15_format_id(id, &cert_info.id);
+	sc_pkcs15_format_id(id, &cert_info.id);
 	cert_info.authority = 0;
-    rv = get_nqapplet_certificate(card, data_id, &cert_info.value);
-    LOG_TEST_RET(card->ctx, rv, "Failed to get certificate");
+	rv = get_nqapplet_certificate(card, data_id, &cert_info.value);
+	LOG_TEST_RET(card->ctx, rv, "Failed to get certificate");
 
-    strlcpy(cert_obj.label, name, sizeof(cert_obj.label));
+	strlcpy(cert_obj.label, name, sizeof(cert_obj.label));
 	cert_obj.flags = 0;
 
-    rv = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
-    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_x509_cert failed");
+	rv = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+	LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_x509_cert failed");
 
-    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-static int add_nqapplet_private_key(sc_pkcs15_card_t *p15card, const char * id, int reference, const char * name, const char * pin_id, unsigned int usage)
+static int add_nqapplet_private_key(sc_pkcs15_card_t *p15card, const char *id, int reference, const char *name, const char *pin_id, unsigned int usage)
 {
-    int rv;
-    struct sc_pkcs15_prkey_info prkey_info;
-    struct sc_pkcs15_object     prkey_obj;
-	sc_card_t * card = p15card->card;
+	int rv;
+	struct sc_pkcs15_prkey_info prkey_info;
+	struct sc_pkcs15_object prkey_obj;
+	sc_card_t *card = p15card->card;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-    memset(&prkey_info, 0, sizeof(prkey_info));
-    memset(&prkey_obj, 0, sizeof(prkey_obj));
+	memset(&prkey_info, 0, sizeof(prkey_info));
+	memset(&prkey_obj, 0, sizeof(prkey_obj));
 
-    sc_pkcs15_format_id(id, &prkey_info.id);
-    prkey_info.usage = usage;
-    prkey_info.native = 1;
-    prkey_info.key_reference = reference;
-    prkey_info.modulus_length = 3072;
+	sc_pkcs15_format_id(id, &prkey_info.id);
+	prkey_info.usage = usage;
+	prkey_info.native = 1;
+	prkey_info.key_reference = reference;
+	prkey_info.modulus_length = 3072;
 
-    strlcpy(prkey_obj.label, name, sizeof(prkey_obj.label));
-    prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
-    sc_pkcs15_format_id(pin_id, &prkey_obj.auth_id);
+	strlcpy(prkey_obj.label, name, sizeof(prkey_obj.label));
+	prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
+	sc_pkcs15_format_id(pin_id, &prkey_obj.auth_id);
 
-    rv = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
-    LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_rsa_prkey failed");
+	rv = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+	LOG_TEST_RET(card->ctx, rv, "sc_pkcs15emu_add_rsa_prkey failed");
 
-    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
 static int add_nqapplet_objects(sc_pkcs15_card_t *p15card)
 {
-    int rv;
-	sc_card_t * card = p15card->card;
+	int rv;
+	sc_card_t *card = p15card->card;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-    // 1) User PIN
-    rv = add_nqapplet_pin(p15card, "1", 0x01);
-    LOG_TEST_RET(card->ctx, rv, "Failed to add PIN 1");
+	// 1) User PIN
+	rv = add_nqapplet_pin(p15card, "1", 0x01);
+	LOG_TEST_RET(card->ctx, rv, "Failed to add PIN 1");
 
-    // 2.1) CH.Auth 
-    rv = add_nqapplet_certificate(p15card, "1", "C.CH.Auth", 0x00);
-    LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. certificate");
+	// 2.1) CH.Auth
+	rv = add_nqapplet_certificate(p15card, "1", "C.CH.Auth", 0x00);
+	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. certificate");
 
-    // 2.2) PrK.CH.Auth
-    rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_DECRYPT);
-    LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. private key");
+	// 2.2) PrK.CH.Auth
+	rv = add_nqapplet_private_key(p15card, "1", 0x01, "PrK.CH.Auth", "1", SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_DECRYPT);
+	LOG_TEST_RET(card->ctx, rv, "Failed to add Auth. private key");
 
-    // 2.1) CH.Auth 
-    rv = add_nqapplet_certificate(p15card, "2", "C.CH.Encr", 0x01);
-    LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. certificate");
+	// 2.1) CH.Auth
+	rv = add_nqapplet_certificate(p15card, "2", "C.CH.Encr", 0x01);
+	LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. certificate");
 
-    // 2.2) PrK.CH.Auth
-    rv = add_nqapplet_private_key(p15card, "2", 0x02, "PrK.CH.Encr", "1", SC_PKCS15_PRKEY_USAGE_DECRYPT);
-    LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. private key");
+	// 2.2) PrK.CH.Auth
+	rv = add_nqapplet_private_key(p15card, "2", 0x02, "PrK.CH.Encr", "1", SC_PKCS15_PRKEY_USAGE_DECRYPT);
+	LOG_TEST_RET(card->ctx, rv, "Failed to add Encr. private key");
 
-    LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
-
 
 int sc_pkcs15emu_nqapplet_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	int rv = SC_ERROR_WRONG_CARD;
-    sc_context_t * ctx;
-	sc_card_t * card;
+	sc_context_t *ctx;
+	sc_card_t *card;
 
-    if (!p15card || ! p15card->card || !p15card->card->ctx) return SC_ERROR_INVALID_ARGUMENTS;
+	if (!p15card || !p15card->card || !p15card->card->ctx)
+	{
+		return SC_ERROR_INVALID_ARGUMENTS;
+	}
 
 	card = p15card->card;
 	ctx = card->ctx;
-	
-    SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
 
-	if (card->type!=SC_CARD_TYPE_NQ_APPLET) {
-        sc_log(p15card->card->ctx, "Unsupported card type: %d", card->type);
-        return SC_ERROR_WRONG_CARD;
-    }
+	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_NORMAL);
 
-    rv = add_nqapplet_objects(p15card);
-    LOG_TEST_RET(ctx, rv, "Failed to add PKCS15");
-
-	if ( aid != NULL ) {
-        struct sc_file *file = sc_file_new();
-        if (file != NULL)
-        {
-            /* PKCS11 depends on the file_app object, provide MF */
-            sc_format_path("3f00", &file->path);
-            sc_file_free(p15card->file_app);
-            p15card->file_app = file;		
-        }
+	if (card->type != SC_CARD_TYPE_NQ_APPLET)
+	{
+		sc_log(p15card->card->ctx, "Unsupported card type: %d", card->type);
+		return SC_ERROR_WRONG_CARD;
 	}
 
-    if ( p15card->tokeninfo != NULL ) {
+	rv = add_nqapplet_objects(p15card);
+	LOG_TEST_RET(ctx, rv, "Failed to add PKCS15");
+
+	if (aid != NULL)
+	{
+		struct sc_file *file = sc_file_new();
+		if (file != NULL)
+		{
+			/* PKCS11 depends on the file_app object, provide MF */
+			sc_format_path("3f00", &file->path);
+			sc_file_free(p15card->file_app);
+			p15card->file_app = file;
+		}
+	}
+
+	if (p15card->tokeninfo != NULL)
+	{
 		sc_pkcs15_free_tokeninfo(p15card->tokeninfo);
 	}
 
-    p15card->tokeninfo = sc_pkcs15_tokeninfo_new();
-    if ( p15card->tokeninfo == NULL ) 
-    {
+	p15card->tokeninfo = sc_pkcs15_tokeninfo_new();
+	if (p15card->tokeninfo == NULL)
+	{
 		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "unable to create tokeninfo struct");
 	}
-    else 
-    {
-		char serial_hex[SC_MAX_SERIALNR*2+2];
+	else
+	{
+		char serial_hex[SC_MAX_SERIALNR * 2 + 2];
 
-		sc_bin_to_hex(card->serialnr.value, card->serialnr.len , serial_hex, sizeof(serial_hex), 0);
+		sc_bin_to_hex(card->serialnr.value, card->serialnr.len, serial_hex, sizeof(serial_hex), 0);
 		p15card->tokeninfo->serial_number = strdup(serial_hex);
 		p15card->tokeninfo->label = strdup(name_Card);
 		p15card->tokeninfo->manufacturer_id = strdup(name_Vendor);
 		p15card->tokeninfo->flags = SC_PKCS15_TOKEN_READONLY;
 	}
 
-    return SC_SUCCESS;
+	return SC_SUCCESS;
 }

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -615,7 +615,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	if (outlen < modlen)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
 
-	buflen = inlen + 256;
+	buflen = inlen + modlen;
 	buf = sc_mem_secure_alloc(buflen);
 	if (buf == NULL)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -57,6 +57,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "din66291",   sc_pkcs15emu_din_66291_init_ex	},
 	{ "esteid2018", sc_pkcs15emu_esteid2018_init_ex	},
 	{ "cardos",     sc_pkcs15emu_cardos_init_ex	},
+	{ "nqapplet",   sc_pkcs15emu_nqapplet_init_ex },
 	{ NULL, NULL }
 };
 
@@ -104,6 +105,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_ESTEID_2018:
 		case SC_CARD_TYPE_CARDOS_V5_0:
 		case SC_CARD_TYPE_CARDOS_V5_3:
+		case SC_CARD_TYPE_NQ_APPLET:
 
 			return 1;
 		default:

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -55,6 +55,7 @@ int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_idprime_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_cardos_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
+int sc_pkcs15emu_nqapplet_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
## NQ-Applet Card Driver and PKCS15 Emulator

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested

## Cards Supported
This PR contains the card driver and the PKCS15 emulator for the JCOP4 based cards released with the NQ Applet by Bundesagentur für Arbeit, a German Federal Agency. The NQ Applet contains 2 3072-Bit RSA private keys with the associated certificates, intended for non qualified PKI operations. The card may include a Q Applet for qualified signatures,  not included in this PR.

The NQ Applet has a limited ISO compatible APDU set, for instance neither SELECT FILE nor MSE is supported.

## 3072-Bit Raw RSA
The applet can execute only raw RSA calculations, thus the input and the output of such calculations require buffers for 384 octets. Unfortunately the function sc_pkcs15_compute_signature() in pkcs15-sec.c defined the buffer size as `buflen = inlen + 256;` which may result an SC_ERROR_BUFFER_TOO_SMALL during padding, like in sc_pkcs1_add_01_padding().

I changed the definition of this buffer size to: `buflen = inlen + modlen;`