### PR TITLE
Memory management in mechanism registering

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5794,7 +5794,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		free(mt);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5804,6 +5804,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5814,6 +5815,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5855,6 +5857,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 			return CKR_HOST_MEMORY;
 		if (flags & SC_ALGORITHM_ECDSA_HASH_NONE) {
 			rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
+			sc_pkcs11_free_mechanism(mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
@@ -5906,6 +5909,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5915,6 +5919,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5924,6 +5929,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5933,6 +5939,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5942,6 +5949,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5956,6 +5964,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -5963,6 +5972,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5974,6 +5984,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6002,6 +6013,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6013,6 +6025,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6036,6 +6049,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6050,6 +6064,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6060,6 +6075,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6088,6 +6104,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6095,6 +6112,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6102,6 +6120,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6230,6 +6249,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_RAW) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6246,6 +6266,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		/* Supported in hardware only, if the card driver declares it. */
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_9796, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6265,6 +6286,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6323,6 +6345,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		mech_info.flags &= ~(CKF_DECRYPT|CKF_ENCRYPT);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_PSS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6364,6 +6387,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		mech_info.flags &= ~(CKF_SIGN|CKF_VERIFY|CKF_SIGN_RECOVER|CKF_VERIFY_RECOVER);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_OAEP, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK) {
 			return rc;
 		}
@@ -6376,6 +6400,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5790,16 +5790,17 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 
 	if (flags & SC_ALGORITHM_GOSTR3410_HASH_NONE) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_GOSTR3410,
-				&mech_info, CKK_GOSTR3410, NULL, NULL);
+				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		free(mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
 	if (flags & SC_ALGORITHM_GOSTR3410_HASH_GOSTR3411) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_GOSTR3410_WITH_GOSTR3411,
-				&mech_info, CKK_GOSTR3410, NULL, NULL);
+				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5809,7 +5810,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 	if (flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
 		mt = sc_pkcs11_new_fw_mechanism(CKM_GOSTR3410_KEY_PAIR_GEN,
-				&mech_info, CKK_GOSTR3410, NULL, NULL);
+				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5849,7 +5850,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 
 	/* add mechs card or driver support */
 	if (flags & SC_ALGORITHM_ECDSA_RAW) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		if (flags & SC_ALGORITHM_ECDSA_HASH_NONE) {
@@ -5901,7 +5902,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	}
 
 	if (flags & SC_ALGORITHM_ECDSA_HASH_SHA1) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5910,7 +5911,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	}
 
 	if (flags & SC_ALGORITHM_ECDSA_HASH_SHA224) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA224, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA224, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5919,7 +5920,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	}
 
 	if (flags & SC_ALGORITHM_ECDSA_HASH_SHA256) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA256, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA256, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5928,7 +5929,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	}
 
 	if (flags & SC_ALGORITHM_ECDSA_HASH_SHA384) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA384, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA384, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5937,7 +5938,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	}
 
 	if (flags & SC_ALGORITHM_ECDSA_HASH_SHA512) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA512, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA512, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5951,14 +5952,14 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mech_info.flags &= ~(CKF_SIGN | CKF_VERIFY);
 		mech_info.flags |= CKF_DERIVE;
 
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
 
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5969,7 +5970,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 	if (flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
 		mech_info.flags |= ec_flags;
-		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_KEY_PAIR_GEN, &mech_info, CKK_EC, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_KEY_PAIR_GEN, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -5997,7 +5998,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 	*/
 #endif
 	if (flags & SC_ALGORITHM_EDDSA_RAW) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_EDDSA, &mech_info, CKK_EC_EDWARDS, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_EDDSA, &mech_info, CKK_EC_EDWARDS, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6008,7 +6009,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 	if (flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
 		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_EDWARDS_KEY_PAIR_GEN,
-			&mech_info, CKK_EC_EDWARDS, NULL, NULL);
+			&mech_info, CKK_EC_EDWARDS, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6031,7 +6032,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 	mech_info.ulMaxKeySize = max_key_size;
 
 	if (flags & SC_ALGORITHM_XEDDSA_RAW) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_XEDDSA, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_XEDDSA, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6045,7 +6046,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		mech_info.flags |= CKF_DERIVE;
 
 		/* Montgomery curves derive function is defined only for CKM_ECDH1_DERIVE mechanism */
-		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6055,7 +6056,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 
 	if (flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
-		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_MONTGOMERY_KEY_PAIR_GEN, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_MONTGOMERY_KEY_PAIR_GEN, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6083,21 +6084,21 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if ((card->caps & SC_CARD_CAP_WRAP_KEY) == SC_CARD_CAP_WRAP_KEY)
 		mech_info.flags |= CKF_WRAP;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_ECB, &mech_info, CKK_AES, NULL, NULL);
+	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_ECB, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt);
 	if (rc != CKR_OK)
 			return rc;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC, &mech_info, CKK_AES, NULL, NULL);
