### PR TITLE
pkcs15init: correct left length calculation to fix buffer overrun bug.

### DIFF
--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -872,7 +872,7 @@ static int cardos_have_verifyrc_package(sc_card_t *card)
 	sc_apdu_t apdu;
         u8        rbuf[SC_MAX_APDU_BUFFER_SIZE];
         int       r;
-	const u8  *p = rbuf, *q;
+	const u8  *p = rbuf, *q, *pp;
 	size_t    len, tlen = 0, ilen = 0;
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0xca, 0x01, 0x88);
@@ -888,13 +888,13 @@ static int cardos_have_verifyrc_package(sc_card_t *card)
 		return 0;
 
 	while (len != 0) {
-		p = sc_asn1_find_tag(card->ctx, p, len, 0xe1, &tlen);
-		if (p == NULL)
+		pp = sc_asn1_find_tag(card->ctx, p, len, 0xe1, &tlen);
+		if (pp == NULL)
 			return 0;
 		if (card->type == SC_CARD_TYPE_CARDOS_M4_3)	{
 			/* the verifyRC package on CardOS 4.3B use Manufacturer ID 0x01	*/
 			/* and Package Number 0x07					*/
-			q = sc_asn1_find_tag(card->ctx, p, tlen, 0x01, &ilen);
+			q = sc_asn1_find_tag(card->ctx, pp, tlen, 0x01, &ilen);
 			if (q == NULL || ilen != 4)
 				return 0;
 			if (q[0] == 0x07)
@@ -902,7 +902,7 @@ static int cardos_have_verifyrc_package(sc_card_t *card)
 		} else if (card->type == SC_CARD_TYPE_CARDOS_M4_4)	{
 			/* the verifyRC package on CardOS 4.4 use Manufacturer ID 0x03	*/
 			/* and Package Number 0x02					*/
-			q = sc_asn1_find_tag(card->ctx, p, tlen, 0x03, &ilen);
+			q = sc_asn1_find_tag(card->ctx, pp, tlen, 0x03, &ilen);
 			if (q == NULL || ilen != 4)
 				return 0;
 			if (q[0] == 0x02)


### PR DESCRIPTION
Fixes #2785

This PR aims to fix the buffer overrun vulnerability in src/pkcs15init/pkcs15-cardos.c, which falsely calculated the length of left bytes in buffer while looking for 2 specific tags in buffer.
This is a recurring bug as one occurence of https://github.com/advisories/GHSA-xq25-8g7f-6hc5, and the fix commit is almost the same.
