### PR TITLE
OAEP (RFC8017) padding check/removal

### DIFF
--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -170,6 +170,10 @@ int sc_pkcs1_strip_02_padding(struct sc_context *ctx, const u8 *data, size_t len
 		u8 *out_dat, size_t *out_len);
 int sc_pkcs1_strip_digest_info_prefix(unsigned int *algorithm,
 		const u8 *in_dat, size_t in_len, u8 *out_dat, size_t *out_len);
+#ifdef ENABLE_OPENSSL
+int sc_pkcs1_strip_oaep_padding(sc_context_t *ctx, u8 *data, size_t len,
+		unsigned long flags);
+#endif
 
 /**
  * PKCS1 encodes the given data.

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -184,6 +184,139 @@ sc_pkcs1_strip_02_padding(sc_context_t *ctx, const u8 *data, size_t len, u8 *out
 	LOG_FUNC_RETURN(ctx, len - n);
 }
 
+#ifdef ENABLE_OPENSSL
+static int mgf1(u8 *mask, size_t len, u8 *seed, size_t seedLen, const EVP_MD *dgst)
+{
+	int i;
+	size_t outlen = 0;
+	u8 cnt[4];
+	EVP_MD_CTX *md_ctx = NULL;
+	int mdlen;
+	u8 md[EVP_MAX_MD_SIZE];
+	int rv = 1;
+
+	if (!(md_ctx = EVP_MD_CTX_new()))
+		goto out;
+
+	mdlen = EVP_MD_size(dgst);
+	if (mdlen < 0)
+		goto out;
+
+	for (i = 0; outlen < len; i++) {
+		cnt[0] = (u8) ((i >> 24) & 255);
+		cnt[1] = (u8) ((i >> 16) & 255);
+		cnt[2] = (u8) ((i >> 8) & 255);
+		cnt[3] = (u8) ((i >> 0) & 255);
+		if (!EVP_DigestInit_ex(md_ctx, dgst, NULL)
+		    || !EVP_DigestUpdate(md_ctx, seed, seedLen)
+		    || !EVP_DigestUpdate(md_ctx, cnt, 4))
+			goto out;
+		if (outlen + mdlen <= len) {
+			if (!EVP_DigestFinal_ex(md_ctx, mask + outlen, NULL))
+				goto out;
+			outlen += mdlen;
+		} else {
+			if (!EVP_DigestFinal_ex(md_ctx, md, NULL))
+				goto out;
+			memcpy(mask + outlen, md, len - outlen);
+			outlen = len;
+		}
+	}
+	rv = 0;
+ out:
+	OPENSSL_cleanse(md, sizeof(md));
+	if (md_ctx)
+		EVP_MD_CTX_free(md_ctx);
+	return rv;
+}
+
+/* forward declarations */
+static const EVP_MD *mgf1_flag2md(unsigned int mgf1);
+static const EVP_MD *hash_flag2md(unsigned int hash);
+
+/* check/remove OAEP - RFC 8017 padding */
+int sc_pkcs1_strip_oaep_padding(sc_context_t *ctx, u8 *data, size_t len, unsigned long flags)
+{
+	size_t i,j;
+	size_t mdlen, dblen;
+	u8 seed[EVP_MAX_MD_SIZE];
+	const EVP_MD *mgf1_md, *hash_md;
+	u8 db[512];		/* up to RSA 4096 */
+	u8 label[EVP_MAX_MD_SIZE];
+	EVP_MD_CTX *md_ctx;
+	unsigned int hash_len = 0;
+
+	LOG_FUNC_CALLED(ctx);
+	if (data == NULL)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
+
+	/*
+	 * https://www.rfc-editor.org/rfc/pdfrfc/rfc8017.txt.pdf, page 26, 3.a.
+         * there is no implementation for label "L" (empty string for now)
+	 */
+	hash_md = hash_flag2md(flags);
+	if (!hash_md)
+		return SC_ERROR_NOT_SUPPORTED;
+
+	memset(label, 0, sizeof(label));
+	if ((md_ctx = EVP_MD_CTX_new())) {
+		if (!EVP_DigestInit_ex(md_ctx, hash_md, NULL)
+		    || !EVP_DigestUpdate(md_ctx, label, 0)
+		    || !EVP_DigestFinal_ex(md_ctx, label, &hash_len))
+			hash_len = 0;
+		EVP_MD_CTX_free(md_ctx);
+	}
+	if (!hash_len)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
+
+	mgf1_md = mgf1_flag2md(flags);
+	if (!mgf1_md)
+		return SC_ERROR_NOT_SUPPORTED;
+
+	mdlen = EVP_MD_size(mgf1_md);
+
+	if (len < 2 * mdlen + 2)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_PADDING);
+
+	if (*data != 0)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_PADDING);
+
+	dblen = len - 1 - mdlen;
+	if (dblen > sizeof(db))
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
+
+	if (mgf1(seed, mdlen, data + mdlen + 1, dblen, mgf1_md))
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
+	for (i = 0; i < mdlen; i++)
+		seed[i] ^= data[i + 1];
+
+	if (mgf1(db, dblen, seed, mdlen, mgf1_md))
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
+	for (i = 0; i < dblen; i++) {
+		db[i] ^= data[i + mdlen + 1];
+		/* clear lHash' if same as lHash */
+		if (i < hash_len)
+			db[i] ^= label[i];
+	}
+	/* if the padding is correct, it is a concatenation:
+	 *   00...00 || 01 || plaintext
+	 * check padding but do not leak information about error:
+	 */
+	for (j = 0, i = 0; i < dblen;) {
+		j += db[i++] + 1;
+		if (i > mdlen) {
+			if (j == i + 1) {
+				/* OK correct padding found */
+				len = dblen - i;
+				memcpy(data, db + i, len);
+				LOG_FUNC_RETURN(ctx, len);
+			}
+		}
+	}
+	LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_PADDING);
+}
+#endif
+
 /* add/remove DigestInfo prefix */
 static int sc_pkcs1_add_digest_info_prefix(unsigned int algorithm,
 	const u8 *in, size_t in_len, u8 *out, size_t *out_len)
