### PR TITLE
Handle reader limits for SC Card unwrap operations - Fixes #2514

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -311,7 +311,7 @@ static int pcsc_transmit(sc_reader_t *reader, sc_apdu_t *apdu)
 	 * The buffer for the returned data needs to be at least 2 bytes
 	 * larger than the expected data length to store SW1 and SW2. */
 	rsize = rbuflen = apdu->resplen <= 256 ? 258 : apdu->resplen + 2;
-	rbuf     = malloc(rbuflen);
+	rbuf = malloc(rbuflen);
 	if (rbuf == NULL) {
 		r = SC_ERROR_OUT_OF_MEMORY;
 		goto out;
@@ -386,7 +386,7 @@ static int refresh_attributes(sc_reader_t *reader)
 			}
 			LOG_FUNC_RETURN(reader->ctx, SC_SUCCESS);
 		}
-		
+
 		/* the system could not detect the reader. It means, the prevoiusly attached reader is disconnected. */
 		if (rv == (LONG)SCARD_E_UNKNOWN_READER
 #ifdef SCARD_E_NO_READERS_AVAILABLE
@@ -424,7 +424,7 @@ static int refresh_attributes(sc_reader_t *reader)
 		if (priv->reader_state.cbAtr > SC_MAX_ATR_SIZE)
 			return SC_ERROR_INTERNAL;
 
-		/* Some cards have a different cold (after a powerup) and warm (after a reset) ATR  */
+		/* Some cards have a different cold (after a powerup) and warm (after a reset) ATR */
 		if (memcmp(priv->reader_state.rgbAtr, reader->atr.value, priv->reader_state.cbAtr) != 0) {
 			reader->atr.len = priv->reader_state.cbAtr;
 			memcpy(reader->atr.value, priv->reader_state.rgbAtr, reader->atr.len);
@@ -556,7 +556,7 @@ static int pcsc_reconnect(sc_reader_t * reader, DWORD action)
 			priv->gpriv->connect_exclusive ? SCARD_SHARE_EXCLUSIVE : SCARD_SHARE_SHARED,
 			protocol, action, &active_proto);
 
-	
+
 	PCSC_TRACE(reader, "SCardReconnect returned", rv);
 	if (rv != SCARD_S_SUCCESS) {
 		PCSC_TRACE(reader, "SCardReconnect failed", rv);
@@ -593,7 +593,7 @@ static void initialize_uid(sc_reader_t *reader)
 			sc_log_hex(reader->ctx, "UID",
 					reader->uid.value, reader->uid.len);
 		} else {
-			sc_log(reader->ctx,  "unable to get UID");
+			sc_log(reader->ctx, "unable to get UID");
 		}
 	}
 }
@@ -1177,7 +1177,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 			priv->modify_ioctl_finish = ntohl(pcsc_tlv->value);
 		} else if (pcsc_tlv->tag == FEATURE_IFD_PIN_PROPERTIES) {
 			priv->pin_properties_ioctl = ntohl(pcsc_tlv->value);
-		} else if (pcsc_tlv->tag == FEATURE_GET_TLV_PROPERTIES)  {
+		} else if (pcsc_tlv->tag == FEATURE_GET_TLV_PROPERTIES) {
 			priv->get_tlv_properties = ntohl(pcsc_tlv->value);
 		} else if (pcsc_tlv->tag == FEATURE_EXECUTE_PACE) {
 			priv->pace_ioctl = ntohl(pcsc_tlv->value);
@@ -1240,11 +1240,11 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 					sc_log(ctx, "Reader has a display: %04X", caps->wLcdLayout);
 					reader->capabilities |= SC_READER_CAP_DISPLAY;
 				}
-				else   {
+				else {
 					sc_log(ctx, "Reader does not have a display.");
 				}
 			}
