### PR TITLE
Remove unneeded linking and flags from compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,6 +554,10 @@ case "${host}" in
 							   have_notify="no"
 							   have_gio2="no"  ])
 			LIBS="$saved_LIBS"
+			if test "${have_gio2}" = "yes"; then
+				# we do not need lglib-2.0
+				GIO2_LIBS="-lgio-2.0 -lgobject-2.0"
+			fi
 		;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -466,9 +466,20 @@ AC_CHECK_LIB(
 
 if test "${WIN32}" = "no"; then
 	dnl dl support
-	AC_SEARCH_LIBS([dlopen], [dl dld], [], [
-		AC_MSG_ERROR([unable to find the dlopen() function])
-	])
+	AC_ARG_VAR([LDL_LIBS], [linker flags for ldl])
+	if test -z "${LDL_LIBS}"; then
+		AC_CHECK_LIB(
+			[dl],
+			[dlopen],
+			[LDL_LIBS="-ldl"],
+			AC_CHECK_LIB(
+				[dld],
+				[dlopen],
+				[LDL_LIBS="-ldld"],
+				AC_MSG_ERROR([unable to find the dlopen() function])
+			)
+		)
+	fi
 
 	dnl Special check for pthread support.
 	AX_PTHREAD(
@@ -1208,6 +1219,7 @@ Compiler flags:          ${CFLAGS}
 Linker flags:            ${LDFLAGS}
 Libraries:               ${LIBS}
 
+LDL_LIBS:                ${LDL_LIBS}
 READLINE_CFLAGS:         ${READLINE_CFLAGS}
 READLINE_LIBS:           ${READLINE_LIBS}
 ZLIB_CFLAGS:             ${ZLIB_CFLAGS}

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -28,6 +28,7 @@ compat_getopt_main_LDADD = libcompat.la
 libpkcs11_la_SOURCES = libpkcs11.c
 
 libscdl_la_SOURCES = libscdl.c
+libscdl_la_LIBADD = $(LDL_LIBS)
 
 TIDY_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 TIDY_FILES = \

--- a/src/sm/Makefile.am
+++ b/src/sm/Makefile.am
@@ -20,6 +20,8 @@ AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(OPTIONAL_READLINE_CFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src/include
 
 libsm_la_SOURCES = sm-common.c sm-common.h
+libsm_la_LIBADD = $(OPENSSL_LIBS)
+libsm_la_CFLAGS = $(OPENSSL_CFLAGS)
 
 libsmiso_la_SOURCES = sm-iso.c
 

--- a/src/smm/Makefile.am
+++ b/src/smm/Makefile.am
@@ -20,7 +20,7 @@ libsmm_local_la_SOURCES = smm-local.c sm-module.h \
 	sm-global-platform.c sm-cwa14890.c \
 	sm-card-authentic.c sm-card-iasecc.c \
 	smm-local.exports
-libsmm_local_la_LIBADD = $(OPTIONAL_OPENSSL_LIBS) ../libopensc/libopensc.la
+libsmm_local_la_LIBADD = $(OPTIONAL_OPENSSL_LIBS)
 libsmm_local_la_LDFLAGS = -module -shared -no-undefined -version-info @OPENSC_LT_CURRENT@:@OPENSC_LT_REVISION@:@OPENSC_LT_AGE@
 
 # noinst_HEADERS = sm.h

--- a/src/tests/p11test/Makefile.am
+++ b/src/tests/p11test/Makefile.am
@@ -35,7 +35,7 @@ p11test_SOURCES = p11test.c p11test_loader.c \
 	p11test_case_secret.c \
 	p11test_helpers.c
 p11test_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(CMOCKA_CFLAGS)
-p11test_LDADD = $(OPTIONAL_OPENSSL_LIBS) $(CMOCKA_LIBS)
+p11test_LDADD = $(OPTIONAL_OPENSSL_LIBS) $(CMOCKA_LIBS) $(LDL_LIBS)
 
 if WIN32
 p11test_SOURCES += $(top_builddir)/win32/versioninfo.rc

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -93,7 +93,7 @@ gids_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 npa_tool_SOURCES = npa-tool.c fread_to_eof.c util.c npa-tool-cmdline.c
 npa_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la \
 				 $(OPENPACE_LIBS)
-npa_tool_CFLAGS = -I$(top_srcdir)/src $(OPENPACE_CFLAGS) $(OPENSSL_CFLAGS)
+npa_tool_CFLAGS = -I$(top_srcdir)/src $(OPENPACE_CFLAGS)
 npa_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 npa_tool_CFLAGS += -Wno-unknown-warning-option

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -38,7 +38,7 @@ bin_PROGRAMS += cryptoflex-tool pkcs15-init netkey-tool piv-tool \
 endif
 
 # compile with $(PTHREAD_CFLAGS) to allow debugging with gdb
-AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(OPTIONAL_READLINE_CFLAGS) $(PTHREAD_CFLAGS)
+AM_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(OPTIONAL_READLINE_CFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)/src -D'DEFAULT_PKCS11_PROVIDER="$(DEFAULT_PKCS11_PROVIDER)"' -D'DEFAULT_ONEPIN_PKCS11_PROVIDER="$(DEFAULT_ONEPIN_PKCS11_PROVIDER)"'
 LIBS = \
 	$(top_builddir)/src/libopensc/libopensc.la \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -93,7 +93,7 @@ gids_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 npa_tool_SOURCES = npa-tool.c fread_to_eof.c util.c npa-tool-cmdline.c
 npa_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la \
 				 $(OPENPACE_LIBS)
-npa_tool_CFLAGS = -I$(top_srcdir)/src $(OPENPACE_CFLAGS)
+npa_tool_CFLAGS = -$(OPENPACE_CFLAGS)
 npa_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 npa_tool_CFLAGS += -Wno-unknown-warning-option
@@ -101,7 +101,7 @@ endif
 
 opensc_notify_SOURCES = opensc-notify.c opensc-notify-cmdline.c
 opensc_notify_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPTIONAL_NOTIFY_LIBS)
-opensc_notify_CFLAGS = -I$(top_srcdir)/src $(PTHREAD_CFLAGS) $(OPTIONAL_NOTIFY_CFLAGS)
+opensc_notify_CFLAGS = $(PTHREAD_CFLAGS) $(OPTIONAL_NOTIFY_CFLAGS)
 opensc_notify_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_notify_CFLAGS += -Wno-unknown-warning-option
@@ -109,7 +109,7 @@ endif
 
 egk_tool_SOURCES = egk-tool.c util.c egk-tool-cmdline.c
 egk_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPTIONAL_ZLIB_LIBS)
-egk_tool_CFLAGS = -I$(top_srcdir)/src $(OPTIONAL_ZLIB_CFLAGS)
+egk_tool_CFLAGS = $(OPTIONAL_ZLIB_CFLAGS)
 egk_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 egk_tool_CFLAGS += -Wno-unknown-warning-option
@@ -117,7 +117,7 @@ endif
 
 goid_tool_SOURCES = goid-tool.c util.c fread_to_eof.c goid-tool-cmdline.c
 goid_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPENPACE_LIBS)
