### PR TITLE
WRAP operation fix for MyEID driver (T0 protocol)

### DIFF
--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1446,7 +1446,7 @@ static int myeid_wrap_key(struct sc_card *card, u8 *out, size_t outlen)
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x2A, 0x84, 0x00);
 	apdu.resp = rbuf;
 	apdu.resplen = sizeof(rbuf);
-	apdu.le = 0;
+	apdu.le = sizeof(rbuf) <= 256 ? sizeof(rbuf) : 256;
 	apdu.lc = 0;
 
 	r = sc_transmit_apdu(card, &apdu);


### PR DESCRIPTION
apdu.le must be greater than 0, because we expect a result (wrapped key).

Although the value 0 seems to be correct in this case (function sc_apdu2bytes() generates the correct field 'Le'), the operation fails in sc_get_response() where Le == 0 generates only SW.

From the point of view of the sc_get_response() function, apdu.le here represents the value "Ne" (see ISO 7816-3 section 12.1.2), and thus apdu.le cannot be 0 in this case.

Fixes #2694

##### Checklist
- [x] PKCS#11 module is tested
