### PR TITLE
Add badges for more cards covered in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ Build and test status of specific cards:
 | [GidsApplet](https://github.com/vletoux/GidsApplet/)                | [![GIDS](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml/badge.svg)](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml) |
 | [IsoApplet](https://github.com/philipWendland/IsoApplet/)           | [![IsoApplet](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml/badge.svg)](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml) |
 | [OsEID (MyEID)](https://sourceforge.net/projects/oseid/)            | [![OsEID (MyEID)](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml/badge.svg)](https://github.com/OpenSC/OpenSC/actions/workflows/linux.yml) |
+| SmartCardHSM                                                        | [![SmartCardHSM](https://gitlab.com/redhat-crypto/OpenSC/badges/sc-hsm/pipeline.svg)](https://gitlab.com/redhat-crypto/OpenSC/pipelines) |
+| ePass2003                                                           | [![ePass2003](https://gitlab.com/redhat-crypto/OpenSC/badges/epass2003/pipeline.svg)](https://gitlab.com/redhat-crypto/OpenSC/pipelines) |


### PR DESCRIPTION
I plugged SC-HSM and ePass tokens to my old machine and the CI on gitlab now runs on them. This PR adds them to readme.

Machine is slow so it will take some time to finish (and valgrind will likely fail). The new machine with to test more cards is on the way.

Any ideas what more should be covered in the p11tests appreciated.

##### Checklist
- [X] Documentation is added or updated