-goid_tool_CFLAGS = -I$(top_srcdir)/src $(OPENPACE_CFLAGS)
+goid_tool_CFLAGS = $(OPENPACE_CFLAGS)
 goid_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 goid_tool_CFLAGS += -Wno-unknown-warning-option
@@ -125,15 +125,13 @@ endif
 
 opensc_asn1_SOURCES = opensc-asn1.c fread_to_eof.c opensc-asn1-cmdline.c
 opensc_asn1_LDADD = $(top_builddir)/src/libopensc/libopensc.la
-opensc_asn1_CFLAGS = -I$(top_srcdir)/src
-opensc_asn1_CFLAGS += -Wno-unused-but-set-variable
+opensc_asn1_CFLAGS = -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_asn1_CFLAGS += -Wno-unknown-warning-option
 endif
 
 pkcs11_register_SOURCES = pkcs11-register.c fread_to_eof.c pkcs11-register-cmdline.c
-pkcs11_register_CFLAGS = -I$(top_srcdir)/src
-pkcs11_register_CFLAGS += -Wno-unused-but-set-variable -Wno-unused-function
+pkcs11_register_CFLAGS = -Wno-unused-but-set-variable -Wno-unused-function
 pkcs11_register_LDADD = \
 	$(top_builddir)/src/common/libpkcs11.la
 if HAVE_UNKNOWN_WARNING_OPTION

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -93,7 +93,6 @@ gids_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 npa_tool_SOURCES = npa-tool.c fread_to_eof.c util.c npa-tool-cmdline.c
 npa_tool_LDADD = $(OPENPACE_LIBS)
 npa_tool_CFLAGS = $(OPENPACE_CFLAGS)
