### PR TITLE
Fixed PIN authentication bypass

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -307,19 +307,6 @@ sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *pi
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_PIN_REFERENCE);
 	auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 
-	/*
-	 * if pin cache is disabled, we can get here with no PIN data.
-	 * in this case, to avoid error or unnecessary pin prompting on pinpad,
-	 * check if the PIN has been already verified and the access condition
-	 * is still open on card.
-	 */
-	if (pinlen == 0) {
-	    r = sc_pkcs15_get_pin_info(p15card, pin_obj);
-
-	    if (r == SC_SUCCESS && auth_info->logged_in == SC_PIN_STATE_LOGGED_IN)
-		LOG_FUNC_RETURN(ctx, r);
-	}
-
 	r = _validate_pin(p15card, auth_info, pinlen);
 
 	if (r)


### PR DESCRIPTION
If two processes are accessing a token, then one process may leave the card usable with an authenticated PIN so that a key may sign/decrypt any data. This is especially the case if the token does not support a way of resetting the authentication status (logout).

We have some tracking of the authentication status in software via PKCS#11, Minidriver (OS-wise) and CryptoTokenKit (OS-wise), which is why a PIN-prompt will appear even though the card may technically be unlocked as described in the above example. However, before this change, an empty PIN was not verified (likely yielding an error during PIN-verification), but it was just checked whether the PIN is authenticated. This defeats the purpose of the PIN verification, because an empty PIN is not the correct one. Especially during OS Logon, we don't want that kind of shortcut, but we want the user to verify the correct PIN (even though the token was left unattended and authentication at the computer).

This essentially reverts commit e6f7373ef066cfab6e3162e8b5f692683db23864.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
