### PR TITLE
cardos-tool: correctly identify CardOS v5.4 cards

### DIFF
--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -198,6 +198,8 @@ static int cardos_info(void)
 	} else if (apdu.resp[0] == 0xc9 &&
 			(apdu.resp[1] == 0x02 || apdu.resp[1] == 0x03)) {
 		printf(" (that's CardOS V5.3)\n");
+	} else if (apdu.resp[0] == 0xc9 && apdu.resp[1] == 0x04) {
+		printf(" (that's CardOS V5.4)\n");
 	} else {
 		printf(" (unknown Version)\n");
 	}


### PR DESCRIPTION
Card name:

```
$ opensc-tool -n
Using reader with a card: Alcor Micro AU9540 00 00
Atos CardOS
```

##### Checklist

Simple fix, Nothing applies.