-npa_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 npa_tool_CFLAGS += -Wno-unknown-warning-option
 endif
@@ -101,7 +100,6 @@ endif
 opensc_notify_SOURCES = opensc-notify.c opensc-notify-cmdline.c
 opensc_notify_LDADD = $(OPTIONAL_NOTIFY_LIBS)
 opensc_notify_CFLAGS = $(PTHREAD_CFLAGS) $(OPTIONAL_NOTIFY_CFLAGS)
-opensc_notify_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_notify_CFLAGS += -Wno-unknown-warning-option
 endif
@@ -109,7 +107,6 @@ endif
 egk_tool_SOURCES = egk-tool.c util.c egk-tool-cmdline.c
 egk_tool_LDADD = $(OPTIONAL_ZLIB_LIBS)
 egk_tool_CFLAGS = $(OPTIONAL_ZLIB_CFLAGS)
-egk_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 egk_tool_CFLAGS += -Wno-unknown-warning-option
 endif
@@ -117,23 +114,19 @@ endif
 goid_tool_SOURCES = goid-tool.c util.c fread_to_eof.c goid-tool-cmdline.c
 goid_tool_LDADD = $(OPENPACE_LIBS)
 goid_tool_CFLAGS = $(OPENPACE_CFLAGS)
-goid_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 goid_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 opensc_asn1_SOURCES = opensc-asn1.c fread_to_eof.c opensc-asn1-cmdline.c
-opensc_asn1_CFLAGS = -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
-opensc_asn1_CFLAGS += -Wno-unknown-warning-option
+opensc_asn1_CFLAGS = -Wno-unknown-warning-option
 endif
 
 pkcs11_register_SOURCES = pkcs11-register.c fread_to_eof.c pkcs11-register-cmdline.c
-pkcs11_register_CFLAGS = -Wno-unused-but-set-variable -Wno-unused-function
-pkcs11_register_LDADD = \
-	$(top_builddir)/src/common/libpkcs11.la
+pkcs11_register_LDADD =	$(top_builddir)/src/common/libpkcs11.la
 if HAVE_UNKNOWN_WARNING_OPTION
-pkcs11_register_CFLAGS += -Wno-unknown-warning-option
+pkcs11_register_CFLAGS = -Wno-unknown-warning-option
 endif
 
 .PHONY: cmdline

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -98,8 +98,7 @@ npa_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 opensc_notify_SOURCES = opensc-notify.c opensc-notify-cmdline.c
-opensc_notify_LDADD = $(OPTIONAL_NOTIFY_LIBS)
-opensc_notify_CFLAGS = $(PTHREAD_CFLAGS) $(OPTIONAL_NOTIFY_CFLAGS)
+opensc_notify_CFLAGS = $(PTHREAD_CFLAGS)
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_notify_CFLAGS += -Wno-unknown-warning-option
 endif

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -60,7 +60,7 @@ pkcs11_tool_SOURCES = pkcs11-tool.c util.c
 pkcs11_tool_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(PTHREAD_CFLAGS)
 pkcs11_tool_LDADD = \
 	$(top_builddir)/src/common/libpkcs11.la \