+	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt);
 	if (rc != CKR_OK)
 			return rc;
 
-	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC_PAD, &mech_info, CKK_AES, NULL, NULL);
+	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC_PAD, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt);
@@ -6227,7 +6228,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	/* Check if we support raw RSA */
 	if (rsa_flags & SC_ALGORITHM_RSA_RAW) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
@@ -6243,7 +6244,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_ISO9796) {
 		/* Supported in hardware only, if the card driver declares it. */
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_9796, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_9796, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
@@ -6262,7 +6263,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	/* No need to Check for PKCS1  We support it in software and turned it on above so always added it */
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
@@ -6320,7 +6321,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_PSS) {
 		CK_FLAGS old_flags = mech_info.flags;
 		mech_info.flags &= ~(CKF_DECRYPT|CKF_ENCRYPT);
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_PSS, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_PSS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK)
 			return rc;
@@ -6361,7 +6362,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_OAEP) {
 		CK_FLAGS old_flags = mech_info.flags;
 		mech_info.flags &= ~(CKF_SIGN|CKF_VERIFY|CKF_SIGN_RECOVER|CKF_VERIFY_RECOVER);
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_OAEP, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_OAEP, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt);
 		if (rc != CKR_OK) {
 			return rc;
@@ -6371,7 +6372,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 	if (rsa_flags & SC_ALGORITHM_ONBOARD_KEY_GEN) {
 		mech_info.flags = CKF_GENERATE_KEY_PAIR;
-		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info, CKK_RSA, NULL, NULL);
+		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt);

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5793,7 +5793,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		free(mt);
 		if (rc != CKR_OK)
 			return rc;
@@ -5803,7 +5803,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5813,7 +5813,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 				&mech_info, CKK_GOSTR3410, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5826,7 +5826,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		unsigned long ext_flags, CK_ULONG min_key_size, CK_ULONG max_key_size)
 {
 	CK_MECHANISM_INFO mech_info;
-	sc_pkcs11_mechanism_type_t *mt;
+	sc_pkcs11_mechanism_type_t *mt, *registered_mt;
 	CK_FLAGS ec_flags = 0;
 	CK_RV rc;
 
@@ -5854,7 +5854,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		if (flags & SC_ALGORITHM_ECDSA_HASH_NONE) {
-			rc = sc_pkcs11_register_mechanism(p11card, mt);
+			rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
@@ -5865,35 +5865,35 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (flags & SC_ALGORITHM_ECDSA_RAW) {
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA1)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA1, CKM_SHA_1, mt);
+					CKM_ECDSA_SHA1, CKM_SHA_1, registered_mt);
 				if (rc != CKR_OK)
 					return rc;
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA224)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA224, CKM_SHA224, mt);
+					CKM_ECDSA_SHA224, CKM_SHA224, registered_mt);
 				if (rc != CKR_OK)
 					return rc;
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA256)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA256, CKM_SHA256, mt);
+					CKM_ECDSA_SHA256, CKM_SHA256, registered_mt);
 				if (rc != CKR_OK)
 					return rc;
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA384)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA384, CKM_SHA384, mt);
+					CKM_ECDSA_SHA384, CKM_SHA384, registered_mt);
 				if (rc != CKR_OK)
 					return rc;
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA512)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA512, CKM_SHA512, mt);
+					CKM_ECDSA_SHA512, CKM_SHA512, registered_mt);
 				if (rc != CKR_OK)
 					return rc;
 			}
