### PR TITLE
Fix usage of pointer after realloc

### DIFF
--- a/src/libopensc/base64.c
+++ b/src/libopensc/base64.c
@@ -150,8 +150,8 @@ int sc_base64_encode(const u8 *in, size_t len, u8 *out, size_t outlen, size_t li
 
 int sc_base64_decode(const char *in, u8 *out, size_t outlen)
 {
-	int len = 0, r, skip;
-	unsigned int i;
+	int len = 0, r = 0, skip = 0;
+	unsigned int i = 0;
 
 	while ((r = from_base64(in, &i, &skip)) > 0) {
 		int finished = 0, s = 16;

--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -181,13 +181,14 @@ static int format_le(size_t le, struct sc_asn1_entry *le_entry,
 
 static int prefix_buf(u8 prefix, u8 *buf, size_t buflen, u8 **cat)
 {
-	u8 *p;
+	u8 *p = NULL;
+	int ptr_same = *cat == buf;
 
 	p = realloc(*cat, buflen + 1);
 	if (!p)
 		return SC_ERROR_OUT_OF_MEMORY;
 
-	if (*cat == buf) {
+	if (ptr_same) {
 		memmove(p + 1, p, buflen);
 	} else {
 		/* Flawfinder: ignore */


### PR DESCRIPTION
Fixes problem found while building OpenSC on Fedora 36, which fails on

https://github.com/OpenSC/OpenSC/blob/be3dcd821e731d458c10a5fdd0d28474a8f20a78/src/sm/sm-iso.c#L194

with an error `pointer may be used after ‘realloc’`.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested