### PR TITLE
Add uninstall hooks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,7 @@ on:
       - .github/setup-linux.sh
       - .github/build.sh
       - .github/push-artifacts.sh
+      - '**.am'
   push:
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,6 +11,7 @@ on:
       - .github/cleanup-macos.sh
       - .github/build.sh
       - .github/push-artifacts.sh
+      - '**.am'
   push:
 
 jobs:

--- a/src/minidriver/Makefile.am
+++ b/src/minidriver/Makefile.am
@@ -27,4 +27,7 @@ opensc_minidriver@LIBRARY_BITNESS@_la_LDFLAGS = $(AM_LDFLAGS) \
 if ENABLE_MINIDRIVER
 install-exec-hook:
 	mv "$(DESTDIR)$(libdir)/opensc-minidriver@LIBRARY_BITNESS@.dll" "$(DESTDIR)$(bindir)/"
+
+uninstall-hook:
+	rm -f "$(DESTDIR)$(bindir)/opensc-minidriver@LIBRARY_BITNESS@.dll"
 endif

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -82,6 +82,11 @@ install-exec-hook:
 		$(LN_S) ../$$l "$(DESTDIR)$(pkcs11dir)/$$l"; \
 	done
 
+uninstall-hook:
+	for l in opensc-pkcs11$(DYN_LIB_EXT) onepin-opensc-pkcs11$(DYN_LIB_EXT) pkcs11-spy$(DYN_LIB_EXT); do \
+		rm -f "$(DESTDIR)$(pkcs11dir)/$$l"; \
+	done
+	rm -df "$(DESTDIR)$(pkcs11dir)" || true
 endif
 
 TIDY_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(OPENSC_PKCS11_CFLAGS)

--- a/src/pkcs11/Makefile.am
+++ b/src/pkcs11/Makefile.am
@@ -73,6 +73,11 @@ install-exec-hook:
 	for l in opensc-pkcs11.dll pkcs11-spy.dll; do \
 		mv "$(DESTDIR)$(libdir)/$$l" "$(DESTDIR)$(bindir)/$$l"; \
 	done
+
+uninstall-hook:
+	for l in opensc-pkcs11.dll pkcs11-spy.dll; do \
+		rm -f "$(DESTDIR)$(bindir)/$$l"; \
+	done
 else
 # see http://wiki.cacert.org/wiki/Pkcs11TaskForce
 install-exec-hook:

--- a/win32/Makefile.am
+++ b/win32/Makefile.am
@@ -22,4 +22,7 @@ customactions@LIBRARY_BITNESS@_la_LDFLAGS = $(AM_LDFLAGS) \
 
 install-exec-hook:
 	mv "$(DESTDIR)$(libdir)/customactions@LIBRARY_BITNESS@.dll" "$(DESTDIR)$(bindir)/"
+
+uninstall-hook:
+	rm -f "$(DESTDIR)$(bindir)/customactions@LIBRARY_BITNESS@.dll"
 endif


### PR DESCRIPTION
Fixes #2372
This PR adds an uninstall script to remove files created in the `install-exec-hook` in makefiles.

##### Checklist
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
