### PR TITLE
Add actions for Packit

### DIFF
--- a/.github/actions/packit/Dockerfile
+++ b/.github/actions/packit/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/packit/packit
+
+RUN git config --system --add safe.directory /github/workspace
+
+ENTRYPOINT ["./.github/test-packit.sh"]

--- a/.github/actions/packit/action.yml
+++ b/.github/actions/packit/action.yml
@@ -1,0 +1,5 @@
+name: Packit RPM build
+description: Action that provides Packit RPM build
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/.github/test-packit.sh
+++ b/.github/test-packit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install build requirements
+REQUIREMENTS=$(sed -n -e '/^BuildRequires*/p' packaging/opensc.spec | sed 's/[^ ]* //')
+sudo dnf install -y ${REQUIREMENTS}
+
+# Run packit
+packit --debug build locally

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -1,0 +1,24 @@
+name: Packit
+on:
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.h'
+      - '**.am'
+  push:
+
+jobs:
+  packit_srpm:
+    runs-on: ubuntu-latest
+    name: Packit SRPM
+    steps:
+        - uses: actions/checkout@v3
+          with:
+              fetch-depth: 0
+        - uses: packit/actions/srpm@main
+        - name: Upload build artifacts
+          uses: actions/upload-artifact@v2
+          with:
+              name: opensc-srpm
+              path:
+                  opensc*.src.rpm

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -5,6 +5,7 @@ on:
       - '**.c'
       - '**.h'
       - '**.am'
+      - .github/workflows/packit.yaml
   push:
 
 jobs:

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -22,3 +22,17 @@ jobs:
               name: opensc-srpm
               path:
                   opensc*.src.rpm
+  packit_rpm:
+    runs-on: ubuntu-latest
+    name: Packit RPM
+    steps:
+        - uses: actions/checkout@v3
+          with:
+              fetch-depth: 0
+        - uses: ./.github/actions/packit
+        - name: Upload build artifacts
+          uses: actions/upload-artifact@v2
+          with:
+              name: opensc-rpm
+              path:
+                  x86_64/opensc*.rpm


### PR DESCRIPTION
The integration of Packit for testing the build on Fedora was already discussed in #2528.
Since there was a problem with installing the packit-as-a-service app in GH actions for OpenSC, this PR adds separate actions for creating SRPM and building RPM with Packit.

As the local build command that Packit provides does not install `BuildRequires` from the spec file nor provide a command for that, there is also a separate script providing the installation of the dependencies.