### PR TITLE
Add support for basic attribute filtering to list objects

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -208,7 +208,12 @@
 						<option>--list-objects</option>,
 						<option>-O</option>
 					</term>
-					<listitem><para>Display a list of objects.</para></listitem>
+					<listitem>
+						<para>Display a list of objects.</para>
+						<para>The options <option>--keytype</option>, <option>--label</option>
+						, <option>--id</option> or <option>--application-id</option> can be
+						used to filter the listed objects.</para>
+					</listitem>
 				</varlistentry>
 
 				<varlistentry>


### PR DESCRIPTION
NOTE: Not sure if anything needs to be mentioned in the docs about this new capability.

fixes #2627

```
Generate some objects

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --write-object /data/keystore/ec_privkey.pem --type privkey --id 2222 --label eckey
Using slot 0 with a present token (0x0)
Created private key:
Private Key Object; EC
  label:      eckey
  ID:         2222
  Usage:      none
  Access:     sensitive, never extractable

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --keygen --key-type AES:32 --label aeskey --id 1111
Using slot 0 with a present token (0x0)
Key generated:
Secret Key Object; AES length 32
  VALUE:      e42d2476fe21337ce66d4f9c073770fbba8a70b171f41dbd5cf6d2cdadbf6cbb
  label:      aeskey
  ID:         1111
  Usage:      encrypt, decrypt
  Access:     never extractable, local

List all objects

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --list-objects
Using slot 0 with a present token (0x0)
Secret Key Object; AES length 32
  VALUE:      e42d2476fe21337ce66d4f9c073770fbba8a70b171f41dbd5cf6d2cdadbf6cbb
  label:      aeskey
  ID:         1111
  Usage:      encrypt, decrypt
  Access:     never extractable, local
Private Key Object; EC
  label:      eckey
  ID:         2222
  Usage:      none
  Access:     sensitive, never extractable

Filter by key type

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --list-objects --type privkey
Using slot 0 with a present token (0x0)
Private Key Object; EC
  label:      eckey
  ID:         2222
  Usage:      none
  Access:     sensitive, never extractable

Filter by id

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --list-objects --id 1111
Using slot 0 with a present token (0x0)
Secret Key Object; AES length 32
  VALUE:      e42d2476fe21337ce66d4f9c073770fbba8a70b171f41dbd5cf6d2cdadbf6cbb
  label:      aeskey
  ID:         1111
  Usage:      encrypt, decrypt
  Access:     never extractable, local

```

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
