### PR TITLE
Fix registering of mechanisms

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5794,7 +5794,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5804,7 +5804,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5815,7 +5815,7 @@ register_gost_mechanisms(struct sc_pkcs11_card *p11card, int flags)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5857,48 +5857,58 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 			return CKR_HOST_MEMORY;
 		if (flags & SC_ALGORITHM_ECDSA_HASH_NONE) {
 			rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
-			sc_pkcs11_free_mechanism(mt);
+			sc_pkcs11_free_mechanism(&mt);
 			if (rc != CKR_OK)
 				return rc;
 		}
 
 #ifdef ENABLE_OPENSSL
 		/* if card supports RAW add sign_and_hash using RAW for mechs  card does not support */
-
+		sc_pkcs11_mechanism_type_t *sign_type = mt ? mt : registered_mt;
 		if (flags & SC_ALGORITHM_ECDSA_RAW) {
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA1)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA1, CKM_SHA_1, registered_mt);
-				if (rc != CKR_OK)
+					CKM_ECDSA_SHA1, CKM_SHA_1, sign_type);
+				if (rc != CKR_OK) {
+					sc_pkcs11_free_mechanism(&mt);
 					return rc;
+				}
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA224)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA224, CKM_SHA224, registered_mt);
-				if (rc != CKR_OK)
+					CKM_ECDSA_SHA224, CKM_SHA224, sign_type);
+				if (rc != CKR_OK) {
+					sc_pkcs11_free_mechanism(&mt);
 					return rc;
+				}
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA256)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA256, CKM_SHA256, registered_mt);
-				if (rc != CKR_OK)
+					CKM_ECDSA_SHA256, CKM_SHA256, sign_type);
+				if (rc != CKR_OK) {
+					sc_pkcs11_free_mechanism(&mt);
 					return rc;
+				}
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA384)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA384, CKM_SHA384, registered_mt);
-				if (rc != CKR_OK)
+					CKM_ECDSA_SHA384, CKM_SHA384, sign_type);
+				if (rc != CKR_OK) {
+					sc_pkcs11_free_mechanism(&mt);
 					return rc;
+				}
 			}
 
 			if (!(flags & SC_ALGORITHM_ECDSA_HASH_SHA512)) {
 				rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
-					CKM_ECDSA_SHA512, CKM_SHA512, registered_mt);
-				if (rc != CKR_OK)
+					CKM_ECDSA_SHA512, CKM_SHA512, sign_type);
+				if (rc != CKR_OK) {
+					sc_pkcs11_free_mechanism(&mt);
 					return rc;
+				}
 			}
 		}
 #endif
@@ -5909,7 +5919,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5919,7 +5929,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5929,7 +5939,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5939,7 +5949,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5949,7 +5959,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5964,7 +5974,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -5972,7 +5982,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -5984,7 +5994,7 @@ static CK_RV register_ec_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6013,7 +6023,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6025,7 +6035,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6049,7 +6059,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6064,7 +6074,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6075,7 +6085,7 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6104,7 +6114,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6112,7 +6122,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6120,7 +6130,7 @@ static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int
 	if (!mt)
 		return CKR_HOST_MEMORY;
 	rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 	if (rc != CKR_OK)
 			return rc;
 
@@ -6249,7 +6259,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_RAW) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_X_509, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6266,7 +6276,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		/* Supported in hardware only, if the card driver declares it. */
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_9796, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}
@@ -6286,7 +6296,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 	if (rsa_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6345,7 +6355,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		mech_info.flags &= ~(CKF_DECRYPT|CKF_ENCRYPT);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_PSS, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, &registered_mt);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 
@@ -6387,7 +6397,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		mech_info.flags &= ~(CKF_SIGN|CKF_VERIFY|CKF_SIGN_RECOVER|CKF_VERIFY_RECOVER);
 		mt = sc_pkcs11_new_fw_mechanism(CKM_RSA_PKCS_OAEP, &mech_info, CKK_RSA, NULL, NULL, NULL);
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK) {
 			return rc;
 		}
@@ -6400,7 +6410,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		if (!mt)
 			return CKR_HOST_MEMORY;
 		rc = sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 		if (rc != CKR_OK)
 			return rc;
 	}

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -31,7 +31,6 @@ struct hash_signature_info {
 	CK_MECHANISM_TYPE	hash_mech;
 	CK_MECHANISM_TYPE	sign_mech;
 	sc_pkcs11_mechanism_type_t *hash_type;
-	sc_pkcs11_mechanism_type_t *sign_type;
 };
 
 /* Also used for verification and decryption data */
