### PR TITLE
macOS: Correct LaunchAgent paths in opensc-uninstall script

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,8 +12,7 @@ on:
       - .github/build.sh
       - .github/push-artifacts.sh
       - '**.am'
-      - MacOSX/build-package.in
-      - 'MacOSX/Distribution*.xml.in'
+      - MacOSX/**
   push:
 
 jobs:

--- a/MacOSX/opensc-uninstall
+++ b/MacOSX/opensc-uninstall
@@ -32,13 +32,13 @@ rm -rf /Applications/Utilities/OpenSCTokenApp.app
 rm -rf "/Applications/Utilities/OpenSC Notify.app"
 rm -rf /Library/OpenSC
 rm -rf /Library/Security/tokend/OpenSC.tokend
-rm -f  /Library/LaunchAgents/pkcs11-register.plist
-rm -f  /Library/LaunchAgents/opensc-notify.plist
+rm -f  /Library/LaunchAgents/org.opensc-project.mac.pkcs11-register.plist
+rm -f  /Library/LaunchAgents/org.opensc-project.mac.opensc-notify.plist
 rm -rf /System/Library/Security/tokend/OpenSC.tokend
 
 # Unload launchagents
-launchctl remove pkcs11-register
-launchctl remove opensc-notify
+launchctl remove org.opensc-project.mac.pkcs11-register
+launchctl remove org.opensc-project.mac.opensc-notify
 
 # delete receipts on 10.6+
 pkgutil --forget org.opensc-project.mac             > /dev/null 2>/dev/null

--- a/MacOSX/opensc-uninstall
+++ b/MacOSX/opensc-uninstall
@@ -36,9 +36,13 @@ rm -f  /Library/LaunchAgents/org.opensc-project.mac.pkcs11-register.plist
 rm -f  /Library/LaunchAgents/org.opensc-project.mac.opensc-notify.plist
 rm -rf /System/Library/Security/tokend/OpenSC.tokend
 
-# Unload launchagents
-launchctl remove org.opensc-project.mac.pkcs11-register
-launchctl remove org.opensc-project.mac.opensc-notify
+# Remove LaunchAgents
+for label in \
+  org.opensc-project.mac.pkcs11-register \
+  org.opensc-project.mac.opensc-notify
+do
+  launchctl asuser "$(id -u "${SUDO_USER:-$USER}")" launchctl remove "$label"
+done
 
 # delete receipts on 10.6+
 pkgutil --forget org.opensc-project.mac             > /dev/null 2>/dev/null


### PR DESCRIPTION
This fixes an omission in e05574d94217e6fbd9186509a1b494fb30ee1431. The names of these files have changed, so they are not deregistered from LaunchServices and uninstalled when running the opensc-uninstall script.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
