### PR TITLE
Bump libressl to 3.8.1

### DIFF
--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-V=libressl-3.7.3
+V=libressl-3.8.1
 
 sudo apt-get remove -y libssl-dev
 


### PR DESCRIPTION
For now, just to check if it works as we do not have any automated mechanism to keep track of libressl releases (#2670).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
