### PR TITLE
openpgp-tool-helpers.c: include header for strnlen

### DIFF
--- a/src/tools/openpgp-tool-helpers.c
+++ b/src/tools/openpgp-tool-helpers.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include "common/compat_strnlen.h"
 #include "openpgp-tool-helpers.h"
 #include "util.h"
 


### PR DESCRIPTION
Closes: #2863

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