-			else   {
+			else {
 				sc_log(ctx,
 						"Returned PIN properties structure has bad length (%lu/%"SC_FORMAT_LEN_SIZE_T"u)",
 						(unsigned long)rcount,
@@ -1266,34 +1266,55 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 		}
 	}
 
+	size_t max_send_size = 0;
+	size_t max_recv_size = 0;
 	if (priv->get_tlv_properties) {
 		/* Try to set reader max_send_size and max_recv_size based on
 		 * detected max_data */
-		int max_data = part10_detect_max_data(reader, card_handle);
-
-		if (max_data > 0) {
-			sc_log(ctx, "Reader supports transceiving %d bytes of data",
-					max_data);
-			if (!priv->gpriv->force_max_send_size)
-				reader->max_send_size = max_data;
-			else
-				sc_log(ctx, "Sending is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
-						" in configuration file", reader->max_send_size);
-			if (!priv->gpriv->force_max_recv_size)
-				reader->max_recv_size = max_data;
-			else
-				sc_log(ctx, "Receiving is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
-						" in configuration file", reader->max_recv_size);
-		} else {
-			sc_log(ctx, "Assuming that the reader supports transceiving "
-					"short length APDUs only");
-		}
+		max_send_size = max_recv_size = part10_detect_max_data(reader, card_handle);
 
 		/* debug the product and vendor ID of the reader */
 		part10_get_vendor_product(reader, card_handle, NULL, NULL);
 	}
+	else {
+		/* Try to set default limits based on device name */
+		if (!strncmp("REINER SCT cyberJack", reader->name, 20)) {
+			max_send_size = 1014;
+			max_recv_size = 1014;
+		}
+		else if (!strncmp("Secure Flash Card", reader->name, 17)) {
+			max_send_size = 478;
+			max_recv_size = 506;
+		}
+	}
 
-	if(gpriv->SCardGetAttrib != NULL) {
+	if (max_send_size > 0) {
+		sc_log(ctx, "Reader supports sending %"SC_FORMAT_LEN_SIZE_T"u bytes of data",
+				max_send_size);
+		if (!priv->gpriv->force_max_send_size)
+			reader->max_send_size = max_send_size;
+		else
+			sc_log(ctx, "Sending is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
+					" in configuration file", reader->max_send_size);
+	} else {
+		sc_log(ctx, "Assuming that the reader supports sending "
+				"short length APDUs only");
+	}
+
+	if (max_recv_size > 0) {
+		sc_log(ctx, "Reader supports receiving %"SC_FORMAT_LEN_SIZE_T"u bytes of data",
+				max_recv_size);
+		if (!priv->gpriv->force_max_recv_size)
+			reader->max_recv_size = max_recv_size;
+		else
+			sc_log(ctx, "Receiving is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
+					" in configuration file", reader->max_recv_size);
+	} else {
+		sc_log(ctx, "Assuming that the reader supports receiving "
+				"short length APDUs only");
+	}
+
+	if (gpriv->SCardGetAttrib != NULL) {
 		rcount = sizeof(buf);
 		if (gpriv->SCardGetAttrib(card_handle, SCARD_ATTR_VENDOR_NAME,
 					buf, &rcount) == SCARD_S_SUCCESS
@@ -1304,7 +1325,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 		}
 
 		rcount = sizeof i;
-		if(gpriv->SCardGetAttrib(card_handle, SCARD_ATTR_VENDOR_IFD_VERSION,
+		if (gpriv->SCardGetAttrib(card_handle, SCARD_ATTR_VENDOR_IFD_VERSION,
 					(u8 *) &i, &rcount) == SCARD_S_SUCCESS
 				&& rcount == sizeof i) {
 			reader->version_major = (i >> 24) & 0xFF;
@@ -1314,7 +1335,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 }
 
 int pcsc_add_reader(sc_context_t *ctx,
-	   	char *reader_name, size_t reader_name_len,
+		char *reader_name, size_t reader_name_len,
 		sc_reader_t **out_reader)
 {
 	int ret = SC_ERROR_INTERNAL;
@@ -1574,7 +1595,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 
 	LOG_FUNC_CALLED(ctx);
 
-	if (!event_reader && !event && reader_states)   {
+	if (!event_reader && !event && reader_states) {
 		sc_log(ctx, "free allocated reader states");
 		free(*reader_states);
 		*reader_states = NULL;
@@ -1684,7 +1705,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 			state = rsp->dwEventState;
 			rsp->dwCurrentState = rsp->dwEventState;
 			if (state & SCARD_STATE_CHANGED) {
-				/* check for hotplug events  */
+				/* check for hotplug events */
 				if (!strcmp(rsp->szReader, "\\\\?PnP?\\Notification")) {
 					sc_log(ctx, "detected hotplug event");
 					/* Windows sends hotplug event on both, attaching and
@@ -1859,7 +1880,7 @@ static int part10_build_verify_pin_block(struct sc_reader *reader, u8 * buf, siz
 	u8 tmp;
 	unsigned int tmp16;
 	unsigned int off;
-	PIN_VERIFY_STRUCTURE *pin_verify  = (PIN_VERIFY_STRUCTURE *)buf;
+	PIN_VERIFY_STRUCTURE *pin_verify = (PIN_VERIFY_STRUCTURE *)buf;
 
 	/* PIN verification control message */
 	pin_verify->bTimerOut = SC_CCID_PIN_TIMEOUT;
@@ -1958,7 +1979,7 @@ static int part10_build_modify_pin_block(struct sc_reader *reader, u8 * buf, siz
 	sc_apdu_t *apdu = data->apdu;
 	u8 tmp;
 	unsigned int tmp16;
-	PIN_MODIFY_STRUCTURE *pin_modify  = (PIN_MODIFY_STRUCTURE *)buf;
+	PIN_MODIFY_STRUCTURE *pin_modify = (PIN_MODIFY_STRUCTURE *)buf;
 	struct sc_pin_cmd_pin *pin_ref =
 		data->flags & SC_PIN_CMD_IMPLICIT_CHANGE ?
 		&data->pin2 : &data->pin1;
@@ -2569,7 +2590,7 @@ int pcsc_use_reader(sc_context_t *ctx, void * pcsc_context_handle, void * pcsc_c
 	gpriv->attached_reader = NULL;
 
 	gpriv->pcsc_ctx = *(SCARDCONTEXT *)pcsc_context_handle;
-	card_handle =  *(SCARDHANDLE *)pcsc_card_handle;
+	card_handle = *(SCARDHANDLE *)pcsc_card_handle;
 
 	if(SCARD_S_SUCCESS == gpriv->SCardGetAttrib(card_handle,
 				SCARD_ATTR_DEVICE_SYSTEM_NAME_A, (LPBYTE)

--- a/src/tests/fuzzing/fuzz_pkcs15_decode.c
+++ b/src/tests/fuzzing/fuzz_pkcs15_decode.c
@@ -108,9 +108,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
 	sc_pkcs15_parse_unusedspace(buf, buf_len, p15card);
 
-	sc_pkcs15_card_free(p15card);
-
 err:
+	sc_pkcs15_card_free(p15card);
 	sc_disconnect_card(card);
 	sc_release_context(ctx);
 	return 0;

--- a/src/tests/fuzzing/fuzz_pkcs15_encode.c
+++ b/src/tests/fuzzing/fuzz_pkcs15_encode.c
@@ -80,8 +80,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	sc_pkcs15_encode_unusedspace(ctx, p15card, &unused_space, &unused_space_len);
 	free(unused_space);
 
-	sc_pkcs15_card_free(p15card);
 err:
+	sc_pkcs15_card_free(p15card);
 	sc_disconnect_card(card);
 	sc_release_context(ctx);
 


### PR DESCRIPTION
Fixes #2514

Using reader with a card: REINER SCT cyberJack RFID komfort (4639352370) 00 00
SmartCard-HSM version 3.4

##### Checklist
- [ ] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
