### PR TITLE
feat(pkcs11-tool): add new --undestroyable

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -78,17 +78,17 @@
 					<listitem>
 						<para>
 							Specify hash algorithm used with RSA-PKCS-PSS signature or RSA-OAEP decryption.
-							Allowed values are "SHA-1", "SHA256", "SHA384", "SHA512", and some tokens may 
+							Allowed values are "SHA-1", "SHA256", "SHA384", "SHA512", and some tokens may
 							also allow "SHA224". Default is "SHA-1".
 						</para>
-						<para> 
+						<para>
 							Note that the input to RSA-PKCS-PSS has to be of the size equal to
 							the specified hash algorithm. E.g., for SHA256 the signature input must
 							be exactly 32 bytes long (for mechanisms SHA256-RSA-PKCS-PSS there is no
 							such restriction). For RSA-OAEP, the plaintext input size mLen must be
 							at most keyLen - 2 - 2*hashLen. For example, for RSA 3072-bit key and
 							SHA384, the longest plaintext to encrypt with RSA-OAEP is (with all
-							sizes in bytes): 384 - 2 - 2*48 = 286, aka 286 bytes. 
+							sizes in bytes): 384 - 2 - 2*48 = 286, aka 286 bytes.
 						</para>
 					</listitem>
 				</varlistentry>
@@ -357,6 +357,13 @@
 
 				<varlistentry>
 					<term>
+						<option>--undestroyable</option>
+					</term>
+					<listitem><para>Set the CKA_DESTROYABLE attribute to false (object cannot be destroyed)</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
 						<option>--set-id</option> <replaceable>id</replaceable>,
 						<option>-e</option> <replaceable>id</replaceable>
 					</term>
@@ -566,7 +573,7 @@
 					</term>
 					<listitem><para>Specify the type of object to operate on.
 					Valid value are <literal>cert</literal>, <literal>privkey</literal>,
-					<literal>pubkey</literal>, <literal>secrkey</literal> 
+					<literal>pubkey</literal>, <literal>secrkey</literal>
 					and <literal>data</literal>.</para></listitem>
 				</varlistentry>
 

--- a/doc/tools/tools.html
+++ b/doc/tools/tools.html
@@ -1557,6 +1557,8 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>Set the CKA_SENSITIVE attribute (object cannot be revealed in plaintext).</p></dd><dt><span class="term">
 						<code class="option">--extractable</code>
 					</span></dt><dd><p>Set the CKA_EXTRACTABLE attribute (object can be extracted)</p></dd><dt><span class="term">
+						<code class="option">--undestroyable</code>
+					</span></dt><dd><p>Set the CKA_DESTROYABLE attribute to false (object cannot be destroyed)</p></dd><dt><span class="term">
 						<code class="option">--set-id</code> <em class="replaceable"><code>id</code></em>,
 						<code class="option">-e</code> <em class="replaceable"><code>id</code></em>
 					</span></dt><dd><p>Set the CKA_ID of the object.</p></dd><dt><span class="term">

--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -450,6 +450,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_ALWAYS_SENSITIVE		(0x165UL)
 #define CKA_KEY_GEN_MECHANISM		(0x166UL)
 #define CKA_MODIFIABLE			(0x170UL)
+#define CKA_DESTROYABLE			(0x172UL)
 #define CKA_ECDSA_PARAMS		(0x180UL)
 #define CKA_EC_PARAMS			(0x180UL)
 #define CKA_EC_POINT			(0x181UL)


### PR DESCRIPTION
Hi All,

In this PR, I am adding a new option which can be used to mark the certificates as undestroyable.
Please, let me know if you want this option for the pkcs11-tool.
Regards,
Alexandre.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
