### PR TITLE
Do not remove sessions in C_GetSessionInfo if card is logged out

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -364,7 +364,7 @@ static int refresh_attributes(sc_reader_t *reader)
 	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
 
-	if (priv->reader_state.szReader == NULL || reader->ctx->flags & SC_READER_REMOVED) {
+	if (priv->reader_state.szReader == NULL || reader->flags & SC_READER_REMOVED) {
 		priv->reader_state.szReader = reader->name;
 		priv->reader_state.dwCurrentState = SCARD_STATE_UNAWARE;
 		priv->reader_state.dwEventState = SCARD_STATE_UNAWARE;
@@ -394,6 +394,8 @@ static int refresh_attributes(sc_reader_t *reader)
 #endif
 				|| rv == (LONG)SCARD_E_SERVICE_STOPPED) {
  			reader->flags &= ~(SC_READER_CARD_PRESENT);
+			reader->flags |= SC_READER_REMOVED;
+			priv->gpriv->removed_reader = reader;
  			SC_FUNC_RETURN(reader->ctx, SC_LOG_DEBUG_VERBOSE, SC_SUCCESS);
  		}
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1420,12 +1420,7 @@ int slot_get_card_state(struct sc_pkcs11_slot *slot)
 
 	if ((rv = sc_detect_card_presence(p15card->card->reader)) <= 0)
 		goto out;
-	if (rv & SC_READER_CARD_CHANGED)
-		return SC_READER_CARD_CHANGED;
-	else if (rv & SC_READER_REMOVED)
-		return SC_READER_REMOVED;
-	else if (rv & SC_READER_CARD_PRESENT)
-		return SC_READER_CARD_PRESENT;
+	return rv;
 out:
 	return 0;
 }

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1408,21 +1408,19 @@ int slot_get_card_state(struct sc_pkcs11_slot *slot)
 	int rv = 0;
 
 	if (slot->p11card == NULL) {
-		goto out;
+		return 0;
 	}
 
 	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
 	if (!fw_data)
-		goto out;
+		return 0;
 	p15card = fw_data->p15_card;
 	if (!p15card)
-		goto out;
+		return 0;
 
 	if ((rv = sc_detect_card_presence(p15card->card->reader)) <= 0)
-		goto out;
+		return 0;
 	return rv;
-out:
-	return 0;
 }
 
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1401,6 +1401,35 @@ out:
 	return logged_in;
 }
 
+int slot_get_card_state(struct sc_pkcs11_slot *slot)
+{
+	struct pkcs15_fw_data *fw_data = NULL;
+	struct sc_pkcs15_card *p15card = NULL;
+	int rv = 0;
+
+	if (slot->p11card == NULL) {
+		goto out;
+	}
+
+	fw_data = (struct pkcs15_fw_data *) slot->p11card->fws_data[slot->fw_data_idx];
+	if (!fw_data)
+		goto out;
+	p15card = fw_data->p15_card;
+	if (!p15card)
+		goto out;
+
+	if ((rv = sc_detect_card_presence(p15card->card->reader)) <= 0)
+		goto out;
+	if (rv & SC_READER_CARD_CHANGED)
+		return SC_READER_CARD_CHANGED;
+	else if (rv & SC_READER_REMOVED)
+		return SC_READER_REMOVED;
+	else if (rv & SC_READER_CARD_PRESENT)
+		return SC_READER_CARD_PRESENT;
+out:
+	return 0;
+}
+
 
 struct sc_pkcs15_object *
 _get_auth_object_by_name(struct sc_pkcs15_card *p15card, char *name, char *label)

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -277,7 +277,7 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	slot = session->slot;
 	card_status = slot_get_card_state(slot);
