### PR TITLE
Keep PCSC reader flags when disconnected

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -672,7 +672,7 @@ static int pcsc_disconnect(sc_reader_t * reader)
 		LONG rv = priv->gpriv->SCardDisconnect(priv->pcsc_card, priv->gpriv->disconnect_action);
 		PCSC_TRACE(reader, "SCardDisconnect returned", rv);
 	}
-	reader->flags = 0;
+	reader->flags &= SC_READER_REMOVED;
 	return SC_SUCCESS;
 }
 


### PR DESCRIPTION
As discussed in #2415, when `C_GetSlotList()` is called before `C_WaitForSlotEvent()`, removing reader is not properly detected. The `C_GetSlotList()` calls `sc_ctx_detect_readers()`, which sets `reader->flags` to `SC_READER_REMOVED` and therefore `card_detect_all()` frees some reader resources and sets `slot->reader` to NULL. However, `card_removed()` also overwrites `reader->flags` from `SC_READER_REMOVED` to 0.

https://github.com/OpenSC/OpenSC/blob/ca01aa7a8edc8280a5ceadebb472c2e3c198d8c2/src/pkcs11/slot.c#L398-L411

Then, `C_WaitForSlotEvent()` calls `card_detect_all()` again, corresponding slots have `slot->reader = NULL` and therefore they are reclaimed via `create_slot()`. The removed reader is set back to the slot, but the event flags `slot->events` are overwritten with 0, and the event can not be detected from `slot->events` (the event flags would be normally changed in `card_detect()`).

https://github.com/OpenSC/OpenSC/blob/ca01aa7a8edc8280a5ceadebb472c2e3c198d8c2/src/pkcs11/slot.c#L145-L161

This behaviour can be fixed by keeping reader flags after disconnecting in reader-pcsc.c, then `card_detect_all()` does not reclaim the slot with the removed reader and event flags are kept for `C_WaitForSlotEvent()`.

Fixes #2415.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
