### PR TITLE
Fix build with libressl >= 3.5.0

### DIFF
--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -38,7 +38,7 @@ extern "C" {
  * LIBRESSL_VERSION_NUMBER  0x3040200fL (changes with its versions)
  */
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L
 #define X509_get_extension_flags(x)	(x->ex_flags)
 #define X509_get_key_usage(x)		(x->ex_kusage)
 #define X509_get_extended_key_usage(x)	(x->ex_xkusage)
@@ -46,7 +46,9 @@ extern "C" {
 
 #if defined(LIBRESSL_VERSION_NUMBER)
 #define OPENSSL_malloc_init()			while(0) continue
+#if LIBRESSL_VERSION_NUMBER < 0x30500000L
 #define FIPS_mode()                             (0)
+#endif
 #define EVP_sha3_224()                          (NULL)
 #define EVP_sha3_256()                          (NULL)
 #define EVP_sha3_384()                          (NULL)


### PR DESCRIPTION
libressl added back `FIPS_mode` since version 3.5.0 and https://github.com/libressl-portable/openbsd/commit/a97eabc90d7647e374c1c6da686aeec63c49ff14

libressl provides `X509_get_extension_flags` since version 3.5.0 and https://github.com/libressl-portable/openbsd/commit/3180723224c1b2c7856a110b8213e4966995d7e0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>