### PR TITLE
Revert "LibreSSL: Use OPENSSL_cleanup()"

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7230,12 +7230,8 @@ BOOL APIENTRY DllMain( HINSTANCE hinstDLL,
 	case DLL_PROCESS_DETACH:
 		sc_notify_close();
 		if (lpReserved == NULL) {
-#if defined(ENABLE_OPENSSL)
-#if defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
 			CRYPTO_secure_malloc_done();
-#else
-			OPENSSL_cleanup();
-#endif
 #endif
 #ifdef ENABLE_OPENPACE
 			EAC_cleanup();

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -252,12 +252,8 @@ __attribute__((destructor))
 int module_close()
 {
 	sc_notify_close();
-#if defined(ENABLE_OPENSSL)
-#if defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(ENABLE_OPENSSL) && defined(OPENSSL_SECURE_MALLOC_SIZE) && !defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_secure_malloc_done();
-#else
-	OPENSSL_cleanup();
-#endif
 #endif
 #ifdef ENABLE_OPENPACE
 	EAC_cleanup();


### PR DESCRIPTION
This reverts commit 79bec702662f8f35f76b1cd15f61d81f7ca9ea66.

(See the discussion of issue #2819....)

Fixes #2819

- [x] PKCS#11 module is tested