-	if (card_status != SC_READER_CARD_PRESENT) {
+	if (!(card_status & SC_READER_CARD_PRESENT)) {
 		/* Card was removed or reinserted, invalidate all sessions */
 		slot->login_user = -1;
 		sc_pkcs11_close_all_sessions(session->slot->id);

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -253,6 +253,7 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	struct sc_pkcs11_session *session;
 	struct sc_pkcs11_slot *slot;
 	const char *name;
+	int card_status = 0, logged_out = 0;
 
 	if (pInfo == NULL_PTR)
 		return CKR_ARGUMENTS_BAD;
@@ -275,16 +276,20 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	pInfo->ulDeviceError = 0;
 
 	slot = session->slot;
-	if (!sc_pkcs11_conf.atomic && slot->login_user >= 0 &&
-	    slot_get_logged_in_state(slot) == SC_PIN_STATE_LOGGED_OUT) {
+	card_status = slot_get_card_state(slot);
+	if (card_status != SC_READER_CARD_PRESENT) {
+		/* Card was removed or reinserted, invalidate all sessions */
 		slot->login_user = -1;
 		sc_pkcs11_close_all_sessions(session->slot->id);
 		rv = CKR_SESSION_HANDLE_INVALID;
 		goto out;
 	}
-	if (slot->login_user == CKU_SO) {
+
+	/* Check whether the user is logged in the card */
+	logged_out = (slot_get_logged_in_state(slot) == SC_PIN_STATE_LOGGED_OUT);
+	if (slot->login_user == CKU_SO && !logged_out) {
 		pInfo->state = CKS_RW_SO_FUNCTIONS;
-	} else if (slot->login_user == CKU_USER || !(slot->token_info.flags & CKF_LOGIN_REQUIRED)) {
+	} else if ((slot->login_user == CKU_USER && !logged_out) || !(slot->token_info.flags & CKF_LOGIN_REQUIRED)) {
 		pInfo->state = (session->flags & CKF_RW_SESSION)
 		    ? CKS_RW_USER_FUNCTIONS : CKS_RO_USER_FUNCTIONS;
 	} else {

--- a/src/pkcs11/pkcs11-session.c
+++ b/src/pkcs11/pkcs11-session.c
@@ -277,7 +277,7 @@ CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,	/* the session's handle */
 
 	slot = session->slot;
 	card_status = slot_get_card_state(slot);
-	if (!(card_status & SC_READER_CARD_PRESENT)) {
+	if (!(card_status & SC_READER_CARD_PRESENT) || card_status & SC_READER_CARD_CHANGED) {
 		/* Card was removed or reinserted, invalidate all sessions */
 		slot->login_user = -1;
 		sc_pkcs11_close_all_sessions(session->slot->id);

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -413,6 +413,7 @@ CK_RV slot_token_removed(CK_SLOT_ID id);
 CK_RV slot_allocate(struct sc_pkcs11_slot **, struct sc_pkcs11_card *);
 CK_RV slot_find_changed(CK_SLOT_ID_PTR idp, int mask);
 int slot_get_logged_in_state(struct sc_pkcs11_slot *slot);
+int slot_get_card_state(struct sc_pkcs11_slot *slot);
 
 /* Login tracking functions */
 CK_RV restore_login_state(struct sc_pkcs11_slot *slot);


### PR DESCRIPTION
In `C_GetSessionInfo`, the existing session should be removed when the card or reader was removed/has changed and not only by logging out of the card.

When checking the functionality of #2666, it was found that IDPrime 940 works with two PINs - default PIN and signature PIN. For signature PIN, it holds that we must log into the card before every operation with a private key, and the card then logs out after every such operation. The `pkcs11-tool` test revealed that this behaviour might cause problems when after such a sensitive operation `C_GetSessionInfo()` is called since it checks whether the card is in the logged-in state, and if not, it removes all existing sessions.

Removing of sessions in `C_GetSessionInfo` was introduced by https://github.com/OpenSC/OpenSC/pull/1875.
Changes were tested with IDPrime 940 (rebased with changes from #2666) and Yubikey 5.

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
