### PR TITLE
framework-pkcs15: Fix use after free issue

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2576,7 +2576,9 @@ pkcs15_create_secret_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 
 out:
 	free(args.key.data); /* if allocated */
-	if (temp_object)
+
+	/* on error, free key_obj, unless it's created by pkcs15init. if OK, let it live as part of key_any_obj. */
+	if (rv != CKR_OK && temp_object)
 		free(key_obj); /* do not free if the object was created by pkcs15init. It will be freed in C_Finalize */
 	return rv;
 }


### PR DESCRIPTION
Newly created pkcs15 secret key object is freed upon success, which maybe used if user calls other PKCS11 functions (like C_DestroyObject) and causes use after free issue.

Signed-off-by: MkfsSion <mkfssion@mkfssion.com>

Card:

> Using reader with a card: Yubico YubiKey OTP+FIDO+CCID 00 00
> Personal Identity Verification Card
> 

##### Checklist
- [x] PKCS#11 module is tested
