### PR TITLE
Do not require a R/W session for --login, ...

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: .github/setup-linux.sh
       - run: .github/build.sh dist
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ubuntu-test-logs
+          path:
+            tests/*.log
       - uses: actions/cache@v2
         id: cache-build
         with:
@@ -29,12 +36,6 @@ jobs:
           name: opensc-build
           path:
             opensc*.tar.gz
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: ubuntu-test-logs
-          path:
-            tests/*.log
 
   build-no-shared:
     runs-on: ubuntu-latest
@@ -56,17 +57,18 @@ jobs:
       - uses: actions/checkout@v2
       - run: .github/setup-linux.sh
       - run: .github/build.sh
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ubuntu-18-test-logs
+          path:
+            tests/*.log
       - uses: actions/cache@v2
         id: cache-build
         with:
           path: ./*
           key: ${{ runner.os }}-18-${{ github.sha }}
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: ubuntu-18-test-logs
-          path:
-            tests/*.log
 
   build-mingw:
     runs-on: ubuntu-latest
@@ -195,8 +197,9 @@ jobs:
       - run: .github/setup-linux.sh ossl3
       - run: .github/build.sh dist ossl3
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
-          name: logs
+          name: openssl-3-logs
           path: |
             tests/*.log
             config.log
@@ -250,8 +253,9 @@ jobs:
       - run: .github/setup-linux.sh libressl
       - run: .github/build.sh dist libressl
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
-          name: logs
+          name: libressl-logs
           path: |
             tests/test-suite.log
             config.log

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -236,6 +236,13 @@
 
 				<varlistentry>
 					<term>
+						<option>--session-rw</option>,
+					</term>
+					<listitem><para>Forces to open the PKCS#11 session with CKF_RW_SESSION.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--login</option>,
 						<option>-l</option>
 					</term>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -858,7 +858,7 @@ int main(int argc, char * argv[])
 			opt_signature_file = optarg;
 			break;
 		case 'l':
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			opt_login = 1;
 			break;
 		case 'm':
@@ -879,7 +879,7 @@ int main(int argc, char * argv[])
 			opt_output = optarg;
 			break;
 		case 'p':
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			opt_login = 1;
 			util_get_pin(optarg, &opt_pin);
 			break;
@@ -894,7 +894,7 @@ int main(int argc, char * argv[])
 			action_count++;
 			break;
 		case 's':
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			do_sign = 1;
 			action_count++;
 			break;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -171,6 +171,7 @@ enum {
 	OPT_UNLOCK_PIN,
 	OPT_PUK,
 	OPT_NEW_PIN,
+	OPT_SESSION_RW,
 	OPT_LOGIN_TYPE,
 	OPT_TEST_EC,
 	OPT_DERIVE,
@@ -223,6 +224,7 @@ static const struct option options[] = {
 	{ "mgf",		1, NULL,		OPT_MGF },
 	{ "salt-len",		1, NULL,		OPT_SALT },
 
+	{ "session-rw",		0, NULL,		OPT_SESSION_RW },
 	{ "login",		0, NULL,		'l' },
 	{ "login-type",		1, NULL,		OPT_LOGIN_TYPE },
 	{ "pin",		1, NULL,		'p' },
@@ -309,6 +311,7 @@ static const char *option_help[] = {
 	"Specify MGF (Message Generation Function) used for RSA-PSS signature and RSA-OAEP decryption (possible values are MGF1-SHA1 to MGF1-SHA512)",
 	"Specify how many bytes should be used for salt in RSA-PSS signatures (default is digest size)",
 
+	"Forces to open the PKCS#11 session with CKF_RW_SESSION",
 	"Log into the token first",
 	"Specify login type ('so', 'user', 'context-specific'; default:'user')",
 	"Supply User PIN on the command line (if used in scripts: careful!)",
@@ -856,6 +859,9 @@ int main(int argc, char * argv[])
 			break;
 		case OPT_SIGNATURE_FILE:
 			opt_signature_file = optarg;
+			break;
+		case OPT_SESSION_RW:
+			need_session |= NEED_SESSION_RW;
 			break;
 		case 'l':
 			need_session |= NEED_SESSION_RO;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -904,12 +904,12 @@ int main(int argc, char * argv[])
 			action_count++;
 			break;
 		case OPT_DECRYPT:
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			do_decrypt = 1;
 			action_count++;
 			break;
 		case OPT_ENCRYPT:
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			do_encrypt = 1;
 			action_count++;
 			break;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -919,7 +919,7 @@ int main(int argc, char * argv[])
 			action_count++;
 			break;
 		case OPT_WRAP:
-			need_session |= NEED_SESSION_RW;
+			need_session |= NEED_SESSION_RO;
 			do_wrap = 1;
 			action_count++;
 			break;


### PR DESCRIPTION
This allows to perform commands like `--login --pin XXX --list-objects` or `--sign ...` on a read-only token (which otherwise could return an  `CKR_TOKEN_WRITE_PROTECTED` error when calling `C_OpenSession()`).

Fixes #2182.

### Open questions
* [x] Should we switch more operations to `NEED_SESSION_RO`? Yes:
  * `--verify`
  * `--encrypt` and `--decrypt`
  * `--wrap`
* [x] Should we add a `--session-rw` flag as discussed in https://github.com/OpenSC/OpenSC/issues/2182#issuecomment-756239151?
    * DONE

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [n/a] Documentation is added or updated
- [n/a] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
  - With our [SignPath](https://about.signpath.io/) PKCS#11 Cryptoprovider
- [n/a] Windows minidriver is tested
- [n/a] macOS tokend is tested
