### PR TITLE
Fix memory issues as reported by valgrind

### DIFF
--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -680,13 +680,14 @@ int pss_sign_verify_test(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 		get_mgf_name(mech->mgf), mech->salt);
 	rv = pss_sign_message(o, info, message, message_length, mech, &sign);
 	if (rv <= 0) {
-		return rv;
+		goto out;
 	}
 	sign_length = (unsigned long) rv;
 
 	debug_print(" [ KEY %s ] Verify message signature", o->id_str);
 	rv = pss_verify_message(o, info, message, message_length, mech,
 		sign, sign_length);
+out:
 	if (mech->mech == CKM_RSA_PKCS_PSS) {
 		free(message);
 	}


### PR DESCRIPTION
These two places showed up in the gitlab CI and all surrounded issues should be fixed with the attached patch.

```
==2220448== 4,160 (288 direct, 3,872 indirect) bytes in 4 blocks are definitely lost in loss record 36 of 37
==2220448==    at 0x4C34F0B: malloc (vg_replace_malloc.c:307)
==2220448==    by 0x4FCB86C: CRYPTO_zalloc (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x4FB4D1A: EVP_PKEY_new (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x504C1EE: ??? (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x504C34C: ??? (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x4EDF8B3: ??? (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x4EE0180: ASN1_item_ex_d2i (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x4EE01FE: ASN1_item_d2i (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x504C5B4: d2i_PUBKEY (in /usr/lib64/libcrypto.so.1.1.1g)
==2220448==    by 0x65525E1: sc_pkcs11_verify_data (openssl.c:526)
==2220448==    by 0x654F37B: sc_pkcs11_verify_final (mechanism.c:852)
==2220448==    by 0x6551565: sc_pkcs11_verif_final (mechanism.c:718)
==2220448== 
==2220448== 5,120 bytes in 130 blocks are definitely lost in loss record 37 of 37
==2220448==    at 0x4C34F0B: malloc (vg_replace_malloc.c:307)
==2220448==    by 0x40B0DA: hash_message (p11test_case_pss_oaep.c:223)
==2220448==    by 0x40C3A5: pss_sign_verify_test (p11test_case_pss_oaep.c:670)
==2220448==    by 0x40C765: pss_oaep_test (p11test_case_pss_oaep.c:790)
==2220448==    by 0x532CF36: ??? (in /usr/lib64/libcmocka.so.0.7.0)
==2220448==    by 0x532D8A0: _cmocka_run_group_tests (in /usr/lib64/libcmocka.so.0.7.0)
==2220448==    by 0x402E56: main (p11test.c:155)
```

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