@@ -5905,7 +5905,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA1, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5914,7 +5914,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA224, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5923,7 +5923,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA256, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5932,7 +5932,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA384, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5941,7 +5941,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDSA_SHA512, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5955,14 +5955,14 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_COFACTOR_DERIVE, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5973,7 +5973,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_KEY_PAIR_GEN, &mech_info, CKK_EC, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6001,7 +6001,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 		mt = sc_pkcs11_new_fw_mechanism(CKM_EDDSA, &mech_info, CKK_EC_EDWARDS, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6012,7 +6012,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 			&mech_info, CKK_EC_EDWARDS, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6035,7 +6035,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		mt = sc_pkcs11_new_fw_mechanism(CKM_XEDDSA, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6049,7 +6049,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		mt = sc_pkcs11_new_fw_mechanism(CKM_ECDH1_DERIVE, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6059,7 +6059,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		mt = sc_pkcs11_new_fw_mechanism(CKM_EC_MONTGOMERY_KEY_PAIR_GEN, &mech_info, CKK_EC_MONTGOMERY, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6087,21 +6087,21 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_ECB, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
+	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 	if (rc != CKR_OK)
 			return rc;
 
 	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
+	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 	if (rc != CKR_OK)
 			return rc;
 
 	mt = sc_pkcs11_new_fw_mechanism(CKM_AES_CBC_PAD, &mech_info, CKK_AES, NULL, NULL, NULL);
 	if (!mt)
 		return CKR_HOST_MEMORY;
-	rc = sc_pkcs11_register_mechanism(p11card, mt);
+	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6122,7 +6122,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	CK_ULONG ec_min_key_size, ec_max_key_size,
 		aes_min_key_size, aes_max_key_size;
 	unsigned long ec_ext_flags;
-	sc_pkcs11_mechanism_type_t *mt;
+	sc_pkcs11_mechanism_type_t *mt, *registered_mt;
 	unsigned int num;
 	int rsa_flags = 0, ec_flags = 0, eddsa_flags = 0, xeddsa_flags = 0;
 	int ec_found = 0, gostr_flags = 0, aes_flags = 0;
@@ -6229,7 +6229,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	/* Check if we support raw RSA */
 	if (rsa_flags & SC_ALGORITHM_RSA_RAW) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL, NULL, NULL);
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6245,7 +6245,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_ISO9796) {
 		/* Supported in hardware only, if the card driver declares it. */
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_9796, &mech_info, CKK_RSA, NULL, NULL, NULL);
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6264,7 +6264,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	/* No need to Check for PKCS1  We support it in software and turned it on above so always added it */
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL, NULL, NULL);
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6275,43 +6275,43 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA1) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA1_RSA_PKCS, CKM_SHA_1, mt);
+				CKM_SHA1_RSA_PKCS, CKM_SHA_1, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA224) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA224_RSA_PKCS, CKM_SHA224, mt);
+				CKM_SHA224_RSA_PKCS, CKM_SHA224, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA256) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA256_RSA_PKCS, CKM_SHA256, mt);
+				CKM_SHA256_RSA_PKCS, CKM_SHA256, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA384) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA384_RSA_PKCS, CKM_SHA384, mt);
+				CKM_SHA384_RSA_PKCS, CKM_SHA384, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA512) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA512_RSA_PKCS, CKM_SHA512, mt);
+				CKM_SHA512_RSA_PKCS, CKM_SHA512, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (!FIPS_mode() && rsa_flags & SC_ALGORITHM_RSA_HASH_MD5) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_MD5_RSA_PKCS, CKM_MD5, mt);
+				CKM_MD5_RSA_PKCS, CKM_MD5, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (!FIPS_mode() && rsa_flags & SC_ALGORITHM_RSA_HASH_RIPEMD160) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_RIPEMD160_RSA_PKCS, CKM_RIPEMD160, mt);
+				CKM_RIPEMD160_RSA_PKCS, CKM_RIPEMD160, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
@@ -6322,37 +6322,37 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		CK_FLAGS old_flags = mech_info.flags;
 		mech_info.flags &= ~(CKF_DECRYPT|CKF_ENCRYPT);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_PSS, &mech_info, CKK_RSA, NULL, NULL, NULL);
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
 		if (rc != CKR_OK)
 			return rc;
 
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA1) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA1_RSA_PKCS_PSS, CKM_SHA_1, mt);
+				CKM_SHA1_RSA_PKCS_PSS, CKM_SHA_1, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA224) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA224_RSA_PKCS_PSS, CKM_SHA224, mt);
+				CKM_SHA224_RSA_PKCS_PSS, CKM_SHA224, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA256) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA256_RSA_PKCS_PSS, CKM_SHA256, mt);
+				CKM_SHA256_RSA_PKCS_PSS, CKM_SHA256, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA384) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA384_RSA_PKCS_PSS, CKM_SHA384, mt);
+				CKM_SHA384_RSA_PKCS_PSS, CKM_SHA384, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA512) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-				CKM_SHA512_RSA_PKCS_PSS, CKM_SHA512, mt);
+				CKM_SHA512_RSA_PKCS_PSS, CKM_SHA512, registered_mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
@@ -6363,7 +6363,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		CK_FLAGS old_flags = mech_info.flags;
 		mech_info.flags &= ~(CKF_SIGN|CKF_VERIFY|CKF_SIGN_RECOVER|CKF_VERIFY_RECOVER);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_OAEP, &mech_info, CKK_RSA, NULL, NULL, NULL);
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK) {
 			return rc;
 		}
