### PR TITLE
iso7816: Fixed reading with discretionary data object

### DIFF
--- a/src/common/compat_overflow.c
+++ b/src/common/compat_overflow.c
@@ -41,4 +41,5 @@
 ADD_OVERFLOW(__builtin_uadd_overflow,   unsigned,           UINT_MAX)
 ADD_OVERFLOW(__builtin_uaddl_overflow,  unsigned long,      ULONG_MAX)
 ADD_OVERFLOW(__builtin_uaddll_overflow, unsigned long long, ULLONG_MAX)
+ADD_OVERFLOW(__builtin_zuadd_overflow,  size_t,             SIZE_MAX)
 #endif

--- a/src/common/compat_overflow.h
+++ b/src/common/compat_overflow.h
@@ -33,6 +33,12 @@
 bool __builtin_uadd_overflow  (unsigned x, unsigned y, unsigned *sum);
 bool __builtin_uaddl_overflow (unsigned long x, unsigned long y, unsigned long *sum);
 bool __builtin_uaddll_overflow(unsigned long long x, unsigned long long y, unsigned long long *sum);
+
+bool __builtin_zuadd_overflow (size_t x, size_t y, size_t *sum);
+#else
+
+#define __builtin_zuadd_overflow __builtin_add_overflow
+
 #endif
 /* TODO
 bool __builtin_usub_overflow  (unsigned x, unsigned y, unsigned *diff);

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -658,14 +658,14 @@ int sc_read_binary(sc_card_t *card, unsigned int idx,
 			sc_log(card->ctx, "Subsequent read failed with %d, returning what was read successfully.", r);
 			break;
 		}
-		if ((idx > SIZE_MAX - (size_t) r)
-				|| (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;
@@ -706,14 +706,14 @@ int sc_write_binary(sc_card_t *card, unsigned int idx,
 		r = card->ops->write_binary(card, idx, buf, chunk, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
-		if ((idx > SIZE_MAX - (size_t) r)
-				|| (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;
@@ -762,14 +762,14 @@ int sc_update_binary(sc_card_t *card, unsigned int idx,
 		r = card->ops->update_binary(card, idx, buf, chunk, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
-		if ((idx > SIZE_MAX - (size_t) r)
-				|| (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;
@@ -808,14 +808,14 @@ int sc_erase_binary(struct sc_card *card, unsigned int idx, size_t count,  unsig
 		r = card->ops->erase_binary(card, idx, todo, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
-		if ((idx > SIZE_MAX - (size_t) r)
-				|| (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;
@@ -982,13 +982,14 @@ int sc_read_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
 			sc_log(card->ctx, "Subsequent read failed with %d, returning what was read successfully.", r);
 			break;
 		}
-		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;
@@ -1070,13 +1071,14 @@ int sc_update_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
 		r = card->ops->update_record(card, rec_nr, idx, buf, chunk, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
-		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
-			/* `idx + r` or `todo - r` would overflow */
-			r = SC_ERROR_OFFSET_TOO_LARGE;
-		}
 		if (r < 0) {
 			sc_unlock(card);
 			LOG_FUNC_RETURN(card->ctx, r);
+		}
+		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
+			/* `idx + r` or `todo - r` would overflow */
+			sc_unlock(card);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OFFSET_TOO_LARGE);
 		}
 
 		todo -= (size_t) r;

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -652,6 +652,12 @@ int sc_read_binary(sc_card_t *card, unsigned int idx,
 		r = card->ops->read_binary(card, idx, buf, chunk, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
+		if (r < 0 && todo != count) {
+			/* the last command failed, but previous ones succeeded.
+			 * Let's just return what we've successfully read. */
+			sc_log(card->ctx, "Subsequent read failed with %d, returning what was read successfully.", r);
+			break;
+		}
 		if ((idx > SIZE_MAX - (size_t) r)
 				|| (size_t) r > todo) {
 			/* `idx + r` or `todo - r` would overflow */
@@ -970,6 +976,12 @@ int sc_read_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
 		r = card->ops->read_record(card, rec_nr, idx, buf, chunk, flags);
 		if (r == 0 || r == SC_ERROR_FILE_END_REACHED)
 			break;
+		if (r < 0 && todo != count) {
+			/* the last command failed, but previous ones succeeded.
+			 * Let's just return what we've successfully read. */
+			sc_log(card->ctx, "Subsequent read failed with %d, returning what was read successfully.", r);
+			break;
+		}
 		if ((idx > SIZE_MAX - (size_t) r) || (size_t) r > todo) {
 			/* `idx + r` or `todo - r` would overflow */
 			r = SC_ERROR_OFFSET_TOO_LARGE;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -167,7 +167,7 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 
 const struct sc_asn1_entry c_asn1_do_data[] = {
 	{ "Offset Data Object", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x14, SC_ASN1_OPTIONAL, NULL, NULL },
-	{ "Discretionary Data Object", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x13, SC_ASN1_ALLOC|SC_ASN1_UNSIGNED, NULL, NULL },
+	{ "Discretionary Data Object", SC_ASN1_OCTET_STRING, SC_ASN1_APP|0x13, SC_ASN1_ALLOC|SC_ASN1_UNSIGNED|SC_ASN1_OPTIONAL, NULL, NULL },
 	{ NULL, 0, 0, 0, NULL, NULL }
 };
 
@@ -212,6 +212,9 @@ int decode_do_data(struct sc_context *ctx,
 	LOG_TEST_RET(ctx,
 			sc_asn1_decode(ctx, asn1_do_data, encoded_data, encoded_data_len, NULL, NULL),
 			"sc_asn1_decode() failed");
+
+	if (!(asn1_do_data[1].flags & SC_ASN1_PRESENT))
+		return SC_ERROR_INVALID_ASN1_OBJECT;
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -242,7 +242,7 @@ iso7816_read_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 		r = encode_do_data(card->ctx, idx, NULL, 0, &encoded_data, &encoded_data_len);
 		LOG_TEST_GOTO_ERR(card->ctx, r, "Could not encode data objects");
 
-		sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xB3, rec_nr, 0);
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0xB3, rec_nr, 0);
 		apdu.lc = encoded_data_len;
 		apdu.datalen = encoded_data_len;
 		apdu.data = encoded_data;


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2738

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
