### PR TITLE
Fix several race conditions

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -531,10 +531,10 @@ int sc_unlock(sc_card_t *card)
 
 	r = sc_mutex_lock(card->ctx, card->mutex);
 	if (r != SC_SUCCESS)
-		return r;
+		LOG_FUNC_RETURN(card->ctx, r);
 
 	if (card->lock_count < 1) {
-		return SC_ERROR_INVALID_ARGUMENTS;
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 	}
 	if (--card->lock_count == 0) {
 		if (card->flags & SC_CARD_FLAG_KEEP_ALIVE) {

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -552,13 +552,13 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	const char *name;
 	CK_RV rv;
 
-	sc_log(context, "C_GetTokenInfo(%lx)", slotID);
 	if (pInfo == NULL_PTR)
 		return CKR_ARGUMENTS_BAD;
 
 	rv = sc_pkcs11_lock();
 	if (rv != CKR_OK)
 		return rv;
+	sc_log(context, "C_GetTokenInfo(%lx)", slotID);
 
 	rv = slot_get_token(slotID, &slot);
 	if (rv != CKR_OK)   {
@@ -610,14 +610,15 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 		}
 	}
 	memcpy(pInfo, &slot->token_info, sizeof(CK_TOKEN_INFO));
-out:
-	sc_pkcs11_unlock();
 
+out:
 	name = lookup_enum(RV_T, rv);
 	if (name)
 		sc_log(context, "C_GetTokenInfo(%lx) returns %s", slotID, name);
 	else
 		sc_log(context, "C_GetTokenInfo(%lx) returns 0x%08lX", slotID, rv);
+	sc_pkcs11_unlock();
+
 	return rv;
 }
 

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -1448,8 +1448,8 @@ CK_RV C_GenerateRandom(CK_SESSION_HANDLE hSession,	/* the session's handle */
 			rv = slot->p11card->framework->get_random(slot, RandomData, ulRandomLen);
 	}
 
-	sc_pkcs11_unlock();
 	SC_LOG_RV("C_GenerateRandom() = %s", rv);
+	sc_pkcs11_unlock();
 	return rv;
 }
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -765,6 +765,7 @@ int main(int argc, char * argv[])
 	if (!(default_provider = OSSL_PROVIDER_load(osslctx, "default"))) {
 		util_fatal("Failed to load OpenSSL \"default\" provider\n");
 	}
+	legacy_provider = OSSL_PROVIDER_try_load(NULL, "legacy", 1);
 #endif
 
 	while (1) {
@@ -6040,10 +6041,8 @@ static int test_digest(CK_SESSION_HANDLE session)
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 		if (!legacy_provider) {
-			if (!(legacy_provider = OSSL_PROVIDER_try_load(NULL, "legacy", 1))) {
-				printf("Failed to load legacy provider\n");
-				return errors;
-			}
+			printf("Failed to load legacy provider\n");
+			return errors;
 		}
 #endif
 	for (; mechTypes[i] != 0xffffff; i++) {
@@ -6247,10 +6246,8 @@ static int sign_verify_openssl(CK_SESSION_HANDLE session,
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(OPENSSL_NO_RIPEMD)
 	if (!legacy_provider) {
-		if (!(legacy_provider = OSSL_PROVIDER_try_load(NULL, "legacy", 1))) {
-			printf("Failed to load legacy provider");
-			return errors;
-		}
+		printf("Failed to load legacy provider");
+		return errors;
 	}
 #endif
 


### PR DESCRIPTION
https://github.com/OpenSC/OpenSC/issues/2707 was haunting me for months now and I was finally able to track the problem down to a race condition in sc_lock().

On my way, I learned about valgrind's [Helgrind](https://valgrind.org/docs/manual/hg-manual.html), which may be used like this:
```sh
valgrind --tool=helgrind --error-limit=no --free-is-write=yes pkcs11-tool --test-threads ILGISL  --test-threads ILGISL --test-threads ILGISL --test-threads ILGISL
```
This still shows some problem in pkcs11-tool, which I am ignoring for now.

Unfortunately, running Firefox with helgrind is not possible, at least on my machine, which caused me a lot of headache while finally fixing the real problem. I think it would be very useful if we could extend pkcs11-tool's thread tests with the tests we already have in place by using `--test --pin=123456`. Currently `--test-threads` only calls C_Initialize (`IL`), C_GetInfo (`GI`) or C_GetSlotList (`SL`).

##### Checklist
- [x] PKCS#11 module is tested