### PR TITLE
Run coverity scan only if the secret token is defined

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HAS_COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN != '' }}
+    if: env.HAS_COVERITY_SCAN_TOKEN == 'true'
     steps:
     - uses: actions/checkout@v3
     - run: .github/setup-linux.sh


### PR DESCRIPTION
No need to try and fail on forks of OpenSC repository.

Without this patch the github action coverity.yml (in my fork repo) fails with:
```
Username/Password Authentication Failed.
Error: Process completed with exit code 6.
```

With no objection I plan to merge this patch.