### PR TITLE
win32: Use newest version of zlib

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -120,10 +120,10 @@ deploy_script:
   - bash -c "if [ \"$DO_PUSH_ARTIFACT\" = yes -a -z \"$APPVEYOR_PULL_REQUEST_NUMBER\" -a \"$APPVEYOR_REPO_NAME\" = \"OpenSC/OpenSC\" ]; then .github/push_artifacts.sh \"AppVeyor build ${APPVEYOR_BUILD_NUMBER}.${APPVEYOR_JOB_NUMBER}\"; fi"
 
 cache:
-  - C:\zlib -> appveyor.yml
-  - C:\zlib-Win32 -> appveyor.yml
-  - C:\zlib-Win64 -> appveyor.yml
-  - C:\openpace -> appveyor.yml
-  - C:\openpace-Win32 -> appveyor.yml
-  - C:\openpace-Win64 -> appveyor.yml
-  - cpdksetup.exe -> appveyor.yml
+  - C:\zlib -> .appveyor.yml
+  - C:\zlib-Win32 -> .appveyor.yml
+  - C:\zlib-Win64 -> .appveyor.yml
+  - C:\openpace -> .appveyor.yml
+  - C:\openpace-Win32 -> .appveyor.yml
+  - C:\openpace-Win64 -> .appveyor.yml
+  - cpdksetup.exe -> .appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
     secure: aLu3tFc7lRJbotnmnHLx/QruIHc5rLaGm1RttoEdy4QILlPXzVkCZ6loYMz0sfrY
   PATH: C:\cygwin\bin;%PATH%
   OPENPACE_VER: 1.1.2
-  ZLIB_VER_DOT: 1.2.11
+  ZLIB_VER_DOT: 1.2.12
   matrix:
   # not compatible with OpenSSL 1.1.1:
   # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013


### PR DESCRIPTION
Only on Windows, we're linking statically against zlib. All other
systems should update their zlib version on their own keeping ABI
stability. Zlib 1.2.12 Fixes a deflate bug when using the Z_FIXED
strategy that can result in out-of-bound accesses, see
https://zlib.net/

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
