### PR TITLE
Fedora packaging update

### DIFF
--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -6,6 +6,7 @@ on:
       - '**.h'
       - '**.am'
       - .github/workflows/packit.yaml
+      - packaging/opensc.spec
   push:
 
 jobs:

--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -70,8 +70,7 @@ CFLAGS="$CFLAGS -Wstrict-aliasing=2 -Wno-deprecated-declarations"
   --disable-assert \
   --enable-pcsc \
   --enable-cmocka \
-  --enable-sm \
-  --with-pcsc-provider=libpcsclite.so.1
+  --enable-sm
 %make_build
 
 

--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -19,6 +19,7 @@ BuildRequires:  bash-completion
 BuildRequires:  zlib-devel
 # For tests
 BuildRequires:  libcmocka-devel
+BuildRequires:  vim-common
 BuildRequires:  softhsm
 BuildRequires:  openssl
 Requires:       pcsc-lite-libs%{?_isa}
@@ -44,7 +45,7 @@ every software/card that does so, too.
 
 # The test-pkcs11-tool-allowed-mechanisms already works in Fedora
 sed -i -e '/XFAIL_TESTS/,$ {
-  s/XFAIL_TESTS.*/XFAIL_TESTS=test-pkcs11-tool-test-threads.sh test-pkcs11-tool-test.sh test-pkcs11-tool-unwrap-wrap-test.sh/
+  s/XFAIL_TESTS.*/XFAIL_TESTS=test-pkcs11-tool-test-threads.sh test-pkcs11-tool-test.sh/
   q
 }' tests/Makefile.am
 
@@ -63,7 +64,7 @@ sed -i -e 's/opensc.conf/opensc-%{_arch}.conf/g' src/libopensc/Makefile.in
 sed -i -e 's|"/lib /usr/lib\b|"/%{_lib} %{_libdir}|' configure # lib64 rpaths
 %set_build_flags
 CFLAGS="$CFLAGS -Wstrict-aliasing=2 -Wno-deprecated-declarations"
-%configure --disable-static\
+%configure --disable-static \
   --disable-autostart-items \
   --disable-notify \
   --disable-assert \


### PR DESCRIPTION
Fixes #2633

This is sync with Fedora spec file (missing dependency for the wrap/unwrap test) and clean up of unneeded configure switches. I prefer to keep the rest of explicit enable/disable configure options to make the configuration more explicit and not depending only on the installed dependencies (as these can change under our hands).