### PR TITLE
Fix .github build actions for build-ix86, build-mingw and build-mingw32

### DIFF
--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -41,7 +41,7 @@ fi
 if [ "$1" == "mingw" -o "$1" == "mingw32" -o "$1" == "ix86" ]; then
 	sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
 	sudo apt-get update -qq
-	sudo apt-get install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+	sudo apt-get install -yqq --allow-downgrades libgd3 libpcre2-8-0 libpcre2-16-0 libpcre2-32-0 
 	sudo apt-get purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
 fi
 


### PR DESCRIPTION
Now that Ubuntu 20.04 is now being used with guthub actions:

    Remove "focal" and use current Ubuntu code name

    Remove installing package libpcre2-posix2 that appears in only in
    focal as a security fix. See: https://packages.ubuntu.com/focal/libpcre2-posix2

 Date:      Thu Dec 8 12:58:03 2022 -0600
 On branch setup-jammy
 Changes to be committed:
	modified:   setup-linux.sh

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
