### PR TITLE
pkcs11-register: Skip Firefox on Windows and macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,19 @@ case "${host}" in
 	;;
 esac
 
+dnl with Firefox's osclientcerts.so we skip registering our PKCS#11 module on Windows and macOS by default
+case "${host}" in
+	*-*-darwin*)
+		PKCS11_REGISTER_SKIP_FIREFOX="on"
+	;;
+	*-mingw*|*-winnt*|*-cygwin*)
+		PKCS11_REGISTER_SKIP_FIREFOX="on"
+	;;
+	*)
+		PKCS11_REGISTER_SKIP_FIREFOX="off"
+	;;
+esac
+
 AX_CODE_COVERAGE()
 
 AX_CHECK_COMPILE_FLAG([-Wunknown-warning-option], [have_unknown_warning_option="yes"], [have_unknown_warning_option="no"])

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -17,6 +17,7 @@ do_subst = $(SED) \
 	   -e 's,[@]PACKAGE_SUMMARY[@],$(PACKAGE_SUMMARY),g' \
 	   -e 's,[@]PACKAGE_VERSION[@],"$(PACKAGE_VERSION)",g' \
 	   -e 's,[@]DEFAULT_PKCS11_PROVIDER[@],"$(DEFAULT_PKCS11_PROVIDER)",g' \
+	   -e 's,[@]PKCS11_REGISTER_SKIP_FIREFOX[@],$(PKCS11_REGISTER_SKIP_FIREFOX),g' \
 	   -e 's,[@]VDFORMAT[@],$(VDFORMAT),g' \
 	   -e 's,[@]X509DIR[@],$(X509DIR),g'
 

--- a/src/tools/pkcs11-register.ggo.in
+++ b/src/tools/pkcs11-register.ggo.in
@@ -12,7 +12,7 @@ option "skip-chrome" -
 
 option "skip-firefox" -
     "Don't install module to Firefox"
-    flag off
+    flag @PKCS11_REGISTER_SKIP_FIREFOX@
 
 option "skip-thunderbird" -
     "Don't install module to Thunderbird"


### PR DESCRIPTION
Firefox added integration of OS specific client certificates in version [72](https://www.mozilla.org/en-US/firefox/72.0/releasenotes/)/[75](https://www.mozilla.org/en-US/firefox/75.0/releasenotes/).  This feature [was enabled by default](https://blog.mozilla.org/security/2021/07/28/making-client-certificates-available-by-default-in-firefox-90/) in version [90](https://www.mozilla.org/en-US/firefox/90.0/releasenotes/).

Since pkcs11-register is executed by default on Windows/macOS startup it may be possible to see an OpenSC token twice in Firefox, i.e. via registering onepin-opensc-pkcs11 and via minidriver/CTK through osclientcerts. We now change the default behavior to avoid such conflicts.

Closes https://github.com/OpenSC/OpenSC/issues/2446

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
