### PR TITLE
Fix one oss-fuzz report, document the way to get better traces from fuzzing and fix coverity warning from recent IDPrime

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -56,7 +56,7 @@ static const struct sc_atr_table idprime_atrs[] = {
 	{ "3b:7f:96:00:00:80:31:80:65:b0:84:61:60:fb:12:0f:fe:82:90:00",
 	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime 930/3930",
-	  SC_CARD_TYPE_IDPRIME_930, 0, NULL }, 
+	  SC_CARD_TYPE_IDPRIME_930, 0, NULL },
 	{ "3b:7f:96:00:00:80:31:80:65:b0:85:59:56:fb:12:0f:fe:82:90:00",
 	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime 940",
@@ -355,7 +355,7 @@ static int idprime_process_keyrefmap(sc_card_t *card, idprime_private_data_t *pr
 		u8 *start = &buf[i * KEYREF_OBJ_LEN];
 		if (start[0] == 0) /* Empty key ref */
 			continue;
-	
+
 		new_keyref.index = start[2];
 		new_keyref.key_reference = start[1];
 		new_keyref.pin_index = start[7];
@@ -558,7 +558,7 @@ static int idprime_init(sc_card_t *card)
 				r = SC_ERROR_INVALID_DATA;
 			LOG_FUNC_RETURN(card->ctx, r);
 		}
-		
+
 		if ((r = idprime_process_keyrefmap(card, priv, r)) != SC_SUCCESS) {
 			idprime_free_private_data(priv);
 			LOG_FUNC_RETURN(card->ctx, r);
@@ -935,13 +935,15 @@ idprime_set_security_env(struct sc_card *card,
 {
 	int r;
 	struct sc_security_env new_env;
-	idprime_private_data_t *priv = card->drv_data;
+	idprime_private_data_t *priv = NULL;
 
 	if (card == NULL || env == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	priv = card->drv_data;
 
 	/* The card requires algorithm reference here */
 	new_env = *env;

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -244,7 +244,7 @@ int sc_pkcs15_decode_prkdf_entry(struct sc_pkcs15_card *p15card,
 			const unsigned char *p = ec_domain;
 			ASN1_OBJECT *object = d2i_ASN1_OBJECT(NULL, &p, ec_domain_len);
 			int nid;
-			const EC_GROUP *group;
+			EC_GROUP *group;
 			if (!object) {
 				r = SC_ERROR_INVALID_ASN1_OBJECT;
 				goto err;
@@ -261,6 +261,7 @@ int sc_pkcs15_decode_prkdf_entry(struct sc_pkcs15_card *p15card,
 				goto err;
 			}
 			info.field_length = EC_GROUP_order_bits(group);
+			EC_GROUP_free(group);
 			if (!info.field_length) {
 				r = SC_ERROR_CORRUPTED_DATA;
 				goto err;
@@ -627,7 +628,7 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 	switch (pk_type) {
 	case EVP_PKEY_RSA: {
 		struct sc_pkcs15_prkey_rsa *dst = &pkcs15_key->u.rsa;
-		
+
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 		const BIGNUM *src_n, *src_e, *src_d, *src_p, *src_q, *src_iqmp, *src_dmp1, *src_dmq1;
 		RSA *src = NULL;
@@ -791,7 +792,7 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 		/*
 		 * In OpenSC the field_length is in bits. Not all curves are a multiple of 8.
 		 * EC_POINT_point2oct handles this and returns octstrings that can handle
-		 * these curves. Get real field_length from OpenSSL. 
+		 * these curves. Get real field_length from OpenSSL.
 		 */
 		dst->params.field_length = EC_GROUP_get_degree(grp);
 

--- a/src/tests/fuzzing/README.md
+++ b/src/tests/fuzzing/README.md
@@ -15,7 +15,7 @@ Example configuration for libFuzzer:
 ./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing CC=clang CFLAGS=-fsanitize=fuzzer-no-link FUZZING_LIBS=-fsanitize=fuzzer
 ```
 
-To add some of the LLVM Sanitizers, modify `FUZZING_LIBS`:  
+To add some of the LLVM Sanitizers, modify `FUZZING_LIBS`:
 ```
 FUZZING_LIBS=-fsanitize=fuzzer,address,undefined
 ```
@@ -29,13 +29,41 @@ Example of testing without fuzzing:
 ./fuzz_pkcs15_reader ./input_file
 ```
 
+## Reproducing issues
+Some of the issues are not reproducible when build outside of the fuzzing images. In that case, the safest
+option is to reproduce them with the python/docker helpers provided by [oss-fuzz](https://github.com/google/oss-fuzz/).
+You can build latest fuzzers in the oss-fuzz containers with the following steps:
+```
+python3 infra/helper.py pull_images
+python3 infra/helper.py build_image opensc
+python3 infra/helper.py build_fuzzers opensc
+```
+After that, you can download reproducer from the oss-fuzz dashboard and run it locally in the container:
+```
+python3 infra/helper.py reproduce opensc fuzz_pkcs15_decode /path/to/testcase
+```
+
+### Expanding incomplete backtraces
+Sometimes the backtrace visible in the oss-fuzz dashboard is not useful, for example showing only part of the
+trace ending inside of (outdated) openssl code:
+```
+Direct leak of 168 byte(s) in 1 object(s) allocated from:
+	    #0 0x5318e6 in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:3
+	    #1 0x7faca8714c0d in CRYPTO_zalloc
+```
+In that case, you can use the address sanitizer option `fast_unwind_on_malloc=0` in `ASAN_OPTIONS` environment
+variable to expand this trace, for example:
+```
+python3 infra/helper.py reproduce -eASAN_OPTIONS='fast_unwind_on_malloc=0' opensc fuzz_pkcs15_decode testcase
+```
+
 ## Fuzzing
 ### libFuzzer
 See libFuzzer [documentation](https://llvm.org/docs/LibFuzzer.html) for details.
 
 Fuzzing with a predefined corpus can be run like this:
 ```
-./fuzz_pkcs15_reader corpus/fuzz_pkcs15_reader 
+./fuzz_pkcs15_reader corpus/fuzz_pkcs15_reader
 ```
 Newly generated input files are stored in the corpus directory.
 


### PR DESCRIPTION


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
