### PR TITLE
Add a limit for nested blocks when parsing

### DIFF
--- a/src/scconf/internal.h
+++ b/src/scconf/internal.h
@@ -33,6 +33,8 @@ extern "C" {
 #define TOKEN_TYPE_STRING	2
 #define TOKEN_TYPE_PUNCT	3
 
+#define DEPTH_LIMIT 16
+
 typedef struct _scconf_parser {
 	scconf_context *config;
 
@@ -49,11 +51,13 @@ typedef struct _scconf_parser {
 	unsigned int error:1;
 	unsigned int warnings:1;
 	char emesg[256];
+	size_t nested_blocks;
 } scconf_parser;
 
 extern int scconf_lex_parse(scconf_parser * parser, const char *filename);
 extern int scconf_lex_parse_string(scconf_parser * parser,
 				   const char *config_string);
+extern void scconf_skip_block(scconf_parser * parser);
 extern void scconf_parse_token(scconf_parser * parser, int token_type, const char *token);
 
 #ifdef __cplusplus

--- a/src/scconf/sclex.c
+++ b/src/scconf/sclex.c
@@ -144,6 +144,12 @@ static int scconf_lex_engine(scconf_parser * parser, BUFHAN * bp)
 			continue;
 		case ',':
 		case '{':
+			if (parser->nested_blocks >= DEPTH_LIMIT) {
+				/* reached the limit, this whole block */
+				scconf_skip_block(parser);
+				continue;
+			}
+			/* fall through */
 		case '}':
 		case '=':
 		case ';':


### PR DESCRIPTION
Related to #2457
This PR adds limit value for number of nested blocks when parsing the configuration file. OSS-Fuzz testcases with huge number of `{`,`}` cause stack-overflow in recursive destroying.

Fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40676
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41434
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41450

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested