### PR TITLE
Fuzzing: limit maximum size of input data

### DIFF
--- a/src/tests/fuzzing/fuzz_scconf_parse_string.c
+++ b/src/tests/fuzzing/fuzz_scconf_parse_string.c
@@ -28,9 +28,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define MAX_SIZE 16000
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     scconf_context *ctx = NULL;
     char *buf = NULL;
+
+    if (size > MAX_SIZE)
+        return 0;
 
     if (!(buf = malloc(size + 1)))
         return 0;


### PR DESCRIPTION
Add size limit for input data in `fuzz_scconf_parse_string.c`. The configuration file has a simple format to be covered with an added size limit set to 16 kB. The change should fix mentioned stack-overflow and timeout issues from OSS-Fuzz. Corresponding test cases contain quite a large amount of data, which creates a long chain of blocks/long list when parsing.

Fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40676
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41434
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41450

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
