### PR TITLE
card-piv.c fix auth length check

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2047,8 +2047,7 @@ static int piv_general_external_authenticate(sc_card_t *card,
 	}
 
 	/* Sanity check the lengths again */
-	tmplen = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL)
-		+ sc_asn1_put_tag(0x82, NULL, cypher_text_len, NULL, 0, NULL);
+	tmplen = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
 	if (output_len != (size_t)tmplen) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Allocated and computed lengths do not match! "
 			 "Expected %"SC_FORMAT_LEN_SIZE_T"d, found: %d\n", output_len, tmplen);


### PR DESCRIPTION
card-piv.c

Fixes #2658 
Replace the test for correct length of response while doing a  "Authentication of PIV Card Application Administrator"

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
