### PR TITLE
fix OpenSSL library detection if pkgconfig not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -678,7 +678,7 @@ PKG_CHECK_MODULES(
 	[have_openssl="yes"],
 	[AC_CHECK_LIB(
 		[crypto],
-		[RSA_version],
+		[RSA_get_version],
 		[
 			have_openssl="yes"
 			OPENSSL_LIBS="-lcrypto"


### PR DESCRIPTION
If pkg-config fails to find OpenSSL, autoconf tries to check for the presence of the RSA_version symbol in the libcrypto library. However, it turns out that RSA_version was never actually part of OpenSSL, so this check will always fail.
To fix this issue, autoconf can search for the RSA_get_version symbol instead, which should be present in OpenSSL since version 1.1.1