### PR TITLE
cardos-tool : exit if no action is specified

### DIFF
--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -1183,7 +1183,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	
-	if(action_count == 0)
+	if (action_count == 0)
 		util_print_usage_and_die(app_name, options, option_help, NULL);
 
 	/* create sc_context_t object */

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -1182,6 +1182,9 @@ int main(int argc, char *argv[])
 			util_print_usage_and_die(app_name, options, option_help, NULL);
 		}
 	}
+	
+	if(action_count == 0)
+		util_print_usage_and_die(app_name, options, option_help, NULL);
 
 	/* create sc_context_t object */
 	memset(&ctx_param, 0, sizeof(ctx_param));


### PR DESCRIPTION
Fixes warning about the unused variable.