### PR TITLE
Build fixes

### DIFF
--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -147,9 +147,9 @@ coolkey_find_matching_cert(sc_card_t *card, sc_cardctl_coolkey_object_t *in_obj,
 static int
 coolkey_get_attribute_ulong(sc_card_t *card, sc_cardctl_coolkey_object_t *obj, CK_ATTRIBUTE_TYPE type, CK_ULONG *value)
 {
-	const u8 *val;
-	size_t val_len;
-	u8 data_type;
+	const u8 *val = NULL;
+	size_t val_len = 0;
+	u8 data_type = 0;
 	int r;
 
 	r  = coolkey_get_attribute(card, obj, type, &val, &val_len, &data_type);
@@ -168,8 +168,8 @@ static int
 coolkey_get_attribute_boolean(sc_card_t *card, sc_cardctl_coolkey_object_t *obj, CK_ATTRIBUTE_TYPE attr_type)
 {
 	int r;
-	const u8 *val;
-	size_t val_len;
+	const u8 *val = NULL;
+	size_t val_len = 0;
 
 	r = coolkey_get_attribute(card, obj, attr_type, &val, &val_len, NULL);
 	if (r < 0) {
@@ -186,7 +186,7 @@ static int
 coolkey_get_attribute_bytes(sc_card_t *card, sc_cardctl_coolkey_object_t *obj, CK_ATTRIBUTE_TYPE type, u8 *data, size_t *data_len, size_t max_data_len)
 {
 	const u8 *val;
-	size_t val_len;
+	size_t val_len = 0;
 	int r;
 
 	r = coolkey_get_attribute(card, obj, type, &val, &val_len, NULL);

--- a/src/pkcs15init/pkcs15-asepcos.c
+++ b/src/pkcs15init/pkcs15-asepcos.c
@@ -221,7 +221,7 @@ static int asepcos_do_store_pin(sc_profile_t *profile, sc_card_t *card,
 {
 	sc_file_t *nfile = NULL;
 	u8  buf[64], sbuf[64], *p = buf, *q = sbuf;
-	int r, akn;
+	int r, akn = 0;
 
 	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -2472,7 +2472,7 @@ int main(int argc, char *argv[])
 		char *line;
 		int cargc;
 		char *cargv[260];
-		int multiple;
+		int multiple = 0;
 		struct command *cmd;
 		char prompt[3*SC_MAX_PATH_STRING_SIZE];
 


### PR DESCRIPTION

The following patches provides fixes to warnings treated as errors spotted
on the process of creating an opensc package for buildroot, where the testing
tools builds the project against multiple toolchains.