### PR TITLE
pkcs11: fixed bad return types

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -3265,7 +3265,7 @@ pkcs15_gen_keypair(struct sc_pkcs11_slot *slot, CK_MECHANISM_PTR pMechanism,
 		der->value = (unsigned char *) ptr;
 		if (rv != CKR_OK)   {
 			sc_unlock(p11card->card);
-			return sc_to_cryptoki_error(rv, "C_GenerateKeyPair");
+			return rv;
 		}
 
 		keygen_args.prkey_args.key.algorithm = SC_ALGORITHM_EC;
@@ -6279,10 +6279,10 @@ static CK_RV register_xeddsa_mechanisms(struct sc_pkcs11_card *p11card, int flag
 	return CKR_OK;
 }
 
-static int sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int flags,
+static CK_RV sc_pkcs11_register_aes_mechanisms(struct sc_pkcs11_card *p11card, int flags,
 		CK_ULONG min_key_size, CK_ULONG max_key_size)
 {
-	int rc;
+	CK_RV rc;
 	CK_MECHANISM_INFO mech_info;
 	sc_pkcs11_mechanism_type_t *mt;
 	sc_card_t* card = p11card->card;

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -60,7 +60,7 @@ operation_data_release(struct operation_data *data)
 
 static CK_RV
 signature_data_buffer_append(struct operation_data *data,
-		const CK_BYTE *in, unsigned int in_len)
+		const CK_BYTE *in, CK_ULONG in_len)
 {
 	if (!data)
 		return CKR_ARGUMENTS_BAD;
@@ -97,7 +97,7 @@ static CK_RV
 sc_pkcs11_copy_mechanism(sc_pkcs11_mechanism_type_t *mt,
 				sc_pkcs11_mechanism_type_t **new_mt)
 {
-	int rv;
+	CK_RV rv;
 
 	*new_mt = calloc(1, sizeof(sc_pkcs11_mechanism_type_t));
 	if (!(*new_mt))
@@ -127,7 +127,8 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 	sc_pkcs11_mechanism_type_t *existing_mt;
 	sc_pkcs11_mechanism_type_t *copy_mt = NULL;
 	sc_pkcs11_mechanism_type_t **p;
-	int i, rv;
+	int i;
+	CK_RV rv;
 
 	if (mt == NULL)
 		return CKR_HOST_MEMORY;


### PR DESCRIPTION
fixes https://github.com/frankmorgner/OpenSCToken/issues/48#issuecomment-1386050986

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
