### PR TITLE
Github test: adjust package dir and git branch of IsoApplet versions

### DIFF
--- a/.github/test-isoapplet.sh
+++ b/.github/test-isoapplet.sh
@@ -2,14 +2,17 @@
 
 set -ex -o xtrace
 
-isoapplet_version="v0"
-isoapplet_branch="main"
-isoapplet_pkgdir="net/pwendland/javacard/pki/isoapplet"
-if [ "$1" = "v1" ]; then
-	isoapplet_branch="isoapplet-v1"
-	isoapplet_version="v1"
-	isoapplet_pkgdir="xyz/wendland/javacard/pki/isoapplet"
+isoapplet_version="$1"
+if [ "$isoapplet_version" = "v0" ]; then
+	isoapplet_branch="main-javacard-v2.2.2"
+elif [ "$isoapplet_version" = "v1" ]; then
+	isoapplet_branch="main"
+else
+	echo "Unknown IsoApplet version: $isoapplet_version"
+	exit 1
 fi
+
+isoapplet_pkgdir="xyz/wendland/javacard/pki/isoapplet"
 
 # install the opensc
 sudo make install


### PR DESCRIPTION
Hi, 
this is a follow-up for this PR:  https://github.com/OpenSC/OpenSC/pull/2642

I updated the main branch of IsoApplet so that it contains the recent version (v1).
Hence, the github branches for the test script need to be updated.

Also, the differentiation of the package dir between the two versions is no longer necessary. 