### PR TITLE
LibreSSL fixes

### DIFF
--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-V=libressl-3.6.1
+V=libressl-3.7.3
 
 sudo apt-get remove -y libssl-dev
 

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1115,7 +1115,7 @@ static int starcos_process_acl(sc_card_t *card, sc_file_t *file,
 			memcpy(p, file->name, (u8)file->namelen);
 			p   += 16;
 		} else {
-			/* (mis)use the fid as aid */
+			/* use the fid as aid */
 			*p++ = 2;
 			memset(p, 0, 16);
 			*p++ = (file->id >> 8) & 0xff;

--- a/src/libopensc/sc-ossl-compat.h
+++ b/src/libopensc/sc-ossl-compat.h
@@ -50,10 +50,12 @@ extern "C" {
 #if LIBRESSL_VERSION_NUMBER < 0x30500000L
 #define FIPS_mode()                             (0)
 #endif
+#ifndef EVP_sha3_224
 #define EVP_sha3_224()                          (NULL)
 #define EVP_sha3_256()                          (NULL)
 #define EVP_sha3_384()                          (NULL)
 #define EVP_sha3_512()                          (NULL)
+#endif
 #if LIBRESSL_VERSION_NUMBER < 0x3070000fL
 #define EVP_PKEY_new_raw_public_key(t, e, p, l) (NULL)
 #define EVP_PKEY_get_raw_public_key(p, pu, l)   (0)

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7230,8 +7230,12 @@ BOOL APIENTRY DllMain( HINSTANCE hinstDLL,
 	case DLL_PROCESS_DETACH:
 		sc_notify_close();
 		if (lpReserved == NULL) {
-#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(ENABLE_OPENSSL)
+#if defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
 			CRYPTO_secure_malloc_done();
+#else
+			OPENSSL_cleanup();
+#endif
 #endif
 #ifdef ENABLE_OPENPACE
 			EAC_cleanup();

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -290,7 +290,7 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 			ENGINE_free(e);
 			e = NULL;
 		}
-#endif /* !OPENSSL_NO_STATIC_ENGINE && !OPENSSL_NO_GOST */
+#endif /* !OPENSSL_NO_STATIC_ENGINE && !OPENSSL_NO_GOST && !LIBRESSL_VERSION_NUMBER */
 	}
 	if (e) {
 		ENGINE_set_default(e, ENGINE_METHOD_ALL);

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -252,8 +252,12 @@ __attribute__((destructor))
 int module_close()
 {
 	sc_notify_close();
-#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(ENABLE_OPENSSL)
+#if defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_secure_malloc_done();
+#else
+	OPENSSL_cleanup();
+#endif
 #endif
 #ifdef ENABLE_OPENPACE
 	EAC_cleanup();


### PR DESCRIPTION
- LibreSSL: Use OPENSSL_cleanup()
- LibreSSL does provide EVP_sha3_*() after 3.7.3

Two fixes coming out of OpenBSD's official `security/opensc` port.
Tested with latest LibreSSL and

```
$ opensc-tool -n
Using reader with a card: Generic Smart Card Reader Interface [Smart Card Reader Interface] (20070818000000000) 00 00
EstEID 2018
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
