### PR TITLE
PIV: Use a single (truncated) AID for selection

### DIFF
--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1678,15 +1678,16 @@ app <replaceable>application</replaceable> {
 			</varlistentry>
 			<varlistentry>
 				<term>
-					<envar>PIV_EXT_AUTH_KEY</envar>,
 					<envar>PIV_9A_KEY</envar>,
 					<envar>PIV_9C_KEY</envar>,
 					<envar>PIV_9D_KEY</envar>,
 					<envar>PIV_9E_KEY</envar>
 				</term>
 				<listitem><para>
-						PIV configuration during initialization with
-						<application>piv-tool</application>.
+						If the PIV PKCS#15 emulator can't find the public keys on
+						the card, the environment variables can be used to load them
+						from the filesystem. Files need to be encoded as
+						subjectPubkeyInfo.
 				</para></listitem>
 			</varlistentry>
 		</variablelist>

--- a/doc/tools/piv-tool.1.xml
+++ b/doc/tools/piv-tool.1.xml
@@ -63,7 +63,7 @@
 					<literal>01</literal> for 2DES, <literal>08</literal> for AES-128,
 					<literal>0A</literal> for AES-192 or <literal>0C</literal> for AES-256.
 					The key is provided by the card vendor. The environment variable
-					<varname>PIV_EXT_AUTH_KEY</varname> must point to either a binary file
+					<envar>PIV_EXT_AUTH_KEY</envar> must point to either a binary file
 					matching the length of the key or a text file containing
 					the key in the format:
 					<code>XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX</code>

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -717,7 +717,6 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 	for (i = 0; i < PIV_NUM_CERTS_AND_KEYS; i++) {
 		struct sc_pkcs15_cert_info cert_info;
 		struct sc_pkcs15_object    cert_obj;
-		sc_pkcs15_der_t   cert_der;
 		sc_pkcs15_cert_t *cert_out = NULL;
 		
 		ckis[i].cert_found = 0;
@@ -748,32 +747,15 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 			continue;
 		}
 
-		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len);
-
-		if (r) {
-			sc_log(card->ctx,  "No cert found,i=%d", i);
-			continue;
-		}
-
-		ckis[i].cert_found = 1;
-		/* cache it using the PKCS15 emulation objects */
-		/* as it does not change */
-		if (cert_der.value) {
-			cert_info.value.value = cert_der.value;
-			cert_info.value.len = cert_der.len;
-			if (!p15card->opts.use_file_cache) {
-				cert_info.path.len = 0; /* use in mem cert from now on */
-			}
-		}
-		/* following will find the cached cert in cert_info */
-		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+		/* following will find and cache cert in cert_info */
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
 		if (r < 0 || cert_out == NULL || cert_out->key == NULL) {
-			sc_log(card->ctx,  "Failed to read/parse the certificate r=%d",r);
+			sc_log(card->ctx,  "Failed to read/parse %s", certs[i].label);
 			if (cert_out != NULL)
 				sc_pkcs15_free_certificate(cert_out);
-			free(cert_der.value);
 			continue;
 		}
+		ckis[i].cert_found = 1;
 
 		/* set the token name to the name of the CN of the first certificate */
 		if (!token_name) {


### PR DESCRIPTION
Simplify the code so that only the AID without version information is
used for applet selection. Note that no other AID has ever been used.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
