### PR TITLE
pkcs11-tool: add cipher test mode

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
       - run: .github/build.sh no-shared
 
   build-ix86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: .github/setup-linux.sh ix86

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -6295,7 +6295,7 @@ static int test_cipher(CK_SESSION_HANDLE session)
 
 		for (CK_ULONG ctlen = 0; ctlen < cipher_algs[i].ctsz;) {
 
-			CK_ULONG isize = min(cipher_algs[i].ctsz - ctlen, CIPHER_CHUNK);
+			CK_ULONG isize = MIN(cipher_algs[i].ctsz - ctlen, CIPHER_CHUNK);
 			CK_ULONG osize = sizeof(ptext1) - poff;
 
 			fct = "C_DecryptUpdate";

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -96,7 +96,9 @@ extern CK_FUNCTION_LIST_3_0 pkcs11_function_list_3_0;
 #define MAX_TEST_THREADS 10
 #endif
 
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#ifndef MIN
+# define MIN(a, b)	(((a) < (b))? (a) : (b))
+#endif
 
 #define NEED_SESSION_RO	0x01
 #define NEED_SESSION_RW	0x02


### PR DESCRIPTION
Add support for non-AEAD ciphers to the tool test
mode to assert that Encrypt/Decrypt APIs work correctly using established test vectors.

Tested using a softhsm supporting the algorithms on a QNX target

```
# pkcs11-tool --module=/system/lib/dll/pkcs11-module.so --test
Using slot 0 with a present token (0x0)
C_SeedRandom() and C_GenerateRandom():
  seems to be OK
Digests:
  all 4 digest functions seem to work
  SHA256: OK
Ciphers:
  AES-ECB: OK
  AES-CBC: OK
Signatures: not implemented
Verify: not implemented
Decryption (currently only for RSA)
No errors

```
