### PR TITLE
Update pkcs15-lib.c

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -4147,7 +4147,7 @@ sc_pkcs15init_update_file(struct sc_profile *profile,
 	}
 
 	/* Present authentication info needed */
-	r = sc_pkcs15init_authenticate(profile, p15card, selected_file, SC_AC_OP_UPDATE);
+	r = sc_pkcs15init_authenticate(profile, p15card, file, SC_AC_OP_UPDATE);
 	if (r >= 0 && datalen)
 		r = sc_update_binary(p15card->card, 0, (const unsigned char *) data, datalen, 0);
 


### PR DESCRIPTION
It will verify the pin or not  by arguemnt alc  of file(selected_file). Otherwise it will return fail ,when update the binary file in function sc_pkcs15init_authenticate.
I use ePass2003 hardware by feitian.
now i change the argument from selected_filed to file.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
