### PR TITLE
Minidriver fixes for ECC keys

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -260,6 +260,15 @@ static const struct sc_atr_table piv_atrs[] = {
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 
+static struct piv_supported_ec_curves {
+	struct sc_object_id oid;
+	size_t size;
+} ec_curves[] = {
+	{{{1, 2, 840, 10045, 3, 1, 7, -1}},     256}, /* secp256r1, nistp256, prime256v1, ansiX9p256r1 */
+	{{{1, 3, 132, 0, 34, -1}},              384}, /* secp384r1, nistp384, prime384v1, ansiX9p384r1 */
+	{{{-1}}, 0} /* This entry must not be touched. */
+};
+
 /* all have same AID */
 static struct piv_aid piv_aids[] = {
 	{SC_CARD_TYPE_PIV_II_GENERIC, /* TODO not really card type but what PIV AID is supported */
@@ -3457,12 +3466,14 @@ static int piv_init(sc_card_t *card)
 	_sc_card_add_rsa_alg(card, 3072, flags, 0); /* optional */
 
 	if (!(priv->card_issues & CI_NO_EC)) {
+		int i;
 		flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW | SC_ALGORITHM_ECDSA_HASH_NONE;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 
-		_sc_card_add_ec_alg(card, 256, flags, ext_flags, NULL);
-		if (!(priv->card_issues & CI_NO_EC384))
-			_sc_card_add_ec_alg(card, 384, flags, ext_flags, NULL);
+		for (i = 0; ec_curves[i].oid.value[0] >= 0; i++) {
+			if (!(priv->card_issues & CI_NO_EC384 && ec_curves[i].size == 384))
+				_sc_card_add_ec_alg(card, ec_curves[i].size, flags, ext_flags, &ec_curves[i].oid);
+		}
 	}
 
 	if (!(priv->card_issues & CI_NO_RANDOM))

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3690,8 +3690,10 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				memcpy(((PBYTE)publicKey) + sizeof(BCRYPT_ECCKEY_BLOB),  pubkey_der.value + 3,  pubkey_der.len -3);
 
 				logprintf(pCardData, 3,
-					  "return info on ECC SIGN_CONTAINER_INDEX %u\n",
-					  (unsigned int)bContainerIndex);
+					  "return info on ECC SIGN_CONTAINER_INDEX %u cbKey:%u dwMagic:%u\n",
+					  (unsigned int)bContainerIndex,
+					  (unsigned int)publicKey->cbKey,
+					  (unsigned int)publicKey->dwMagic);
 			}
 			if (cont->size_key_exchange)   {
 				sz = (DWORD) (sizeof(BCRYPT_ECCKEY_BLOB) +  pubkey_der.len -3);
@@ -3729,13 +3731,22 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 				memcpy(((PBYTE)publicKey) + sizeof(BCRYPT_ECCKEY_BLOB),  pubkey_der.value + 3,  pubkey_der.len -3);
 
 				logprintf(pCardData, 3,
-					  "return info on ECC KEYX_CONTAINER_INDEX %u\n",
-					  (unsigned int)bContainerIndex);
+					  "return info on ECC KEYX_CONTAINER_INDEX %u cbKey:%u dwMagic:%u\n",
+					  (unsigned int)bContainerIndex,
+					  (unsigned int)publicKey->cbKey,
+					  (unsigned int)publicKey->dwMagic);
 			}
 		}
 	}
 	logprintf(pCardData, 7, "returns container(idx:%u) info\n",
 		  (unsigned int)bContainerIndex);