@@ -497,11 +630,13 @@ int sc_get_encoding_flags(sc_context_t *ctx,
 	} else if ((caps & SC_ALGORITHM_RSA_RAW) &&
 				(iflags & SC_ALGORITHM_RSA_PAD_PKCS1
 				|| iflags & SC_ALGORITHM_RSA_PAD_PSS
+#ifdef ENABLE_OPENSSL
+				|| iflags & SC_ALGORITHM_RSA_PAD_OAEP
+#endif
 				|| iflags & SC_ALGORITHM_RSA_PAD_NONE)) {
 		/* Use the card's raw RSA capability on the padded input */
 		*sflags = SC_ALGORITHM_RSA_PAD_NONE;
 		*pflags = iflags;
-		/* TODO emulate the OAEP decryption */
 
 	} else if ((caps & (SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE)) &&
 			(iflags & SC_ALGORITHM_RSA_PAD_PKCS1)) {

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -312,7 +312,14 @@ int sc_pkcs15_decipher(struct sc_pkcs15_card *p15card,
 		r = sc_pkcs1_strip_02_padding(ctx, out, s, out, &s);
 		LOG_TEST_RET(ctx, r, "Invalid PKCS#1 padding");
 	}
-
+#ifdef ENABLE_OPENSSL
+	if (pad_flags & SC_ALGORITHM_RSA_PAD_OAEP)
+	{
+		size_t s = r;
+		r = sc_pkcs1_strip_oaep_padding(ctx, out, s, flags);
+		LOG_TEST_RET(ctx, r, "Invalid OAEP padding");
+	}
+#endif
 	LOG_FUNC_RETURN(ctx, r);
 }
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -6251,7 +6251,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		rsa_flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
 #ifdef ENABLE_OPENSSL
 		rsa_flags |= SC_ALGORITHM_RSA_PAD_PSS;
-		/* TODO support OAEP decryption & encryption using OpenSSL */
+		rsa_flags |= SC_ALGORITHM_RSA_PAD_OAEP;
 #endif
 	}
 

--- a/src/tests/p11test/virt_cacard_ref.json
+++ b/src/tests/p11test/virt_cacard_ref.json
@@ -151,6 +151,12 @@
 		"1024",
 		"3072",
 		"0x00002800"
+	],
+	[
+		"RSA_PKCS_OAEP",
+		"1024",
+		"3072",
+		"0x00000201"
 	]],
 	"result": "pass"
 },
@@ -967,6 +973,51 @@
 		""
 	],
 	[
+		"00:01",
+		"RSA_PKCS_OAEP",
+		"SHA_1",
+		"MGF1_SHA_1",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:01",
+		"RSA_PKCS_OAEP",
+		"SHA224",
+		"MGF1_SHA224",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:01",
+		"RSA_PKCS_OAEP",
+		"SHA256",
+		"MGF1_SHA256",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:01",
+		"RSA_PKCS_OAEP",
+		"SHA384",
+		"MGF1_SHA384",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:01",
+		"RSA_PKCS_OAEP",
+		"SHA512",
+		"MGF1_SHA512",
+		"0",
+		"",
+		"YES"
+	],
+	[
 		"00:02",
 		"RSA_PKCS_PSS",
 		"SHA_1",
@@ -1372,6 +1423,51 @@
 		""
 	],
 	[
+		"00:02",
+		"RSA_PKCS_OAEP",
+		"SHA_1",
+		"MGF1_SHA_1",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:02",
+		"RSA_PKCS_OAEP",
+		"SHA224",
+		"MGF1_SHA224",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:02",
+		"RSA_PKCS_OAEP",
+		"SHA256",
+		"MGF1_SHA256",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:02",
+		"RSA_PKCS_OAEP",
+		"SHA384",
+		"MGF1_SHA384",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:02",
+		"RSA_PKCS_OAEP",
+		"SHA512",
+		"MGF1_SHA512",
+		"0",
+		"",
+		"YES"
+	],
+	[
 		"00:03",
 		"RSA_PKCS_PSS",
 		"SHA_1",
@@ -1775,6 +1871,51 @@
 		"-1",
 		"YES",
 		""
+	],
+	[
+		"00:03",
+		"RSA_PKCS_OAEP",
+		"SHA_1",
+		"MGF1_SHA_1",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:03",
+		"RSA_PKCS_OAEP",
+		"SHA224",
+		"MGF1_SHA224",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:03",
+		"RSA_PKCS_OAEP",
+		"SHA256",
+		"MGF1_SHA256",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:03",
+		"RSA_PKCS_OAEP",
+		"SHA384",
+		"MGF1_SHA384",
+		"0",
+		"",
+		"YES"
+	],
+	[
+		"00:03",
+		"RSA_PKCS_OAEP",
+		"SHA512",
+		"MGF1_SHA512",
+		"0",
+		"",
+		"YES"
 	]],
 	"result": "pass"
 },


### PR DESCRIPTION
If the card does not support OAEP, but RSA RAW operation is available,
OAEP padding check/removal is now supported by the software.

- [x] PKCS#11 module is tested

OAEP decrypt is tested by github actions (OsEID simulation).