### PR TITLE
Handle certificate decompression in pkcs15 layer

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -841,7 +841,7 @@ authentic_select_file(struct sc_card *card, const struct sc_path *path,
 
 static int
 authentic_read_binary(struct sc_card *card, unsigned int idx,
-		unsigned char *buf, size_t count, unsigned long flags)
+		unsigned char *buf, size_t count, unsigned long *flags)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;

--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -296,7 +296,7 @@ static int belpic_select_file(sc_card_t *card,
 }
 
 static int belpic_read_binary(sc_card_t *card,
-			      unsigned int idx, u8 * buf, size_t count, unsigned long flags)
+			      unsigned int idx, u8 * buf, size_t count, unsigned long *flags)
 {
 	int r;
 

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -49,9 +49,6 @@
 #include "internal.h"
 #include "simpletlv.h"
 #include "cardctl.h"
-#ifdef ENABLE_ZLIB
-#include "compression.h"
-#endif
 #include "iso7816.h"
 #include "card-cac-common.h"
 #include "pkcs15.h"
@@ -577,16 +574,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		}
 		/* if the info byte is 1, then the cert is compressed, decompress it */
 		if ((cert_type & 0x3) == 1) {
-#ifdef ENABLE_ZLIB
-			r = sc_decompress_alloc(&priv->cache_buf, &priv->cache_buf_len,
-				cert_ptr, cert_len, COMPRESSION_AUTO);
-#else
-			sc_log(card->ctx, "CAC compression not supported, no zlib");
-			r = SC_ERROR_NOT_SUPPORTED;
-#endif
-			if (r)
-				goto done;
-		} else if (cert_len > 0) {
+			*flags |= SC_FILE_COMPRESSED;
+		}
+		if (cert_len > 0) {
 			priv->cache_buf = malloc(cert_len);
 			if (priv->cache_buf == NULL) {
 				r = SC_ERROR_OUT_OF_MEMORY;

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -574,7 +574,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		}
 		/* if the info byte is 1, then the cert is compressed, decompress it */
 		if ((cert_type & 0x3) == 1 && flags) {
-			*flags |= SC_FILE_COMPRESSED_AUTO;
+			*flags |= SC_FILE_FLAG_COMPRESSED_AUTO;
 		}
 		if (cert_len > 0) {
 			priv->cache_buf = malloc(cert_len);

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -450,7 +450,7 @@ fail:
  * as well as set that we want the cert from the object.
  */
 static int cac_read_binary(sc_card_t *card, unsigned int idx,
-		unsigned char *buf, size_t count, unsigned long flags)
+		unsigned char *buf, size_t count, unsigned long *flags)
 {
 	cac_private_data_t * priv = CAC_DATA(card);
 	int r = 0;

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -574,7 +574,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		}
 		/* if the info byte is 1, then the cert is compressed, decompress it */
 		if ((cert_type & 0x3) == 1) {
-			*flags |= SC_FILE_COMPRESSED;
+			*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 		if (cert_len > 0) {
 			priv->cache_buf = malloc(cert_len);

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -573,7 +573,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 			}
 		}
 		/* if the info byte is 1, then the cert is compressed, decompress it */
-		if ((cert_type & 0x3) == 1) {
+		if ((cert_type & 0x3) == 1 && flags) {
 			*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 		if (cert_len > 0) {

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -49,9 +49,6 @@
 #include "internal.h"
 #include "simpletlv.h"
 #include "cardctl.h"
-#ifdef ENABLE_ZLIB
-#include "compression.h"
-#endif
 #include "iso7816.h"
 #include "card-cac-common.h"
 #include "pkcs15.h"
@@ -171,16 +168,9 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if the info byte is 1, then the cert is compressed, decompress it */
 	if ((cert_type & 0x3) == 1) {
-#ifdef ENABLE_ZLIB
-		r = sc_decompress_alloc(&priv->cache_buf, &priv->cache_buf_len,
-			cert_ptr, cert_len, COMPRESSION_AUTO);
-#else
-		sc_log(card->ctx, "CAC compression not supported, no zlib");
-		r = SC_ERROR_NOT_SUPPORTED;
-#endif
-		if (r)
-			goto done;
-	} else if (cert_len > 0) {
+		*flags |= SC_FILE_COMPRESSED;
+	}
+	if (cert_len > 0) {
 		priv->cache_buf = malloc(cert_len);
 		if (priv->cache_buf == NULL) {
 			r = SC_ERROR_OUT_OF_MEMORY;

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -168,7 +168,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if the info byte is 1, then the cert is compressed, decompress it */
 	if ((cert_type & 0x3) == 1) {
-		*flags |= SC_FILE_COMPRESSED;
+		*flags |= SC_FILE_COMPRESSED_AUTO;
 	}
 	if (cert_len > 0) {
 		priv->cache_buf = malloc(cert_len);

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -168,7 +168,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if the info byte is 1, then the cert is compressed, decompress it */
 	if ((cert_type & 0x3) == 1) {
-		*flags |= SC_FILE_COMPRESSED_AUTO;
+		*flags |= SC_FILE_FLAG_COMPRESSED_AUTO;
 	}
 	if (cert_len > 0) {
 		priv->cache_buf = malloc(cert_len);

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -122,7 +122,7 @@ static int cac_cac1_get_certificate(sc_card_t *card, u8 **out_buf, size_t *out_l
  * as well as set that we want the cert from the object.
  */
 static int cac_read_binary(sc_card_t *card, unsigned int idx,
-		unsigned char *buf, size_t count, unsigned long flags)
+		unsigned char *buf, size_t count, unsigned long *flags)
 {
 	cac_private_data_t * priv = CAC_DATA(card);
 	int r = 0;

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -1175,7 +1175,7 @@ fail:
  * translate the objects into their PKCS #15 equivalent data structures.
  */
 static int coolkey_read_binary(sc_card_t *card, unsigned int idx,
-		u8 *buf, size_t count, unsigned long flags)
+		u8 *buf, size_t count, unsigned long *flags)
 {
 	coolkey_private_data_t * priv = COOLKEY_DATA(card);
 	int r = 0, len;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -1078,7 +1078,7 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
  */
 static int dnie_read_binary(struct sc_card *card,
 			    unsigned int idx,
-			    u8 * buf, size_t count, unsigned long flags)
+			    u8 * buf, size_t count, unsigned long *flags)
 {
 	int res = 0;
 	sc_context_t *ctx = NULL;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -38,7 +38,6 @@
 #include "opensc.h"
 #include "cardctl.h"
 #include "internal.h"
-#include "compression.h"
 #include "cwa14890.h"
 #include "cwa-dnie.h"
 
@@ -904,34 +903,32 @@ static int dnie_finish(struct sc_card *card)
 /* ISO 7816-4 functions */
 
 /**
- * Uncompress data if in compressed format.
+ * Check whether data are compressed.
  *
  * @param card pointer to sc_card_t structure
  * @param from buffer to get data from
- * @param len pointer to buffer length
- * @return uncompressed or original buffer; len points to new buffer length
- *        on error return null
+ * @param len buffer length
+ * @return 1 if data are compressed, 0 otherwise; len points to expected length of decompressed data
  */
-static u8 *dnie_uncompress(sc_card_t * card, u8 * from, size_t *len)
+
+static int dnie_is_compressed(sc_card_t * card, u8 * from, size_t len)
 {
-	u8 *upt = from;
 #ifdef ENABLE_ZLIB
-	int res = SC_SUCCESS;
 	size_t uncompressed = 0L;
 	size_t compressed = 0L;
 
 	if (!card || !card->ctx || !from || !len)
-		return NULL;
+		return 0;
 	LOG_FUNC_CALLED(card->ctx);
 
 	/* if data size not enough for compression header assume uncompressed */
-	if (*len < 8)
+	if (len < 8)
 		goto compress_exit;
 	/* evaluate compressed an uncompressed sizes (little endian format) */
 	uncompressed = lebytes2ulong(from);
 	compressed = lebytes2ulong(from + 4);
 	/* if compressed size doesn't match data length assume not compressed */
-	if (compressed != (*len) - 8)
+	if (compressed != len - 8)
 		goto compress_exit;
 	/* if compressed size greater than uncompressed, assume uncompressed data */
 	if (uncompressed < compressed)
@@ -940,32 +937,14 @@ static u8 *dnie_uncompress(sc_card_t * card, u8 * from, size_t *len)
 	if (uncompressed > MAX_FILE_SIZE)
 		goto compress_exit;
 
-	sc_log(card->ctx, "Data seems to be compressed. calling uncompress");
-	/* ok: data seems to be compressed */
-	upt = calloc(uncompressed, sizeof(u8));
-	if (!upt) {
-		sc_log(card->ctx, "alloc() for uncompressed buffer failed");
-		return NULL;
-	}
-	*len = uncompressed;
-	res = sc_decompress(upt,	/* try to uncompress by calling sc_xx routine */
-			    len,
-			    from + 8, (size_t) compressed, COMPRESSION_ZLIB);
-	if (res != SC_SUCCESS) {
-		sc_log(card->ctx, "Uncompress() failed or data not compressed");
-		goto compress_exit;	/* assume not need uncompression */
-	}
-	/* Done; update buffer len and return pt to uncompressed data */
-	sc_log_hex(card->ctx, "Compressed data", from + 8, compressed);
-	sc_log_hex(card->ctx, "Uncompressed data", upt, uncompressed);
- compress_exit:
-
+	sc_log(card->ctx, "Data seems to be compressed.");
+	return 1;
+compress_exit:
 #endif
 
-	sc_log(card->ctx, "uncompress: returning with%s de-compression ",
-	       (upt == from) ? "out" : "");
-	return upt;
-}
+	sc_log(card->ctx, "Data not compressed.");
+	return 0;
+}	
 
 /**
  * Fill file cache for read_binary() operation.
@@ -985,14 +964,14 @@ static u8 *dnie_uncompress(sc_card_t * card, u8 * from, size_t *len)
  * @param card Pointer to card structure
  * @return SC_SUCCESS if OK; else error code
  */
-static int dnie_fill_cache(sc_card_t * card)
+static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
 {
 	u8 tmp[MAX_RESP_BUFFER_SIZE];
 	sc_apdu_t apdu;
 	size_t count = 0;
 	size_t len = 0;
 	u8 *buffer = NULL;
-	u8 *pt = NULL, *p;
+	u8 *p;
 	sc_context_t *ctx = NULL;
 
 	if (!card || !card->ctx)
@@ -1068,21 +1047,15 @@ static int dnie_fill_cache(sc_card_t * card)
 	}
 
  read_done:
-	/* no more data to read: check if data is compressed */
-	pt = dnie_uncompress(card, buffer, &len);
+	if (dnie_is_compressed(card, buffer, len)) {
+		*flags |= SC_FILE_COMPRESSED;
+	}
 	free((void *)apdu.data);
 	if (apdu.resp != tmp)
 		free(apdu.resp);
-	if (pt == NULL) {
-		sc_log(ctx, "Uncompress process failed");
-		free(buffer);
-		LOG_FUNC_RETURN(ctx, SC_ERROR_INTERNAL);
-	}
-	if (pt != buffer)
-		free(buffer);
 
 	/* ok: as final step, set correct cache data into dnie_priv structures */
-	GET_DNIE_PRIV_DATA(card)->cache = pt;
+	GET_DNIE_PRIV_DATA(card)->cache = buffer;
 	GET_DNIE_PRIV_DATA(card)->cachelen = len;
 	sc_log(ctx,
 	       "fill_cache() done. length '%"SC_FORMAT_LEN_SIZE_T"u' bytes",
@@ -1117,7 +1090,7 @@ static int dnie_read_binary(struct sc_card *card,
 	LOG_FUNC_CALLED(ctx);
 	if (idx == 0 || GET_DNIE_PRIV_DATA(card)->cache == NULL) {
 		/* on first block or no cache, try to fill */
-		res = dnie_fill_cache(card);
+		res = dnie_fill_cache(card, flags);
 		if (res < 0) {
 			sc_log(ctx, "Cannot fill cache. using iso_read_binary()");
 			return iso_ops->read_binary(card, idx, buf, count, flags);

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -1049,6 +1049,8 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
  read_done:
 	if (dnie_is_compressed(card, buffer, len)) {
 		*flags |= SC_FILE_COMPRESSED;
+		buffer += 8;
+		len -= 8;
 	}
 	free((void *)apdu.data);
 	if (apdu.resp != tmp)

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -1048,7 +1048,8 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
 
  read_done:
 	if (dnie_is_compressed(card, buffer, len)) {
-		*flags |= SC_FILE_COMPRESSED_ZLIB;
+		if (flags)
+			*flags |= SC_FILE_COMPRESSED_ZLIB;
 		buffer += 8;
 		len -= 8;
 	}

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -1053,7 +1053,7 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
 
 	if (dnie_is_compressed(card, buffer, len)) {
 		if (flags)
-			*flags |= SC_FILE_COMPRESSED_ZLIB;
+			*flags |= SC_FILE_FLAG_COMPRESSED_ZLIB;
 		/* Remove first 8 bytes with compression info*/
 		len -= 8;
 		p = malloc(len);

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -1048,7 +1048,7 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
 
  read_done:
 	if (dnie_is_compressed(card, buffer, len)) {
-		*flags |= SC_FILE_COMPRESSED;
+		*flags |= SC_FILE_COMPRESSED_ZLIB;
 		buffer += 8;
 		len -= 8;
 	}

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -423,7 +423,7 @@ out:
 
 static int entersafe_read_binary(sc_card_t *card,
 								 unsigned int idx, u8 *buf, size_t count,
-								 unsigned long flags)
+								 unsigned long *flags)
 {
 	sc_apdu_t apdu;
 	u8 recvbuf[SC_MAX_APDU_BUFFER_SIZE];

--- a/src/libopensc/card-esteid2018.c
+++ b/src/libopensc/card-esteid2018.c
@@ -143,7 +143,7 @@ static int esteid_select_file(struct sc_card *card, const struct sc_path *in_pat
 }
 
 // temporary hack, overload 6B00 SW processing
-static int esteid_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t count, unsigned long flags) {
+static int esteid_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t count, unsigned long *flags) {
 	int r;
 	int (*saved)(struct sc_card *, unsigned int, unsigned int) = card->ops->check_sw;
 	LOG_FUNC_CALLED(card->ctx);

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1069,7 +1069,8 @@ static int gids_read_binary(sc_card_t *card, unsigned int offset,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		}
 		if (buffer[0] == 1 && buffer[1] == 0) {
-			*flags |= SC_FILE_COMPRESSED_ZLIB;
+			if (flags)
+				*flags |= SC_FILE_COMPRESSED_ZLIB;
 			/* compressed data are starting on position buffer + 4 */
 			data->buffersize = sizeof(data->buffer) - 4;
 			memcpy(data->buffer, buffer + 4, buffersize);

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1069,19 +1069,10 @@ static int gids_read_binary(sc_card_t *card, unsigned int offset,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		}
 		if (buffer[0] == 1 && buffer[1] == 0) {
-			size_t expectedsize = buffer[2] + buffer[3] * 0x100;
-			data->buffersize = sizeof(data->buffer);
-			r = sc_decompress(data->buffer, &(data->buffersize), buffer+4, buffersize-4, COMPRESSION_ZLIB);
-			if (r != SC_SUCCESS) {
-				sc_log(card->ctx,  "Zlib error: %d", r);
-				LOG_FUNC_RETURN(card->ctx, r);
-			}
-			if (data->buffersize != expectedsize) {
-				sc_log(card->ctx, 
-					 "expected size: %"SC_FORMAT_LEN_SIZE_T"u real size: %"SC_FORMAT_LEN_SIZE_T"u",
-					 expectedsize, data->buffersize);
-				LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
-			}
+			*flags |= SC_FILE_COMPRESSED;
+			/* compressed data are starting on position buffer + 4 */
+			data->buffersize = sizeof(data->buffer) - 4;
+			memcpy(data->buffer, buffer + 4, buffersize);
 		} else {
 			sc_log(card->ctx,  "unknown compression method %d", buffer[0] + (buffer[1] <<8));
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1069,7 +1069,7 @@ static int gids_read_binary(sc_card_t *card, unsigned int offset,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		}
 		if (buffer[0] == 1 && buffer[1] == 0) {
-			*flags |= SC_FILE_COMPRESSED;
+			*flags |= SC_FILE_COMPRESSED_ZLIB;
 			/* compressed data are starting on position buffer + 4 */
 			data->buffersize = sizeof(data->buffer) - 4;
 			memcpy(data->buffer, buffer + 4, buffersize);

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1048,7 +1048,7 @@ gids_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left
 
 // used to read existing certificates
 static int gids_read_binary(sc_card_t *card, unsigned int offset,
-		unsigned char *buf, size_t count, unsigned long flags) {
+		unsigned char *buf, size_t count, unsigned long *flags) {
 	struct gids_private_data *data = (struct gids_private_data *) card->drv_data;
 	struct sc_context *ctx = card->ctx;
 	int r;

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1070,7 +1070,7 @@ static int gids_read_binary(sc_card_t *card, unsigned int offset,
 		}
 		if (buffer[0] == 1 && buffer[1] == 0) {
 			if (flags)
-				*flags |= SC_FILE_COMPRESSED_ZLIB;
+				*flags |= SC_FILE_FLAG_COMPRESSED_ZLIB;
 			/* compressed data are starting on position buffer + 4 */
 			data->buffersize = sizeof(data->buffer) - 4;
 			memcpy(data->buffer, buffer + 4, buffersize);

--- a/src/libopensc/card-gpk.c
+++ b/src/libopensc/card-gpk.c
@@ -678,7 +678,7 @@ done:
  */
 static int
 gpk_read_binary(sc_card_t *card, unsigned int offset,
-		u8 *buf, size_t count, unsigned long flags)
+		u8 *buf, size_t count, unsigned long *flags)
 {
 	struct gpk_private_data *priv = DRVDATA(card);
 

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -726,7 +726,7 @@ err:
 
 static int
 iasecc_read_binary(struct sc_card *card, unsigned int offs,
-		unsigned char *buf, size_t count, unsigned long flags)
+		unsigned char *buf, size_t count, unsigned long *flags)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -590,7 +590,8 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 			/* Data will be decompressed later */
 			data_buffer += 4;
 			r = priv->file_size - 4;
-			*flags |= SC_FILE_COMPRESSED_AUTO;
+			if (flags)
+				*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 		priv->cache_buf = malloc(r);
 		if (priv->cache_buf == NULL) {

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -555,7 +555,7 @@ static int idprime_select_file(sc_card_t *card, const sc_path_t *in_path, sc_fil
 
 // used to read existing certificates
 static int idprime_read_binary(sc_card_t *card, unsigned int offset,
-	unsigned char *buf, size_t count, unsigned long flags)
+	unsigned char *buf, size_t count, unsigned long *flags)
 {
 	struct idprime_private_data *priv = card->drv_data;
 	int r = 0;

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -590,7 +590,7 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 			/* Data will be decompressed later */
 			data_buffer += 4;
 			r = priv->file_size - 4;
-			*flags |= SC_FILE_COMPRESSED;
+			*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 		priv->cache_buf = malloc(r);
 		if (priv->cache_buf == NULL) {

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -28,9 +28,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef ENABLE_ZLIB
-#include "compression.h"
-#endif
 
 #include "cardctl.h"
 #include "pkcs15.h"
@@ -550,8 +547,6 @@ static int idprime_select_file(sc_card_t *card, const sc_path_t *in_path, sc_fil
 		if (len == HEADER_LEN && data[0] == 0x01 && data[1] == 0x00) {
 			/* Cache the real file size for the caching read_binary() */
 			priv->file_size = (*file_out)->size;
-			/* Fix the information in the file structure to not confuse upper layers */
-			(*file_out)->size = (data[3]<<8) | data[2];
 		}
 	}
 	/* Return the exit code of the select command */
@@ -576,6 +571,7 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 
 		// this function is called to read and uncompress the certificate
 		u8 buffer[SC_MAX_EXT_APDU_BUFFER_SIZE];
+		u8 *data_buffer = buffer;
 		if (sizeof(buffer) < count || sizeof(buffer) < priv->file_size) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 		}
@@ -591,33 +587,17 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		}
 		if (buffer[0] == 1 && buffer[1] == 0) {
-#ifdef ENABLE_ZLIB
-			size_t expectedsize = buffer[2] + buffer[3] * 0x100;
-			r = sc_decompress_alloc(&priv->cache_buf, &(priv->cache_buf_len),
-				buffer+4, priv->file_size-4, COMPRESSION_AUTO);
-			if (r != SC_SUCCESS) {
-				sc_log(card->ctx, "Zlib error: %d", r);
-				LOG_FUNC_RETURN(card->ctx, r);
-			}
-			if (priv->cache_buf_len != expectedsize) {
-				sc_log(card->ctx,
-					 "expected size: %"SC_FORMAT_LEN_SIZE_T"u real size: %"SC_FORMAT_LEN_SIZE_T"u",
-					 expectedsize, priv->cache_buf_len);
-				LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
-			}
-#else
-			sc_log(card->ctx, "compression not supported, no zlib");
-			return SC_ERROR_NOT_SUPPORTED;
-#endif /* ENABLE_ZLIB */
-		} else {
-			/* assuming uncompressed certificate */
-			priv->cache_buf = malloc(r);
-			if (priv->cache_buf == NULL) {
-				return SC_ERROR_OUT_OF_MEMORY;
-			}
-			memcpy(priv->cache_buf, buffer, r);
-			priv->cache_buf_len = r;
+			/* Data will be decompressed later */
+			data_buffer += 4;
+			r = priv->file_size - 4;
+			*flags |= SC_FILE_COMPRESSED;
 		}
+		priv->cache_buf = malloc(r);
+		if (priv->cache_buf == NULL) {
+			return SC_ERROR_OUT_OF_MEMORY;
+		}
+		memcpy(priv->cache_buf, data_buffer, r);
+		priv->cache_buf_len = r;
 		priv->cached = 1;
 	}
 	if (offset >= priv->cache_buf_len) {

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -591,7 +591,7 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 			data_buffer += 4;
 			r = priv->file_size - 4;
 			if (flags)
-				*flags |= SC_FILE_COMPRESSED_AUTO;
+				*flags |= SC_FILE_FLAG_COMPRESSED_AUTO;
 		}
 		priv->cache_buf = malloc(r);
 		if (priv->cache_buf == NULL) {

--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -312,7 +312,7 @@ itacns_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 
 static int itacns_read_binary(sc_card_t *card,
 			       unsigned int idx, u8 *buf, size_t count,
-			       unsigned long flags)
+			       unsigned long *flags)
 {
 	size_t already_read = 0;
 	int requested;

--- a/src/libopensc/card-muscle.c
+++ b/src/libopensc/card-muscle.c
@@ -198,7 +198,7 @@ static int muscle_create_file(sc_card_t *card, sc_file_t *file)
 	return r;
 }
 
-static int muscle_read_binary(sc_card_t *card, unsigned int idx, u8* buf, size_t count, unsigned long flags)
+static int muscle_read_binary(sc_card_t *card, unsigned int idx, u8* buf, size_t count, unsigned long *flags)
 {
 	mscfs_t *fs = MUSCLE_FS(card);
 	int r;

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -2110,7 +2110,7 @@ auth_update_binary(struct sc_card *card, unsigned int offset,
 
 static int
 auth_read_binary(struct sc_card *card, unsigned int offset,
-		unsigned char *buf, size_t count, unsigned long flags)
+		unsigned char *buf, size_t count, unsigned long *flags)
 {
 	int rv;
 	struct sc_pkcs15_bignum bn[2];
@@ -2125,7 +2125,7 @@ auth_read_binary(struct sc_card *card, unsigned int offset,
 
 	sc_log(card->ctx,
 	       "offset %i; size %"SC_FORMAT_LEN_SIZE_T"u; flags 0x%lX",
-	       offset, count, flags);
+	       offset, count, *flags);
 	sc_log(card->ctx,"last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -2125,7 +2125,7 @@ auth_read_binary(struct sc_card *card, unsigned int offset,
 
 	sc_log(card->ctx,
 	       "offset %i; size %"SC_FORMAT_LEN_SIZE_T"u; flags 0x%lX",
-	       offset, count, *flags);
+	       offset, count, flags ? *flags : 0);
 	sc_log(card->ctx,"last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -1577,7 +1577,7 @@ pgp_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
  */
 static int
 pgp_read_binary(sc_card_t *card, unsigned int idx,
-		u8 *buf, size_t count, unsigned long flags)
+		u8 *buf, size_t count, unsigned long *flags)
 {
 	struct pgp_priv_data *priv = DRVDATA(card);
 	pgp_blob_t	*blob;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1139,7 +1139,7 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
  * as well as set that we want the cert from the object.
  */
 static int
-piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t count, unsigned long flags)
+piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t count, unsigned long *flags)
 {
 	piv_private_data_t * priv = PIV_DATA(card);
 	int enumtag;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1193,7 +1193,7 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 	if (priv->return_only_cert || piv_objects[enumtag].flags & PIV_OBJECT_TYPE_PUBKEY) {
 		rbuf = priv->obj_cache[enumtag].internal_obj_data;
 		rbuflen = priv->obj_cache[enumtag].internal_obj_len;
-		if (priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_COMPRESSED) {
+		if ((priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_COMPRESSED) && flags) {
 			*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 	} else {

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -50,9 +50,6 @@
 #include "internal.h"
 #include "asn1.h"
 #include "cardctl.h"
-#ifdef ENABLE_ZLIB
-#include "compression.h"
-#endif
 #include "simpletlv.h"
 
 enum {
@@ -131,6 +128,7 @@ enum {
  */
 
 #define PIV_OBJ_CACHE_VALID			1
+#define PIV_OBJ_CACHE_COMPRESSED	2
 #define PIV_OBJ_CACHE_NOT_PRESENT	8
 
 typedef struct piv_obj_cache {
@@ -1096,27 +1094,14 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_FILE_NOT_FOUND);
 
 		if(compressed) {
-#ifdef ENABLE_ZLIB
-			size_t len;
-			u8* newBuf = NULL;
-
-			if(SC_SUCCESS != sc_decompress_alloc(&newBuf, &len, tag, taglen, COMPRESSION_AUTO))
-				LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_VALID);
-
-			priv->obj_cache[enumtag].internal_obj_data = newBuf;
-			priv->obj_cache[enumtag].internal_obj_len = len;
-#else
-			sc_log(card->ctx, "PIV compression not supported, no zlib");
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
-#endif
+			priv->obj_cache[enumtag].flags |= PIV_OBJ_CACHE_COMPRESSED;
 		}
-		else {
-			if (!(priv->obj_cache[enumtag].internal_obj_data = malloc(taglen)))
-				LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		/* internal certificate remains compressed */
+		if (!(priv->obj_cache[enumtag].internal_obj_data = malloc(taglen)))
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 
-			memcpy(priv->obj_cache[enumtag].internal_obj_data, tag, taglen);
-			priv->obj_cache[enumtag].internal_obj_len = taglen;
-		}
+		memcpy(priv->obj_cache[enumtag].internal_obj_data, tag, taglen);
+		priv->obj_cache[enumtag].internal_obj_len = taglen;
 
 	/* convert pub key to internal */
 /* TODO: -DEE need to fix ...  would only be used if we cache the pub key, but we don't today */
@@ -1208,6 +1193,9 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 	if (priv->return_only_cert || piv_objects[enumtag].flags & PIV_OBJECT_TYPE_PUBKEY) {
 		rbuf = priv->obj_cache[enumtag].internal_obj_data;
 		rbuflen = priv->obj_cache[enumtag].internal_obj_len;
+		if (priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_COMPRESSED) {
+			*flags |= SC_FILE_COMPRESSED;
+		}
 	} else {
 		rbuf = priv->obj_cache[enumtag].obj_data;
 		rbuflen = priv->obj_cache[enumtag].obj_len;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1194,7 +1194,7 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 		rbuf = priv->obj_cache[enumtag].internal_obj_data;
 		rbuflen = priv->obj_cache[enumtag].internal_obj_len;
 		if (priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_COMPRESSED) {
-			*flags |= SC_FILE_COMPRESSED;
+			*flags |= SC_FILE_COMPRESSED_AUTO;
 		}
 	} else {
 		rbuf = priv->obj_cache[enumtag].obj_data;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1194,7 +1194,7 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 		rbuf = priv->obj_cache[enumtag].internal_obj_data;
 		rbuflen = priv->obj_cache[enumtag].internal_obj_len;
 		if ((priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_COMPRESSED) && flags) {
-			*flags |= SC_FILE_COMPRESSED_AUTO;
+			*flags |= SC_FILE_FLAG_COMPRESSED_AUTO;
 		}
 	} else {
 		rbuf = priv->obj_cache[enumtag].obj_data;

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -785,7 +785,7 @@ static int sc_hsm_logout(sc_card_t * card)
 /* NOTE: idx is an offset into the card's file, not into buf */
 static int sc_hsm_read_binary(sc_card_t *card,
 			       unsigned int idx, u8 *buf, size_t count,
-			       unsigned long flags)
+			       unsigned long *flags)
 {
 	sc_context_t *ctx = card->ctx;
 	sc_apdu_t apdu;

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -617,7 +617,7 @@ int sc_delete_file(sc_card_t *card, const sc_path_t *path)
 }
 
 int sc_read_binary(sc_card_t *card, unsigned int idx,
-		   unsigned char *buf, size_t count, unsigned long flags)
+		   unsigned char *buf, size_t count, unsigned long *flags)
 {
 	size_t max_le = sc_get_max_recv_size(card);
 	size_t todo = count;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -136,7 +136,7 @@ iso7816_check_sw(struct sc_card *card, unsigned int sw1, unsigned int sw2)
 
 
 static int
-iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t count, unsigned long flags)
+iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t count, unsigned long *flags)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -658,7 +658,7 @@ struct sc_card_operations {
 	 * @see sc_read_binary()
 	 */
 	int (*read_binary)(struct sc_card *card, unsigned int idx,
-			u8 * buf, size_t count, unsigned long flags);
+			u8 * buf, size_t count, unsigned long *flags);
 	/**
 	 * @brief Write data to a binary EF with a single command
 	 *
@@ -1250,7 +1250,7 @@ int sc_list_files(struct sc_card *card, u8 *buf, size_t buflen);
  * @return number of bytes read or an error code
  */
 int sc_read_binary(struct sc_card *card, unsigned int idx, u8 * buf,
-		   size_t count, unsigned long flags);
+		   size_t count, unsigned long *flags);
 /**
  * @brief Write data to a binary EF
  *

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -652,7 +652,7 @@ struct sc_card_operations {
 	 * @param  idx    index within the file with the data to read
 	 * @param  buf    buffer to the read data
 	 * @param  count  number of bytes to read
-	 * @param  flags  flags for the READ BINARY command (currently not used)
+	 * @param  flags  flags for the READ BINARY command (optional)
 	 * @return number of bytes read or an error code
 	 *
 	 * @see sc_read_binary()

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2407,9 +2407,9 @@ static int decompress_file(sc_card_t *card, unsigned char *buf, size_t buflen,
 	int rv = SC_SUCCESS;
 	int method = 0;
 
-	if (flags & SC_FILE_COMPRESSED_GZIP) {
+	if (flags & SC_FILE_FLAG_COMPRESSED_GZIP) {
 		method = COMPRESSION_GZIP;
-	} else if (flags & SC_FILE_COMPRESSED_ZLIB) {
+	} else if (flags & SC_FILE_FLAG_COMPRESSED_ZLIB) {
 		method = COMPRESSION_ZLIB;
 	} else {
 		method = COMPRESSION_AUTO;
@@ -2589,9 +2589,9 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 			/* sc_read_binary may return less than requested */
 			len = r;
 
-			if (flags & SC_FILE_COMPRESSED_AUTO
-			    || flags & SC_FILE_COMPRESSED_ZLIB
-			    || flags & SC_FILE_COMPRESSED_GZIP) {
+			if (flags & SC_FILE_FLAG_COMPRESSED_AUTO
+			    || flags & SC_FILE_FLAG_COMPRESSED_ZLIB
+			    || flags & SC_FILE_FLAG_COMPRESSED_GZIP) {
 				unsigned char *decompressed_buf = NULL;
 				size_t decompressed_len = 0;
 				r = decompress_file(p15card->card, data, len, &decompressed_buf, &decompressed_len, flags);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2412,9 +2412,10 @@ static int decompress_file(sc_card_t *card, unsigned char *buf, size_t buflen,
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 	}
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
-#endif
+#else
 	sc_log(card->ctx, "Compression not supported, no zlib");
 	LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+#endif
 }
 
 int

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -226,7 +226,9 @@ typedef struct sc_acl_entry {
 #define SC_FILE_EF_CYCLIC_TLV		0x07
 
 /* Data compression */
-#define SC_FILE_COMPRESSED		0x08
+#define SC_FILE_COMPRESSED_AUTO		0x08
+#define SC_FILE_COMPRESSED_ZLIB		0x09
+#define SC_FILE_COMPRESSED_GZIP		0x0a
 
 /* File status flags */
 /* ISO7816-4: Unless otherwise specified, the security attributes are valid for the operational state.*/

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -225,6 +225,9 @@ typedef struct sc_acl_entry {
 #define SC_FILE_EF_CYCLIC		0x06
 #define SC_FILE_EF_CYCLIC_TLV		0x07
 
+/* Data compression */
+#define SC_FILE_COMPRESSED		0x08
+
 /* File status flags */
 /* ISO7816-4: Unless otherwise specified, the security attributes are valid for the operational state.*/
 #define SC_FILE_STATUS_ACTIVATED	0x00 /* ISO7816-4: Operational state (activated)   (5, 7) */

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -225,10 +225,10 @@ typedef struct sc_acl_entry {
 #define SC_FILE_EF_CYCLIC		0x06
 #define SC_FILE_EF_CYCLIC_TLV		0x07
 
-/* Data compression */
-#define SC_FILE_COMPRESSED_AUTO		0x08
-#define SC_FILE_COMPRESSED_ZLIB		0x09
-#define SC_FILE_COMPRESSED_GZIP		0x0a
+/* File flags */
+#define SC_FILE_FLAG_COMPRESSED_AUTO		0x01
+#define SC_FILE_FLAG_COMPRESSED_ZLIB		0x02
+#define SC_FILE_FLAG_COMPRESSED_GZIP		0x04
 
 /* File status flags */
 /* ISO7816-4: Unless otherwise specified, the security attributes are valid for the operational state.*/

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -643,6 +643,7 @@ awp_update_object_list(struct sc_pkcs15_card *p15card, struct sc_profile *profil
 	unsigned char *buff = NULL;
 	int rv;
 	unsigned ii;
+	unsigned long flags;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx,  "type %i, num %i", type, num);
@@ -722,7 +723,8 @@ awp_update_object_list(struct sc_pkcs15_card *p15card, struct sc_profile *profil
 	if (rv < 0)
 		goto done;
 
-	rv = sc_read_binary(p15card->card, 0, buff, lst_file->size, lst_file->ef_structure);
+	flags = lst_file->ef_structure;
+	rv = sc_read_binary(p15card->card, 0, buff, lst_file->size, &flags);
 	if (rv < 0)
 		goto done;
 


### PR DESCRIPTION
This PR moves decompression from drivers to the pkcs15 layer (`sc_pkcs15_read_file()`), as discussed in #2125.

Decompression is removed from `*read_binary()` functions from drivers and moved after calling `sc_read_binary()` in `sc_pkcs15_read_file()`. Whether the data read by `sc_read_binary()` are compressed is denoted by `unsigned long *flags` - the driver sets the corresponding mask `SC_FILE_COMPRESSED`. The former `unsigned long flags` parameter is changed to a pointer to propagate the information about compression out of `sc_read_binary()`.

Changes tested with cards
- Gemalto IDPrime 3810 (OSv1)
- PIV Card

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
