### PR TITLE
Add configuration option for on-disk caching of private data

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -749,24 +749,16 @@ app <em class="replaceable"><code>application</code></em> {
 					</span></dt><dd><p>
 							Whether to cache the card's files (e.g.
 							certificates) on disk in
-							<code class="option">file_cache_dir</code> (Default:
-							<code class="literal">false</code>).
-						</p><p>
-							If caching is done by a system process, the
-							cached files may be placed inaccessible from
-							the user account. Use a globally readable and
-							writable location if you wish to share the
-							cached information. Note that the cached files
-							may contain personal data such as name and mail
-							address.
-					</p></dd><dt><span class="term">
-						<code class="option">cache_private_data = <em class="replaceable"><code>bool</code></em>;</code>
-					</span></dt><dd><p>
-							Whether to cache private card's files (e.g.
-							certificates) on disk in
-							<code class="option">file_cache_dir</code>
-							Usable only with <option>use_file_caching</option>.
-							(Default: <code class="literal">false</code>).
+							<code class="option">file_cache_dir</code>.
+							Possible parameters:
+							</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem"><p>
+									<code class="literal">yes</code>: Cache all files (public and private).
+								</p></li><li class="listitem"><p>
+									<code class="literal">public</code>: Cache only public files.
+								</p></li><li class="listitem"><p>
+									<code class="literal">no</code>: File caching disabled.
+								</p></li></ul></div><p>
+							(Default:<code class="literal">no</code>).
 						</p><p>
 							If caching is done by a system process, the
 							cached files may be placed inaccessible from

--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -760,6 +760,22 @@ app <em class="replaceable"><code>application</code></em> {
 							may contain personal data such as name and mail
 							address.
 					</p></dd><dt><span class="term">
+						<code class="option">cache_private_data = <em class="replaceable"><code>bool</code></em>;</code>
+					</span></dt><dd><p>
+							Whether to cache private card's files (e.g.
+							certificates) on disk in
+							<code class="option">file_cache_dir</code>
+							Usable only with <option>use_file_caching</option>.
+							(Default: <code class="literal">false</code>).
+						</p><p>
+							If caching is done by a system process, the
+							cached files may be placed inaccessible from
+							the user account. Use a globally readable and
+							writable location if you wish to share the
+							cached information. Note that the cached files
+							may contain personal data such as name and mail
+							address.
+					</p></dd><dt><span class="term">
 						<code class="option">file_cache_dir = <em class="replaceable"><code>filename</code></em>;</code>
 					</span></dt><dd><p>
 							Where to cache the card's files. The default values are:

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1143,6 +1143,28 @@ app <replaceable>application</replaceable> {
 				</varlistentry>
 				<varlistentry>
 					<term>
+						<option>cache_private_data = <replaceable>bool</replaceable>;</option>
+					</term>
+					<listitem><para>
+							Whether to cache private card's files (e.g.
+							private keys) on disk in
+							<option>file_cache_dir</option>.
+							Usable only with <option>use_file_caching</option>
+							(Default:
+							<literal>false</literal>).
+						</para>
+						<para>
+							If caching is done by a system process, the
+							cached files may be placed inaccessible from
+							the user account. Use a globally readable and
+							writable location if you wish to share the
+							cached information. Note that the cached files
+							may contain personal data such as name and mail
+							address.
+					</para></listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
 						<option>file_cache_dir = <replaceable>filename</replaceable>;</option>
 					</term>
 					<listitem><para>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1146,22 +1146,13 @@ app <replaceable>application</replaceable> {
 						<option>cache_private_data = <replaceable>bool</replaceable>;</option>
 					</term>
 					<listitem><para>
-							Whether to cache private card's files (e.g.
-							private keys) on disk in
-							<option>file_cache_dir</option>.
+							Whether to cache private card's files
+							on disk in <option>file_cache_dir</option>.
 							Usable only with <option>use_file_caching</option>
 							(Default:
 							<literal>false</literal>).
 						</para>
-						<para>
-							If caching is done by a system process, the
-							cached files may be placed inaccessible from
-							the user account. Use a globally readable and
-							writable location if you wish to share the
-							cached information. Note that the cached files
-							may contain personal data such as name and mail
-							address.
-					</para></listitem>
+					</listitem>
 				</varlistentry>
 				<varlistentry>
 					<term>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1128,8 +1128,20 @@ app <replaceable>application</replaceable> {
 					<listitem><para>
 							Whether to cache the card's files (e.g.
 							certificates) on disk in
-							<option>file_cache_dir</option> (Default:
-							<literal>false</literal>).
+							<option>file_cache_dir</option>.
+							Possible parameters:
+							<itemizedlist>
+								<listitem><para>
+									<literal>yes</literal>: Cache all files (public and private).
+								</para></listitem>
+									<literal>public</literal>: Cache only public files.
+								<listitem><para>
+								</para></listitem>
+									<literal>no</literal>: File caching disabled.
+								<listitem><para>
+								</para></listitem>
+							</itemizedlist>
+							(Default: <literal>no</literal>).
 						</para>
 						<para>
 							If caching is done by a system process, the
