### PR TITLE
p11test: Fix myeid initialization

### DIFF
--- a/src/tests/p11test/runtest.sh
+++ b/src/tests/p11test/runtest.sh
@@ -129,15 +129,15 @@ function card_setup() {
 			;;
 		"myeid")
 			GENERATE_KEYS=0 # we generate them directly here
-			P11LIB="../pkcs11/.libs/opensc-pkcs11.so"
-			PKCS15_INIT --erase-card --so-pin $SOPIN
-			PKCS15_INIT -C --pin $PIN --puk $SOPIN --so-pin $SOPIN --so-puk $SOPIN
-			PKCS15_INIT -P -a 1 -l "Basic PIN" --pin $PIN --puk $PIN
-			INIT=$PKCS15_INIT --auth-id 01 --so-pin $SOPIN --pin $PIN
-			INIT --generate-key ec:prime256v1 --id 01 --label="EC key"
-			INIT --generate-key rsa:2048 --id 02 --label="RSA key" --key-usage=sign,decrypt
-			INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:256 --extractable --id 03 --label="AES key" --key-usage=sign,decrypt
-			PKCS15_INIT -F
+			P11LIB="../../pkcs11/.libs/opensc-pkcs11.so"
+			$PKCS15_INIT --erase-card --so-pin $SOPIN
+			$PKCS15_INIT -C --pin $PIN --puk $SOPIN --so-pin $SOPIN --so-puk $SOPIN
+			$PKCS15_INIT -P -a 1 -l "Basic PIN" --pin $PIN --puk $PIN
+			INIT="$PKCS15_INIT --auth-id 01 --so-pin $SOPIN --pin $PIN"
+			$INIT --generate-key ec:prime256v1 --id 01 --label="EC key"
+			$INIT --generate-key rsa:2048 --id 02 --label="RSA key" --key-usage=sign,decrypt
+			$INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:256 --extractable --id 03 --label="AES key" --key-usage=sign,decrypt
+			$PKCS15_INIT -F
 			;;
 		*)
 			echo "Error: Missing argument."

--- a/src/tests/p11test/runtest.sh
+++ b/src/tests/p11test/runtest.sh
@@ -134,7 +134,7 @@ function card_setup() {
 			$PKCS15_INIT -C --pin $PIN --puk $SOPIN --so-pin $SOPIN --so-puk $SOPIN
 			$PKCS15_INIT -P -a 1 -l "Basic PIN" --pin $PIN --puk $PIN
 			INIT="$PKCS15_INIT --auth-id 01 --so-pin $SOPIN --pin $PIN"
-			$INIT --generate-key ec:prime256v1 --id 01 --label="EC key"
+			$INIT --generate-key ec:prime256v1 --id 01 --label="EC key" --key-usage=sign,keyAgreement
 			$INIT --generate-key rsa:2048 --id 02 --label="RSA key" --key-usage=sign,decrypt
 			$INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:256 --extractable --id 03 --label="AES key" --key-usage=sign,decrypt
 			$PKCS15_INIT -F

--- a/src/tests/p11test/runtest.sh
+++ b/src/tests/p11test/runtest.sh
@@ -136,7 +136,8 @@ function card_setup() {
 			INIT="$PKCS15_INIT --auth-id 01 --so-pin $SOPIN --pin $PIN"
 			$INIT --generate-key ec:prime256v1 --id 01 --label="EC key" --key-usage=sign,keyAgreement
 			$INIT --generate-key rsa:2048 --id 02 --label="RSA key" --key-usage=sign,decrypt
-			$INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:256 --extractable --id 03 --label="AES key" --key-usage=sign,decrypt
+			$INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:256 --extractable --id 03 --label="AES256 key" --key-usage=sign,decrypt
+			$INIT --store-secret-key /dev/urandom --secret-key-algorithm aes:128 --extractable --id 04 --label="AES128 key" --key-usage=sign,decrypt
 			$PKCS15_INIT -F
 			;;
 		*)


### PR DESCRIPTION
This PR fixes the `myeid` part of `runtest.sh` by adding the missing `$` signs to indicate shell variables. It also enables more versatile testing by
* allowing ECDH and
* adding another AES key to test key wrapping.

##### Checklist
- [x] PKCS#11 module is tested