### PR TITLE
include ATR of SafeNet eToken 5110 in the IDPrime driver

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -69,6 +69,10 @@ static const struct sc_atr_table idprime_atrs[] = {
 	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:00:00:00:00:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime MD 8840, 3840, 3810, 840, 830 and MD 940 Cards",
 	  SC_CARD_TYPE_IDPRIME_GENERIC, 0, NULL },
+	{ "3b:ff:96:00:00:81:31:fe:43:80:31:80:65:b0:85:59:56:fb:12:0f:fe:82:90:00:00",
+	  "ff:ff:00:ff:ff:ff:ff:00:ff:ff:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:ff:ff:00",
+	  "Gemalto IDPrime MD 8840, 3840, 3810, 840 and 830 Cards",
+	  SC_CARD_TYPE_IDPRIME_GENERIC, 0, NULL },
 	{ NULL, NULL, NULL, 0, 0, NULL }
 };
 


### PR DESCRIPTION
I have a USB token labelled *SafeNet 5110* (cf. https://github.com/OpenSC/OpenSC/issues/1320) known to be an IDPrime "card". It turns out to work well with the IDPrime driver (possibly thanks to  #2666) after adding the appropriate ATR (also listed [here](https://github.com/LudovicRousseau/pcsc-tools/blob/d202099ef9344ad3930980cdf70573639f2befc3/smartcard_list.txt#L13287-L13288)) to [card-idprime.c](https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/card-idprime.c).

``` text
$./pkcs11-tool --login --test
Using slot 1 with a present token (0x4)
Logging in to "QES JS".
Please enter User PIN: 
C_SeedRandom() and C_GenerateRandom():
  seeding (C_SeedRandom) not supported
  seems to be OK
Digests:
  all 4 digest functions seem to work
  MD5: OK
  RIPEMD160: OK
  SHA-1: OK
  SHA256: OK
Signatures (currently only for RSA)
  testing key 0 (Private key 1) 
  all 4 signature functions seem to work
  testing signature mechanisms:
    RSA-PKCS: OK
    SHA256-RSA-PKCS: OK
Verify (currently only for RSA)
  testing key 0 (Private key 1)
    RSA-PKCS: OK
Decryption (currently only for RSA)
  testing key 0 (Private key 1) -- can't be used to decrypt, skipping
No errors
```
I only have a single (production) token. I am therefore not very keen on testing any other (advanced) features of the driver.

It appears that none of the IDPrime cards are included in the Windows minidriver. I guess this must have been deliberate. An attempt to include the token resulted in an error.
``` text
>certutil /scinfo
=======================================================
Analyzing card in reader: SafeNet eToken 5100 [eToken 5110 SC] 01 00
Microsoft Base Smart Card Crypto Provider: Missing stored keyset
Microsoft Smart Card Key Storage Provider: Missing stored keyset

--------------===========================--------------
CertUtil: -SCInfo command FAILED: 0x80090016 (-2146893802 NTE_BAD_KEYSET)
CertUtil: Keyset does not exist
```

Feel free to change `SC_CARD_TYPE_IDPRIME_GENERIC` (or the description) to a more appropriate value.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