@@ -1140,19 +1152,6 @@ app <replaceable>application</replaceable> {
 							may contain personal data such as name and mail
 							address.
 					</para></listitem>
-				</varlistentry>
-				<varlistentry>
-					<term>
-						<option>cache_private_data = <replaceable>bool</replaceable>;</option>
-					</term>
-					<listitem><para>
-							Whether to cache private card's files
-							on disk in <option>file_cache_dir</option>.
-							Usable only with <option>use_file_caching</option>
-							(Default:
-							<literal>false</literal>).
-						</para>
-					</listitem>
 				</varlistentry>
 				<varlistentry>
 					<term>

--- a/etc/opensc.conf
+++ b/etc/opensc.conf
@@ -2,6 +2,6 @@ app default {
 	# debug = 3;
 	# debug_file = opensc-debug.txt;
 	framework pkcs15 {
-		# use_file_caching = true;
+		# use_file_caching = public;
 	}
 }

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -886,6 +886,11 @@ app default {
 		# Default: false
 		# use_file_caching = true;
 		#
+		# Whether to cache private objects.
+		#
+		# Default: false
+		# cache_private_data = false;
+		#
 		# set a path for caching
 		# so you do not use the env variables and for pam_pkcs11
 		# (with certificate check)  where $HOME is not set

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -883,13 +883,8 @@ app default {
 		# inaccessible from the user account. Use a global caching directory if
 		# you wish to share the cached information.
 		#
-		# Default: false
-		# use_file_caching = true;
-		#
-		# Whether to cache private objects.
-		#
-		# Default: false
-		# cache_private_data = false;
+		# Default: no
+		# use_file_caching = public;
 		#
 		# set a path for caching
 		# so you do not use the env variables and for pam_pkcs11

--- a/src/libopensc/pkcs15-actalis.c
+++ b/src/libopensc/pkcs15-actalis.c
@@ -168,7 +168,7 @@ static int sc_pkcs15emu_actalis_init(sc_pkcs15_card_t * p15card)
 	const char *authPRKEY = "Authentication Key";
 	/* const char *nonrepPRKEY = "Non repudiation Key"; */
 
-	p15card->opts.use_file_cache = 1;	
+	p15card->opts.use_file_cache = SC_PKCS15_OPTS_CACHE_ALL_FILES;	
 
 	/* Get Serial number */
 	sc_format_path("3F0030000001", &path);

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -252,7 +252,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
 		sc_pkcs15_format_id(pins[0].id, &prkey_obj.auth_id);
 
-		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len);
+		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len, 0);
 
 		if (r) {
 			sc_log(card->ctx,  "No cert found,i=%d", i);

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -274,7 +274,7 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		}
 
 		/* following will find the cached cert in cert_info */
-		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+		r =  sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert_out);
 		if (r < 0 || cert_out->key == NULL) {
 			sc_log(card->ctx,  "Failed to read/parse the certificate r=%d",r);
 			if (cert_out != NULL)

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -384,7 +384,7 @@ sc_pkcs15_read_certificate(struct sc_pkcs15_card *p15card, const struct sc_pkcs1
 		sc_der_copy(&der, &info->value);
 	}
 	else if (info->path.len) {
-		r = sc_pkcs15_read_file(p15card, &info->path, &der.value, &der.len);
+		r = sc_pkcs15_read_file(p15card, &info->path, &der.value, &der.len, 0);
 		LOG_TEST_RET(ctx, r, "Unable to read certificate file.");
 	}
 	else   {

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -367,7 +367,7 @@ sc_pkcs15_pubkey_from_cert(struct sc_context *ctx,
 
 int
 sc_pkcs15_read_certificate(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_cert_info *info,
-		struct sc_pkcs15_cert **cert_out)
+		int private_obj, struct sc_pkcs15_cert **cert_out)
 {
 	struct sc_context *ctx = NULL;
 	struct sc_pkcs15_cert *cert = NULL;
@@ -384,7 +384,7 @@ sc_pkcs15_read_certificate(struct sc_pkcs15_card *p15card, const struct sc_pkcs1
 		sc_der_copy(&der, &info->value);
 	}
 	else if (info->path.len) {
-		r = sc_pkcs15_read_file(p15card, &info->path, &der.value, &der.len, 0);
+		r = sc_pkcs15_read_file(p15card, &info->path, &der.value, &der.len, private_obj);
 		LOG_TEST_RET(ctx, r, "Unable to read certificate file.");
 	}
 	else   {

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -431,7 +431,7 @@ coolkey_get_public_key_from_certificate(sc_pkcs15_card_t *p15card, sc_cardctl_co
 	if (r < 0) {
 		goto fail;
 	}
-	r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+	r = sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert_out);
 	if (r < 0) {
 		goto fail;
 	}

--- a/src/libopensc/pkcs15-coolkey.c
+++ b/src/libopensc/pkcs15-coolkey.c
@@ -423,7 +423,8 @@ coolkey_get_public_key_from_certificate(sc_pkcs15_card_t *p15card, sc_cardctl_co
 	sc_pkcs15_cert_info_t cert_info;
 	sc_pkcs15_cert_t *cert_out = NULL;
 	sc_pkcs15_pubkey_t *key = NULL;
-	int r;
+	int r, private_obj;
+	unsigned int flags;
 
 	memset(&cert_info, 0, sizeof(cert_info));
 
@@ -431,7 +432,10 @@ coolkey_get_public_key_from_certificate(sc_pkcs15_card_t *p15card, sc_cardctl_co
 	if (r < 0) {
 		goto fail;
 	}
-	r = sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert_out);
+
+	coolkey_get_flags(p15card->card, obj, &flags);
+	private_obj = flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	r = sc_pkcs15_read_certificate(p15card, &cert_info, private_obj, &cert_out);
 	if (r < 0) {
 		goto fail;
 	}

--- a/src/libopensc/pkcs15-data.c
+++ b/src/libopensc/pkcs15-data.c
@@ -41,6 +41,7 @@
 int
 sc_pkcs15_read_data_object(struct sc_pkcs15_card *p15card,
 		const struct sc_pkcs15_data_info *info,
+		int private_obj,
 		struct sc_pkcs15_data **data_object_out)
 {
 	struct sc_context *ctx = p15card->card->ctx;
@@ -53,7 +54,7 @@ sc_pkcs15_read_data_object(struct sc_pkcs15_card *p15card,
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
 	if (!info->data.value)   {
-		r = sc_pkcs15_read_file(p15card, &info->path, (unsigned char **) &info->data.value, (size_t *) &info->data.len);
+		r = sc_pkcs15_read_file(p15card, &info->path, (unsigned char **) &info->data.value, (size_t *) &info->data.len, private_obj);
 		LOG_TEST_RET(ctx, r, "Cannot get DATA object data");
 	}
 

--- a/src/libopensc/pkcs15-din-66291.c
+++ b/src/libopensc/pkcs15-din-66291.c
@@ -149,7 +149,7 @@ sc_pkcs15emu_din_66291_init(sc_pkcs15_card_t *p15card)
 
             if (i == 0) {
                 sc_pkcs15_cert_t *cert;
-                if (SC_SUCCESS == sc_pkcs15_read_certificate(p15card, &cert_info, &cert)) {
+                if (SC_SUCCESS == sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert)) {
                     static const struct sc_object_id cn_oid = {{ 2, 5, 4, 3, -1 }};
                     u8 *cn_name = NULL;
                     size_t cn_len = 0;

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -90,7 +90,7 @@ sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 			continue;
 
 		sc_pkcs15_cert_t *cert = NULL;
-		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert);
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert);
 		if (r < 0)
 			goto err;
 		if (cert->key->algorithm == SC_ALGORITHM_EC)

--- a/src/libopensc/pkcs15-esteid2018.c
+++ b/src/libopensc/pkcs15-esteid2018.c
@@ -87,7 +87,7 @@ static int sc_pkcs15emu_esteid2018_init(sc_pkcs15_card_t *p15card) {
 			continue;
 
 		sc_pkcs15_cert_t *cert = NULL;
-		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert);
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert);
 		LOG_TEST_GOTO_ERR(card->ctx, r, "Could not read authentication certificate");
 
 		if (cert->key->algorithm == SC_ALGORITHM_EC)

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -345,6 +345,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 		struct sc_pkcs15_cert_info cert_info;
 		struct sc_pkcs15_object    cert_obj;
 		sc_pkcs15_cert_t 		*cert_out;
+		int private_obj;
 
 		memset(&cert_info, 0, sizeof(cert_info));
 		memset(&cert_obj,  0, sizeof(cert_obj));
@@ -410,8 +411,8 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 		}
 
 		/* now lets see if we have a matching key for this cert */
-		
-		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+		private_obj = cert_obj.flags & SC_PKCS15_CO_FLAG_PRIVATE;
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, private_obj, &cert_out);
 		if (r < 0) {
 			free(gsdata);
 			sc_pkcs15_card_clear(p15card);

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -51,13 +51,15 @@ _iasecc_md_update_keyinfo(struct sc_pkcs15_card *p15card, struct sc_pkcs15_objec
 	struct sc_pkcs15_id id;
 	int rv, offs;
 	unsigned flags;
+	int private_obj;
 
 	LOG_FUNC_CALLED(ctx);
 
 	if (!dobj)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobj->data, &ddata);
+	private_obj = dobj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobj->data, private_obj, &ddata);
 	LOG_TEST_RET(ctx, rv, "Failed to read container DATA object data");
 
 	offs = 0;
@@ -184,12 +186,13 @@ _iasecc_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 	count = rv;
 	for(ii=0; ii<count; ii++)   {
 		struct sc_pkcs15_data_info *dinfo = (struct sc_pkcs15_data_info *)dobjs[ii]->data;
+		int private_obj = dobjs[ii]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
 
 		if (strcmp(dinfo->app_label, IASECC_GEMALTO_MD_APPLICATION_NAME))
 			continue;
 
 		if (!strcmp(dobjs[ii]->label, IASECC_GEMALTO_MD_DEFAULT_CONT_LABEL))   {
-			rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobjs[ii]->data, &default_guid);
+			rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)dobjs[ii]->data, private_obj, &default_guid);
 			LOG_TEST_RET(ctx, rv, "Failed to read 'default container' DATA object data");
 			break;
 		}

--- a/src/libopensc/pkcs15-idprime.c
+++ b/src/libopensc/pkcs15-idprime.c
@@ -195,7 +195,7 @@ static int sc_pkcs15emu_idprime_init(sc_pkcs15_card_t *p15card)
 		}
 
 		/* following will find the cached cert in cert_info */
-		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+		r =  sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert_out);
 		if (r < 0 || cert_out->key == NULL) {
 			sc_log(card->ctx,  "Failed to read/parse the certificate r=%d",r);
 			if (cert_out != NULL)

--- a/src/libopensc/pkcs15-idprime.c
+++ b/src/libopensc/pkcs15-idprime.c
@@ -173,7 +173,7 @@ static int sc_pkcs15emu_idprime_init(sc_pkcs15_card_t *p15card)
 		prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
 		sc_pkcs15_format_id(pin_id, &prkey_obj.auth_id);
 
-		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len);
+		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len, 0);
 
 		if (r) {
 			sc_log(card->ctx,  "No cert found,i=%d", i);

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -493,6 +493,7 @@ static int itacns_add_data_files(sc_pkcs15_card_t *p15card)
 	sc_pkcs15_data_info_t dinfo;
 	struct sc_pkcs15_object *objs[32];
 	struct sc_pkcs15_data_info *cinfo;
+	int private_obj;
 
 	for(i=0; i < array_size; i++) {
 		sc_path_t path;
@@ -548,7 +549,8 @@ static int itacns_add_data_files(sc_pkcs15_card_t *p15card)
 		return SC_SUCCESS;
 	}
 
-	rv = sc_pkcs15_read_data_object(p15card, cinfo, &p15_personaldata);
+	private_obj = objs[i]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	rv = sc_pkcs15_read_data_object(p15card, cinfo, private_obj, &p15_personaldata);
 	if (rv) {
 		sc_log(p15card->card->ctx,
 			"Could not read EF_DatiPersonali: "

--- a/src/libopensc/pkcs15-itacns.c
+++ b/src/libopensc/pkcs15-itacns.c
@@ -198,6 +198,7 @@ static int itacns_add_cert(sc_pkcs15_card_t *p15card,
 #ifdef ENABLE_OPENSSL
 	X509 *x509;
 	sc_pkcs15_cert_t *cert;
+	int private_obj;
 #endif
 
 	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_NORMAL);
@@ -228,8 +229,8 @@ static int itacns_add_cert(sc_pkcs15_card_t *p15card,
 
 	/* If we have OpenSSL, read keyUsage */
 #ifdef ENABLE_OPENSSL
-
-	r = sc_pkcs15_read_certificate(p15card, &info, &cert);
+	private_obj = obj_flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	r = sc_pkcs15_read_certificate(p15card, &info, private_obj, &cert);
 	LOG_TEST_RET(p15card->card->ctx, r,
 		"Could not read X.509 certificate");
 

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -721,6 +721,7 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		struct sc_pkcs15_object    cert_obj;
 		sc_pkcs15_der_t   cert_der;
 		sc_pkcs15_cert_t *cert_out = NULL;
+		int private_obj;
 		
 		ckis[i].cert_found = 0;
 		ckis[i].key_alg = -1;
@@ -750,7 +751,8 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 			continue;
 		}
 
-		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len);
+		private_obj = cert_obj.flags & SC_PKCS15_CO_FLAG_PRIVATE;
+		r = sc_pkcs15_read_file(p15card, &cert_info.path, &cert_der.value, &cert_der.len, private_obj);
 
 		if (r) {
 			sc_log(card->ctx,  "No cert found,i=%d", i);

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -765,12 +765,12 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		if (cert_der.value) {
 			cert_info.value.value = cert_der.value;
 			cert_info.value.len = cert_der.len;
-			if (!p15card->opts.use_file_cache) {
+			if (!p15card->opts.use_file_cache || (private_obj && !p15card->opts.cache_private_data)) {
 				cert_info.path.len = 0; /* use in mem cert from now on */
 			}
 		}
 		/* following will find the cached cert in cert_info */
-		r =  sc_pkcs15_read_certificate(p15card, &cert_info, &cert_out);
+		r =  sc_pkcs15_read_certificate(p15card, &cert_info, private_obj, &cert_out);
 		if (r < 0 || cert_out == NULL || cert_out->key == NULL) {
 			sc_log(card->ctx,  "Failed to read/parse the certificate r=%d",r);
 			if (cert_out != NULL)

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -765,7 +765,8 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		if (cert_der.value) {
 			cert_info.value.value = cert_der.value;
 			cert_info.value.len = cert_der.len;
-			if (!p15card->opts.use_file_cache || (private_obj && !p15card->opts.cache_private_data)) {
+			if (!p15card->opts.use_file_cache
+			    || (private_obj && !(p15card->opts.use_file_cache & SC_PKCS15_OPTS_CACHE_ALL_FILES))) {
 				cert_info.path.len = 0; /* use in mem cert from now on */
 			}
 		}

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -883,6 +883,7 @@ sc_pkcs15_read_pubkey(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_obj
 	unsigned char *data = NULL;
 	size_t	len;
 	int	algorithm, r;
+	int	private_obj;
 
 	if (p15card == NULL || p15card->card == NULL || p15card->card->ops == NULL
 			|| obj == NULL || out == NULL) {
@@ -951,7 +952,8 @@ sc_pkcs15_read_pubkey(struct sc_pkcs15_card *p15card, const struct sc_pkcs15_obj
 	}
 	else if (info->path.len)   {
 		sc_log(ctx, "Read from EF and decode");
-		r = sc_pkcs15_read_file(p15card, &info->path, &data, &len);
+		private_obj = obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+		r = sc_pkcs15_read_file(p15card, &info->path, &data, &len, private_obj);
 		LOG_TEST_GOTO_ERR(ctx, r, "Failed to read public key file.");
 
 		if ((algorithm == SC_ALGORITHM_EC || algorithm == SC_ALGORITHM_EDDSA || algorithm == SC_ALGORITHM_XEDDSA)

--- a/src/libopensc/pkcs15-westcos.c
+++ b/src/libopensc/pkcs15-westcos.c
@@ -131,7 +131,7 @@ static int sc_pkcs15emu_westcos_init(sc_pkcs15_card_t * p15card)
 		cert_info.id.value[0] = 0x45;
 		cert_info.authority = 0;
 		cert_info.path = path;
-		r = sc_pkcs15_read_certificate(p15card, &cert_info, &cert);
+		r = sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert);
 		cert_obj.data = (void *) cert;
 		if (!r) {
 			strlcpy(cert_obj.label, "User certificate",

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2103,7 +2103,7 @@ sc_pkcs15_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 		sc_log(ctx, "unknown DF type: %d", df->type);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 	}
-	r = sc_pkcs15_read_file(p15card, &df->path, &buf, &bufsize);
+	r = sc_pkcs15_read_file(p15card, &df->path, &buf, &bufsize, 0);
 	LOG_TEST_RET(ctx, r, "pkcs15 read file failed");
 
 	p = buf;
@@ -2344,7 +2344,7 @@ sc_pkcs15_parse_unusedspace(const unsigned char *buf, size_t buflen, struct sc_p
 
 int
 sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_path,
-		unsigned char **buf, size_t *buflen)
+		unsigned char **buf, size_t *buflen, int private_data)
 {
 	struct sc_context *ctx;
 	struct sc_file *file = NULL;
@@ -2361,7 +2361,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 	sc_log(ctx, "path=%s, index=%u, count=%d", sc_print_path(in_path), in_path->index, in_path->count);
 
 	r = -1; /* file state: not in cache */
-	if (p15card->opts.use_file_cache) {
+	if (p15card->opts.use_file_cache && (p15card->opts.cache_private_data || !private_data)) {
 		r = sc_pkcs15_read_cached_file(p15card, in_path, &data, &len);
 
 		if (!r && in_path->aid.len > 0 && in_path->len >= 2)   {
@@ -2449,7 +2449,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 
 		sc_file_free(file);
 
-		if (len && p15card->opts.use_file_cache) {
+		if (len && p15card->opts.use_file_cache && (p15card->opts.cache_private_data || !private_data)) {
 			sc_pkcs15_cache_file(p15card, in_path, data, len);
 		}
 	}

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2370,7 +2370,8 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 	sc_log(ctx, "path=%s, index=%u, count=%d", sc_print_path(in_path), in_path->index, in_path->count);
 
 	r = -1; /* file state: not in cache */
-	if (p15card->opts.use_file_cache && (p15card->opts.cache_private_data || !private_data)) {
+	if (p15card->opts.use_file_cache
+	    && ((p15card->opts.use_file_cache & SC_PKCS15_OPTS_CACHE_ALL_FILES) || !private_data)) {
 		r = sc_pkcs15_read_cached_file(p15card, in_path, &data, &len);
 
 		if (!r && in_path->aid.len > 0 && in_path->len >= 2)   {
@@ -2458,7 +2459,8 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 
 		sc_file_free(file);
 
-		if (len && p15card->opts.use_file_cache && (p15card->opts.cache_private_data || !private_data)) {
+		if (len && p15card->opts.use_file_cache
+		    && ((p15card->opts.use_file_cache & SC_PKCS15_OPTS_CACHE_ALL_FILES) || !private_data)) {
 			sc_pkcs15_cache_file(p15card, in_path, data, len);
 		}
 	}

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1236,6 +1236,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 
 	p15card->card = card;
 	p15card->opts.use_file_cache = 0;
+	p15card->opts.cache_private_data = 0;
 	p15card->opts.use_pin_cache = 1;
 	p15card->opts.pin_cache_counter = 10;
 	p15card->opts.pin_cache_ignore_user_consent = 0;
@@ -1250,6 +1251,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 	conf_block = sc_get_conf_block(ctx, "framework", "pkcs15", 1);
 	if (conf_block) {
 		p15card->opts.use_file_cache = scconf_get_bool(conf_block, "use_file_caching", p15card->opts.use_file_cache);
+		p15card->opts.cache_private_data = scconf_get_bool(conf_block, "cache_private_data", p15card->opts.cache_private_data);
 		p15card->opts.use_pin_cache = scconf_get_bool(conf_block, "use_pin_caching", p15card->opts.use_pin_cache);
 		p15card->opts.pin_cache_counter = scconf_get_int(conf_block, "pin_cache_counter", p15card->opts.pin_cache_counter);
 		p15card->opts.pin_cache_ignore_user_consent = scconf_get_bool(conf_block, "pin_cache_ignore_user_consent",

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -583,7 +583,6 @@ typedef struct sc_pkcs15_card {
 
 	struct sc_pkcs15_card_opts {
 		int use_file_cache;
-		int cache_private_data;
 		int use_pin_cache;
 		int pin_cache_counter;
 		int pin_cache_ignore_user_consent;
@@ -607,6 +606,11 @@ typedef struct sc_pkcs15_card {
 
 /* flags suitable for struct sc_pkcs15_card */
 #define SC_PKCS15_CARD_FLAG_EMULATED			0x02000000
+
+/* suitable for struct sc_pkcs15_card.opts.use_file_cache */
+#define SC_PKCS15_OPTS_CACHE_NO_FILES			0
+#define SC_PKCS15_OPTS_CACHE_PUBLIC_FILES		1
+#define SC_PKCS15_OPTS_CACHE_ALL_FILES			2
 
 /* suitable for struct sc_pkcs15_card.opts.private_certificate */
 #define SC_PKCS15_CARD_OPTS_PRIV_CERT_PROTECT		0

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -744,6 +744,7 @@ void sc_pkcs15_free_data_object(struct sc_pkcs15_data *data_object);
 
 int sc_pkcs15_read_certificate(struct sc_pkcs15_card *card,
 			       const struct sc_pkcs15_cert_info *info,
+			       int private_obj,
 			       struct sc_pkcs15_cert **cert);
 void sc_pkcs15_free_certificate(struct sc_pkcs15_cert *cert);
 int sc_pkcs15_find_cert_by_id(struct sc_pkcs15_card *card,

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -914,7 +914,7 @@ void sc_pkcs15_free_object(struct sc_pkcs15_object *obj);
 /* Generic file i/o */
 int sc_pkcs15_read_file(struct sc_pkcs15_card *p15card,
 			const struct sc_path *path,
-			u8 **buf, size_t *buflen);
+			u8 **buf, size_t *buflen, int private_data);
 
 /* Caching functions */
 int sc_pkcs15_read_cached_file(struct sc_pkcs15_card *p15card,

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -583,6 +583,7 @@ typedef struct sc_pkcs15_card {
 
 	struct sc_pkcs15_card_opts {
 		int use_file_cache;
+		int cache_private_data;
 		int use_pin_cache;
 		int pin_cache_counter;
 		int pin_cache_ignore_user_consent;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -728,6 +728,7 @@ void sc_pkcs15_free_key_params(struct sc_pkcs15_key_params *params);
 
 int sc_pkcs15_read_data_object(struct sc_pkcs15_card *p15card,
 			       const struct sc_pkcs15_data_info *info,
+			       int private_obj,
 			       struct sc_pkcs15_data **data_object_out);
 int sc_pkcs15_find_data_object_by_id(struct sc_pkcs15_card *p15card,
 				     const struct sc_pkcs15_id *id,

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -693,7 +693,7 @@ __pkcs15_create_cert_object(struct pkcs15_fw_data *fw_data, struct sc_pkcs15_obj
 		p15_cert = NULL;			/* will read cert when needed */
 	}
 	else    {
-		rv = sc_pkcs15_read_certificate(fw_data->p15_card, p15_info, &p15_cert);
+		rv = sc_pkcs15_read_certificate(fw_data->p15_card, p15_info, 0, &p15_cert);
 		if (rv < 0)
 			return rv;
 	}
@@ -1028,13 +1028,15 @@ check_cert_data_read(struct pkcs15_fw_data *fw_data, struct pkcs15_cert_object *
 {
 	struct pkcs15_pubkey_object *obj2;
 	int rv;
+	int private_obj;
 
 	if (!cert)
 		return SC_ERROR_OBJECT_NOT_FOUND;
 
 	if (cert->cert_data)
 		return 0;
-	rv = sc_pkcs15_read_certificate(fw_data->p15_card, cert->cert_info, &cert->cert_data);
+	private_obj = cert->cert_flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	rv = sc_pkcs15_read_certificate(fw_data->p15_card, cert->cert_info, private_obj, &cert->cert_data);
 	if (rv < 0)
 		return rv;
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5008,6 +5008,7 @@ pkcs15_dobj_get_value(struct sc_pkcs11_session *session,
 	struct pkcs15_fw_data *fw_data = NULL;
 	struct sc_card *card;
 	int rv;
+	int private_obj;
 
 	if (!p11card)
 		return sc_to_cryptoki_error(SC_ERROR_INVALID_CARD, "C_GetAttributeValue");
@@ -5030,7 +5031,8 @@ pkcs15_dobj_get_value(struct sc_pkcs11_session *session,
 	if (rv < 0)
 		return sc_to_cryptoki_error(rv, "C_GetAttributeValue");
 
-	rv = sc_pkcs15_read_data_object(fw_data->p15_card, dobj->info, out_data);
+	private_obj = dobj->data_flags;
+	rv = sc_pkcs15_read_data_object(fw_data->p15_card, dobj->info, private_obj, out_data);
 
 	sc_unlock(card);
 	if (rv < 0)

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -1473,7 +1473,7 @@ iasecc_md_gemalto_unset_default(struct sc_pkcs15_card *p15card, struct sc_profil
 	struct sc_pkcs15_prkey_info *key_info = (struct sc_pkcs15_prkey_info *)key_obj->data;
 	unsigned char guid[40];
 	size_t guid_len;
-	int rv, ii, keys_num;
+	int rv, ii, keys_num, private_obj;
 
 	LOG_FUNC_CALLED(ctx);
 
@@ -1487,7 +1487,8 @@ iasecc_md_gemalto_unset_default(struct sc_pkcs15_card *p15card, struct sc_profil
 	if (rv == SC_ERROR_OBJECT_NOT_FOUND)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
-	rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)data_obj->data, &dod);
+	private_obj = data_obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	rv = sc_pkcs15_read_data_object(p15card, (struct sc_pkcs15_data_info *)data_obj->data, private_obj, &dod);
 	LOG_TEST_RET(ctx, rv, "Cannot read from 'CSP/'Default Key Container'");
 
 	if (guid_len != dod->data_len || memcmp(guid, dod->data, guid_len)) {

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -1455,11 +1455,12 @@ awp_update_df_create_prvkey(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	rv = sc_pkcs15_find_cert_by_id(p15card, &key_info->id, &cert_obj);
 	if (!rv)   {
 		struct sc_pkcs15_cert_info *cert_info = (struct sc_pkcs15_cert_info *) cert_obj->data;
+		int private_obj = cert_obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
 
 		path = cert_info->path;
 		cc.cert_id = (path.value[path.len-1] & 0xFF) + (path.value[path.len-2] & 0xFF) * 0x100;
 
-		rv = sc_pkcs15_read_certificate(p15card, cert_info, &p15cert);
+		rv = sc_pkcs15_read_certificate(p15card, cert_info, private_obj, &p15cert);
 		SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "AWP 'update private key' DF failed:  cannot get certificate");
 
 		rv = sc_pkcs15_allocate_object_content(ctx, cert_obj, p15cert->data.value, p15cert->data.len);

--- a/src/tests/p15dump.c
+++ b/src/tests/p15dump.c
@@ -74,7 +74,7 @@ static int dump_unusedspace(void)
 	}
 	path.count = -1;
 
-	r = sc_pkcs15_read_file(p15card, &path, &buf, &buf_len);
+	r = sc_pkcs15_read_file(p15card, &path, &buf, &buf_len, 0);
 	if (r < 0) {
 		if (r == SC_ERROR_FILE_NOT_FOUND) {
 			printf("\nNo EF(UnusedSpace) file\n");

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -466,6 +466,7 @@ static int read_data_object(void)
 	for (i = 0; i < count; i++) {
 		struct sc_pkcs15_data_info *cinfo = (struct sc_pkcs15_data_info *) objs[i]->data;
 		struct sc_pkcs15_data *data_object = NULL;
+		int private_obj;
 
 		if (!sc_format_oid(&oid, opt_data))   {
 			if (!sc_compare_oid(&oid, &cinfo->app_oid))
@@ -480,7 +481,8 @@ static int read_data_object(void)
 			printf("Reading data object with label '%s'\n", opt_data);
 		r = authenticate(objs[i]);
 		if (r >= 0) {
-			r = sc_pkcs15_read_data_object(p15card, cinfo, &data_object);
+			private_obj = objs[i]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+			r = sc_pkcs15_read_data_object(p15card, cinfo, private_obj, &data_object);
 			if (r) {
 				fprintf(stderr, "Data object read failed: %s\n", sc_strerror(r));
 				if (r == SC_ERROR_FILE_NOT_FOUND)
@@ -527,7 +529,8 @@ static int list_data_objects(void)
 			}
 			if (objs[i]->auth_id.len == 0) {
 				struct sc_pkcs15_data *data_object;
-				r = sc_pkcs15_read_data_object(p15card, cinfo, &data_object);
+				int private_obj = objs[i]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+				r = sc_pkcs15_read_data_object(p15card, cinfo, private_obj, &data_object);
 				if (r) {
 					fprintf(stderr, "Data object read failed: %s\n", sc_strerror(r));
 					if (r == SC_ERROR_FILE_NOT_FOUND)
@@ -559,7 +562,8 @@ static int list_data_objects(void)
 		printf("\tPath:            %s\n", sc_print_path(&cinfo->path));
 		if (objs[i]->auth_id.len == 0) {
 			struct sc_pkcs15_data *data_object;
-			r = sc_pkcs15_read_data_object(p15card, cinfo, &data_object);
+			int private_obj = objs[i]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+			r = sc_pkcs15_read_data_object(p15card, cinfo, private_obj, &data_object);
 			if (r) {
 				fprintf(stderr, "Data object read failed: %s\n", sc_strerror(r));
 				if (r == SC_ERROR_FILE_NOT_FOUND)

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -269,6 +269,7 @@ static void print_cert_info(const struct sc_pkcs15_object *obj)
 	struct sc_pkcs15_cert_info *cert_info = (struct sc_pkcs15_cert_info *) obj->data;
 	struct sc_pkcs15_cert *cert_parsed = NULL;
 	int rv;
+	int private_obj;
 
 	if (compact) {
 		printf("\tPath:%s  ID:%s", sc_print_path(&cert_info->path),
@@ -286,7 +287,8 @@ static void print_cert_info(const struct sc_pkcs15_object *obj)
 
 	print_access_rules(obj->access_rules, SC_PKCS15_MAX_ACCESS_RULES);
 
-	rv = sc_pkcs15_read_certificate(p15card, cert_info, &cert_parsed);
+	private_obj = obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+	rv = sc_pkcs15_read_certificate(p15card, cert_info, private_obj, &cert_parsed);
 	if (rv >= 0 && cert_parsed)   {
 		printf("\tEncoded serial : %02X %02X ", *(cert_parsed->serial), *(cert_parsed->serial + 1));
 		util_hex_dump(stdout, cert_parsed->serial + 2, cert_parsed->serial_len - 2, "");
@@ -431,13 +433,15 @@ static int read_certificate(void)
 	for (i = 0; i < count; i++) {
 		struct sc_pkcs15_cert_info *cinfo = (struct sc_pkcs15_cert_info *) objs[i]->data;
 		struct sc_pkcs15_cert *cert;
+		int private_obj;
 
 		if (sc_pkcs15_compare_id(&id, &cinfo->id) != 1)
 			continue;
 
 		if (verbose)
 			printf("Reading certificate with ID '%s'\n", opt_cert);
-		r = sc_pkcs15_read_certificate(p15card, cinfo, &cert);
+		private_obj = objs[i]->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+		r = sc_pkcs15_read_certificate(p15card, cinfo, private_obj, &cert);
 		if (r) {
 			fprintf(stderr, "Certificate read failed: %s\n", sc_strerror(r));
 			return 1;
@@ -806,11 +810,13 @@ static int read_public_key(void)
 		r = sc_pkcs15_read_pubkey(p15card, obj, &pubkey);
 	} else if (r == SC_ERROR_OBJECT_NOT_FOUND) {
 		/* No pubkey - try if there's a certificate */
+		int private_obj;
 		r = sc_pkcs15_find_cert_by_id(p15card, &id, &obj);
 		if (r >= 0) {
 			if (verbose)
 				printf("Reading certificate with ID '%s'\n", opt_pubkey);
-			r = sc_pkcs15_read_certificate(p15card, (sc_pkcs15_cert_info_t *) obj->data, &cert);
+			private_obj = obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+			r = sc_pkcs15_read_certificate(p15card, (sc_pkcs15_cert_info_t *) obj->data, private_obj, &cert);
 		}
 		if (r >= 0)
 			pubkey = cert->key;
@@ -980,11 +986,13 @@ static int read_ssh_key(void)
 	}
 	else if (r == SC_ERROR_OBJECT_NOT_FOUND) {
 		/* No pubkey - try if there's a certificate */
+		int private_obj;
 		r = sc_pkcs15_find_cert_by_id(p15card, &id, &obj);
 		if (r >= 0) {
 			if (verbose)
 				fprintf(stderr,"Reading certificate with ID '%s'\n", opt_pubkey);
-			r = sc_pkcs15_read_certificate(p15card, (sc_pkcs15_cert_info_t *) obj->data, &cert);
+			private_obj = obj->flags & SC_PKCS15_CO_FLAG_PRIVATE;
+			r = sc_pkcs15_read_certificate(p15card, (sc_pkcs15_cert_info_t *) obj->data, private_obj, &cert);
 		}
 		if (r >= 0)
 			pubkey = cert->key;


### PR DESCRIPTION
This PR adds the configuration option `cache_private_data` that enables switching off on-disk caching of data flagged as private (with `SC_PKCS15_CO_FLAG_PRIVATE`). When both options `use_file_caching` and `cache_private_data` are enabled in config file, private objects are cached along with non-private. By default, caching of private data is disabled.

Most on-disk caching happens in `sc_pkcs15_read_file()`, which is extended with a flag whether it is private data or not.

Fixes #2210

##### Checklist
- [x] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
