### PR TITLE
libopensc, pkcs15init: silence some gcc errors spotted on Ubuntu 23.10

### DIFF
--- a/src/libopensc/card-asepcos.c
+++ b/src/libopensc/card-asepcos.c
@@ -336,7 +336,7 @@ static int asepcos_akn_to_fileid(sc_card_t *card, sc_cardctl_asepcos_akn2fileid_
 {
 	int r;
 	u8  sbuf[32], rbuf[SC_MAX_APDU_BUFFER_SIZE];
-	sc_apdu_t apdu;
+	sc_apdu_t apdu = {0};
 
 	sbuf[0] = p->akn & 0xff;
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x28, 0x02, 0x01);
@@ -365,7 +365,7 @@ static int asepcos_set_sec_attributes(sc_card_t *card, const u8 *data, size_t le
 	int is_ef)
 {
 	int r, type = is_ef != 0 ? 0x02 : 0x04;
-	sc_apdu_t apdu;
+	sc_apdu_t apdu = {0};
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x8a, type, 0xab);
 	apdu.cla    |= 0x80;
@@ -537,7 +537,7 @@ static int asepcos_create_file(sc_card_t *card, sc_file_t *file)
 {
 	if (file->type == SC_FILE_TYPE_DF) {
 		int r, type;
-		sc_apdu_t apdu;
+		sc_apdu_t apdu = {0};
 		u8  sbuf[SC_MAX_APDU_BUFFER_SIZE], *p = &sbuf[0];
 
 		*p++ = (file->id >> 8) & 0xff;

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -1388,7 +1388,7 @@ static int starcos_erase_card(sc_card_t *card)
 {	/* restore the delivery state */
 	int r;
 	u8  sbuf[2];
-	sc_apdu_t apdu;
+	sc_apdu_t apdu = {0};
 
 	sbuf[0] = 0x3f;
 	sbuf[1] = 0x00;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -900,7 +900,7 @@ iso7816_create_file(struct sc_card *card, sc_file_t *file)
 static int
 iso7816_get_response(struct sc_card *card, size_t *count, u8 *buf)
 {
-	struct sc_apdu apdu;
+	struct sc_apdu apdu = {0};
 	int r;
 	size_t rlen;
 

--- a/src/pkcs15init/pkcs15-asepcos.c
+++ b/src/pkcs15init/pkcs15-asepcos.c
@@ -223,7 +223,7 @@ static int asepcos_do_store_pin(sc_profile_t *profile, sc_card_t *card,
 	u8  buf[64], sbuf[64], *p = buf, *q = sbuf;
 	int r, akn = 0;
 
-	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
+	if (auth_info == NULL || auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;
 
 	/* outer tag */
@@ -318,7 +318,7 @@ static int asepcos_do_store_pin(sc_profile_t *profile, sc_card_t *card,
  */
 static int have_onepin(sc_profile_t *profile)
 {
-        sc_pkcs15_auth_info_t sopin;
+        sc_pkcs15_auth_info_t sopin = {0};
 
         sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &sopin);
 
@@ -354,7 +354,7 @@ static int asepcos_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	if (!pin || !pin_len)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
-	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
+	if (auth_info == NULL || auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
         	return SC_ERROR_OBJECT_NOT_VALID;
 
 	pid = (auth_info->attrs.pin.reference & 0xff) | (((tpath.len >> 1) - 1) << 16);
@@ -393,7 +393,7 @@ static int asepcos_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		/* Create PUK (if specified). Note: we need to create the PUK
 		 * the PIN as the PUK fileid is used in the PIN acl.
 		 */
-		struct sc_pkcs15_auth_info puk_ainfo;
+		struct sc_pkcs15_auth_info puk_ainfo = {0};
 
 		if (auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN)
 			sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PUK, &puk_ainfo);

--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -210,7 +210,7 @@ cardos_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_file_t *d
 		return r;
 
 	if (puk && puk_len) {
-		struct sc_pkcs15_auth_info puk_ainfo;
+		struct sc_pkcs15_auth_info puk_ainfo = {0};
 
 		sc_profile_get_pin_info(profile,
 				SC_PKCS15INIT_USER_PUK, &puk_ainfo);

--- a/src/pkcs15init/pkcs15-entersafe.c
+++ b/src/pkcs15init/pkcs15-entersafe.c
@@ -472,7 +472,7 @@ static int entersafe_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15ca
 static int entersafe_sanity_check(sc_profile_t *profile, sc_pkcs15_card_t *p15card)
 {
 	struct sc_context *ctx = p15card->card->ctx;
-	struct sc_pkcs15_auth_info profile_auth;
+	struct sc_pkcs15_auth_info profile_auth = {0};
 	struct sc_pkcs15_object *objs[32];
 	int rv, nn, ii, update_df = 0;
 

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -729,7 +729,7 @@ static int epass2003_pkcs15_sanity_check(sc_profile_t * profile,
 					 sc_pkcs15_card_t * p15card)
 {
 	struct sc_context *ctx = p15card->card->ctx;
-	struct sc_pkcs15_auth_info profile_auth;
+	struct sc_pkcs15_auth_info profile_auth = {0};
 	struct sc_pkcs15_object *objs[32];
 	int rv, nn, ii, update_df = 0;
 

--- a/src/pkcs15init/pkcs15-incrypto34.c
+++ b/src/pkcs15init/pkcs15-incrypto34.c
@@ -224,7 +224,7 @@ incrypto34_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		return r;
 
 	if (puk && puk_len) {
-		struct sc_pkcs15_auth_info puk_ainfo;
+		struct sc_pkcs15_auth_info puk_ainfo = {0};
 
 		sc_profile_get_pin_info(profile,
 				SC_PKCS15INIT_USER_PUK, &puk_ainfo);

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -1014,6 +1014,9 @@ sc_pkcs15init_store_puk(struct sc_pkcs15_card *p15card,
 	auth_info = (struct sc_pkcs15_auth_info *) pin_obj->data;
 
 	sc_profile_get_pin_info(profile, SC_PKCS15INIT_USER_PUK, auth_info);
+	if (auth_info == NULL)
+		LOG_TEST_RET(ctx, SC_ERROR_OBJECT_NOT_FOUND, "Failed to retrieve auth_info");
+
 	auth_info->auth_id = args->puk_id;
 
 	/* Now store the PINs */
@@ -1078,6 +1081,9 @@ sc_pkcs15init_store_pin(struct sc_pkcs15_card *p15card, struct sc_profile *profi
 	auth_info = (struct sc_pkcs15_auth_info *) pin_obj->data;
 
 	sc_profile_get_pin_info(profile, SC_PKCS15INIT_USER_PIN, auth_info);
+	if (auth_info == NULL)
+		LOG_TEST_RET(ctx, SC_ERROR_OBJECT_NOT_FOUND, "Failed to retrieve auth_info");
+
 	auth_info->auth_id = args->auth_id;
 
 	/* Now store the PINs */
@@ -3255,7 +3261,7 @@ sc_pkcs15init_update_any_df(struct sc_pkcs15_card *p15card,
 	struct sc_card	*card = p15card->card;
 	struct sc_file	*file = NULL;
 	unsigned char	*buf = NULL;
-	size_t		bufsize;
+	size_t		bufsize = 0;
 	int		update_odf = is_new, r = 0;
 
 	LOG_FUNC_CALLED(ctx);
@@ -3429,7 +3435,7 @@ sc_pkcs15init_change_attrib(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_card	*card = p15card->card;
 	unsigned char	*buf = NULL;
-	size_t		bufsize;
+	size_t		bufsize = 0;
 	int		df_type, r = 0;
 	struct sc_pkcs15_df *df;
 	struct sc_pkcs15_id new_id = *((struct sc_pkcs15_id *) new_value);
@@ -4397,6 +4403,9 @@ sc_pkcs15init_qualify_pin(struct sc_card *card, const char *pin_name,
 	struct sc_pkcs15_pin_attributes *pin_attrs;
 
 	LOG_FUNC_CALLED(ctx);
+	if (auth_info == NULL)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_OBJECT_NOT_FOUND);
+
 	if (pin_len == 0 || auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -312,7 +312,7 @@ myeid_create_pin(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	unsigned char data[20];
 	struct sc_cardctl_myeid_data_obj data_obj;
 	struct sc_pkcs15_auth_info *auth_info = (struct sc_pkcs15_auth_info *) pin_obj->data;
-	struct sc_pkcs15_auth_info puk_ainfo;
+	struct sc_pkcs15_auth_info puk_ainfo = {0};
 	int r;
 
 	LOG_FUNC_CALLED(ctx);

--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -271,7 +271,7 @@ cosm_create_reference_data(struct sc_profile *profile, struct sc_pkcs15_card *p1
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_card *card = p15card->card;
-	struct sc_pkcs15_auth_info profile_auth_pin, profile_auth_puk;
+	struct sc_pkcs15_auth_info profile_auth_pin = {0}, profile_auth_puk = {0};
 	struct sc_cardctl_oberthur_createpin_info args;
 	int rv;
 	unsigned char oberthur_puk[16] = {

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -42,7 +42,7 @@ static int setcos_create_pin_internal(sc_profile_t *, sc_pkcs15_card_t *,
 static int
 setcos_puk_retries(sc_profile_t *profile, int pin_ref)
 {
-	sc_pkcs15_auth_info_t auth_info;
+	sc_pkcs15_auth_info_t auth_info = {0};
 
 	auth_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 	auth_info.attrs.pin.reference = 1; /* Default SO PIN ref. */
@@ -169,19 +169,19 @@ static int
 setcos_select_pin_reference(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	sc_pkcs15_auth_info_t *auth_info)
 {
-	sc_pkcs15_auth_info_t auth_info_prof;
+	sc_pkcs15_auth_info_t auth_info_prof = {0};
 
 	auth_info_prof.attrs.pin.reference = 1; /* Default SO PIN ref. */
 	auth_info_prof.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 	sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &auth_info_prof);
 
 	/* For the SO pin, we take the first available pin reference = 1 */
-	if (auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN)
+	if (auth_info != NULL && auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN)
 		auth_info->attrs.pin.reference = auth_info_prof.attrs.pin.reference;
 	/* sc_pkcs15init_create_pin() starts checking if -1 is an acceptable
 	 * pin reference, which isn't for the SetCOS cards. And since the
 	 * value 1 has been assigned to the SO pin, we'll jump to 2. */
-	else if (auth_info->attrs.pin.reference <= 0) {
+	else if (auth_info != NULL && auth_info->attrs.pin.reference <= 0) {
 		if (auth_info_prof.attrs.pin.reference != 1)
 			return SC_ERROR_INVALID_PIN_REFERENCE;
 		auth_info->attrs.pin.reference = auth_info_prof.attrs.pin.reference + 1;

--- a/src/pkcs15init/pkcs15-starcos.c
+++ b/src/pkcs15init/pkcs15-starcos.c
@@ -83,7 +83,7 @@ static int starcos_init_card(sc_profile_t *profile, sc_pkcs15_card_t *p15card)
 	sc_file_t	*mf_file, *isf_file, *ipf_file;
 	sc_path_t	tpath;
 	u8		*p = mf_data.data.mf.header, tmp = 0;
-	sc_pkcs15_auth_info_t sopin;
+	sc_pkcs15_auth_info_t sopin = {0};
 
 	/* test if we already have a MF */
 	memset(&tpath, 0, sizeof(sc_path_t));
@@ -180,7 +180,7 @@ static int starcos_create_dir(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 	sc_starcos_create_data df_data, ipf_data;
 	sc_file_t	*isf_file, *ipf_file;
 	u8		*p = df_data.data.df.header, tmp = 0;
-	sc_pkcs15_auth_info_t sopin;
+	sc_pkcs15_auth_info_t sopin = {0};
 
 	sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &sopin);
 
@@ -255,7 +255,7 @@ static int starcos_create_dir(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 
 static int have_onepin(sc_profile_t *profile)
 {
-	sc_pkcs15_auth_info_t sopin;
+	sc_pkcs15_auth_info_t sopin = {0};
 
 	sc_profile_get_pin_info(profile, SC_PKCS15INIT_SO_PIN, &sopin);
 
@@ -428,7 +428,7 @@ static int starcos_create_pin(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		return r;
 
 	if (puk && puk_len) {
-		sc_pkcs15_auth_info_t puk_info;
+		sc_pkcs15_auth_info_t puk_info = {0};
 
 		if (puk_len > 8)
 			return SC_ERROR_INVALID_ARGUMENTS;


### PR DESCRIPTION
development release with gcc-13, lto and O3 optimization level E.g. of error:
libtool: link: gcc -g -O0 -Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/opensc-0.23.0-1 -Wno-error=deprecated-declarations -Wno-error=stringop-overflow -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -Wl,-z -Wl,relro -o fuzz_pkcs15init fuzz_pkcs15init.o fuzzer_reader.o fuzzer.o  ../../../src/libopensc/.libs/libopensc.a -lz -lgio-2.0 -lgobject-2.0 -leac -lcrypto ../../../src/common/.libs/libscdl.a -ldl ../../../src/pkcs15init/.libs/libpkcs15init.a ../../../src/common/.libs/libcompat.a -pthread ../../../src/pkcs15init/pkcs15-lib.c: In function 'sc_pkcs15init_update_any_df': ../../../src/pkcs15init/pkcs15-lib.c:3247:21: error: 'bufsize' may be used uninitialized [-Werror=maybe-uninitialized]
 3247 |                 r = sc_pkcs15init_update_file(profile, p15card, file, buf, bufsize);
      |                     ^
../../../src/pkcs15init/pkcs15-lib.c:3234:25: note: 'bufsize' was declared here
 3234 |         size_t          bufsize;
      |                         ^
lto1: all warnings being treated as errors

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
