### PR TITLE
cardos: fixed reading file information blocks

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -496,7 +496,7 @@ static int cardos_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 {
 	sc_apdu_t apdu;
 	u8        rbuf[256], offset = 0;
-	const u8  *p = rbuf, *q;
+	const u8  *p = rbuf, *q, *tag;
 	int       r;
 	size_t    fids = 0, len;
 
@@ -525,15 +525,17 @@ get_next_part:
 	while (len != 0) {
 		size_t   tlen = 0, ilen = 0;
 		/* is there a file information block (0x6f) ? */
-		p = sc_asn1_find_tag(card->ctx, p, len, 0x6f, &tlen);
-		if (p == NULL) {
+		tag = sc_asn1_find_tag(card->ctx, p, len, 0x6f, &tlen);
+		if (tag == NULL) {
 			sc_log(card->ctx,  "directory tag missing");
 			return SC_ERROR_INTERNAL;
 		}
+		len -= tlen - (tag - p);
+		p = tag + tlen;
 		if (tlen == 0)
 			/* empty directory */
 			break;
-		q = sc_asn1_find_tag(card->ctx, p, tlen, 0x86, &ilen);
+		q = sc_asn1_find_tag(card->ctx, tag, tlen, 0x86, &ilen);
 		if (q == NULL || ilen != 2) {
 			sc_log(card->ctx,  "error parsing file id TLV object");
 			return SC_ERROR_INTERNAL;
@@ -547,13 +549,11 @@ get_next_part:
 			/* not enough space left in buffer => break */
 			break;
 		/* extract next offset */
-		q = sc_asn1_find_tag(card->ctx, p, tlen, 0x8a, &ilen);
+		q = sc_asn1_find_tag(card->ctx, tag, tlen, 0x8a, &ilen);
 		if (q != NULL && ilen == 1) {
 			offset = (u8)ilen;
 			goto get_next_part;
 		}
-		len -= tlen + 2;
-		p   += tlen;
 	}
 
 	r = fids;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -530,7 +530,7 @@ get_next_part:
 			sc_log(card->ctx,  "directory tag missing");
 			return SC_ERROR_INTERNAL;
 		}
-		len -= tlen - (tag - p);
+		len = len - tlen - (tag - p);
 		p = tag + tlen;
 		if (tlen == 0)
 			/* empty directory */


### PR DESCRIPTION
currently untested

fixes Stack-buffer-overflow READ
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47035

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
