### PR TITLE
sm-eac: mark first field of capdu_eac_mse as optional and fix #2726

### DIFF
--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -192,7 +192,7 @@ static int encode_mse_cdata(struct sc_context *ctx, int protocol,
 
 	struct sc_asn1_entry capdu_eac_mse[] = {
 		{ "Cryptographic mechanism reference",
-			SC_ASN1_OCTET_STRING, SC_ASN1_CTX|0x00, 0, NULL, NULL },
+			SC_ASN1_OCTET_STRING, SC_ASN1_CTX|0x00, SC_ASN1_OPTIONAL, NULL, NULL },
 		{ "Reference of a public key / secret key",
 			SC_ASN1_OCTET_STRING, SC_ASN1_CTX|0x03, SC_ASN1_OPTIONAL, NULL, NULL },
 		{ "Reference of a private key / Reference for computing a session key",


### PR DESCRIPTION
sm-eac: mark cryptographic mechanism field as optional and fix asn.1 encode error in encode_mse_cdata during terminal authentication. Fixes #2726.

The fix was tested using PersoSim (https://persosim.secunet.com/de/downloads/).
