### PR TITLE
show 'sign' usage for secret keys

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5198,7 +5198,7 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 		printf("%sdecrypt", sepa);
 		sepa = ", ";
 	}
-	if (!pub && getSIGN(sess, obj)) {
+	if ((!pub || sec) && getSIGN(sess, obj)) {
 		printf("%ssign", sepa);
 		sepa = ", ";
 	}


### PR DESCRIPTION
Secret keys can be used for signing in algorithms like HMAC and CMAC so they should display their CKA_SIGN attribute value when listing object attributes

Before
```
echo -n "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b" | xxd -r -p - > key.bin
pkcs11-tool --module=... --write-object key.bin --usage-sign --type secrkey --label hmackey --id 1234
Using slot 0 with a present token (0x0)
Created secret key:
Secret Key Object; Generic secret length 20
VALUE: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
label: hmackey
ID: 1234
Usage: verify
Access: never extractable
```
After
```
echo -n "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b" | xxd -r -p - > key.bin
pkcs11-tool --module=... --write-object key.bin --usage-sign --type secrkey --label hmackey --id 1234
Using slot 0 with a present token (0x0)
Created secret key:
Secret Key Object; Generic secret length 20
VALUE: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
label: hmackey
ID: 1234
Usage: sign, verify
Access: never extractable
```

Fixes #2851 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested (tested with my own custom PKCS#11 module)