### PR TITLE
fixed setting CKP_PUBLIC_CERTIFICATES_TOKEN

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1538,8 +1538,8 @@ _add_public_objects(struct sc_pkcs11_slot *slot, struct pkcs15_fw_data *fw_data)
 		if (obj->p15_object->flags & SC_PKCS15_CO_FLAG_PRIVATE) {
 			/* If we found some non-accessible public object,
 			 * we can no longer claim Public Ceritificate Token conformance */
-			if (obj->p15_object->type & SC_PKCS15_TYPE_PUBKEY ||
-				obj->p15_object->type & SC_PKCS15_TYPE_CERT) {
+			if ((obj->p15_object->type & SC_PKCS15_TYPE_CLASS_MASK) == SC_PKCS15_TYPE_PUBKEY ||
+				(obj->p15_object->type & SC_PKCS15_TYPE_CLASS_MASK) == SC_PKCS15_TYPE_CERT) {
 				public_certificates = 0;
 			}
 			continue;


### PR DESCRIPTION
Due to a bug in checking the object bitmask, a *private* data object would be considered to be a private certificate and the CKP_PUBLIC_CERTIFICATES_TOKEN would not be set to this slot.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
- [x] PKCS#11 module is tested