### PR TITLE
PIV: Fixed detection of PIV AID via empty discovery

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2573,57 +2573,37 @@ static int piv_select_file(sc_card_t *card, const sc_path_t *in_path,
 
 }
 
-static int piv_parse_discovery(sc_card_t *card, u8 * rbuf, size_t rbuflen, int aid_only)
+static int piv_parse_discovery(sc_card_t *card, u8 *rbuf, size_t rbuflen, int aid_only)
 {
-	piv_private_data_t * priv = PIV_DATA(card);
-	int r = 0;
-	const u8 * body;
-	size_t bodylen;
-	const u8 * aid;
-	size_t aidlen;
-	const u8 * pinp;
-	size_t pinplen;
-	unsigned int cla_out, tag_out;
+	unsigned int cla, tag;
+	const u8 *aid, *policy, *body = rbuf;
+	size_t body_len, aid_len, policy_len;
 
+	/* Wee need to be strict about the (mandatory) structure of the Discovery
+	 * Object and the PIV Card Application AID to make sure that compliant
+	 * application is selected. */
+	if (SC_SUCCESS != sc_asn1_read_tag(&body, rbuflen, &cla, &tag, &body_len)
+			|| cla+tag != 0x7E
+			|| NULL == (aid = sc_asn1_find_tag(card->ctx, body, body_len, 0x4F, &aid_len))
+			|| aid_len < piv_aid.len || memcmp(aid, piv_aid.value, piv_aid.len) != 0)
+		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_CARD, "Discovery object not PIV");
 
-	if (rbuflen != 0) {
-		body = rbuf;
-		if ((r = sc_asn1_read_tag(&body, rbuflen, &cla_out, &tag_out,  &bodylen)) != SC_SUCCESS) {
-			sc_log(card->ctx, "DER problem %d",r);
-			r = SC_ERROR_INVALID_ASN1_OBJECT;
-			goto err;
-		}
-
-		sc_log(card->ctx,
-				"Discovery 0x%2.2x 0x%2.2x %p:%"SC_FORMAT_LEN_SIZE_T"u",
-				cla_out, tag_out, body, bodylen);
-		if ( cla_out+tag_out == 0x7E && body != NULL && bodylen != 0) {
-			aidlen = 0;
-			aid = sc_asn1_find_tag(card->ctx, body, bodylen, 0x4F, &aidlen);
-			if (aid == NULL || aidlen < piv_aids[0].len_short ||
-				memcmp(aid,piv_aids[0].value,piv_aids[0].len_short) != 0) { /*TODO look at long */
-				sc_log(card->ctx, "Discovery object not PIV");
-				r = SC_ERROR_INVALID_CARD; /* This is an error */
-				goto err;
-			}
-			if (aid_only == 0) {
-				pinp = sc_asn1_find_tag(card->ctx, body, bodylen, 0x5F2F, &pinplen);
-				if (pinp && pinplen == 2) {
-					sc_log(card->ctx, "Discovery pinp flags=0x%2.2x 0x%2.2x",*pinp, *(pinp+1));
-					r = SC_SUCCESS;
-					if ((*pinp & 0x60) == 0x60 && *(pinp+1) == 0x20) { /* use Global pin */
-						sc_log(card->ctx, "Pin Preference - Global");
-						priv->pin_preference = 0x00;
-					}
-				}
-			}
-		}
+	/* Let's be less strict about parsing the mandatory PIN Usage Policy. If it
+	 * is present check whether the mandatory PIV Card Application PIN
+	 * satisfies the PIV Access Control Rules (ACRs) and whether the optional
+	 * Global PIN satisfies the PIV ACRs. If so, prefer the global PIN. */
+	if (aid_only == 0
+			&& NULL != (policy = sc_asn1_find_tag(card->ctx, body, body_len,
+					0x5F2F, &policy_len))
+			&& policy_len >= 2
+			&& (policy[0] & 0x60) == 0x60 && policy[1] == 0x20) {
+		piv_private_data_t * priv = PIV_DATA(card);
+		sc_log(card->ctx, "Pin Preference - Global");
+		priv->pin_preference = 0x00;
 	}
 
-err:
-	LOG_FUNC_RETURN(card->ctx, r);
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
-
 
 /* normal way to get the discovery object via cache */
 static int piv_process_discovery(sc_card_t *card)


### PR DESCRIPTION
Since we are using the discovery object to detect whether it's a proper
PIV application, `piv_parse_discovery()` should not return SC_SUCCESS on
empty files or on files with *some* ASN.1 structure... Instead, at least
the encoding of the PIV AID should be strictly according NIST SP 800-73-4

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
