### PR TITLE
OpenSSL FIPS_mode not defined in 3.0.0

### DIFF
--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -96,8 +96,11 @@ extern "C" {
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
 #define EC_POINT_get_affine_coordinates_GFp     EC_POINT_get_affine_coordinates
 #define EC_POINT_set_affine_coordinates_GFp     EC_POINT_set_affine_coordinates
+#define EVP_PKEY_CTX_set_rsa_keygen_pubexp      EVP_PKEY_CTX_set1_rsa_keygen_pubexp
+#define FIPS_mode()                             OSSL_PROVIDER_available(NULL, "fips")
 #endif
 
 /*


### PR DESCRIPTION
When trying to test with OpenSSL-3.0.0 the use of  `FIPS_mode()`
in two places pkcs11-tool.c and framework-pkcs11.c
causes a run time error like:
"./pkcs11-tool: symbol lookup error: /opt/ossl-3.0.0/lib/opensc-pkcs11.so: undefined symbol: FIPS_mode"

sc-ossl-sc-ossl-compat.h was modified to define it as a macro returning 0.
pkcs11-tool.c was changed to check the OpenSSL version

 On branch master
 Your branch is up to date with 'upstream/master'.

 Changes to be committed:
	modified:   sc-ossl-compat.h
	modified:   ../tools/pkcs11-tool.c

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X ] PKCS#11 module is tested with both 1.1.1 and 3.0.0

