### PR TITLE
Update actions/virtual-environments#4589 workaround

### DIFF
--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -41,7 +41,6 @@ fi
 if [ "$1" == "mingw" -o "$1" == "mingw32" -o "$1" == "ix86" ]; then
 	sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
 	sudo apt-get update -qq
-	sudo apt-get install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
 	sudo apt-get purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
 fi
 


### PR DESCRIPTION
The workaround for i386 that is necessary to install wine has to be changed again.
See PR #2584 and https://github.com/actions/runner-images/issues/4589#issuecomment-1260157764 for reference.

