### PR TITLE
iso-sm: check for maximum receive length

### DIFF
--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -477,9 +477,13 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	if (apdu->cse & SC_APDU_EXT) {
 		sm_apdu->cse = SC_APDU_CASE_4_EXT;
 		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 3 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
+		if (sm_apdu->resplen > SC_MAX_EXT_APDU_RESP_SIZE)
+			sm_apdu->resplen = SC_MAX_EXT_APDU_RESP_SIZE;
 	} else {
 		sm_apdu->cse = SC_APDU_CASE_4_SHORT;
 		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 2 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
+		if (sm_apdu->resplen > SC_MAX_APDU_RESP_SIZE)
+			sm_apdu->resplen = SC_MAX_APDU_RESP_SIZE;
 	}
 	resp_data = calloc(sm_apdu->resplen, 1);
 	if (!resp_data) {


### PR DESCRIPTION
avoids PC/SC sending SCARD_E_INSUFFICIENT_BUFFER, see
https://github.com/LudovicRousseau/PCSC/issues/137

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