-	$(OPTIONAL_OPENSSL_LIBS) $(PTHREAD_CFLAGS)
+	$(OPTIONAL_OPENSSL_LIBS)
 if ENABLE_SHARED
 else
 pkcs11_tool_LDADD += \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -124,8 +124,8 @@ goid_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 opensc_asn1_SOURCES = opensc-asn1.c fread_to_eof.c opensc-asn1-cmdline.c
-opensc_asn1_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPTIONAL_ZLIB_LIBS)
-opensc_asn1_CFLAGS = -I$(top_srcdir)/src $(OPTIONAL_ZLIB_CFLAGS)
+opensc_asn1_LDADD = $(top_builddir)/src/libopensc/libopensc.la
+opensc_asn1_CFLAGS = -I$(top_srcdir)/src
 opensc_asn1_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_asn1_CFLAGS += -Wno-unknown-warning-option

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -91,16 +91,15 @@ gids_tool_SOURCES = gids-tool.c util.c
 gids_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS)
 
 npa_tool_SOURCES = npa-tool.c fread_to_eof.c util.c npa-tool-cmdline.c
-npa_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la \
-				 $(OPENPACE_LIBS)
-npa_tool_CFLAGS = -$(OPENPACE_CFLAGS)
+npa_tool_LDADD = $(OPENPACE_LIBS)
+npa_tool_CFLAGS = $(OPENPACE_CFLAGS)
 npa_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 npa_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 opensc_notify_SOURCES = opensc-notify.c opensc-notify-cmdline.c
-opensc_notify_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPTIONAL_NOTIFY_LIBS)
+opensc_notify_LDADD = $(OPTIONAL_NOTIFY_LIBS)
 opensc_notify_CFLAGS = $(PTHREAD_CFLAGS) $(OPTIONAL_NOTIFY_CFLAGS)
 opensc_notify_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
@@ -108,7 +107,7 @@ opensc_notify_CFLAGS += -Wno-unknown-warning-option
 endif
 
 egk_tool_SOURCES = egk-tool.c util.c egk-tool-cmdline.c
-egk_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPTIONAL_ZLIB_LIBS)
+egk_tool_LDADD = $(OPTIONAL_ZLIB_LIBS)
 egk_tool_CFLAGS = $(OPTIONAL_ZLIB_CFLAGS)
 egk_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
@@ -116,7 +115,7 @@ egk_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 goid_tool_SOURCES = goid-tool.c util.c fread_to_eof.c goid-tool-cmdline.c
-goid_tool_LDADD = $(top_builddir)/src/libopensc/libopensc.la $(OPENPACE_LIBS)
+goid_tool_LDADD = $(OPENPACE_LIBS)
 goid_tool_CFLAGS = $(OPENPACE_CFLAGS)
 goid_tool_CFLAGS += -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
@@ -124,7 +123,6 @@ goid_tool_CFLAGS += -Wno-unknown-warning-option
 endif
 
 opensc_asn1_SOURCES = opensc-asn1.c fread_to_eof.c opensc-asn1-cmdline.c
-opensc_asn1_LDADD = $(top_builddir)/src/libopensc/libopensc.la
 opensc_asn1_CFLAGS = -Wno-unused-but-set-variable
 if HAVE_UNKNOWN_WARNING_OPTION
 opensc_asn1_CFLAGS += -Wno-unknown-warning-option


### PR DESCRIPTION
This PR removes uneeded libraries and flags from linking of tools and opensc libraries. The `-ldl` is moved from `LIBS` to `LDL_LIBS` and is linked only when needed. Also `GIO_LIBS` contains only `-lgio-2.0 -lgobject-2.0`, as `lglib-2.0` is not needed.

Fixes  #2566, but there still may be redundant (transitive) dependencies as described in https://github.com/OpenSC/OpenSC/issues/2566#issuecomment-1206535919.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