@@ -6375,7 +6375,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		if (!mt)
 			return CKR_HOST_MEMORY;
-		rc = sc_pkcs11_register_mechanism(p11card, mt);
+		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
 		if (rc != CKR_OK)
 			return rc;
 	}

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -121,7 +121,7 @@ sc_pkcs11_copy_mechanism(sc_pkcs11_mechanism_type_t *mt,
  */
 CK_RV
 sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
-				sc_pkcs11_mechanism_type_t *mt)
+				sc_pkcs11_mechanism_type_t *mt, sc_pkcs11_mechanism_type_t **result_mt)
 {
 	sc_pkcs11_mechanism_type_t *existing_mt;
 	sc_pkcs11_mechanism_type_t *copy_mt = NULL;
@@ -168,6 +168,9 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 	p11card->mechanisms = p;
 	p[p11card->nmechanisms++] = copy_mt;
 	p[p11card->nmechanisms] = NULL;
+	/* Return registered mechanism for further use */
+	if (result_mt)
+		*result_mt = copy_mt;
 	return CKR_OK;
 }
 
@@ -1376,7 +1379,7 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 		return CKR_HOST_MEMORY;
 	}
 
-	rv = sc_pkcs11_register_mechanism(p11card, new_type);
+	rv = sc_pkcs11_register_mechanism(p11card, new_type, NULL);
 	if (CKR_OK != rv) {
 		new_type->free_mech_data(new_type->mech_data);
 		free(new_type);

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -98,6 +98,8 @@ static CK_RV
 sc_pkcs11_copy_mechanism(sc_pkcs11_mechanism_type_t *mt,
 				sc_pkcs11_mechanism_type_t **new_mt)
 {
+	int rv;
+
 	*new_mt = calloc(1, sizeof(sc_pkcs11_mechanism_type_t));
 	if (!(*new_mt))
 		return CKR_HOST_MEMORY;
@@ -105,9 +107,9 @@ sc_pkcs11_copy_mechanism(sc_pkcs11_mechanism_type_t *mt,
 	memcpy(*new_mt, mt, sizeof(sc_pkcs11_mechanism_type_t));
 	/* mech_data needs specific function for making copy*/
 	if (mt->copy_mech_data
-		&& mt->copy_mech_data(mt->mech_data, (void **) &(*new_mt)->mech_data) != CKR_OK) {
+		&& (rv = mt->copy_mech_data(mt->mech_data, (void **) &(*new_mt)->mech_data)) != CKR_OK) {
 		free(*new_mt);
-		return CKR_HOST_MEMORY;
+		return rv;
 	}
 	
 	return CKR_OK;
@@ -1344,8 +1346,11 @@ void free_info(const void *info)
 
 CK_RV copy_hash_signature_info(const void *mech_data, void **new_data)
 {
+	if (mech_data == NULL || new_data == NULL)
+		return CKR_ARGUMENTS_BAD;
+
 	*new_data = calloc(1, sizeof(struct hash_signature_info));
-	if (!new_data)
+	if (!(*new_data))
 		return CKR_HOST_MEMORY;
 	
 	memcpy(*new_data, mech_data, sizeof(struct hash_signature_info));

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -128,7 +128,7 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 	sc_pkcs11_mechanism_type_t *existing_mt;
 	sc_pkcs11_mechanism_type_t *copy_mt = NULL;
 	sc_pkcs11_mechanism_type_t **p;
-	int i;
+	int i, rv;
 
 	if (mt == NULL)
 		return CKR_HOST_MEMORY;
@@ -163,9 +163,9 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 			(p11card->nmechanisms + 2) * sizeof(*p));
 	if (p == NULL)
 		return CKR_HOST_MEMORY;
-	if (sc_pkcs11_copy_mechanism(mt, &copy_mt) != CKR_OK) {
+	if ((rv = sc_pkcs11_copy_mechanism(mt, &copy_mt)) != CKR_OK) {
 		free(p);
-		return CKR_HOST_MEMORY;
+		return rv;
 	}
 	p11card->mechanisms = p;
 	p[p11card->nmechanisms++] = copy_mt;

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1324,7 +1324,6 @@ void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t *mt)
 	if (mt->free_mech_data)
 		mt->free_mech_data(mt->mech_data);
 	free(mt);
-	mt = NULL;
 }
 
 /*

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1315,6 +1315,16 @@ sc_pkcs11_new_fw_mechanism(CK_MECHANISM_TYPE mech,
 	return mt;
 }
 
+void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t *mt)
+{
+	if (!mt)
+		return;
+	if (mt->free_mech_data)
+		mt->free_mech_data(mt->mech_data);
+	free(mt);
+	mt = NULL;
+}
+
 /*
  * Register generic mechanisms
  */
@@ -1380,10 +1390,7 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 	}
 
 	rv = sc_pkcs11_register_mechanism(p11card, new_type, NULL);
-	if (CKR_OK != rv) {
-		new_type->free_mech_data(new_type->mech_data);
-		free(new_type);
-	}
+	sc_pkcs11_free_mechanism(new_type);
 
 	return rv;
 }

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -273,23 +273,23 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 #endif /* !defined(OPENSSL_NO_ENGINE) */
 
 	openssl_sha1_mech.mech_data = EVP_sha1();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech), NULL);
 	openssl_sha224_mech.mech_data = EVP_sha224();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha224_mech, sizeof openssl_sha224_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha224_mech, sizeof openssl_sha224_mech), NULL);
 	openssl_sha256_mech.mech_data = EVP_sha256();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech), NULL);
 	openssl_sha384_mech.mech_data = EVP_sha384();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech), NULL);
 	openssl_sha512_mech.mech_data = EVP_sha512();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech), NULL);
 	if (!FIPS_mode()) {
 		openssl_md5_mech.mech_data = EVP_md5();
-		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech));
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech), NULL);
 		openssl_ripemd160_mech.mech_data = EVP_ripemd160();
