### PR TITLE
removed dead code

### DIFF
--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1879,7 +1879,7 @@ init_gost_params(struct sc_pkcs15init_keyarg_gost_params *params, EVP_PKEY *pkey
 #else
 	char name[256]; size_t name_len = 0;
 #endif
-	int nid = 0;
+	int nid = NID_undef;
 
 	assert(pkey);
 	if (EVP_PKEY_id(pkey) == NID_id_GostR3410_2001) {
@@ -1888,7 +1888,7 @@ init_gost_params(struct sc_pkcs15init_keyarg_gost_params *params, EVP_PKEY *pkey
 		key = EVP_PKEY_get0(pkey);
 		assert(key);
 		assert(EC_KEY_get0_group(key));
-		EC_GROUP_get_curve_name(EC_KEY_get0_group(key));
+		nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(key));
 #else
 		assert(EVP_PKEY_get_group_name(pkey, name ,sizeof(name), &name_len));
 		nid = OBJ_txt2nid(name);


### PR DESCRIPTION
fixes coverity scan 374950 Logically dead code

Note that althoug this now is *correct* code, it looks that `init_gost_params` is
actually broken for OpenSSL 3.0 and later, because no are initialized...

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
