### PR TITLE
Remove only -lglib-2.0 from GIO_LIBS2

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -11,6 +11,7 @@ on:
       - .github/push-artifacts.sh
       - '**.am'
       - doc/**
+      - configure.ac
   push:
 
 permissions:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,7 @@ on:
       - .github/push-artifacts.sh
       - '**.am'
       - doc/**
+      - configure.ac
   push:
 
 permissions:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,7 @@ on:
       - .github/push-artifacts.sh
       - '**.am'
       - MacOSX/**
+      - configure.ac
   push:
 
 permissions:

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -7,6 +7,7 @@ on:
       - '**.am'
       - .github/workflows/packit.yaml
       - packaging/opensc.spec
+      - configure.ac
   push:
 
 jobs:

--- a/configure.ac
+++ b/configure.ac
@@ -554,10 +554,8 @@ case "${host}" in
 							   have_notify="no"
 							   have_gio2="no"  ])
 			LIBS="$saved_LIBS"
-			if test "${have_gio2}" = "yes"; then
-				# we do not need lglib-2.0
-				GIO2_LIBS="-lgio-2.0 -lgobject-2.0"
-			fi
+			# we do not need glib-2.0
+			GIO2_LIBS=$(echo "$GIO2_LIBS" | sed 's/-lglib-2.0//g')
 		;;
 esac
 


### PR DESCRIPTION
This is the alternative PR to #2689, fixing the problems described in #2615. The `pkg-config` sets `GIO2_LIBS` variable, and then only the unneeded `-lglib-2.0` is removed.