### PR TITLE
Fix for 'Coverity scan' CID 380537

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5552,7 +5552,14 @@ pkcs15_skey_encrypt(struct sc_pkcs11_session *session, void *obj,
 	   can be an init operation or final operation..*/
 
 	if (skey && !(skey->info->usage & SC_PKCS15_PRKEY_USAGE_ENCRYPT))
+		skey = NULL;
+
+	/* TODO: should we look for a compatible key automatically? prv_next not implemented yet. */
+	/* skey = skey->prv_next; */
+
+	if (skey == NULL)
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
 	sc_log(context, "Using mechanism %lx.", pMechanism->mechanism);
 
 	switch (pMechanism->mechanism) {


### PR DESCRIPTION
	modified:   src/pkcs11/framework-pkcs15.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

- [x] PKCS#11 module is tested
