### PR TITLE
symmetric decryption

### DIFF
--- a/.github/test-oseid.sh
+++ b/.github/test-oseid.sh
@@ -44,7 +44,7 @@ echo | ./OsEID-tool INIT
 ./OsEID-tool EC-ECDH-TEST
 ./OsEID-tool UNWRAP-WRAP-TEST
 ./OsEID-tool DES-AES-UPLOAD-KEYS
-./OsEID-tool SYM-ENCRYPT-TEST
+./OsEID-tool SYM-CRYPT-TEST
 popd
 
 # this does not work as we have random key IDs in here

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -2095,13 +2095,12 @@ myeid_encrypt_sym(struct sc_card *card, const u8 *data, size_t datalen, u8 *out,
 {
 	return myeid_enc_dec_sym(card, data, datalen, out, outlen, 0);
 }
-/*
+
 static int
 myeid_decrypt_sym(struct sc_card *card, const u8 *data, size_t datalen, u8 *out, size_t *outlen)
 {
 	return myeid_enc_dec_sym(card, data, datalen, out, outlen, 1);
 }
-*/
 
 static struct sc_card_driver * sc_get_driver(void)
 {
@@ -2134,7 +2133,7 @@ static struct sc_card_driver * sc_get_driver(void)
 	myeid_ops.wrap			= myeid_wrap_key;
 	myeid_ops.unwrap		= myeid_unwrap_key;
 	myeid_ops.encrypt_sym		= myeid_encrypt_sym;
-/*	myeid_ops.decrypt_sym		= myeid_decrypt_sym;*/
+	myeid_ops.decrypt_sym		= myeid_decrypt_sym;
 	return &myeid_drv;
 }
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1325,7 +1325,8 @@ static struct sc_card_operations iso_ops = {
 	NULL,			/* card_reader_lock_obtained */
 	NULL,			/* wrap */
 	NULL,			/* unwrap */
-	NULL			/* encrypt_sym */
+	NULL,			/* encrypt_sym */
+	NULL			/* decrypt_sym */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/libopensc.exports
+++ b/src/libopensc/libopensc.exports
@@ -83,6 +83,7 @@ sc_ctx_use_reader
 sc_ctx_win32_get_config_value
 _sc_delete_reader
 sc_decipher
+sc_decrypt_sym
 sc_delete_file
 sc_delete_record
 sc_der_copy
@@ -183,6 +184,7 @@ sc_pkcs15_encode_tokeninfo
 sc_pkcs15_encode_unusedspace
 sc_pkcs15_encrypt_sym
 sc_pkcs15_erase_pubkey
+sc_pkcs15_decrypt_sym
 sc_pkcs15_dup_pubkey
 sc_pkcs15_find_cert_by_id
 sc_pkcs15_find_data_object_by_app_oid

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -818,6 +818,8 @@ struct sc_card_operations {
 
 	int (*encrypt_sym)(struct sc_card *card, const u8 *plaintext, size_t plaintext_len,
 			u8 *out, size_t *outlen);
+	int (*decrypt_sym)(struct sc_card *card, const u8 *EncryptedData, size_t EncryptedDataLen,
+			u8 *out, size_t *outlen);
 };
 
 typedef struct sc_card_driver {
@@ -1383,6 +1385,9 @@ int sc_reset_retry_counter(struct sc_card *card, unsigned int type,
 int sc_build_pin(u8 *buf, size_t buflen, struct sc_pin_cmd_pin *pin, int pad);
 
 int sc_encrypt_sym(struct sc_card *card, const u8 *Data, size_t DataLen,
+		u8 *out, size_t *outlen);
+
+int sc_decrypt_sym(struct sc_card *card, const u8 *EncryptedData, size_t EncryptedDataLen,
 		u8 *out, size_t *outlen);
 
 /********************************************************************/

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -870,3 +870,90 @@ sc_pkcs15_encrypt_sym(struct sc_pkcs15_card *p15card,
 
 	LOG_FUNC_RETURN(ctx, r);
 }
+
+int
+sc_pkcs15_decrypt_sym(struct sc_pkcs15_card *p15card,
+		const struct sc_pkcs15_object *obj,
+		unsigned long flags,
+		const u8 *in, size_t inlen, u8 *out, size_t *outlen,
+		const u8 *param, size_t paramlen)
+{
+
+	sc_context_t *ctx = p15card->card->ctx;
+
+	int i, r;
+	sc_algorithm_info_t *alg_info = NULL;
+	sc_security_env_t senv;
+	sc_sec_env_param_t senv_param;
+	const struct sc_pkcs15_skey_info *skey;
+	unsigned long pad_flags = 0, sec_flags = 0;
+	int revalidated_cached_pin = 0;
+	sc_path_t path;
+
+	sc_log(ctx, "called with flags 0x%lX", flags);
+
+	skey = (const struct sc_pkcs15_skey_info *)obj->data;
+	if (!(skey->usage & SC_PKCS15_PRKEY_USAGE_DECRYPT))
+		LOG_TEST_RET(ctx, SC_ERROR_NOT_ALLOWED, "This key cannot be used for encryption");
+
+	r = format_senv(p15card, obj, &senv, &alg_info);
+	LOG_TEST_RET(ctx, r, "Could not initialize security environment");
+	senv.operation = SC_SEC_OPERATION_DECRYPT_SYM;
+
+	r = sc_get_encoding_flags(ctx, flags, alg_info->flags, &pad_flags, &sec_flags);
+	LOG_TEST_RET(ctx, r, "cannot encode security operation flags");
+	senv.algorithm_flags = sec_flags;
+
+	for (i = 0; i < SC_MAX_SUPPORTED_ALGORITHMS && senv.supported_algos[i].reference; i++) {
+		if ((senv.supported_algos[i].mechanism == CKM_AES_ECB && sec_flags == SC_ALGORITHM_AES_ECB) ||
+				(senv.supported_algos[i].mechanism == CKM_AES_CBC && sec_flags == SC_ALGORITHM_AES_CBC) ||
+				(senv.supported_algos[i].mechanism == CKM_AES_CBC_PAD && sec_flags == SC_ALGORITHM_AES_CBC_PAD)) {
+			senv.algorithm_ref = senv.supported_algos[i].algo_ref;
+			senv.flags |= SC_SEC_ENV_ALG_REF_PRESENT;
+			break;
+		}
+	}
+
+	if ((sec_flags & (SC_ALGORITHM_AES_CBC | SC_ALGORITHM_AES_CBC_PAD)) > 0) {
+		senv_param = (sc_sec_env_param_t){
+				SC_SEC_ENV_PARAM_IV, (void *)param, paramlen};
+		LOG_TEST_RET(ctx, sec_env_add_param(&senv, &senv_param), "failed to add IV to security environment");
+	}
+
+	LOG_TEST_RET(p15card->card->ctx, get_file_path(obj, &path), "Failed to get key file path.");
+
+	LOG_TEST_RET(p15card->card->ctx, r, "sc_lock() failed");
+
+	do {
+		r = SC_SUCCESS;
+		if (outlen == NULL) {
+			/* C_DecryptInit */
+			/* select key file and set sec env */
+			if (path.len != 0 || path.aid.len != 0) {
+				r = select_key_file(p15card, obj, &senv);
+				if (r < 0)
+					sc_log(p15card->card->ctx, "Unable to select key file");
+			}
+			if (r == SC_SUCCESS) {
+				r = sc_set_security_env(p15card->card, &senv, 0);
+				if (r < 0)
+					sc_log(p15card->card->ctx, "Unable to set security env");
+			}
+		}
+
+		if (r == SC_SUCCESS)
+			r = sc_decrypt_sym(p15card->card, in, inlen, out, outlen);
+
+		if (revalidated_cached_pin)
+			/* only re-validate once */
+			break;
+		if (r == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED) {
+			r = sc_pkcs15_pincache_revalidate(p15card, obj);
+			if (r < 0)
+				break;
+			revalidated_cached_pin = 1;
+		}
+	} while (revalidated_cached_pin);
+
+	LOG_FUNC_RETURN(ctx, r);
+}

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -686,6 +686,12 @@ int sc_pkcs15_encrypt_sym(struct sc_pkcs15_card *p15card,
 		const u8 *in, size_t inlen, u8 *out, size_t *outlen,
 		const u8 *param, size_t paramlen);
 
+int sc_pkcs15_decrypt_sym(struct sc_pkcs15_card *p15card,
+		const struct sc_pkcs15_object *obj,
+		unsigned long flags,
+		const u8 *in, size_t inlen, u8 *out, size_t *outlen,
+		const u8 *param, size_t paramlen);
+
 int sc_pkcs15_read_pubkey(struct sc_pkcs15_card *,
 		const struct sc_pkcs15_object *, struct sc_pkcs15_pubkey **);
 int sc_pkcs15_decode_pubkey_rsa(struct sc_context *,

--- a/src/libopensc/sec.c
+++ b/src/libopensc/sec.c
@@ -353,3 +353,19 @@ sc_encrypt_sym(struct sc_card *card, const u8 *plaintext, size_t plaintext_len,
 	r = card->ops->encrypt_sym(card, plaintext, plaintext_len, out, outlen);
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
 }
+
+int
+sc_decrypt_sym(struct sc_card *card, const u8 *data, size_t data_len,
+		u8 *out, size_t *outlen)
+{
+	int r;
+
+	if (card == NULL)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	LOG_FUNC_CALLED(card->ctx);
+	if (card->ops->decrypt_sym == NULL)
+		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_NOT_SUPPORTED);
+	r = card->ops->decrypt_sym(card, data, data_len, out, outlen);
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
+}

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4396,6 +4396,21 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 	unsigned char decrypted[512]; /* FIXME: Will not work for keys above 4096 bits */
 	int	buff_too_small, rv, flags = 0, prkey_has_path = 0;
 
+	if (pulDataLen == NULL) {
+		/* This is call from the C_DecyptInit function */
+		sc_log(context, "C_DecryptInit...");
+		return CKR_OK;
+	}
+	if (pEncryptedData == NULL && ulEncryptedDataLen == 0) {
+		/* This is call from the C_DecryptFinalize function */
+		sc_log(context, "C_DecryptFinalize...");
+		*pulDataLen = 0;
+		return CKR_OK;
+	}
+	/* DecryptUpdate: we assume this code is called only once per session, either
+	 * from the C_Decrypt function or from an application using the C_DecryptUpdate call
+	 */
+
 	sc_log(context, "Initiating decryption.");
 
 	if (!p11card)

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2387,7 +2387,6 @@ pkcs15_create_private_key(struct sc_pkcs11_slot *slot, struct sc_profile *profil
 out:	return rv;
 }
 
-
 /*
  * Secret key objects can be stored on card, if the card supports them
  *
@@ -5609,6 +5608,83 @@ pkcs15_skey_encrypt(struct sc_pkcs11_session *session, void *obj,
 	return sc_to_cryptoki_error(rv, "C_Encrypt...");
 }
 
+static CK_RV
+pkcs15_skey_decrypt(struct sc_pkcs11_session *session, void *obj,
+		CK_MECHANISM_PTR pMechanism,
+		CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen,
+		CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
+{
+	struct sc_pkcs11_card *p11card = session->slot->p11card;
+	struct pkcs15_fw_data *fw_data = NULL;
+	struct pkcs15_skey_object *skey = (struct pkcs15_skey_object *)obj;
+	int rv, flags = 0;
+	size_t lDataLen, *lpDataLen;
+
+	if (!p11card)
+		return sc_to_cryptoki_error(SC_ERROR_INVALID_CARD, "C_Decrypt...");
+	fw_data = (struct pkcs15_fw_data *)p11card->fws_data[session->slot->fw_data_idx];
+	if (!fw_data)
+		return sc_to_cryptoki_error(SC_ERROR_INTERNAL, "C_Decrypt...");
+	if (!fw_data->p15_card)
+		return sc_to_cryptoki_error(SC_ERROR_INVALID_CARD, "C_Decrypt...");
+
+	if (pMechanism == NULL) {
+		sc_log(context, "No mechanism specified\n");
+		return CKR_ARGUMENTS_BAD;
+	}
+
+	/* do not check NULL/0 in Data/DecryptedData here, this
+	   can be an init operation or final operation..*/
+
+	if (skey && !(skey->info->usage & SC_PKCS15_PRKEY_USAGE_DECRYPT))
+		skey = NULL;
+
+	/* Please read comments in pkcs15_skey_unwrap() and pkcs15_skey_wrap() */
+
+	if (skey == NULL)
+		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	sc_log(context, "Using mechanism %lx.", pMechanism->mechanism);
+
+	switch (pMechanism->mechanism) {
+	case CKM_AES_ECB:
+		/* handle this in card driver
+		if (ulDataLen % 16)
+			return CKR_DATA_LEN_RANGE; */
+		flags |= SC_ALGORITHM_AES_ECB;
+		break;
+	case CKM_AES_CBC:
+		/* handle this in card driver
+		if (ulDataLen % 16)
+			return CKR_DATA_LEN_RANGE; */
+		flags |= SC_ALGORITHM_AES_CBC;
+		break;
+	case CKM_AES_CBC_PAD:
+		flags |= SC_ALGORITHM_AES_CBC_PAD;
+		break;
+	default:
+		return CKR_MECHANISM_INVALID;
+	}
+
+	rv = sc_lock(p11card->card);
+
+	if (rv < 0)
+		return sc_to_cryptoki_error(rv, "C_Decrypt...");
+
+	/* pointer CK_ULONG_PTR to size_t conversion */
+	lpDataLen = pulDataLen ? &lDataLen : NULL;
+
+	rv = sc_pkcs15_decrypt_sym(fw_data->p15_card, skey->prv_p15obj, flags,
+			pEncryptedData, ulEncryptedDataLen, pData, lpDataLen,
+			pMechanism->pParameter, pMechanism->ulParameterLen);
+
+	if (pulDataLen)
+		*pulDataLen = *lpDataLen;
+
+	sc_unlock(p11card->card);
+	return sc_to_cryptoki_error(rv, "C_Decrypt...");
+}
+
 /*
  *  Secret key objects, currently used only to retrieve derived session key
  */
@@ -5621,7 +5697,7 @@ struct sc_pkcs11_object_ops pkcs15_skey_ops = {
 	NULL,	/* get_size */
 	NULL,	/* sign */
 	pkcs15_skey_unwrap,
-	NULL,	/* decrypt */
+	pkcs15_skey_decrypt,	/* decrypt */
 	pkcs15_skey_encrypt,	/* encrypt */
 	NULL,	/* derive */
 	NULL,	/* can_do */

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -66,7 +66,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha1_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL,NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -87,7 +87,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha224_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -108,7 +108,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha256_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -129,7 +129,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha384_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -150,7 +150,7 @@ static sc_pkcs11_mechanism_type_t openssl_sha512_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -171,7 +171,7 @@ static sc_pkcs11_mechanism_type_t openssl_gostr3411_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL,NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -192,7 +192,7 @@ static sc_pkcs11_mechanism_type_t openssl_md5_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */
@@ -213,7 +213,7 @@ static sc_pkcs11_mechanism_type_t openssl_ripemd160_mech = {
 	sc_pkcs11_openssl_md_final,
 	NULL, NULL, NULL, NULL,	/* sign_* */
 	NULL, NULL, NULL,	/* verif_* */
-	NULL, NULL,		/* decrypt_* */
+	NULL, NULL, NULL, NULL,	/* decrypt_* */
 	NULL, NULL, NULL, NULL, /* encrypt */
 	NULL,			/* derive */
 	NULL,			/* wrap */

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -303,6 +303,11 @@ struct sc_pkcs11_mechanism_type {
 					CK_BYTE_PTR, CK_ULONG);
 	CK_RV		  (*decrypt_init)(sc_pkcs11_operation_t *,
 					struct sc_pkcs11_object *);
+	CK_RV		  (*decrypt_update)(sc_pkcs11_operation_t *,
+					CK_BYTE_PTR, CK_ULONG,
+					CK_BYTE_PTR, CK_ULONG_PTR);
+	CK_RV		  (*decrypt_final)(sc_pkcs11_operation_t *,
+					CK_BYTE_PTR, CK_ULONG_PTR);
 	CK_RV		  (*decrypt)(sc_pkcs11_operation_t *,
 					CK_BYTE_PTR, CK_ULONG,
 					CK_BYTE_PTR, CK_ULONG_PTR);
@@ -470,6 +475,8 @@ CK_RV sc_pkcs11_verif_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG);
 #endif
 CK_RV sc_pkcs11_decr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_KEY_TYPE);
 CK_RV sc_pkcs11_decr(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV sc_pkcs11_decr_update(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV sc_pkcs11_decr_final(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG_PTR);
 
 CK_RV sc_pkcs11_encr_init(struct sc_pkcs11_session *, CK_MECHANISM_PTR, struct sc_pkcs11_object *, CK_MECHANISM_TYPE);
 CK_RV sc_pkcs11_encr(struct sc_pkcs11_session *, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);


### PR DESCRIPTION
pkcs#11 - new functions: C_DecryptUpdate() and C_DecryptFinal()
adapted functions: C_DecryptInit(), C_Decrypt()

pkcs#15 - new functions: pkcs15_skey_decrypt, sc_pkcs15_decrypt_sym
adapted function: pkcs15_prkey_decrypt()
also implements: sc_decrypt_sym

MyEID driver: support for symmetric decrypt (AES-ECB, AES-CBC, AES-CBC-PAD).


- [x] PKCS#11 module is tested
