### PR TITLE
CI: pin macos-12 to allow building for macOS 10.12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - run: .github/setup-macos.sh
@@ -44,7 +44,7 @@ jobs:
           PASS_SECRETS_TAR_ENC: ${{ secrets.PASS_SECRETS_TAR_ENC }}
 
   push-artifacts:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [build]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Xcode 14 is the last version which ships the SDK for 10.12. So we are pinning the Github Runner to macos-12, which still has this version installed. This avoids the following warning:

/Users/runner/work/OpenSC/OpenSC/OpenSCToken/OpenSCTokenApp.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 13.1.99. (in target 'OpenSCTokenApp' from project 'OpenSCTokenApp')
warning: ONLY_ACTIVE_ARCH=YES requested with multiple ARCHS and no active architecture could be computed; building for all applicable architectures (in target 'OpenSCTokenApp' from project 'OpenSCTokenApp')

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