-		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech));
+		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech), NULL);
 	}
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech));
+	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech), NULL);
 }
 
 

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -226,6 +226,7 @@ static void * dup_mem(void *in, size_t in_len)
 void
 sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 {
+	sc_pkcs11_mechanism_type_t *mt = NULL;
 #if !defined(OPENSSL_NO_ENGINE)
 	ENGINE *e;
 /* crypto locking removed in 1.1 */
@@ -273,23 +274,47 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 #endif /* !defined(OPENSSL_NO_ENGINE) */
 
 	openssl_sha1_mech.mech_data = EVP_sha1();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech), NULL);
+	mt = dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 	openssl_sha224_mech.mech_data = EVP_sha224();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha224_mech, sizeof openssl_sha224_mech), NULL);
+	mt = dup_mem(&openssl_sha224_mech, sizeof openssl_sha224_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 	openssl_sha256_mech.mech_data = EVP_sha256();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech), NULL);
+	mt = dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 	openssl_sha384_mech.mech_data = EVP_sha384();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech), NULL);
+	mt = dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 	openssl_sha512_mech.mech_data = EVP_sha512();
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech), NULL);
+	mt = dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 	if (!FIPS_mode()) {
 		openssl_md5_mech.mech_data = EVP_md5();
-		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech), NULL);
+		mt = dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech);
+		sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
+
 		openssl_ripemd160_mech.mech_data = EVP_ripemd160();
