### PR TITLE
Fix pkcs11-tool unwrap / incorrect CKA_ID

### DIFF
--- a/.github/setup-fedora.sh
+++ b/.github/setup-fedora.sh
@@ -14,8 +14,7 @@ fi
 
 sudo dnf install -y $DEPS
 
-# The test-pkcs11-tool-unwrap-wrap-test.sh is broken in Fedora for some reason
 sed -i -e '/XFAIL_TESTS/,$ {
-  s/XFAIL_TESTS.*/XFAIL_TESTS=test-pkcs11-tool-test-threads.sh test-pkcs11-tool-test.sh test-pkcs11-tool-unwrap-wrap-test.sh/
+  s/XFAIL_TESTS.*/XFAIL_TESTS=test-pkcs11-tool-test-threads.sh test-pkcs11-tool-test.sh/
   q
 }' tests/Makefile.am

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3347,6 +3347,8 @@ unwrap_key(CK_SESSION_HANDLE session)
 		{CKA_CLASS, &secret_key_class, sizeof(secret_key_class)},
 		{CKA_TOKEN, &_true, sizeof(_true)},
 	};
+	CK_BYTE object_id[100];
+	size_t id_len;
 	CK_OBJECT_HANDLE hSecretKey;
 	int n_attr = 2;
 	CK_RV rv;
@@ -3450,9 +3452,6 @@ unwrap_key(CK_SESSION_HANDLE session)
 	}
 
 	if (opt_application_id != NULL) {
-		CK_BYTE object_id[100];
-		size_t id_len;
-
 		id_len = sizeof(object_id);
 		if (!sc_hex_to_bin(opt_application_id, object_id, &id_len)) {
 			FILL_ATTR(keyTemplate[n_attr], CKA_ID, object_id, id_len);


### PR DESCRIPTION
"object_id[]" and "id_len" must be allocated so that it is not deallocated or overwritten (on the stack) at the time of the C_UnwrapKey() call.

	modified:   src/tools/pkcs11-tool.c

