### PR TITLE
Unbreak openssl 3.0 and libressl pipelines

### DIFF
--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -4,7 +4,7 @@ set -ex -o xtrace
 
 V=libressl-3.4.2
 
-sudo apt-get remove -y openssl libssl-dev java8-runtime-headless default-jre-headless
+sudo apt-get remove -y libssl-dev
 
 if [ ! -d "$V" ]; then
 	# letsencrypt CA does not seem to be included in CI runner

--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -55,12 +55,12 @@ sudo apt-get install -y build-essential $DEPS
 
 # install openssl 3.0 if needed
 if [ "$1" == "ossl3" -o "$2" == "ossl3" ]; then
-	./.github/setup-openssl.sh
+	./.github/setup-openssl.sh &> /tmp/openssl.log || cat /tmp/openssl.log
 fi
 
 # install libressl if needed
 if [ "$1" == "libressl" -o "$2" == "libressl" ]; then
-	./.github/setup-libressl.sh
+	./.github/setup-libressl.sh &> /tmp/libressl.log || cat /tmp/libressl.log
 fi
 
 if [ "$1" == "mingw" -o "$1" == "mingw32" ]; then

--- a/.github/setup-openssl.sh
+++ b/.github/setup-openssl.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-sudo apt-get remove -y openssl libssl-dev java8-runtime-headless default-jre-headless
+sudo apt-get remove -y libssl-dev
 
 if [ ! -d "openssl" ]; then
 	git clone --single-branch --branch=openssl-3.0 --depth 1 https://github.com/openssl/openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -191,10 +191,10 @@ jobs:
   build-openssl-3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: .github/setup-linux.sh ossl3
       - run: .github/build.sh dist ossl3
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: logs
           path: |
@@ -218,8 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-openssl-3]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         id: cache-build
         with:
           path: ./*
@@ -231,8 +231,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-openssl-3]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         id: cache-build
         with:
           path: ./*
@@ -246,10 +246,10 @@ jobs:
   build-libressl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: .github/setup-linux.sh libressl
       - run: .github/build.sh dist libressl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: logs
           path: |
@@ -266,8 +266,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-libressl]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         id: cache-build
         with:
           path: ./*
@@ -279,8 +279,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-libressl]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         id: cache-build
         with:
           path: ./*

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -194,13 +194,21 @@ jobs:
       - uses: actions/checkout@v2
       - run: .github/setup-linux.sh ossl3
       - run: .github/build.sh dist ossl3
+      - uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            tests/*.log
+            config.log
       - uses: actions/cache@v2
         id: cache-build
+        if: ${{ success() }}
         with:
           path: ./*
           key: ${{ runner.os }}-${{ github.sha }}-ossl3
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
+        if: ${{ success() }}
         with:
           name: opensc-build
           path:
@@ -232,9 +240,9 @@ jobs:
       - run: .github/setup-linux.sh oseid ossl3
       - run: .github/test-oseid.sh
 
-  ###########################
-  ## LibreSSL 3.0 pipeline ##
-  ###########################
+  #######################
+  ## LibreSSL pipeline ##
+  #######################
   build-libressl:
     runs-on: ubuntu-latest
     steps:
@@ -242,7 +250,6 @@ jobs:
       - run: .github/setup-linux.sh libressl
       - run: .github/build.sh dist libressl
       - uses: actions/upload-artifact@v2
-        if: failure()
         with:
           name: logs
           path: |
@@ -250,6 +257,7 @@ jobs:
             config.log
       - uses: actions/cache@v2
         id: cache-build
+        if: ${{ success() }}
         with:
           path: ./*
           key: ${{ runner.os }}-${{ github.sha }}-libressl


### PR DESCRIPTION
I think the main problem with these pipelines was the removal of openssl which caused some watchdog to not work and the builds were timing out.

This also updates the actions to v3, cleans up some of the pipelines and hides a lot of unneeded output from the openssl/libressl build.

I also tried to update libressl ot 3.5.2 but build was failing for some reason. This might be something to explore further or I will open a new issue for this.