### PR TITLE
Sym crypt hw

### DIFF
--- a/.github/test-oseid.sh
+++ b/.github/test-oseid.sh
@@ -43,6 +43,8 @@ echo | ./OsEID-tool INIT
 ./OsEID-tool EC-SIGN-PKCS11-TEST
 ./OsEID-tool EC-ECDH-TEST
 ./OsEID-tool UNWRAP-WRAP-TEST
+./OsEID-tool DES-AES-UPLOAD-KEYS
+./OsEID-tool SYM-ENCRYPT-TEST
 popd
 
 # this does not work as we have random key IDs in here

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1324,7 +1324,8 @@ static struct sc_card_operations iso_ops = {
 	NULL,			/* read_public_key */
 	NULL,			/* card_reader_lock_obtained */
 	NULL,			/* wrap */
-	NULL			/* unwrap */
+	NULL,			/* unwrap */
+	NULL			/* encrypt_sym */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -94,6 +94,7 @@ sc_do_log_noframe
 _sc_debug
 _sc_debug_hex
 sc_enum_apps
+sc_encrypt_sym
 sc_encode_oid
 sc_parse_ef_atr
 sc_establish_context
@@ -180,6 +181,7 @@ sc_pkcs15_encode_pukdf_entry
 sc_pkcs15_encode_skdf_entry
 sc_pkcs15_encode_tokeninfo
 sc_pkcs15_encode_unusedspace
+sc_pkcs15_encrypt_sym
 sc_pkcs15_erase_pubkey
 sc_pkcs15_dup_pubkey
 sc_pkcs15_find_cert_by_id

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -59,7 +59,8 @@ extern "C" {
 #define SC_SEC_OPERATION_DERIVE         0x0004
 #define SC_SEC_OPERATION_WRAP		0x0005
 #define SC_SEC_OPERATION_UNWRAP		0x0006
-
+#define SC_SEC_OPERATION_ENCRYPT_SYM	0x0007
+#define SC_SEC_OPERATION_DECRYPT_SYM	0x0008
 /* sc_security_env flags */
 #define SC_SEC_ENV_ALG_REF_PRESENT	0x0001
 #define SC_SEC_ENV_FILE_REF_PRESENT	0x0002
@@ -814,6 +815,9 @@ struct sc_card_operations {
 	int (*wrap)(struct sc_card *card, u8 *out, size_t outlen);
 
 	int (*unwrap)(struct sc_card *card, const u8 *crgram, size_t crgram_len);
+
+	int (*encrypt_sym)(struct sc_card *card, const u8 *plaintext, size_t plaintext_len,
+			u8 *out, size_t *outlen);
 };
 
 typedef struct sc_card_driver {
@@ -1378,6 +1382,8 @@ int sc_reset_retry_counter(struct sc_card *card, unsigned int type,
 			   const u8 *newref, size_t newlen);
 int sc_build_pin(u8 *buf, size_t buflen, struct sc_pin_cmd_pin *pin, int pad);
 
+int sc_encrypt_sym(struct sc_card *card, const u8 *Data, size_t DataLen,
+		u8 *out, size_t *outlen);
 
 /********************************************************************/
 /*               ISO 7816-9 related functions                       */

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -680,6 +680,12 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 				unsigned long alg_flags, const u8 *in,
 				size_t inlen, u8 *out, size_t outlen, void *pMechanism);
 
+int sc_pkcs15_encrypt_sym(struct sc_pkcs15_card *p15card,
+		const struct sc_pkcs15_object *obj,
+		unsigned long flags,
+		const u8 *in, size_t inlen, u8 *out, size_t *outlen,
+		const u8 *param, size_t paramlen);
+
 int sc_pkcs15_read_pubkey(struct sc_pkcs15_card *,
 		const struct sc_pkcs15_object *, struct sc_pkcs15_pubkey **);
 int sc_pkcs15_decode_pubkey_rsa(struct sc_context *,

--- a/src/libopensc/sec.c
+++ b/src/libopensc/sec.c
@@ -337,3 +337,19 @@ int sc_build_pin(u8 *buf, size_t buflen, struct sc_pin_cmd_pin *pin, int pad)
 
 	return i;
 }
+
+int
+sc_encrypt_sym(struct sc_card *card, const u8 *plaintext, size_t plaintext_len,
+		u8 *out, size_t *outlen)
+{
+	int r;
+
+	if (card == NULL)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	LOG_FUNC_CALLED(card->ctx);
+	if (card->ops->encrypt_sym == NULL)
+		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_NOT_SUPPORTED);
+	r = card->ops->encrypt_sym(card, plaintext, plaintext_len, out, outlen);
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
+}

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -67,6 +67,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha1_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -87,6 +88,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -107,6 +109,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -127,6 +130,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -147,6 +151,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -167,6 +172,7 @@ static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -187,6 +193,7 @@ static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
@@ -207,6 +214,7 @@ static sc_pkcs11_mechanism_type_t openssl_ripemd160_mech = {
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
 	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -105,7 +105,10 @@ struct sc_pkcs11_object_ops {
 			CK_MECHANISM_PTR,
 			CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen,
 			CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen);
-
+	CK_RV (*encrypt)(struct sc_pkcs11_session *, void *,
+			CK_MECHANISM_PTR,
+			CK_BYTE_PTR pData, CK_ULONG ulDataLen,
+			CK_BYTE_PTR pEncryptedData, CK_ULONG_PTR pulEncryptedDataLen);
 	CK_RV (*derive)(struct sc_pkcs11_session *, void *,
 			CK_MECHANISM_PTR,
 			CK_BYTE_PTR pSeedData, CK_ULONG ulSeedDataLen,
@@ -258,6 +261,7 @@ enum {
 	SC_PKCS11_OPERATION_VERIFY,
 	SC_PKCS11_OPERATION_DIGEST,
 	SC_PKCS11_OPERATION_DECRYPT,
+	SC_PKCS11_OPERATION_ENCRYPT,
 	SC_PKCS11_OPERATION_DERIVE,
 	SC_PKCS11_OPERATION_WRAP,
 	SC_PKCS11_OPERATION_UNWRAP,
@@ -301,6 +305,16 @@ struct sc_pkcs11_mechanism_type {
 					struct sc_pkcs11_object *);
 	CK_RV		  (*decrypt)(sc_pkcs11_operation_t *,
 					CK_BYTE_PTR, CK_ULONG,
+					CK_BYTE_PTR, CK_ULONG_PTR);
+	CK_RV		  (*encrypt_init)(sc_pkcs11_operation_t *,
+					struct sc_pkcs11_object *);
+	CK_RV		  (*encrypt)(sc_pkcs11_operation_t *,
+					CK_BYTE_PTR, CK_ULONG,
+					CK_BYTE_PTR, CK_ULONG_PTR);
+	CK_RV		  (*encrypt_update)(sc_pkcs11_operation_t *,
+					CK_BYTE_PTR, CK_ULONG,
+					CK_BYTE_PTR, CK_ULONG_PTR);
+	CK_RV		  (*encrypt_final)(sc_pkcs11_operation_t *,
 					CK_BYTE_PTR, CK_ULONG_PTR);
 	CK_RV		  (*derive)(sc_pkcs11_operation_t *,
 					struct sc_pkcs11_object *,
@@ -456,6 +470,12 @@ CK_RV sc_pkcs11_verif_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 #endif
 CK_RV sc_pkcs11_decr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE);
 CK_RV sc_pkcs11_decr(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+
+CK_RV sc_pkcs11_encr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
+CK_RV sc_pkcs11_encr(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV sc_pkcs11_encr_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV sc_pkcs11_encr_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
+
 CK_RV sc_pkcs11_wrap(struct sc_pkcs11_session *,CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE, struct sc_pkcs11_object *, CK_BYTE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_unwrap(struct sc_pkcs11_session *,CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE, CK_BYTE_PTR, CK_ULONG, struct sc_pkcs11_object *);
 CK_RV sc_pkcs11_deri(struct sc_pkcs11_session *, CK_MECHANISM_PTR,


### PR DESCRIPTION
symmetric encryption

New code:
pkcs#11: C_EncryptInit, C_Encrypt, C_EncryptUpdate, C_EncryptFinal
pkcs#15: pkcs15_skey_encrypt, sc_pkcs15_encrypt_sym
also implements: sc_encrypt_sym

MyEID driver: support for symmetric crypt

Tested:  MyEID 4.0.1, 4.5.5 card, pkcs11-tool --encrypt, 128 bit AES key (small file encryption by C_encrypt, and big file by C_EncryptUpdate and C_EncrytpFinal), all supported mechanisms: AES-ECB, AEC-CBC, AES-CBC-PAD.

- [x ] PKCS#11 module is tested

