### PR TITLE
pkcs11-register: disable autostart by default on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,7 +288,7 @@ AC_ARG_ENABLE(
 	[autostart-items],
 	[AS_HELP_STRING([--enable-autostart-items],[enable autostart items @<:@enabled@:>@])],
 	,
-	[enable_autostart="yes"]
+	[enable_autostart="no"]
 )
 
 AC_ARG_ENABLE(

--- a/src/tools/pkcs11-register.c
+++ b/src/tools/pkcs11-register.c
@@ -106,7 +106,7 @@ get_next_profile_path(const char **profiles_ini, const char *home, const char *b
 		}
 		/* adjust format to respect the maximum length of profile_path */
 		char format[32];
-		if (0 > snprintf(format, sizeof(format), "Path=%%%ds", (int)(p_len-1))
+		if (0 > snprintf(format, sizeof(format), "Path=%%%d[^\n]", (int)(p_len-1))
 				|| 1 != sscanf(path, format, p))
 			continue;
 


### PR DESCRIPTION
In macOS and Windows it is still added by default via the installers

fixes https://github.com/OpenSC/OpenSC/issues/2060

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
