### PR TITLE
Fix record based files

### DIFF
--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -1089,7 +1089,7 @@ gpk_set_security_env(sc_card_t *card,
 	LOG_TEST_RET(card->ctx, r, "Failed to select PK file");
 
 	/* Read the sys record of the PK file to find out the key length */
-	r = sc_read_record(card, 1, sysrec, sizeof(sysrec),
+	r = sc_read_record(card, 1, 0, sysrec, sizeof(sysrec),
 			SC_RECORD_BY_REC_NR);
 	LOG_TEST_RET(card->ctx, r, "Failed to read PK sysrec");
 	if (r != 7 || sysrec[0] != 0) {

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -314,7 +314,7 @@ static int load_special_files(sc_card_t * card)
 
 	for (recno = 1;; recno++) {
 		u8 recbuf[256];
-		r = sc_read_record(card, recno, recbuf, sizeof(recbuf),
+		r = sc_read_record(card, recno, 0, recbuf, sizeof(recbuf),
 					SC_RECORD_BY_REC_NR);
 
 		if (r == SC_ERROR_RECORD_NOT_FOUND)
@@ -345,7 +345,7 @@ static int load_special_files(sc_card_t * card)
 
 	for (recno = 1;; recno++) {
 		u8 recbuf[256];
-		r = sc_read_record(card, recno, recbuf, sizeof(recbuf),
+		r = sc_read_record(card, recno, 0, recbuf, sizeof(recbuf),
 					SC_RECORD_BY_REC_NR);
 
 		if (r == SC_ERROR_RECORD_NOT_FOUND)
@@ -1155,7 +1155,7 @@ static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
 			return SC_ERROR_INTERNAL;
 
 		/* read the number of tries left for the PIN */
-		r = sc_read_record (card, ref_to_record[data->pin_reference], buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+		r = sc_read_record (card, ref_to_record[data->pin_reference], 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 		if (r < 0)
 			return SC_ERROR_INTERNAL;
 		if (buf[0] != 0x80 || buf[3] != 0x90)

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -2195,7 +2195,7 @@ err:
 
 
 static int
-auth_read_record(struct sc_card *card, unsigned int nr_rec,
+auth_read_record(struct sc_card *card, unsigned int nr_rec, unsigned int idx,
 		unsigned char *buf, size_t count, unsigned long flags)
 {
 	struct sc_apdu apdu;
@@ -2206,7 +2206,7 @@ auth_read_record(struct sc_card *card, unsigned int nr_rec,
 	       "auth_read_record(): nr_rec %i; count %"SC_FORMAT_LEN_SIZE_T"u",
 	       nr_rec, count);
 
-	if (nr_rec > 0xFF)
+	if (nr_rec > 0xFF || idx != 0)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xB2, nr_rec, 0);

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -199,7 +199,7 @@ static int starcos_determine_pin_format34(sc_card_t *card, unsigned int * pin_fo
 	rv = sc_select_file(card, &path, &file);
 	LOG_TEST_RET(ctx, rv, "Cannot select EF.PWDD file");
 
-	if ( (rv = sc_read_record(card, rec_no, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0 ) {
+	if ( (rv = sc_read_record(card, rec_no, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0 ) {
 		starcos_ctrl_ref_template ctrl_ref_template;
 		memset((void*)&ctrl_ref_template, 0, sizeof(ctrl_ref_template));
 		rv = starcos_parse_supported_sec_mechanisms(card, buf, rv, &ctrl_ref_template);
@@ -236,7 +236,7 @@ static int starcos_determine_pin_format35(sc_card_t *card, unsigned int * pin_fo
 	rv = sc_select_file(card, &path, &file);
 	LOG_TEST_RET(ctx, rv, "Cannot select EF.KEYD file");
 
-	while ( (rv = sc_read_record(card, rec_no++, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0 ) {
+	while ( (rv = sc_read_record(card, rec_no++, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0 ) {
 		if ( buf[0] != TAG_STARCOS35_PIN_REFERENCE ) continue;
 
 		memset((void*)&ctrl_ref_template, 0, sizeof(ctrl_ref_template));

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -950,8 +950,8 @@ int sc_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-int sc_read_record(sc_card_t *card, unsigned int rec_nr, u8 *buf,
-		   size_t count, unsigned long flags)
+int sc_read_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
+		   u8 *buf ,size_t count, unsigned long flags)
 {
 	int r;
 
@@ -963,7 +963,7 @@ int sc_read_record(sc_card_t *card, unsigned int rec_nr, u8 *buf,
 	if (card->ops->read_record == NULL)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
-	r = card->ops->read_record(card, rec_nr, buf, count, flags);
+	r = card->ops->read_record(card, rec_nr, idx, buf, count, flags);
 	if (r == SC_SUCCESS) {
 		r = count;
 	}
@@ -1013,8 +1013,8 @@ int sc_append_record(sc_card_t *card, const u8 * buf, size_t count,
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 
-int sc_update_record(sc_card_t *card, unsigned int rec_nr, const u8 * buf,
-		     size_t count, unsigned long flags)
+int sc_update_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
+		     const u8 * buf, size_t count, unsigned long flags)
 {
 	int r;
 
@@ -1026,7 +1026,7 @@ int sc_update_record(sc_card_t *card, unsigned int rec_nr, const u8 * buf,
 	if (card->ops->update_record == NULL)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
-	r = card->ops->update_record(card, rec_nr, buf, count, flags);
+	r = card->ops->update_record(card, rec_nr, idx, buf, count, flags);
 	if (r == SC_SUCCESS) {
 		r = count;
 	}

--- a/src/libopensc/dir.c
+++ b/src/libopensc/dir.c
@@ -227,7 +227,7 @@ int sc_enum_apps(sc_card_t *card)
 		/* Arbitrary set '16' as maximal number of records to check out:
 		 * to avoid endless loop because of some incomplete cards/drivers */
 		for (rec_nr = 1; rec_nr < 16; rec_nr++) {
-			r = sc_read_record(card, rec_nr, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+			r = sc_read_record(card, rec_nr, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 			if (r == SC_ERROR_RECORD_NOT_FOUND)
 				break;
 			LOG_TEST_RET(ctx, r, "read_record() failed");
@@ -361,7 +361,7 @@ static int update_single_record(sc_card_t *card, sc_app_info_t *app)
 	if (r)
 		return r;
 	if (app->rec_nr > 0)
-		r = sc_update_record(card, (unsigned int)app->rec_nr, rec, rec_size, SC_RECORD_BY_REC_NR);
+		r = sc_update_record(card, (unsigned int)app->rec_nr, 0, rec, rec_size, SC_RECORD_BY_REC_NR);
 	else if (app->rec_nr == 0) {
 		/* create new record entry */
 		r = sc_append_record(card, rec, rec_size, 0);
@@ -375,7 +375,7 @@ static int update_single_record(sc_card_t *card, sc_app_info_t *app)
 				if (card->app[i]->rec_nr > rec_nr)
 					rec_nr = card->app[i]->rec_nr;
 			rec_nr++;
-			r = sc_update_record(card, (unsigned int)rec_nr, rec, rec_size, SC_RECORD_BY_REC_NR);
+			r = sc_update_record(card, (unsigned int)rec_nr, 0, rec, rec_size, SC_RECORD_BY_REC_NR);
 		}
 	} else {
 		sc_log(card->ctx, "invalid record number\n");

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -329,7 +329,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 	const unsigned char *p, *end;
 	unsigned int cla = 0, tag = 0;
 	size_t length;
-	int size;
+	uint32_t size;
 
 	file->status = SC_FILE_STATUS_UNKNOWN;
 
@@ -350,11 +350,17 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 				/* fall through */
 			case 0x80:
 				/* determine the file size */
-				if (sc_asn1_decode_integer(p, length, &size, 0) == 0 && size >= 0) {
+				file->size = 0;
+				if(p && length < 5) {
+					size = 0;
+					for(size_t i=0; i<length; i++) {
+						size <<= 8;
+						size |= (uint32_t) p[i];
+					}
 					file->size = size;
-					sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u",
-							file->size);
 				}
+				
+				sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u", file->size);
 				break;
 
 			case 0x82:

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -165,31 +165,115 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 }
 
 
+const struct sc_asn1_entry c_asn1_do_data[] = {
+	{ "Offset Data Object", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x14, SC_ASN1_OPTIONAL, NULL, NULL },
+	{ "Discretionary Data Object", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x13, SC_ASN1_ALLOC|SC_ASN1_UNSIGNED, NULL, NULL },
+	{ NULL, 0, 0, 0, NULL, NULL }
+};
+
+int encode_do_data(struct sc_context *ctx,
+		unsigned int idx, const unsigned char *data, size_t data_len,
+		u8 **out, size_t *outlen)
+{
+	unsigned char offset_buffer[2];
+	size_t offset_buffer_len = sizeof offset_buffer;
+	struct sc_asn1_entry asn1_do_data[sizeof c_asn1_do_data / sizeof *c_asn1_do_data];
+	sc_copy_asn1_entry(c_asn1_do_data, asn1_do_data);
+
+	if (idx > 0xFFFF)
+		LOG_TEST_RET(ctx, SC_ERROR_INTERNAL, "Offset beyond 0xFFFF not supported");
+	offset_buffer[0] = (u8) (idx >> 8);
+	offset_buffer[1] = (u8) (idx & 0x00FF);
+	sc_format_asn1_entry(asn1_do_data + 0, offset_buffer, &offset_buffer_len, 1);
+
+	if (data && data_len) {
+		sc_format_asn1_entry(asn1_do_data + 1, (void *) &data, &data_len, 1);
+	} else {
+		sc_format_asn1_entry(asn1_do_data + 1, NULL, NULL, 0);
+	}
+
+	LOG_TEST_RET(ctx,
+			sc_asn1_encode(ctx, asn1_do_data, out, outlen),
+			"sc_asn1_encode() failed");
+
+	return SC_SUCCESS;
+}
+
+int decode_do_data(struct sc_context *ctx,
+		const unsigned char *encoded_data, size_t encoded_data_len,
+		u8 **out, size_t *outlen)
+{
+	struct sc_asn1_entry asn1_do_data[sizeof c_asn1_do_data / sizeof *c_asn1_do_data];
+	sc_copy_asn1_entry(c_asn1_do_data, asn1_do_data);
+
+	sc_format_asn1_entry(asn1_do_data + 0, NULL, NULL, 0);
+	sc_format_asn1_entry(asn1_do_data + 1, out, outlen, 0);
+
+	LOG_TEST_RET(ctx,
+			sc_asn1_decode(ctx, asn1_do_data, encoded_data, encoded_data_len, NULL, NULL),
+			"sc_asn1_decode() failed");
+
+	return SC_SUCCESS;
+}
+
 static int
 iso7816_read_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 		u8 *buf, size_t count, unsigned long flags)
 {
 	struct sc_apdu apdu;
 	int r;
+	/* XXX maybe use some bigger buffer */
+	unsigned char resp[SC_MAX_APDU_RESP_SIZE];
+	unsigned char *encoded_data = NULL, *decoded_data = NULL;
+	size_t encoded_data_len = 0, decoded_data_len = 0;
 
-	if (rec_nr > 0xFF || idx != 0)
+	if (rec_nr > 0xFF)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xB2, rec_nr, 0);
-	apdu.le = count;
-	apdu.resplen = count;
-	apdu.resp = buf;
+	if (idx == 0) {
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xB2, rec_nr, 0);
+		apdu.le = count;
+		apdu.resplen = count;
+		apdu.resp = buf;
+	} else {
+		r = encode_do_data(card->ctx, idx, NULL, 0, &encoded_data, &encoded_data_len);
+		LOG_TEST_GOTO_ERR(card->ctx, r, "Could not encode data objects");
+
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xB3, rec_nr, 0);
+		apdu.lc = encoded_data_len;
+		apdu.datalen = encoded_data_len;
+		apdu.data = encoded_data;
+		apdu.le = sizeof resp;
+		apdu.resplen = sizeof resp;
+		apdu.resp = resp;
+	}
 	apdu.p2 = (flags & SC_RECORD_EF_ID_MASK) << 3;
 	if (flags & SC_RECORD_BY_REC_NR)
 		apdu.p2 |= 0x04;
 
 	fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-	if (apdu.resplen == 0)
-		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+	LOG_TEST_GOTO_ERR(card->ctx, r, "APDU transmit failed");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_GOTO_ERR(card->ctx, r, "Card returned error");
 
-	LOG_FUNC_RETURN(card->ctx, apdu.resplen);
+	if (idx == 0) {
+		r = apdu.resplen;
+	} else {
+		r = decode_do_data(card->ctx, apdu.resp, apdu.resplen,
+				&decoded_data, &decoded_data_len);
+		LOG_TEST_GOTO_ERR(card->ctx, r, "Could not decode data objects");
+		if (decoded_data_len <= count) {
+			count = decoded_data_len;
+		}
+		memcpy(buf, decoded_data, count);
+		r = count;
+	}
+
+err:
+	free(encoded_data);
+	free(decoded_data);
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 
@@ -247,27 +331,41 @@ iso7816_update_record(struct sc_card *card, unsigned int rec_nr, unsigned int id
 {
 	struct sc_apdu apdu;
 	int r;
+	unsigned char *encoded_data = NULL;
+	size_t encoded_data_len = 0;
 
-	if (rec_nr > 0xFF || idx != 0)
+	if (rec_nr > 0xFF)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_3, 0xDC, rec_nr, 0);
-	apdu.lc = count;
-	apdu.datalen = count;
-	apdu.data = buf;
+	if (idx == 0) {
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3, 0xDC, rec_nr, 0);
+		apdu.lc = count;
+		apdu.datalen = count;
+		apdu.data = buf;
+	} else {
+		r = encode_do_data(card->ctx, idx, buf, count, &encoded_data, &encoded_data_len);
+		LOG_TEST_GOTO_ERR(card->ctx, r, "Could not encode data objects");
+
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3, 0xDD, rec_nr, 0);
+		apdu.lc = encoded_data_len;
+		apdu.datalen = encoded_data_len;
+		apdu.data = encoded_data;
+	}
 	apdu.p2 = (flags & SC_RECORD_EF_ID_MASK) << 3;
 	if (flags & SC_RECORD_BY_REC_NR)
 		apdu.p2 |= 0x04;
 
 	fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+	LOG_TEST_GOTO_ERR(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	LOG_TEST_RET(card->ctx, r, "Card returned error");
+	LOG_TEST_GOTO_ERR(card->ctx, r, "Card returned error");
+	r = count;
 
+err:
+	free(encoded_data);
 	LOG_FUNC_RETURN(card->ctx, count);
 }
-
 
 static int
 iso7816_write_binary(struct sc_card *card,

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -166,13 +166,13 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 
 
 static int
-iso7816_read_record(struct sc_card *card,
-		unsigned int rec_nr, u8 *buf, size_t count, unsigned long flags)
+iso7816_read_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
+		u8 *buf, size_t count, unsigned long flags)
 {
 	struct sc_apdu apdu;
 	int r;
 
-	if (rec_nr > 0xFF)
+	if (rec_nr > 0xFF || idx != 0)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xB2, rec_nr, 0);
@@ -242,11 +242,14 @@ iso7816_append_record(struct sc_card *card,
 
 
 static int
-iso7816_update_record(struct sc_card *card, unsigned int rec_nr,
+iso7816_update_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 		const u8 *buf, size_t count, unsigned long flags)
 {
 	struct sc_apdu apdu;
 	int r;
+
+	if (rec_nr > 0xFF || idx != 0)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3, 0xDC, rec_nr, 0);
 	apdu.lc = count;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -357,7 +357,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 						size <<= 8;
 						size |= (uint32_t) p[i];
 					}
-					file->size = size;
+					file->size = (size > MAX_FILE_SIZE)? MAX_FILE_SIZE:size;
 				}
 				
 				sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u", file->size);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -706,13 +706,13 @@ struct sc_card_operations {
 	int (*erase_binary)(struct sc_card *card, unsigned int idx,
 			    size_t count, unsigned long flags);
 
-	int (*read_record)(struct sc_card *card, unsigned int rec_nr,
+	int (*read_record)(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 			   u8 * buf, size_t count, unsigned long flags);
 	int (*write_record)(struct sc_card *card, unsigned int rec_nr,
 			    const u8 * buf, size_t count, unsigned long flags);
 	int (*append_record)(struct sc_card *card, const u8 * buf,
 			     size_t count, unsigned long flags);
-	int (*update_record)(struct sc_card *card, unsigned int rec_nr,
+	int (*update_record)(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 			     const u8 * buf, size_t count, unsigned long flags);
 
 	/* select_file: Does the equivalent of SELECT FILE command specified
@@ -1298,13 +1298,14 @@ int sc_erase_binary(struct sc_card *card, unsigned int idx,
  * Reads a record from the current (i.e. selected) file.
  * @param  card    struct sc_card object on which to issue the command
  * @param  rec_nr  SC_READ_RECORD_CURRENT or a record number starting from 1
+ * @param  idx     index within the record with the data to read
  * @param  buf     Pointer to a buffer for storing the data
  * @param  count   Number of bytes to read
  * @param  flags   flags (may contain a short file id of a file to select)
  * @retval number of bytes read or an error value
  */
-int sc_read_record(struct sc_card *card, unsigned int rec_nr, u8 * buf,
-		   size_t count, unsigned long flags);
+int sc_read_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
+		   u8 * buf, size_t count, unsigned long flags);
 /**
  * Writes data to a record from the current (i.e. selected) file.
  * @param  card    struct sc_card object on which to issue the command
@@ -1330,13 +1331,14 @@ int sc_append_record(struct sc_card *card, const u8 * buf, size_t count,
  * Updates the data of a record from the current (i.e. selected) file.
  * @param  card    struct sc_card object on which to issue the command
  * @param  rec_nr  SC_READ_RECORD_CURRENT or a record number starting from 1
+ * @param  idx     index within the record with the data to read
  * @param  buf     buffer with to the new data to be written
  * @param  count   number of bytes to update
  * @param  flags   flags (may contain a short file id of a file to select)
  * @retval number of bytes written or an error value
  */
-int sc_update_record(struct sc_card *card, unsigned int rec_nr, const u8 * buf,
-		     size_t count, unsigned long flags);
+int sc_update_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
+		     const u8 * buf, size_t count, unsigned long flags);
 int sc_delete_record(struct sc_card *card, unsigned int rec_nr);
 
 /* get/put data functions */

--- a/src/libopensc/pkcs15-esteid.c
+++ b/src/libopensc/pkcs15-esteid.c
@@ -54,7 +54,7 @@ sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 	LOG_TEST_GOTO_ERR(card->ctx, r, "select esteid PD failed");
 
 	/* read the serial (document number) */
-	r = sc_read_record (card, SC_ESTEID_PD_DOCUMENT_NR, buff, sizeof(buff), SC_RECORD_BY_REC_NR);
+	r = sc_read_record (card, SC_ESTEID_PD_DOCUMENT_NR, 0, buff, sizeof(buff), SC_RECORD_BY_REC_NR);
 	LOG_TEST_GOTO_ERR(card->ctx, r, "read document number failed");
 	buff[MIN((size_t) r, (sizeof buff)-1)] = '\0';
 	set_string(&p15card->tokeninfo->serial_number, (const char *)buff);
@@ -136,7 +136,7 @@ sc_pkcs15emu_esteid_init (sc_pkcs15_card_t * p15card)
 		memset(&pin_obj, 0, sizeof(pin_obj));
 
 		/* read the number of tries left for the PIN */
-		r = sc_read_record (card, (unsigned int) i + 1, buff, sizeof(buff), SC_RECORD_BY_REC_NR);
+		r = sc_read_record (card, (unsigned int) i + 1, 0, buff, sizeof(buff), SC_RECORD_BY_REC_NR);
 		if (r < 6)
 			goto err;
 

--- a/src/libopensc/pkcs15-gemsafeGPK.c
+++ b/src/libopensc/pkcs15-gemsafeGPK.c
@@ -271,7 +271,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 		r = sc_select_file(card, &path, NULL);
 		if (r < 0) 
 			continue;
-		r = sc_read_record(card, 1, sysrec, sizeof(sysrec), SC_RECORD_BY_REC_NR);
+		r = sc_read_record(card, 1, 0, sysrec, sizeof(sysrec), SC_RECORD_BY_REC_NR);
 		if (r != 7 || sysrec[0] != 0) {
 			continue;
 		}
@@ -292,7 +292,7 @@ static int sc_pkcs15emu_gemsafeGPK_init(sc_pkcs15_card_t *p15card)
 		sc_pkcs15_format_id("", &kinfo[num_keyinfo].id); 
 
 		sc_log(card->ctx, "reading modulus");
-		r = sc_read_record(card, 2, modulus_buf, 
+		r = sc_read_record(card, 2, 0, modulus_buf, 
 				kinfo[num_keyinfo].modulus_len+1, SC_RECORD_BY_REC_NR);
 		if (r < 0) 
 			continue;

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -281,7 +281,7 @@ sc_oberthur_read_file(struct sc_pkcs15_card *p15card, const char *in_path,
 				rv = 0;
 				break;
 			}
-			rv = sc_read_record(card, rec, *out + offs + 2, rec_len, SC_RECORD_BY_REC_NR);
+			rv = sc_read_record(card, rec, 0, *out + offs + 2, rec_len, SC_RECORD_BY_REC_NR);
 			if (rv == SC_ERROR_RECORD_NOT_FOUND)   {
 				rv = 0;
 				break;

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -137,7 +137,7 @@ static int insert_key(
 		}
 		sc_log(ctx, 
 			"Searching for Key-Ref %02X\n", key_reference);
-		while ((r = sc_read_record(card, ++rec_no, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0) {
+		while ((r = sc_read_record(card, ++rec_no, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0) {
 			int found = 0;
 			if (buf[0] != 0xA0 || r < 2)
 				continue;
@@ -240,7 +240,7 @@ static int insert_pin(
 		}
 		sc_log(ctx, 
 			"Searching for PIN-Ref %02X\n", pin_reference);
-		while ((r = sc_read_record(card, ++rec_no, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0) {
+		while ((r = sc_read_record(card, ++rec_no, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR)) > 0) {
 			int found = 0, fbz = -1;
 			if (r < 2 || buf[0] != 0xA0)
 				continue;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2423,12 +2423,18 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 			// in_path->count: ignored!
 
 			if(file->record_length > 0) {
-				len = (file->record_length > MAX_FILE_SIZE)? MAX_FILE_SIZE:file->record_length + 5;
+				if(file->record_length > MAX_FILE_SIZE) {
+					len = MAX_FILE_SIZE;
+					sc_log(ctx, "  record size truncated, encoded length: %"SC_FORMAT_LEN_SIZE_T"u", file->record_length);
+				} else {
+					len = file->record_length;
+				}
 			} else {
-				len = 0x2000 + 5;
+				len = MAX_FILE_SIZE;
 			}
 			
 			if ((in_path->index <= 0) || (in_path->index > (int)(file->record_count))) {
+				sc_log(ctx, "  record number out of bounds: %d", in_path->index);
 				r = SC_ERROR_RECORD_NOT_FOUND;
 				goto fail_unlock;
 			}
@@ -2494,6 +2500,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 		else if (file->ef_structure == SC_FILE_EF_LINEAR_VARIABLE) {
 
 			u8 offset_buffer[] = {0x54, 0x02, 0x00, 0x00};
+			u8 response_buffer[SC_MAX_APDU_RESP_SIZE];
 			struct sc_apdu apdu;
 			uint16_t offset_u16 = 0;
 			u8 *data_do;
@@ -2507,15 +2514,16 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 				sc_format_apdu(p15card->card, &apdu, SC_APDU_CASE_4_SHORT, 0xB3, in_path->index, 4);
 				
 				apdu.data = offset_buffer;
-				apdu.datalen = 4;
-				apdu.lc = 4;
+				apdu.datalen = sizeof(offset_buffer);
+				apdu.lc = sizeof(offset_buffer);
 				apdu.le = 0;
 				
-				apdu.resp = data + offset_u16;
-				apdu.resplen = len - offset_u16;
+				apdu.resp = response_buffer;
+				apdu.resplen = sizeof(response_buffer);
 	
 				r = sc_transmit_apdu(p15card->card, &apdu);
-				if(r < 0 || apdu.resplen == 0) break;
+				if (r < 0 || apdu.resplen == 0)
+					break;
 
 				data_do = NULL;
 				r = sc_decode_do53(ctx, &data_do, &data_do_len,	apdu.resp, apdu.resplen);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2419,15 +2419,17 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 
 		if (file->ef_structure == SC_FILE_EF_LINEAR_VARIABLE) {
 
-			// in_path->index = record_no, in_path->count ignored!
+			// in_path->index: record_no
+			// in_path->count: ignored!
+
 			if(file->record_length > 0) {
-				len = file->record_length + 5;
+				len = (file->record_length > MAX_FILE_SIZE)? MAX_FILE_SIZE:file->record_length + 5;
 			} else {
 				len = 0x2000 + 5;
 			}
 			
 			if ((in_path->index <= 0) || (in_path->index > (int)(file->record_count))) {
-				r = SC_ERROR_INVALID_ASN1_OBJECT;
+				r = SC_ERROR_RECORD_NOT_FOUND;
 				goto fail_unlock;
 			}
 		
@@ -2435,7 +2437,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 
 			if (in_path->count < 0) {
 				if (file->size)
-					len = file->size;
+					len = (file->size > MAX_FILE_SIZE)? MAX_FILE_SIZE:file->size;
 				else
 					len = 1024;
 				offset = 0;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2498,46 +2498,12 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 			len = head-data;
 		}
 		else if (file->ef_structure == SC_FILE_EF_LINEAR_VARIABLE) {
-
-			u8 offset_buffer[] = {0x54, 0x02, 0x00, 0x00};
-			u8 response_buffer[SC_MAX_APDU_RESP_SIZE];
-			struct sc_apdu apdu;
-			uint16_t offset_u16 = 0;
-			u8 *data_do;
-			size_t data_do_len;
-
-			do {
-
-				offset_buffer[2] = (u8) (offset_u16 >> 8);
-				offset_buffer[3] = (u8) (offset_u16 & 0x00ff);
-
-				sc_format_apdu(p15card->card, &apdu, SC_APDU_CASE_4_SHORT, 0xB3, in_path->index, 4);
-				
-				apdu.data = offset_buffer;
-				apdu.datalen = sizeof(offset_buffer);
-				apdu.lc = sizeof(offset_buffer);
-				apdu.le = 0;
-				
-				apdu.resp = response_buffer;
-				apdu.resplen = sizeof(response_buffer);
-	
-				r = sc_transmit_apdu(p15card->card, &apdu);
-				if (r < 0 || apdu.resplen == 0)
-					break;
-
-				data_do = NULL;
-				r = sc_decode_do53(ctx, &data_do, &data_do_len,	apdu.resp, apdu.resplen);
-				if (r < 0) goto fail_unlock;
-
-				if(data_do) {
-					memcpy(data + offset_u16, data_do, data_do_len);
-					offset_u16 += data_do_len;
-					free(data_do);
-				}
-
-			} while(r == SC_SUCCESS);
-
-			len = offset_u16;
+			r = sc_read_record(p15card->card, in_path->index, offset, data, len, SC_RECORD_BY_REC_NR);
+			if (r < 0) {
+				goto fail_unlock;
+			}
+			/* sc_read_record may return less than requested */
+			len = r;
 		}
 		else {
 			r = sc_read_binary(p15card->card, offset, data, len, 0);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2475,7 +2475,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 				if (l > 256) {
 					l = 256;
 				}
-				r = sc_read_record(p15card->card, i, head, l, SC_RECORD_BY_REC_NR);
+				r = sc_read_record(p15card->card, i, 0, head, l, SC_RECORD_BY_REC_NR);
 				if (r == SC_ERROR_RECORD_NOT_FOUND)
 					break;
 				if (r < 0) {

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2353,6 +2353,28 @@ sc_pkcs15_parse_unusedspace(const unsigned char *buf, size_t buflen, struct sc_p
 
 
 int
+sc_decode_do53(sc_context_t *ctx, u8 **data, size_t *data_len,
+		const u8 *buf, size_t buflen)
+{
+	struct sc_asn1_entry c_asn1_do53[] = {
+		{ "do53", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x13, SC_ASN1_ALLOC|SC_ASN1_UNSIGNED, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry asn1_do53[2];
+	int r;
+
+	LOG_FUNC_CALLED(ctx);
+	sc_copy_asn1_entry(c_asn1_do53, asn1_do53);
+	sc_format_asn1_entry(asn1_do53, data, data_len, 0);
+
+	r = sc_asn1_decode(ctx, asn1_do53, buf, buflen, NULL, NULL);
+	LOG_TEST_RET(ctx, r, "ASN.1 parsing of do-53 failed");
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+
+int
 sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_path,
 		unsigned char **buf, size_t *buflen, int private_data)
 {
@@ -2394,22 +2416,41 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 
 		/* Handle the case where the ASN.1 Path object specified
 		 * index and length values */
-		if (in_path->count < 0) {
-			if (file->size)
-				len = file->size;
-			else
-				len = 1024;
-			offset = 0;
-		}
-		else {
-			offset = in_path->index;
-			len = in_path->count;
-			/* Make sure we're within proper bounds */
-			if (offset >= file->size || offset + len > file->size) {
+
+		if (file->ef_structure == SC_FILE_EF_LINEAR_VARIABLE) {
+
+			// in_path->index = record_no, in_path->count ignored!
+			if(file->record_length > 0) {
+				len = file->record_length + 5;
+			} else {
+				len = 0x2000 + 5;
+			}
+			
+			if ((in_path->index <= 0) || (in_path->index > (int)(file->record_count))) {
 				r = SC_ERROR_INVALID_ASN1_OBJECT;
 				goto fail_unlock;
 			}
+		
+		} else {
+
+			if (in_path->count < 0) {
+				if (file->size)
+					len = file->size;
+				else
+					len = 1024;
+				offset = 0;
+			}
+			else {
+				offset = in_path->index;
+				len = in_path->count;
+				/* Make sure we're within proper bounds */
+				if (offset >= file->size || offset + len > file->size) {
+					r = SC_ERROR_INVALID_ASN1_OBJECT;
+					goto fail_unlock;
+				}
+			}
 		}
+
 		data = malloc(len);
 		if (data == NULL) {
 			r = SC_ERROR_OUT_OF_MEMORY;
@@ -2447,6 +2488,46 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 				}
 			}
 			len = head-data;
+		}
+		else if (file->ef_structure == SC_FILE_EF_LINEAR_VARIABLE) {
+
+			u8 offset_buffer[] = {0x54, 0x02, 0x00, 0x00};
+			struct sc_apdu apdu;
+			uint16_t offset_u16 = 0;
+			u8 *data_do;
+			size_t data_do_len;
+
+			do {
+
+				offset_buffer[2] = (u8) (offset_u16 >> 8);
+				offset_buffer[3] = (u8) (offset_u16 & 0x00ff);
+
+				sc_format_apdu(p15card->card, &apdu, SC_APDU_CASE_4_SHORT, 0xB3, in_path->index, 4);
+				
+				apdu.data = offset_buffer;
+				apdu.datalen = 4;
+				apdu.lc = 4;
+				apdu.le = 0;
+				
+				apdu.resp = data + offset_u16;
+				apdu.resplen = len - offset_u16;
+	
+				r = sc_transmit_apdu(p15card->card, &apdu);
+				if(r < 0 || apdu.resplen == 0) break;
+
+				data_do = NULL;
+				r = sc_decode_do53(ctx, &data_do, &data_do_len,	apdu.resp, apdu.resplen);
+				if (r < 0) goto fail_unlock;
+
+				if(data_do) {
+					memcpy(data + offset_u16, data_do, data_do_len);
+					offset_u16 += data_do_len;
+					free(data_do);
+				}
+
+			} while(r == SC_SUCCESS);
+
+			len = offset_u16;
 		}
 		else {
 			r = sc_read_binary(p15card->card, offset, data, len, 0);

--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -819,7 +819,7 @@ do_cardos_extract_pubkey(sc_card_t *card, int nr, u8 tag,
 	u8	buf[256];
 	int	r, count;
 
-	r = sc_read_record(card, nr, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+	r = sc_read_record(card, nr, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 	if (r < 0)
 		return r;
 	count = r - 4;

--- a/src/pkcs15init/pkcs15-gpk.c
+++ b/src/pkcs15init/pkcs15-gpk.c
@@ -702,7 +702,7 @@ gpk_pkfile_init_public(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_file
 	for (n = 0; n < 6; n++)
 		sysrec[6] ^= sysrec[n];
 
-	r = sc_read_record(p15card->card, 1, buffer, sizeof(buffer),
+	r = sc_read_record(p15card->card, 1, 0, buffer, sizeof(buffer),
 			SC_RECORD_BY_REC_NR);
 	if (r >= 0) {
 		if (r != 7 || buffer[0] != 0) {
@@ -711,7 +711,7 @@ gpk_pkfile_init_public(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_file
 			goto out;
 		}
 
-		r = sc_update_record(p15card->card, 1, sysrec, sizeof(sysrec),
+		r = sc_update_record(p15card->card, 1, 0, sysrec, sizeof(sysrec),
 				SC_RECORD_BY_REC_NR);
 	} else {
 		r = sc_append_record(p15card->card, sysrec, sizeof(sysrec), 0);
@@ -735,7 +735,7 @@ gpk_pkfile_update_public(struct sc_profile *profile,
 
 	/* If we've been given a key with public parts, write them now */
 	for (n = 2; n < 256; n++) {
-		r = sc_read_record(p15card->card, n, buffer, sizeof(buffer),
+		r = sc_read_record(p15card->card, n, 0, buffer, sizeof(buffer),
 				SC_RECORD_BY_REC_NR);
 		if (r < 0) {
 			r = 0;
@@ -755,7 +755,7 @@ gpk_pkfile_update_public(struct sc_profile *profile,
 		for (m = 0, found = 0; m < part->count; m++) {
 			pe = part->components + m;
 			if (pe->tag == tag) {
-				r = sc_update_record(p15card->card, n,
+				r = sc_update_record(p15card->card, n, 0,
 						pe->data, pe->size,
 						SC_RECORD_BY_REC_NR);
 				if (r < 0)
@@ -1046,7 +1046,7 @@ gpk_read_rsa_key(sc_card_t *card, struct sc_pkcs15_pubkey_rsa *rsa)
 		u8		buffer[256];
 		size_t		m;
 
-		r = sc_read_record(card, n, buffer, sizeof(buffer),
+		r = sc_read_record(card, n, 0, buffer, sizeof(buffer),
 				SC_RECORD_BY_REC_NR);
 		if (r < 1)
 			break;

--- a/src/pkcs15init/pkcs15-incrypto34.c
+++ b/src/pkcs15init/pkcs15-incrypto34.c
@@ -656,7 +656,7 @@ incrypto34_extract_pubkey(sc_card_t *card, int nr, u8 tag,
 	u8	buf[256];
 	int	r, count;
 
-	r = sc_read_record(card, nr, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+	r = sc_read_record(card, nr, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 	if (r < 0)
 		return r;
 	count = r - 4;

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -371,7 +371,7 @@ awp_update_container_entry (struct sc_pkcs15_card *p15card, struct sc_profile *p
 	else   {
 		rv = sc_select_file(p15card->card, &list_file->path, NULL);
 		if (!rv)
-			rv = sc_read_record(p15card->card, rec, buff, list_file->record_length, SC_RECORD_BY_REC_NR);
+			rv = sc_read_record(p15card->card, rec, 0, buff, list_file->record_length, SC_RECORD_BY_REC_NR);
 	}
 	if (rv < 0)   {
 		free(buff);
@@ -415,7 +415,7 @@ awp_update_container_entry (struct sc_pkcs15_card *p15card, struct sc_profile *p
 			rv = sc_append_record(p15card->card, buff, list_file->record_length, SC_RECORD_BY_REC_NR);
 	}
 	else   {
-		rv = sc_update_record(p15card->card, rec, buff, list_file->record_length, SC_RECORD_BY_REC_NR);
+		rv = sc_update_record(p15card->card, rec, 0, buff, list_file->record_length, SC_RECORD_BY_REC_NR);
 	}
 
 	free(buff);
@@ -477,7 +477,7 @@ awp_update_container(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	for (rec=0; rec < file->record_count; rec++)   {
 		unsigned char tmp[256];
 
-		rv = sc_read_record(p15card->card, rec + 1, tmp, sizeof(tmp), SC_RECORD_BY_REC_NR);
+		rv = sc_read_record(p15card->card, rec + 1, 0, tmp, sizeof(tmp), SC_RECORD_BY_REC_NR);
 		if (rv >= AWP_CONTAINER_RECORD_LEN)
 			memcpy(list + rec*AWP_CONTAINER_RECORD_LEN, tmp, AWP_CONTAINER_RECORD_LEN);
 		else
@@ -1659,7 +1659,7 @@ awp_delete_from_container(struct sc_pkcs15_card *p15card,
 		LOG_TEST_RET(ctx, SC_ERROR_OUT_OF_MEMORY, "AWP update container entry: allocation error");
 
 	for (rec = 1; rec <= (unsigned)file->record_count; rec++)   {
-		rv = sc_read_record(p15card->card, rec, buff, file->record_length, SC_RECORD_BY_REC_NR);
+		rv = sc_read_record(p15card->card, rec, 0, buff, file->record_length, SC_RECORD_BY_REC_NR);
 		if (rv < 0)   {
 			sc_log(ctx,  "AWP update contaner entry: read record error %i", rv);
 			break;
@@ -1697,7 +1697,7 @@ awp_delete_from_container(struct sc_pkcs15_card *p15card,
 				break;
 			}
 
-			rv = sc_update_record(p15card->card, rec, buff, rec_len, SC_RECORD_BY_REC_NR);
+			rv = sc_update_record(p15card->card, rec, 0, buff, rec_len, SC_RECORD_BY_REC_NR);
 			if (rv < 0)   {
 				sc_log(ctx,  "AWP update contaner entry: update record error %i", rv);
 				break;

--- a/src/tools/eidenv.c
+++ b/src/tools/eidenv.c
@@ -156,7 +156,7 @@ static void do_esteid(sc_card_t *card)
 
 		/* print the counters */
 		for (i = 1; i <= 4; i++) {
-			r = sc_read_record(card, i, buff, 128, SC_RECORD_BY_REC_NR);
+			r = sc_read_record(card, i, 0, buff, 128, SC_RECORD_BY_REC_NR);
 			if (r < 0)
 				goto out;
 			key_used[i - 1] = 0xffffff - ((unsigned char) buff[0xc] * 65536
@@ -180,7 +180,7 @@ static void do_esteid(sc_card_t *card)
 	}
 
 	for (i = 0; esteid_data[i].recno != 0; i++) {
-		r = sc_read_record(card, esteid_data[i].recno, buff, 50, SC_RECORD_BY_REC_NR);
+		r = sc_read_record(card, esteid_data[i].recno, 0, buff, 50, SC_RECORD_BY_REC_NR);
 		if (r < 0) {
 			fprintf (stderr, "Failed to read record %d from card: %s\n",
 						esteid_data[i].recno, sc_strerror (r));

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -803,7 +803,7 @@ static int read_and_print_record_file(sc_file_t *file, unsigned char sfi, unsign
 	for (rec = (wanted > 0) ? wanted : 1; wanted == 0 || wanted == rec; rec++) {
 		r = sc_lock(card);
 		if (r == SC_SUCCESS)
-			r = sc_read_record(card, rec, buf, sizeof(buf),
+			r = sc_read_record(card, rec, 0, buf, sizeof(buf),
 					SC_RECORD_BY_REC_NR | sfi);
 		else
 			r = SC_ERROR_READER_LOCKED;
@@ -1582,7 +1582,7 @@ static int do_get_record(int argc, char **argv)
 		goto err;
 	}
 
-	r = sc_read_record(card, rec, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+	r = sc_read_record(card, rec, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 	if (r < 0)   {
 		fprintf(stderr, "Cannot read record %"SC_FORMAT_LEN_SIZE_T"u; return %i\n", rec, r);
 		goto err;
@@ -1710,7 +1710,7 @@ static int do_update_record(int argc, char **argv)
 		goto err;
 	}
 
-	r = sc_read_record(card, rec, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+	r = sc_read_record(card, rec, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 	if (r < 0) {
 		fprintf(stderr, "Cannot read record %"SC_FORMAT_LEN_SIZE_T"u of %04X: %s\n",
 			rec, file->id, sc_strerror(r));
@@ -1732,7 +1732,7 @@ static int do_update_record(int argc, char **argv)
 
 	r = sc_lock(card);
 	if (r == SC_SUCCESS)
-		r = sc_update_record(card, rec, buf, buflen, SC_RECORD_BY_REC_NR);
+		r = sc_update_record(card, rec, 0, buf, buflen, SC_RECORD_BY_REC_NR);
 	sc_unlock(card);
 	if (r < 0) {
 		fprintf(stderr, "Cannot update record %"SC_FORMAT_LEN_SIZE_T"u of %04X: %s\n.",
@@ -2174,7 +2174,7 @@ static int do_asn1(int argc, char **argv)
 
 		r = sc_lock(card);
 		if (r == SC_SUCCESS)
-			r = sc_read_record(card, rec, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+			r = sc_read_record(card, rec, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 		else
 			r = SC_ERROR_READER_LOCKED;
 		sc_unlock(card);

--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -428,7 +428,7 @@ static int print_file(sc_card_t *in_card, const sc_file_t *file,
 			printf("Record %"SC_FORMAT_LEN_SIZE_T"u\n", rec_nr);
 			r = sc_lock(card);
 			if (r == SC_SUCCESS)
-				r = sc_read_record(in_card, rec_nr, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
+				r = sc_read_record(in_card, rec_nr, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 			sc_unlock(card);
 			if (r > 0)
 				util_hex_dump_asc(stdout, buf, r, 0);


### PR DESCRIPTION
This pull request is based on #2511 and it implements my changes on top of it. That is,
- sc_read_record and sc_update_record (and their driver call backs) get a new parameter idx for specifying an offset
- sc_read_record and sc_update_record can now handle big amounts of data that is split up into several chunks written or read with an offset

Currently changes are untested and I'd be happy to hear from @wcosnc whether it works properly now.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
