### PR TITLE
westcos: Generate 2k RSA keys by default

### DIFF
--- a/doc/tools/westcos-tool.1.xml
+++ b/doc/tools/westcos-tool.1.xml
@@ -75,7 +75,7 @@
 					<listitem><para>Generate a private key on the card. The card must not have
 					been finalized and a PIN must be installed (i.e. the file for the PIN must
 					have been created, see option <option>-i</option>).
-					By default the key length is 1536 bits. User authentication is required for
+					By default the key length is 2048 bits. User authentication is required for
 					this operation. </para></listitem>
 				</varlistentry>
 

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -384,7 +384,7 @@ int main(int argc, char *argv[])
 				opt_wait = 1;
 				break;
 			case 'g':
-				if(keylen == 0) keylen = 1536;
+				if(keylen == 0) keylen = 2048;
 				break;
 			case 'o':
 				overwrite = 1;


### PR DESCRIPTION
Bump the default RSA key size in the westcos tool. The 2k is supported by the driver and using smaller values is no longer recommended and flagged by the github scanning tool as a potential security issue:

https://github.com/OpenSC/OpenSC/security/code-scanning/5