@@ -1387,7 +1386,6 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 		return CKR_HOST_MEMORY;
 
 	info->mech = mech;
-	info->sign_type = sign_type;
 	info->hash_type = hash_type;
 	info->sign_mech = sign_type->mech;
 	info->hash_mech = hash_mech;

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1317,13 +1317,14 @@ sc_pkcs11_new_fw_mechanism(CK_MECHANISM_TYPE mech,
 	return mt;
 }
 
-void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t *mt)
+void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t **mt)
 {
-	if (!mt)
+	if (!mt || !(*mt))
 		return;
-	if (mt->free_mech_data)
-		mt->free_mech_data(mt->mech_data);
-	free(mt);
+	if ((*mt)->free_mech_data)
+		(*mt)->free_mech_data((*mt)->mech_data);
+	free(*mt);
+	*mt = NULL;
 }
 
 /*
@@ -1398,7 +1399,7 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 	}
 
 	rv = sc_pkcs11_register_mechanism(p11card, new_type, NULL);
-	sc_pkcs11_free_mechanism(new_type);
+	sc_pkcs11_free_mechanism(&new_type);
 
 	return rv;
 }

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -276,44 +276,44 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 	openssl_sha1_mech.mech_data = EVP_sha1();
 	mt = dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 	openssl_sha224_mech.mech_data = EVP_sha224();
 	mt = dup_mem(&openssl_sha224_mech, sizeof openssl_sha224_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 	openssl_sha256_mech.mech_data = EVP_sha256();
 	mt = dup_mem(&openssl_sha256_mech, sizeof openssl_sha256_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 	openssl_sha384_mech.mech_data = EVP_sha384();
 	mt = dup_mem(&openssl_sha384_mech, sizeof openssl_sha384_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 	openssl_sha512_mech.mech_data = EVP_sha512();
 	mt = dup_mem(&openssl_sha512_mech, sizeof openssl_sha512_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 	if (!FIPS_mode()) {
 		openssl_md5_mech.mech_data = EVP_md5();
 		mt = dup_mem(&openssl_md5_mech, sizeof openssl_md5_mech);
 		sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 
 		openssl_ripemd160_mech.mech_data = EVP_ripemd160();
 		mt = dup_mem(&openssl_ripemd160_mech, sizeof openssl_ripemd160_mech);
 		sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(mt);
+		sc_pkcs11_free_mechanism(&mt);
 
 	}
 	openssl_gostr3411_mech.mech_data = EVP_get_digestbynid(NID_id_GostR3411_94);
 	mt = dup_mem(&openssl_gostr3411_mech, sizeof openssl_gostr3411_mech);
 	sc_pkcs11_register_mechanism(p11card, mt, NULL);
-	sc_pkcs11_free_mechanism(mt);
+	sc_pkcs11_free_mechanism(&mt);
 
 }
 

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -465,7 +465,7 @@ sc_pkcs11_mechanism_type_t *sc_pkcs11_find_mechanism(struct sc_pkcs11_card *,
 sc_pkcs11_mechanism_type_t *sc_pkcs11_new_fw_mechanism(CK_MECHANISM_TYPE,
 				CK_MECHANISM_INFO_PTR, CK_KEY_TYPE,
 				const void *, void (*)(const void *), CK_RV (*)(const void *, void **));
-void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t *mt);
+void sc_pkcs11_free_mechanism(sc_pkcs11_mechanism_type_t **mt);
 sc_pkcs11_operation_t *sc_pkcs11_new_operation(sc_pkcs11_session_t *,
 				sc_pkcs11_mechanism_type_t *);
 void sc_pkcs11_release_operation(sc_pkcs11_operation_t **);


### PR DESCRIPTION
This PR fixes calling `sc_pkcs11_register_sign_and_hash_mechanism()` to take proper mechanism as `sign_type`.

After creating new mechanism in `register_ec_mechanisms()` it can be either registered before `sc_pkcs11_register_sign_and_hash_mechanism()` for `SC_ALGORITHM_ECDSA_HASH_NONE` or not registered. In that case, original `mt` is used as sign_type.

Also, the pointer to `sign_type` in `struct hash_signature_info` is removed from the struct since it is not used anywhere. That also fixes the leaking of `sign_type` in the case when it is not registered before, and therefore not released with `p11card`.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
