### PR TITLE
pkcs11.h: do not use generic 'interface' variable

### DIFF
--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -1256,7 +1256,7 @@ _CK_DECLARE_FUNCTION (C_GetInterfaceList,
 _CK_DECLARE_FUNCTION (C_GetInterface,
 		      (unsigned char *interface_name,
 		       struct ck_version *version,
-		       struct ck_interface **interface,
+		       struct ck_interface **interface_ptr,
 		       ck_flags_t flags));
 
 _CK_DECLARE_FUNCTION (C_LoginUser,


### PR DESCRIPTION
Hi,

interface term conflicts with Windows basetyps.h macro.

See: https://github.com/OpenSC/pkcs11-helper/issues/48

As this is the source of truth for this file for many projects, please accept the fix so that MSC people may use pkcs11.h in application.

Thanks to @selvanair for reporting.

Thanks,
Alon
