### PR TITLE
Fix issues with uninitialized object identifiiers with OpenPACE

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GH_TOKEN:
     secure: aLu3tFc7lRJbotnmnHLx/QruIHc5rLaGm1RttoEdy4QILlPXzVkCZ6loYMz0sfrY
   PATH: C:\cygwin\bin;%PATH%
-  OPENPACE_VER: 1.1.1
+  OPENPACE_VER: 1.1.2
   ZLIB_VER_DOT: 1.2.11
   matrix:
   # not compatible with OpenSSL 1.1.1:

--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -63,7 +63,7 @@ export OBJCFLAGS=$CFLAGS
 
 if ! test -e $BUILDPATH/openpace_bin/$PREFIX/lib/pkgconfig; then
 	if ! test -e openpace; then
-		git clone --depth=1 https://github.com/frankmorgner/openpace.git -b 1.1.1
+		git clone --depth=1 https://github.com/frankmorgner/openpace.git -b 1.1.2
 	fi
 	cd openpace
 	autoreconf -vis

--- a/configure.ac
+++ b/configure.ac
@@ -737,6 +737,7 @@ AC_MSG_CHECKING([for EAC_CTX_init_pace])
 AC_TRY_LINK_FUNC(EAC_CTX_init_pace, [ AC_MSG_RESULT([yes]) ],
                  [ AC_MSG_WARN([Cannot link against libeac])
                  have_openpace="no" ])
+AC_CHECK_FUNCS([EAC_OBJ_nid2obj])
 
 CPPFLAGS="$saved_CPPFLAGS"
 LIBS="$saved_LIBS"

--- a/doc/tools/npa-tool.1.xml
+++ b/doc/tools/npa-tool.1.xml
@@ -28,6 +28,11 @@
 			stored on the German eID card (neuer Personalausweis, <abbrev>nPA</abbrev>),
 			and to perform some write and verification operations.
 		</para>
+		<para>
+			Extended Access Control version 2 is performed according to ICAO Doc
+			9303 or BSI TR-03110 so that other identity cards and machine
+			readable travel documents (MRTDs) may be read as well.
+		</para>
 	</refsect1>
 
 	<refsect1>

--- a/src/libopensc/card-edo.c
+++ b/src/libopensc/card-edo.c
@@ -59,16 +59,6 @@ static struct {
 };
 
 
-static void edo_eac_init() {
-	extern void EAC_init(void);
-	static int initialized = 0;
-	if (!initialized) {
-		EAC_init();
-		initialized = 1;
-	}
-}
-
-
 static int edo_match_card(sc_card_t* card) {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	if (_sc_match_atr(card, edo_atrs, &card->type) >= 0) {
@@ -290,8 +280,6 @@ static int edo_set_security_env(struct sc_card* card, const struct sc_security_e
  */
 static int edo_init(sc_card_t* card) {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-
-	edo_eac_init();
 
 	memset(&card->sm_ctx, 0, sizeof card->sm_ctx);
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1386,11 +1386,13 @@ int iso7816_read_binary_sfid(sc_card_t *card, unsigned char sfid,
 			*ef_len += r;
 			break;
 		}
-		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
-			break;
-		if (r < 0) {
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not read EF.");
-			goto err;
+		if (r <= 0) {
+			if (*ef_len > 0)
+				break;
+			else {
+				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Could not read EF.");
+				goto err;
+			}
 		}
 		*ef_len += r;
 

--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -59,6 +59,7 @@ IMPLEMENT_ASN1_FUNCTIONS(ASN1_AUXILIARY_DATA)
 #include <eac/ca.h>
 #include <eac/cv_cert.h>
 #include <eac/eac.h>
+#include <eac/objects.h>
 #include <eac/pace.h>
 #include <eac/ta.h>
 #include <openssl/bio.h>
@@ -414,7 +415,11 @@ static int format_mse_cdata(struct sc_context *ctx, int protocol,
 	}
 
 	if (protocol) {
+#ifndef HAVE_EAC_OBJ_NID2OBJ
 		data->cryptographic_mechanism_reference = OBJ_nid2obj(protocol);
+#else
+		data->cryptographic_mechanism_reference = EAC_OBJ_nid2obj(protocol);
+#endif
 		if (!data->cryptographic_mechanism_reference) {
 			sc_debug(ctx, SC_LOG_DEBUG_VERBOSE, "Error setting Cryptographic mechanism reference of MSE:Set AT data");
 			r = SC_ERROR_INTERNAL;

--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -1141,6 +1141,7 @@ int perform_pace(sc_card_t *card,
 		sc_debug_hex(card->ctx, SC_LOG_DEBUG_SM, "EF.CardAccess", pace_output->ef_cardaccess,
 				pace_output->ef_cardaccess_length);
 
+		EAC_init();
 		eac_ctx = EAC_CTX_new();
 		if (!eac_ctx
 				|| !EAC_CTX_init_ef_cardaccess(pace_output->ef_cardaccess,
@@ -1525,6 +1526,7 @@ int perform_terminal_authentication(sc_card_t *card,
 		 * seems valid. */
 		card->caps |= SC_CARD_CAP_APDU_EXT;
 
+		EAC_init();
 		eac_ctx = EAC_CTX_new();
 		if (!eac_ctx
 				|| !EAC_CTX_init_ef_cardaccess(ef_cardaccess,

--- a/src/tools/goid-tool.c
+++ b/src/tools/goid-tool.c
@@ -598,9 +598,6 @@ int paccess_main(struct sc_context *ctx, sc_card_t *card, struct gengetopt_args_
             }
         }
 
-#ifdef ENABLE_OPENPACE
-        EAC_init();
-#endif
         SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
                 perform_terminal_authentication(card,
                     (const unsigned char **) certs, certs_lens,

--- a/src/tools/npa-tool.c
+++ b/src/tools/npa-tool.c
@@ -28,6 +28,7 @@
 #include "sm/sslutil.h"
 #include "util.h"
 #include <eac/pace.h>
+#include <eac/objects.h>
 #include <libopensc/card-npa.h>
 #include <libopensc/log.h>
 #include <libopensc/opensc.h>
@@ -258,7 +259,11 @@ static int add_to_ASN1_AUXILIARY_DATA_NPA_TOOL(
 		goto err;
 	}
 
+#ifndef HAVE_EAC_OBJ_NID2OBJ
 	template->type = OBJ_nid2obj(nid);
+#else
+	template->type = EAC_OBJ_nid2obj(nid);
+#endif
 	if (!template->type) {
 		r = SC_ERROR_INTERNAL;
 		goto err;

--- a/src/tools/sceac-example.c
+++ b/src/tools/sceac-example.c
@@ -80,10 +80,6 @@ main (int argc, char **argv)
 		exit(1);
 	}
 
-	/* initialize OpenPACE */
-	EAC_init();
-
-
 	/* Now we try to change the PIN. Therefore we need to establish a SM channel
 	 * with PACE.
 	 *
@@ -135,7 +131,6 @@ err:
 	sc_reset(card, 1);
 	sc_disconnect_card(card);
 	sc_release_context(ctx);
-	EAC_cleanup();
 
 	return -r;
 }


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2354

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