+
+	logprintf(pCardData, 1,
+		  "CardGetContainerInfo bContainerIndex=%u, dwFlags=0x%08X, dwVersion=%lu, cbSigPublicKey=%lu, cbKeyExPublicKey=%lu\n",
+		  (unsigned int)bContainerIndex, (unsigned int)dwFlags,
+		  (unsigned long)pContainerInfo->dwVersion,
+		  (unsigned long)pContainerInfo->cbSigPublicKey,
+		  (unsigned long)pContainerInfo->cbKeyExPublicKey);
 
 err:
 	free(pubkey_der.value);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2788,7 +2788,8 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 		for (i = 0; i < count; i++) {
 			algo_info = vs->p15card->card->algorithms + i;
 			if (algo_info->algorithm == SC_ALGORITHM_EC) {
-				flag = SC_ALGORITHM_ECDH_CDH_RAW | SC_ALGORITHM_EXT_EC_NAMEDCURVE;
+				flag = SC_ALGORITHM_ECDH_CDH_RAW;
+				/* TODO  check if namedCurve matches Windows supported curves */
 				/* ECDHE */
 				if ((dwKeySpec == AT_ECDHE_P256) && (algo_info->key_length == 256) && (algo_info->flags & flag)) {
 					keysize = 256;
@@ -2803,11 +2804,12 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 					break;
 				}
 				/* ECDSA */
-				flag = SC_ALGORITHM_ECDSA_HASH_NONE|
+				flag = SC_ALGORITHM_ECDSA_RAW|
+						SC_ALGORITHM_ECDSA_HASH_NONE|
 						SC_ALGORITHM_ECDSA_HASH_SHA1|
 						SC_ALGORITHM_ECDSA_HASH_SHA224|
-						SC_ALGORITHM_ECDSA_HASH_SHA256|
-						SC_ALGORITHM_EXT_EC_NAMEDCURVE;
+						SC_ALGORITHM_ECDSA_HASH_SHA256;
+				/* TODO  check if namedCurve matches Windows supported curves */
 				if ((dwKeySpec == AT_ECDSA_P256) && (algo_info->key_length == 256) && (algo_info->flags & flag)) {
 					keysize = 256;
 					break;
@@ -6284,7 +6286,8 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 		if (cbData < sizeof(*pKeySizes))
 			MD_FUNC_RETURN(pCardData, 1, ERROR_INSUFFICIENT_BUFFER);
 
-		dwret = md_query_key_sizes(pCardData, 0, pKeySizes);
+		/* dwFlags has key_type */
+		dwret = md_query_key_sizes(pCardData, dwFlags, pKeySizes);
 		if (dwret != SCARD_S_SUCCESS)
 			MD_FUNC_RETURN(pCardData, 1, dwret);
 	}

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -98,7 +98,7 @@ HINSTANCE g_inst;
 #define NULLSTR(a) (a == NULL ? "<NULL>" : a)
 #define NULLWSTR(a) (a == NULL ? L"<NULL>" : a)
 
-#define MD_MAX_KEY_CONTAINERS 12
+#define MD_MAX_KEY_CONTAINERS 32
 #define MD_CARDID_SIZE 16
 
 #define MD_ROLE_USER_SIGN (ROLE_ADMIN + 1)

--- a/win32/OpenSC.wxs.in
+++ b/win32/OpenSC.wxs.in
@@ -86,6 +86,9 @@
               <!-- install an alias for the Base smart card CSP. Using a different CSP in minidriver installation deactivate the plug and play feature
                   but not all other components like the pin change screen available after ctrl+alt+del.
                   It is because the "80000001" entry is still returning the minidriver dll.-->
+              <!-- PR #2523 no longer uses "Provider = OpenSC CSP", but existing certificates in cert store 
+	          may have "Provider = OpenSC CSP" so we continue to add it for backward compatibility.
+		  Run: "certutil -Silent -store -user My" and look for "Provider = OpenSC CSP". -->
               <Component Id="openscBaseCSP" Guid="*" Win64="$(var.Win64YesNo)">
                 <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Cryptography\Defaults\Provider\OpenSC CSP">
                   <RegistryValue Type="string" Name="Image Path" Value="basecsp.dll" KeyPath="yes"/>


### PR DESCRIPTION
Fix for https://github.com/arekinath/PivApplet/issues/64

Minidriver fixes for ECC keys.

Cards with ECC keys need the KSP.

A minidriver is considered to support both CSP and KSP if registry has both:
"Crypto Provider"="Microsoft Base Smart Card Crypto Provider" and 
 "Smart Card Key Storage Provider"="Microsoft Smart Card Key Storage Provider"

Rather then change "Crypto Provider" a new registry key was added:
"InstalledBy"="OpenSC" which is used during uninstall to remove OpenSC registry.
Users and vendors are not expected to use this key so their entries are not deleted by OpenSC.

MD_MAX_KEY_CONTAINERS changed from 13 to 32 to support known cards that have more the 12 keys. 
    
"CardGetProperty" "CP_CARD_KEYSIZES" passes key_type in dwFlags
    
SC_ALGORITHM_EXT_EC_NAMEDCURVE in not in the flags, but in ext_flags
so remove from the test. If any test is needed it should be to match
the curve name supported by Windows.

 On branch minidriver-ECC
 Changes to be committed:
	modified:   minidriver.c

Tested on Windows 10 using Idemia PIV card with 8 ECC keys. 

Implementation of this PR will affect existing  installations, as the Microsoft cert store saves "Provider = OpenSC CSP" This may require uses to cleanup the cert store so "Provider = Microsoft Base Smart Card Crypto Provider" for RSA. Some entries in cert store have "Provider = Microsoft Smart Card Key Storage Provider" for ECC keys if found on a card.  

In other words we should never have tampered with the "Crypto Provider"="Microsoft Base Smart Card Crypto Provider" in the registry.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
