### PR TITLE
feat(pkcs11-tool): print CKA_UNIQUE_ID value for keys and certificates

### DIFF
--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -397,6 +397,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_TOKEN			(1UL)
 #define CKA_PRIVATE			(2UL)
 #define CKA_LABEL			(3UL)
+#define CKA_UNIQUE_ID		(4UL)
 #define CKA_APPLICATION			(0x10UL)
 #define CKA_VALUE			(0x11UL)
 #define CKA_OBJECT_ID			(0x12UL)

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -677,6 +677,7 @@ ATTR_METHOD(MODULUS_BITS, CK_ULONG);			/* getMODULUS_BITS */
 ATTR_METHOD(VALUE_LEN, CK_ULONG);			/* getVALUE_LEN */
 ATTR_METHOD(PROFILE_ID, CK_ULONG);			/* getPROFILE_ID */
 VARATTR_METHOD(LABEL, char);				/* getLABEL */
+VARATTR_METHOD(UNIQUE_ID, char);			/* getUNIQUE_ID */
 VARATTR_METHOD(APPLICATION, char);			/* getAPPLICATION */
 VARATTR_METHOD(ID, unsigned char);			/* getID */
 VARATTR_METHOD(OBJECT_ID, unsigned char);		/* getOBJECT_ID */
@@ -4851,6 +4852,7 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 	unsigned char	*id, *oid, *value;
 	const char      *sepa;
 	char		*label;
+	char		*unique_id;
 	int		pub = 1;
 	int		sec = 0;
 
@@ -5166,6 +5168,10 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 			printf("\n");
 		}
 	}
+	if ((unique_id = getUNIQUE_ID(sess, obj, NULL)) != NULL) {
+		printf("  Unique ID:  %s\n", unique_id);
+		free(unique_id);
+	}
 
 	suppress_warn = 0;
 }
@@ -5176,6 +5182,7 @@ static void show_cert(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 	CK_ULONG	size;
 	unsigned char	*id;
 	char		*label;
+	char		*unique_id;
 #if defined(ENABLE_OPENSSL)
 	unsigned char	*subject;
 	unsigned char	*serial_number;
@@ -5243,6 +5250,10 @@ static void show_cert(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 			printf("%02x", id[n]);
 		printf("\n");
 		free(id);
+	}
+	if ((unique_id = getUNIQUE_ID(sess, obj, NULL)) != NULL) {
+		printf("  Unique ID:  %s\n", unique_id);
+		free(unique_id);
 	}
 }
 


### PR DESCRIPTION
Hi All,
Our PKCS#11 implementation is using the CKA_UNIQUE_ID attribute and it is quite convenient to be able to display it with the pkcs11-tool.
This is the new output:
Certificate Object; type = X.509 cert
  subject:    DN: C=FR, ST=PACA, L=Valbonne, O=Trustonic, CN=*.trustonic.com
  serial:     63E2A7CA72264EAB2E1E70ADC52341D44EC2D4A7
  ID:         01
  **Unique ID:  cef6c9a53f838aff0bd8125c3b3b0631b4bcb1bbbee70de0d106b5504c63b92a71794f2aa765c6514e7a3f3770913fe3e03a3e3697aba0c8b6e64dbc1fcd0c14**

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
