### PR TITLE
sc_pkcs11_en/decrypt: Do not add to null pointer

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1410,7 +1410,9 @@ sc_pkcs11_encrypt(sc_pkcs11_operation_t *operation,
 
 	/* EncryptFinalize */
 	rv = key->ops->encrypt(operation->session, key, &operation->mechanism,
-			NULL, 0, pEncryptedData + ulEncryptedDataLen, &ulLastEncryptedPartLen);
+			NULL, 0,
+			pEncryptedData ? pEncryptedData + ulEncryptedDataLen : NULL,
+			&ulLastEncryptedPartLen);
 
 	if (pulEncryptedDataLen)
 		*pulEncryptedDataLen = ulEncryptedDataLen + ulLastEncryptedPartLen;
@@ -1545,7 +1547,8 @@ sc_pkcs11_decrypt(sc_pkcs11_operation_t *operation,
 
 	/* DecryptFinalize */
 	rv = key->ops->decrypt(operation->session, key, &operation->mechanism,
-			NULL, 0, pData + ulDataLen, &ulLastDataLen);
+			NULL, 0, pData ? pData + ulDataLen : NULL,
+			&ulLastDataLen);
 	if (pulDataLen)
 		*pulDataLen = ulDataLen + ulLastDataLen;
 	return rv;


### PR DESCRIPTION
These functions may be called with a NULL output buffer, which gets passed to the card driver. Now it is possible that NULL gets incremented and passed again to the driver in the finalization phase. This problem causing a segmentation fault was discovered by running `p11test` on a `myeid` card.

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
