### PR TITLE
Revert "Remove redundant -lglib-2.0 library"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,10 +554,6 @@ case "${host}" in
 							   have_notify="no"
 							   have_gio2="no"  ])
 			LIBS="$saved_LIBS"
-			if test "${have_gio2}" = "yes"; then
-				# we do not need lglib-2.0
-				GIO2_LIBS="-lgio-2.0 -lgobject-2.0"
-			fi
 		;;
 esac
 


### PR DESCRIPTION
Fixes failure to link libopensc on FreeBSD

````
ld: error: unable to find library -lgio-2.0
ld: error: unable to find library -lgobject-2.0
````

This reverts commit f43169a8d7dc9dc9df99c15bcec0c804b8efd856.


- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
