### PR TITLE
pkcs11-register: recognize firefox-esr

### DIFF
--- a/src/tools/pkcs11-register.c
+++ b/src/tools/pkcs11-register.c
@@ -231,6 +231,7 @@ add_module_firefox(const char *module_path, const char *module_name, const char 
 		{"APPDATA", "Mozilla\\Firefox"},
 #else
 		{"HOME", ".mozilla/firefox"},
+		{"HOME", ".mozilla/firefox-esr"},
 #endif
 	};
 


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2581

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
