### PR TITLE
Define arm64 as a supported architecture in the Installer package

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,8 @@ on:
       - .github/build.sh
       - .github/push-artifacts.sh
       - '**.am'
+      - MacOSX/build-package.in
+      - 'MacOSX/Distribution*.xml.in'
   push:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ win32/OpenSC.wixobj
 win32/OpenSC.wixpdb
 
 MacOSX/build-package
-MacOSX/Distribution.xml
+MacOSX/Distribution*.xml
 
 *.dmg
 *.pkg

--- a/MacOSX/Distribution_universal.xml.in
+++ b/MacOSX/Distribution_universal.xml.in
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--
+https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/DistributionDefinitionRef/
+-->
+<installer-gui-script minSpecVersion="2">
+    <allowed-os-versions>
+      <os-version min="10.10"/>
+    </allowed-os-versions>
+    <background file="background.jpg" mime-type="image/jpeg" scaling="tofit"/>
+    <welcome file="Welcome.html" mime-type="text/html"/>
+    <title>@PACKAGE_STRING@</title>
+    <options customize="allow" hostArchitectures="arm64,x86_64" require-scripts="false" rootVolumeOnly="true"/>
+    <script>
+      <![CDATA[
+	function osx_before_catalina() {
+	 if((system.compareVersions(system.version.ProductVersion, '10.15')) == -1)
+	 {
+	  return true;
+	 }
+	 else
+	 {
+	  return false;
+	 }
+	}
+	function osx_after_catalina() {
+	 if((system.compareVersions(system.version.ProductVersion, '10.15')) >= 0)
+	 {
+	  return true;
+	 }
+	 else
+	 {
+	  return false;
+	 }
+	}
+	function osx_after_yosemite() {
+	 if((system.compareVersions(system.version.ProductVersion, '10.12')) >= 0)
+	 {
+	  return true;
+	 }
+	 else
+	 {
+	  return false;
+	 }
+	}
+      ]]>
+    </script>
+    <choices-outline>
+        <line choice="default" />
+        <line choice="startup" />
+        <line choice="tokend" />
+        <line choice="token" />
+    </choices-outline>
+    <choice id="default" title="PKCS#11 module and smart card tools" enabled="false">
+        <pkg-ref id="org.opensc-project.mac">OpenSC.pkg</pkg-ref>
+    </choice>
+    <choice id="tokend" title="TokenD-based smart card driver" start_selected="osx_before_catalina()">
+        <pkg-ref id="org.opensc-project.tokend">OpenSC-tokend.pkg</pkg-ref>
+    </choice>
+    <choice id="token" title="CryptoTokenKit-based smart card driver" visible="osx_after_yosemite()" start_selected="osx_after_catalina()">
+        <pkg-ref id="org.opensc-project.mac.opensctoken">OpenSCToken.pkg</pkg-ref>
+    </choice>
+    <choice id="startup" title="Automatic startup items">
+        <pkg-ref id="org.opensc-project.startup">OpenSC-startup.pkg</pkg-ref>
+    </choice>
+</installer-gui-script>

--- a/MacOSX/Makefile.am
+++ b/MacOSX/Makefile.am
@@ -1,5 +1,10 @@
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
-EXTRA_DIST = build build-package.in Distribution.xml.in libtool-bundle opensc-uninstall \
+EXTRA_DIST = build \
+	build-package.in \
+	Distribution.xml.in \
+	Distribution_universal.xml.in \
+	libtool-bundle \
+	opensc-uninstall \
 	resources \
 	resources/background.jpg \
 	resources/Welcome.html.in \

--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -58,6 +58,9 @@ export CFLAGS="$CFLAGS -isysroot $SDK_PATH"
 if test -n "${BUILD_ARM}"; then
 	export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
 	export LDFLAGS="$LDFLAGS -arch x86_64 -arch arm64"
+	DISTRIBUTION_XML=MacOSX/Distribution_universal.xml
+else
+	DISTRIBUTION_XML=MacOSX/Distribution.xml
 fi
 export OBJCFLAGS=$CFLAGS
 
@@ -220,7 +223,7 @@ pkgbuild --root ${BUILDPATH}/target_token $COMPONENT_TOKEN --identifier org.open
 pkgbuild --root ${BUILDPATH}/target_startup --component-plist MacOSX/target_startup.plist --identifier org.opensc-project.startup --version @PACKAGE_VERSION@ --install-location / OpenSC-startup.pkg
 
 # Build product
-productbuild --distribution MacOSX/Distribution.xml --package-path . --resources MacOSX/resources "${imagedir}/OpenSC @PACKAGE_VERSION@.pkg"
+productbuild --distribution $DISTRIBUTION_XML --package-path . --resources MacOSX/resources "${imagedir}/OpenSC @PACKAGE_VERSION@.pkg"
 
 # Sign installer
 if test -n "${INSTALLER_SIGN_IDENTITY}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1150,6 +1150,7 @@ AC_CONFIG_FILES([
 	MacOSX/Makefile
 	MacOSX/build-package
 	MacOSX/Distribution.xml
+	MacOSX/Distribution_universal.xml
 	MacOSX/resources/Welcome.html
 ])
 


### PR DESCRIPTION
The Installer app assumes that the package requires Rosetta 2, unless arm64 is explicitly declared.

s. https://scriptingosx.com/2020/12/platform-support-in-macos-installer-packages-pkg/

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-→

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

Fixes #2608 