### PR TITLE
p11test: Fix elliptic curve tests

### DIFF
--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -557,16 +557,11 @@ int callback_public_keys(test_certs_t *objects,
 			EC_KEY_free(ec);
 #else
 			ctx = EVP_PKEY_CTX_new_from_name(0, "EC", 0);
-			unsigned char pubkey[80]; size_t pubkey_len = 0;
-			if (EVP_PKEY_get_octet_string_param(o->key, OSSL_PKEY_PARAM_PUB_KEY, pubkey, sizeof(pubkey), &pubkey_len) != 1) {
-				debug_print(" [WARN %s ] Cannot get params from EVP_PKEY", o->id_str);
-				goto ec_out;
-			}
 
 			const char *curve_name = OBJ_nid2sn(nid);
 			if (!(bld = OSSL_PARAM_BLD_new()) ||
 				OSSL_PARAM_BLD_push_utf8_string(bld, "group", curve_name, strlen(curve_name)) != 1 ||
-				OSSL_PARAM_BLD_push_octet_string(bld, "pub", pubkey, pubkey_len) != 1 ||
+				OSSL_PARAM_BLD_push_octet_string(bld, "pub", pub, pub_len) != 1 ||
 				!(params = OSSL_PARAM_BLD_to_param(bld))) {
 				debug_print(" [WARN %s ] Cannot set params from EVP_PKEY", o->id_str);
 				goto ec_out;

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -464,7 +464,7 @@ int callback_public_keys(test_certs_t *objects,
 	} else if (o->key_type == CKK_EC) {
 		int ec_error = 1;
 		ASN1_OBJECT *oid = NULL;
-		ASN1_OCTET_STRING *s = NULL;
+		ASN1_OCTET_STRING *pub_asn1 = NULL;
 		const unsigned char *pub, *p;
 		char *hex = NULL;
 		BIGNUM *bn = NULL;
@@ -500,11 +500,11 @@ int callback_public_keys(test_certs_t *objects,
 		EC_GROUP_set_asn1_flag(ecgroup, OPENSSL_EC_NAMED_CURVE);
 
 		p = template[7].pValue;
-		s = d2i_ASN1_OCTET_STRING(NULL, &p, template[7].ulValueLen);
-		pub = ASN1_STRING_get0_data(s);
-		pub_len = ASN1_STRING_length(s);
+		pub_asn1 = d2i_ASN1_OCTET_STRING(NULL, &p, template[7].ulValueLen);
+		pub = ASN1_STRING_get0_data(pub_asn1);
+		pub_len = ASN1_STRING_length(pub_asn1);
 		bn = BN_bin2bn(pub, pub_len, NULL);
-		ASN1_STRING_free(s);
+		ASN1_STRING_free(pub_asn1);
 		if (bn == NULL) {
 			debug_print(" [WARN %s ] Cannot convert EC_POINT from"
 				" PKCS#11 to BIGNUM", o->id_str);

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -567,8 +567,6 @@ int callback_public_keys(test_certs_t *objects,
 				EC_POINT_free(ecpoint);
 				return -1;
 			}
-			EC_GROUP_free(ecgroup);
-			EC_POINT_free(ecpoint);
 			o->verify_public = 1;
 		} else { /* store the public key for future use */
 			o->type = EVP_PKEY_EC;
@@ -577,9 +575,7 @@ int callback_public_keys(test_certs_t *objects,
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 			EC_KEY *ec = EC_KEY_new_by_curve_name(nid);
 			EC_KEY_set_public_key(ec, ecpoint);
-			EC_POINT_free(ecpoint);
 			EC_KEY_set_group(ec, ecgroup);
-			EC_GROUP_free(ecgroup);
 			EVP_PKEY_set1_EC_KEY(o->key, ec);
 			EC_KEY_free(ec);
 #else
@@ -620,6 +616,8 @@ int callback_public_keys(test_certs_t *objects,
 			OSSL_PARAM_free(params);
 #endif
 		}
+		EC_GROUP_free(ecgroup);
+		EC_POINT_free(ecpoint);
 	} else if (o->key_type == CKK_EC_EDWARDS
 		|| o->key_type == CKK_EC_MONTGOMERY) {
 		EVP_PKEY *key = NULL;

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -557,16 +557,15 @@ int callback_public_keys(test_certs_t *objects,
 			EC_KEY_free(ec);
 #else
 			ctx = EVP_PKEY_CTX_new_from_name(0, "EC", 0);
-			char curve_name[80]; size_t curve_name_len = 0;
 			unsigned char pubkey[80]; size_t pubkey_len = 0;
-			if (EVP_PKEY_get_group_name(o->key, curve_name, sizeof(curve_name), &curve_name_len)||
-				EVP_PKEY_get_octet_string_param(o->key, OSSL_PKEY_PARAM_PUB_KEY, pubkey, sizeof(pubkey), &pubkey_len) != 1) {
+			if (EVP_PKEY_get_octet_string_param(o->key, OSSL_PKEY_PARAM_PUB_KEY, pubkey, sizeof(pubkey), &pubkey_len) != 1) {
 				debug_print(" [WARN %s ] Cannot get params from EVP_PKEY", o->id_str);
 				goto ec_out;
 			}
 
+			const char *curve_name = OBJ_nid2sn(nid);
 			if (!(bld = OSSL_PARAM_BLD_new()) ||
-				OSSL_PARAM_BLD_push_utf8_string(bld, "group", curve_name, curve_name_len) != 1 ||
+				OSSL_PARAM_BLD_push_utf8_string(bld, "group", curve_name, strlen(curve_name)) != 1 ||
 				OSSL_PARAM_BLD_push_octet_string(bld, "pub", pubkey, pubkey_len) != 1 ||
 				!(params = OSSL_PARAM_BLD_to_param(bld))) {
 				debug_print(" [WARN %s ] Cannot set params from EVP_PKEY", o->id_str);

--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -506,7 +506,7 @@ int callback_public_keys(test_certs_t *objects,
 		bn = BN_bin2bn(pub, pub_len, NULL);
 		ASN1_STRING_free(s);
 		if (bn == NULL) {
-			debug_print(" [WARN %s ] Can not convert EC_POINT from"
+			debug_print(" [WARN %s ] Cannot convert EC_POINT from"
 				" PKCS#11 to BIGNUM", o->id_str);
 			goto ec_out;
 		}
@@ -514,14 +514,14 @@ int callback_public_keys(test_certs_t *objects,
 		hex = BN_bn2hex(bn);
 		BN_free(bn);
 		if (hex == NULL) {
-			debug_print(" [WARN %s ] Can not convert EC_POINT from"
+			debug_print(" [WARN %s ] Cannot convert EC_POINT from"
 				" BIGNUM hex representation", o->id_str);
 			goto ec_out;
 		}
 		ecpoint = EC_POINT_hex2point(ecgroup, hex, NULL, NULL);
 		OPENSSL_free(hex);
 		if (ecpoint == NULL) {
-			debug_print(" [WARN %s ] Can not convert EC_POINT from"
+			debug_print(" [WARN %s ] Cannot convert EC_POINT from"
 				" BIGNUM to OpenSSL format", o->id_str);
 			goto ec_out;
 		}
@@ -539,14 +539,14 @@ int callback_public_keys(test_certs_t *objects,
 			if (EVP_PKEY_get_group_name(o->key, curve_name, sizeof(curve_name), &curve_name_len) != 1 ||
 				(cert_nid = OBJ_txt2nid(curve_name)) == NID_undef ||
 				(cert_group = EC_GROUP_new_by_curve_name(cert_nid)) == NULL) {
-				fprintf(stderr, "Can not get EC_GROUP from EVP_PKEY");
+				fprintf(stderr, "Cannot get EC_GROUP from EVP_PKEY");
 				goto ec_out;
 			}
 			cert_point = EC_POINT_new(cert_group);
 			if (!cert_point ||
 				EVP_PKEY_get_octet_string_param(o->key, OSSL_PKEY_PARAM_PUB_KEY, pubkey, sizeof(pubkey), &pubkey_len) != 1 ||
 				EC_POINT_oct2point(cert_group, cert_point, pubkey, pubkey_len, NULL) != 1) {
-				fprintf(stderr, "Can not get EC_POINT from EVP_PKEY");
+				fprintf(stderr, "Cannot get EC_POINT from EVP_PKEY");
 				goto ec_out;
 			}
 #endif
@@ -575,7 +575,7 @@ int callback_public_keys(test_certs_t *objects,
 			unsigned char pubkey[80]; size_t pubkey_len = 0;
 			if (EVP_PKEY_get_group_name(o->key, curve_name, sizeof(curve_name), &curve_name_len)||
 				EVP_PKEY_get_octet_string_param(o->key, OSSL_PKEY_PARAM_PUB_KEY, pubkey, sizeof(pubkey), &pubkey_len) != 1) {
-				debug_print(" [WARN %s ] Can not get params from EVP_PKEY", o->id_str);
+				debug_print(" [WARN %s ] Cannot get params from EVP_PKEY", o->id_str);
 				goto ec_out;
 			}
 
@@ -583,14 +583,14 @@ int callback_public_keys(test_certs_t *objects,
 				OSSL_PARAM_BLD_push_utf8_string(bld, "group", curve_name, curve_name_len) != 1 ||
 				OSSL_PARAM_BLD_push_octet_string(bld, "pub", pubkey, pubkey_len) != 1 ||
 				!(params = OSSL_PARAM_BLD_to_param(bld))) {
-				debug_print(" [WARN %s ] Can not set params from EVP_PKEY", o->id_str);
+				debug_print(" [WARN %s ] Cannot set params from EVP_PKEY", o->id_str);
 				goto ec_out;
 			}
 
 			if (ctx == NULL || params == NULL ||
 				EVP_PKEY_fromdata_init(ctx) != 1 ||
 				EVP_PKEY_fromdata(ctx, &o->key, EVP_PKEY_PUBLIC_KEY, params) != 1) {
-				debug_print(" [WARN %s ] Can not set params for EVP_PKEY", o->id_str);
+				debug_print(" [WARN %s ] Cannot set params for EVP_PKEY", o->id_str);
 				goto ec_out;
 			}
 #endif
@@ -685,7 +685,7 @@ int callback_public_keys(test_certs_t *objects,
 		a = template[7].pValue;
 		os = d2i_ASN1_OCTET_STRING(NULL, &a, (long)template[7].ulValueLen);
 		if (!os) {
-			debug_print(" [WARN %s ] Can not decode EC_POINT", o->id_str);
+			debug_print(" [WARN %s ] Cannot decode EC_POINT", o->id_str);
 			return -1;
 		}
 		if (os->length != 32) {
@@ -707,7 +707,7 @@ int callback_public_keys(test_certs_t *objects,
 			/* TODO check EVP_PKEY type */
 
 			if (EVP_PKEY_get_raw_public_key(o->key, NULL, &publen) != 1) {
-				debug_print(" [WARN %s ] Can not get size of the key", o->id_str);
+				debug_print(" [WARN %s ] Cannot get size of the key", o->id_str);
 				ASN1_STRING_free(os);
 				return -1;
 			}

--- a/src/tests/p11test/p11test_case_ec_derive.c
+++ b/src/tests/p11test/p11test_case_ec_derive.c
@@ -281,7 +281,7 @@ int test_derive(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 	if (pctx == NULL ||
 		EVP_PKEY_derive_init(pctx) != 1 ||
 		EVP_PKEY_derive_set_peer(pctx, o->key) != 1) {
-		debug_print(" [ KEY %s ] Can not derive key", o->id_str);
+		debug_print(" [ KEY %s ] Cannot derive key", o->id_str);
 		EVP_PKEY_free(evp_pkey);
 		return 1;
 	}
@@ -346,7 +346,7 @@ int test_derive(test_cert_t *o, token_info_t *info, test_mech_t *mech)
 #else
 	if (EVP_PKEY_get_octet_string_param(evp_pkey, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, pub, pub_len, NULL) != 1) {
 #endif
-		debug_print(" [ KEY %s ] Can not get public key", o->id_str);
+		debug_print(" [ KEY %s ] Cannot get public key", o->id_str);
 		EVP_PKEY_free(evp_pkey);
 		free(secret);
 		free(pub);

--- a/src/tests/p11test/p11test_case_ec_derive.c
+++ b/src/tests/p11test/p11test_case_ec_derive.c
@@ -31,12 +31,14 @@ pkcs11_derive(test_cert_t *o, token_info_t * info,
 	CK_OBJECT_HANDLE newkey;
 	CK_OBJECT_CLASS newkey_class = CKO_SECRET_KEY;
 	CK_KEY_TYPE newkey_type = CKK_GENERIC_SECRET;
+	CK_ULONG newkey_len = o->bits / 8;
 	CK_BBOOL true = TRUE;
 	CK_BBOOL false = FALSE;
 	CK_ATTRIBUTE template[] = {
 		{CKA_TOKEN, &false, sizeof(false)}, /* session only object */
 		{CKA_CLASS, &newkey_class, sizeof(newkey_class)},
 		{CKA_KEY_TYPE, &newkey_type, sizeof(newkey_type)},
+		{CKA_VALUE_LEN, &newkey_len, sizeof(newkey_len)},
 		{CKA_SENSITIVE, &false, sizeof(false)},
 		{CKA_EXTRACTABLE, &true, sizeof(true)},
 		{CKA_ENCRYPT, &true, sizeof(true)},
@@ -45,7 +47,7 @@ pkcs11_derive(test_cert_t *o, token_info_t * info,
 		{CKA_UNWRAP, &true, sizeof(true)}
 	};
 	CK_ATTRIBUTE get_value = {CKA_VALUE, NULL_PTR, 0};
-	CK_ULONG template_len = 9;
+	CK_ULONG template_len = 10;
 
 	params.pSharedData = NULL;
 	params.ulSharedDataLen = 0;

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -70,7 +70,7 @@ rsa_x_509_pad_message(const unsigned char *message,
 	size_t padding_len = pad_message_length - (*message_length) - 3;
 
 	if (pad_message_length - (*message_length) <= 11) {
-		debug_print("Can not pad message - buffer to small");
+		debug_print("Cannot pad message - buffer too small");
 		return NULL;
 	}
 	if ((pad_message = malloc(pad_message_length)) == NULL) {
@@ -86,7 +86,7 @@ rsa_x_509_pad_message(const unsigned char *message,
 	} else {
 		pad_message[1] = 0x02;
 		if (RAND_bytes(pad_message + 2, padding_len) != 1) {
-			debug_print("Can not generate random bytes.");
+			debug_print("Cannot generate random bytes.");
 		}
 	}
 	memcpy(pad_message + 2 + padding_len, message, (*message_length) * sizeof(unsigned char));


### PR DESCRIPTION
This PR fixes various errors and eliminates unnecessary complexity mostly in elliptic curve–related code of `p11test`. In particular, it fixes:
* OpenSSL 3 support (apparently not tested earlier)
* memory leak when successfully saving an EC key (with OpenSSL 3)
* ECDH test case (mandatory attribute added)
* spelling errors

Testing was done with a `myeid` card.

##### Checklist
- [x] PKCS#11 module is tested
