### PR TITLE
enable use_file_cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OpenSC documentation
 
+
 Wiki is [available online](https://github.com/OpenSC/OpenSC/wiki)
 
 Please take a look at the documentation before trying to use OpenSC.

--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -745,7 +745,7 @@ app <em class="replaceable"><code>application</code></em> {
 									locked"</code>).
 						</p></dd></dl></div><p>
 			</p></div><div class="refsect2"><a name="framework%20pkcs15"></a><h3>Configuration of PKCS#15 Framework</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
-						<code class="option">use_file_caching = <em class="replaceable"><code>bool</code></em>;</code>
+						<code class="option">use_file_caching = <em class="replaceable"><code>value</code></em>;</code>
 					</span></dt><dd><p>
 							Whether to cache the card's files (e.g.
 							certificates) on disk in
@@ -758,7 +758,28 @@ app <em class="replaceable"><code>application</code></em> {
 								</p></li><li class="listitem"><p>
 									<code class="literal">no</code>: File caching disabled.
 								</p></li></ul></div><p>
-							(Default:<code class="literal">no</code>).
+							(Default: <code class="literal">public</code>
+							for the following card drivers
+							<code class="literal">akis</code>,
+							<code class="literal">atrust-acos</code>,
+							<code class="literal">belpic</code>,
+							<code class="literal">cac1</code>,
+							<code class="literal">cac</code>,
+							<code class="literal">coolkey</code>,
+							<code class="literal">dnie</code>,
+							<code class="literal">edo</code>,
+							<code class="literal">esteid2018</code>,
+							<code class="literal">flex</code>,
+							<code class="literal">cyberflex</code>,
+							<code class="literal">gemsafeV1</code>,
+							<code class="literal">idprime</code>,
+							<code class="literal">itacns</code>,
+							<code class="literal">jpki</code>,
+							<code class="literal">MaskTech</code>,
+							<code class="literal">mcrd</code>,
+							<code class="literal">npa</code>,
+							<code class="literal">nqapplet</code>,
+							<code class="literal">tcos</code> and otherwise <code class="literal">no</code>).
 						</p><p>
 							If caching is done by a system process, the
 							cached files may be placed inaccessible from
@@ -847,7 +868,7 @@ app <em class="replaceable"><code>application</code></em> {
 							List of the builtin pkcs15 emulators to test
 							(Default: <code class="literal">internal</code>)
 						</p><p>
-							Special value <code class="literal">internal</code> will try all not disabled builtin pkcs15 emulators.
+							Special value of <code class="literal">internal</code> will try all not disabled builtin pkcs15 emulators.
 						</p><p>
 							Special value of <code class="literal">old</code> will try all disabled pkcs15 emulators.
 					</p></dd><dt><span class="term">

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1123,7 +1123,7 @@ app <replaceable>application</replaceable> {
 			<variablelist>
 				<varlistentry>
 					<term>
-						<option>use_file_caching = <replaceable>bool</replaceable>;</option>
+						<option>use_file_caching = <replaceable>value</replaceable>;</option>
 					</term>
 					<listitem><para>
 							Whether to cache the card's files (e.g.
@@ -1134,14 +1134,35 @@ app <replaceable>application</replaceable> {
 								<listitem><para>
 									<literal>yes</literal>: Cache all files (public and private).
 								</para></listitem>
+								<listitem><para>
 									<literal>public</literal>: Cache only public files.
-								<listitem><para>
 								</para></listitem>
-									<literal>no</literal>: File caching disabled.
 								<listitem><para>
+									<literal>no</literal>: File caching disabled.
 								</para></listitem>
 							</itemizedlist>
-							(Default: <literal>no</literal>).
+							(Default: <literal>public</literal>
+							for the following card drivers
+							<literal>akis</literal>,
+							<literal>atrust-acos</literal>,
+							<literal>belpic</literal>,
+							<literal>cac1</literal>,
+							<literal>cac</literal>,
+							<literal>coolkey</literal>,
+							<literal>dnie</literal>,
+							<literal>edo</literal>,
+							<literal>esteid2018</literal>,
+							<literal>flex</literal>,
+							<literal>cyberflex</literal>,
+							<literal>gemsafeV1</literal>,
+							<literal>idprime</literal>,
+							<literal>itacns</literal>,
+							<literal>jpki</literal>,
+							<literal>MaskTech</literal>,
+							<literal>mcrd</literal>,
+							<literal>npa</literal>,
+							<literal>nqapplet</literal>,
+							<literal>tcos</literal> and otherwise <literal>no</literal>).
 						</para>
 						<para>
 							If caching is done by a system process, the

--- a/etc/opensc.conf
+++ b/etc/opensc.conf
@@ -1,7 +1,4 @@
 app default {
 	# debug = 3;
 	# debug_file = opensc-debug.txt;
-	framework pkcs15 {
-		# use_file_caching = public;
-	}
 }

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -883,7 +883,7 @@ app default {
 		# inaccessible from the user account. Use a global caching directory if
 		# you wish to share the cached information.
 		#
-		# Default: no
+		# Default: `public` for static cards, `false` otherwise
 		# use_file_caching = public;
 		#
 		# set a path for caching


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2444

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
