### PR TITLE
pkcs15-init: Fix formatting rtecp cards

### DIFF
--- a/src/pkcs15init/pkcs15-rtecp.c
+++ b/src/pkcs15init/pkcs15-rtecp.c
@@ -120,6 +120,8 @@ static int rtecp_init(sc_profile_t *profile, sc_pkcs15_card_t *p15card)
 	create_sysdf(profile, card, "Resrv2-DF");
 	create_sysdf(profile, card, "Resrv3-DF");
 	create_sysdf(profile, card, "Resrv4-DF");
+	create_sysdf(profile, card, "Resrv5-DF");
+	create_sysdf(profile, card, "Resrv6-DF");
 
 	return sc_select_file(card, sc_get_mf_path(), NULL);
 }

--- a/src/pkcs15init/rutoken_ecp.profile
+++ b/src/pkcs15init/rutoken_ecp.profile
@@ -110,6 +110,14 @@ filesystem {
 
             DF Resrv1-DF {
                 file-id = 1001;
+
+                DF Resrv5-DF {
+                    file-id = 8001;
+                }
+
+                DF Resrv6-DF {
+                    file-id = 8002;
+                }
             }
             DF Resrv2-DF {
                 file-id = 1002;

--- a/src/pkcs15init/rutoken_lite.profile
+++ b/src/pkcs15init/rutoken_lite.profile
@@ -90,6 +90,14 @@ filesystem {
 
             DF Resrv1-DF {
                 file-id = 1001;
+
+                DF Resrv5-DF {
+                    file-id = 8001;
+                }
+
+                DF Resrv6-DF {
+                    file-id = 8002;
+                }
             }
             DF Resrv2-DF {
                 file-id = 1002;


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
