### PR TITLE
Windows changed readers

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1026,7 +1026,9 @@ sc_reader_t *sc_ctx_get_reader(sc_context_t *ctx, unsigned int i);
  * @param  ctx   pointer to a sc_context_t
  * @param  pcsc_context_handle pointer to the  new context_handle to use
  * @param  pcsc_card_handle pointer to the new card_handle to use
- * @return SC_SUCCESS on success and an error code otherwise.
+ * @return SC_SUCCESS or 1 on success and an error code otherwise.
+ *		a return of 1 indicates to call reinit_card_for, as
+ *		the reader has changed.
  */
 int sc_ctx_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_card_handle);
 

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -2559,7 +2559,7 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 					|| strcmp(reader_name, reader->name) != 0) {
 				sc_log(ctx, "Reader name changed from \"%s\" to \"%s\"", reader->name, reader_name);
 	
-				ret = SC_ERROR_READER; /* tell caller to cleanup old reader and any cached data then try again */
+				ret = 1; /* tell caller to cleanup old reader and any cached data then try again */
 				ctx->flags |= SC_CTX_FLAG_TERMINATE; /* but don't do any operations on handle and try again */
 				goto out;
 			}

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -2506,6 +2506,8 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 {
 	SCARDHANDLE card_handle;
 	struct pcsc_global_private_data *gpriv = (struct pcsc_global_private_data *) ctx->reader_drv_data;
+	sc_reader_t *reader = NULL;
+	struct pcsc_private_data *priv = NULL;
 	char reader_name[128];
 	DWORD reader_name_size = sizeof(reader_name);
 	int ret = SC_ERROR_INTERNAL;
@@ -2522,20 +2524,49 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 		goto out;
 	}
 
-	/* Only minidriver calls this and only uses one reader */
-	/* if we already have a reader, update it */
-	if (sc_ctx_get_reader_count(ctx) > 0) {
-		sc_log(ctx, "Reusing the reader");
-		sc_reader_t *reader = list_get_at(&ctx->readers, 0);
+	/* Only minidriver calls pcsc use_reader as minidriver uses one reader
+	 * if we already have a reader 
+	 * first see if we are trying to free it 
+	 * test if new handles point to the same reader 
+	 * if they do use it,
+	 * if not set SC_CTX_FLAG_TERMINATE so we remove it before getting new reader
+	 */
 
-		if (reader) {
-			struct pcsc_private_data *priv = reader->drv_data;
-			priv->pcsc_card =*(SCARDHANDLE *)pcsc_card_handle;
+	if (sc_ctx_get_reader_count(ctx) > 0) {
+		reader = list_get_at(&ctx->readers, 0);
+
+		if (reader == NULL) {
+			ret = SC_ERROR_INTERNAL;
+			goto out;
+		}
+
+		if (ctx->flags & SC_CTX_FLAG_TERMINATE) {
+			sc_log(ctx, "Freeing reader");
+			ctx->flags &= ~SC_CTX_FLAG_TERMINATE;
+			_sc_delete_reader(ctx, reader);
+			reader = NULL;
+			/* fall thru to get new reader */
+		} else {
+			sc_log(ctx, "Try Reusing the reader");
+	
+			priv = reader->drv_data;
+			memset(reader_name, 0, sizeof(reader_name));
+	
+			/* check if new handles are for the same reader as old handles */
+			if (SCARD_S_SUCCESS != gpriv->SCardGetAttrib(*(SCARDHANDLE *)pcsc_card_handle,
+					SCARD_ATTR_DEVICE_SYSTEM_NAME_A, (LPBYTE)
+					reader_name, &reader_name_size)
+					|| strcmp(reader_name, reader->name) != 0) {
+				sc_log(ctx, "Reader name changed from \"%s\" to \"%s\"", reader->name, reader_name);
+	
+				ret = SC_ERROR_READER; /* tell caller to cleanup old reader and any cached data then try again */
+				ctx->flags |= SC_CTX_FLAG_TERMINATE; /* but don't do any operations on handle and try again */
+				goto out;
+			}
+
+			priv->pcsc_card = *(SCARDHANDLE *)pcsc_card_handle;
 			gpriv->pcsc_ctx = *(SCARDCONTEXT *)pcsc_context_handle;
 			ret = SC_SUCCESS;
-			goto out;
-		} else {
-			ret = SC_ERROR_INTERNAL;
 			goto out;
 		}
 	}
@@ -2549,7 +2580,7 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 	if(SCARD_S_SUCCESS == gpriv->SCardGetAttrib(card_handle,
 				SCARD_ATTR_DEVICE_SYSTEM_NAME_A, (LPBYTE)
 				reader_name, &reader_name_size)) {
-		sc_reader_t *reader = NULL;
+		reader = NULL;
 
 		ret = pcsc_add_reader(ctx, reader_name, reader_name_size, &reader);
 		if (ret == SC_SUCCESS) {


### PR DESCRIPTION
Possible solution to #2517  It needs testing, and is being submitted as a PR to get Windows artifacts.

    Windows is using new reader with card
    
    Issue #2517 reports that minidriver may be presented with new handles
    to PCSC, even if card is moved from one reader to another.
    The previous code assumed this would never happen, assuming
    that would be two operations: card is removed from one
    reader then inserted at some time later inserted into another.
    
    pcsc_use_reader now tests if the reader name has changed and will return
    SC_ERROR_READER so minidriver can call reinit_card to will cleanup
    and then start using the new reader.
    
    The assumption is if card is removed, it could be modified on another system
    then inserted on original system with changed data. 
    

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
