### PR TITLE
pkcs15-init: Set algorithm after parsing spec

### DIFF
--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1793,13 +1793,14 @@ do_generate_skey(struct sc_profile *profile, const char *spec)
 
 	if ((r = init_skeyargs(&skey_args)) < 0)
 		return r;
-	skey_args.algorithm = algorithm;
 
 	algorithm = parse_alg_spec(alg_types_sym, spec, &keybits, 0);
 	if (algorithm < 0) {
 		util_error("Invalid symmetric key spec: \"%s\"", spec);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
+
+	skey_args.algorithm = algorithm;
 	skey_args.value_len = keybits;
 
 	r = sc_lock(g_p15card->card);


### PR DESCRIPTION
Move the algorithm setting in `do_generate_skey()` after parsing the spec.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