-		sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech), NULL);
+		mt = dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech);
+		sc_pkcs11_register_mechanism(p11card, mt, NULL);
+		sc_pkcs11_free_mechanism(mt);
+
 	}
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
-	sc_pkcs11_register_mechanism(p11card, dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech), NULL);
+	mt = dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(mt);
+
 }
 
 

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -72,6 +72,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha1_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
@@ -91,6 +92,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
@@ -110,6 +112,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
@@ -129,6 +132,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
@@ -148,6 +152,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
@@ -167,6 +172,7 @@ static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
@@ -186,6 +192,7 @@ static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static sc_pkcs11_mechanism_type_t openssl_ripemd160_mech = {
@@ -205,6 +212,7 @@ static sc_pkcs11_mechanism_type_t openssl_ripemd160_mech = {
 	NULL,			/* unwrap */
 	NULL,			/* mech_data */
 	NULL,			/* free_mech_data */
+	NULL,			/* copy_mech_data */
 };
 
 static void * dup_mem(void *in, size_t in_len)

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -51,6 +51,7 @@ static sc_pkcs11_mechanism_type_t find_mechanism = {
 	NULL,		/* unwrap */
 	NULL,		/* mech_data */
 	NULL,		/* free_mech_data */
+	NULL,		/* copy_mech_data */
 };
 
 static void

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -319,6 +319,7 @@ struct sc_pkcs11_mechanism_type {
 	const void *  mech_data;
 	/* free mechanism specific data */
 	void		  (*free_mech_data)(const void *mech_data);
+	CK_RV		  (*copy_mech_data)(const void *mech_data, void **new_data);
 };
 typedef struct sc_pkcs11_mechanism_type sc_pkcs11_mechanism_type_t;
 
@@ -463,7 +464,7 @@ sc_pkcs11_mechanism_type_t *sc_pkcs11_find_mechanism(struct sc_pkcs11_card *,
 				CK_MECHANISM_TYPE, unsigned int);
 sc_pkcs11_mechanism_type_t *sc_pkcs11_new_fw_mechanism(CK_MECHANISM_TYPE,
 				CK_MECHANISM_INFO_PTR, CK_KEY_TYPE,
-				const void *, void (*)(const void *));
+				const void *, void (*)(const void *), CK_RV (*)(const void *, void **));
 sc_pkcs11_operation_t *sc_pkcs11_new_operation(sc_pkcs11_session_t *,
 				sc_pkcs11_mechanism_type_t *);
 void sc_pkcs11_release_operation(sc_pkcs11_operation_t **);

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -465,6 +465,7 @@ sc_pkcs11_mechanism_type_t *sc_pkcs11_find_mechanism(struct sc_pkcs11_card *,
 sc_pkcs11_mechanism_type_t *sc_pkcs11_new_fw_mechanism(CK_MECHANISM_TYPE,
 				CK_MECHANISM_INFO_PTR, CK_KEY_TYPE,
 				const void *, void (*)(const void *), CK_RV (*)(const void *, void **));
+void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t *mt);
 sc_pkcs11_operation_t *sc_pkcs11_new_operation(sc_pkcs11_session_t *,
 				sc_pkcs11_mechanism_type_t *);
 void sc_pkcs11_release_operation(sc_pkcs11_operation_t **);

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -434,7 +434,7 @@ CK_RV attr_extract(CK_ATTRIBUTE_PTR, void *, size_t *);
 
 /* Generic Mechanism functions */
 CK_RV sc_pkcs11_register_mechanism(struct sc_pkcs11_card *,
-				sc_pkcs11_mechanism_type_t *);
+				sc_pkcs11_mechanism_type_t *, sc_pkcs11_mechanism_type_t **);
 CK_RV sc_pkcs11_get_mechanism_list(struct sc_pkcs11_card *,
 				CK_MECHANISM_TYPE_PTR, CK_ULONG_PTR);
 CK_RV sc_pkcs11_get_mechanism_info(struct sc_pkcs11_card *, CK_MECHANISM_TYPE,


### PR DESCRIPTION
Fixes #2508


This PR removes freeing of the `mt` attribute, that was added in https://github.com/OpenSC/OpenSC/commit/ede23473b49958af4d5a2d1a8a1eb72aaf5884a2. Now, the `mt` is copied in `sc_pkcs11_register_mechanism()`, so it can be freed after calling the function. Since `sc_pkcs11_mechanism_type_t` contains mechanism private data, the structure is extended by a pointer to a function for copying this data.

 If needed, the copy can be returned for further use (e.g. in `sc_pkcs11_register_sign_and_hash_mechanism()`).

Also, the changes touch duplicates in openssl.c of SHA mechanisms in `sc_pkcs11_register_openssl_mechanisms()` - they are first stored in a variable and released after copying in `sc_pkcs11_register_mechanism()`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
