### PR TITLE
Minor fixes for Idprime 940

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -384,10 +384,6 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (card->type == SC_CARD_TYPE_IDPRIME_940 && list_empty(&priv->keyrefmap)) {
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
-	}
-
 	buf = malloc(length);
 	if (buf == NULL) {
 		goto done;

--- a/src/libopensc/pkcs15-idprime.c
+++ b/src/libopensc/pkcs15-idprime.c
@@ -136,7 +136,7 @@ static int sc_pkcs15emu_idprime_init(sc_pkcs15_card_t *p15card)
 		pin_info.attrs.pin.pad_char = 0x00;
 
 		sc_log(card->ctx,  "IDPrime Adding Digital Signature pin with label=%s", sig_pin_label);
-		strncpy(pin_obj.label, pin_label, SC_PKCS15_MAX_LABEL_SIZE - 1);
+		strncpy(pin_obj.label, sig_pin_label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 		pin_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
 
 		r = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
@@ -347,7 +347,7 @@ fail:
 	LOG_TEST_GOTO_ERR(card->ctx, r, "Can not finalize cert objects.");
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
-	
+
 err:
 	sc_pkcs15_card_clear(p15card);
 	LOG_FUNC_RETURN(card->ctx, r);


### PR DESCRIPTION
Fixes: #2877

The keyrefmap was mandatory to start processing index file, which was a regression since 0.23.0, where users reported the card worked for them already.

Additionally, the signature pin was label was not propagated to the PKCS#15 objects and only printed in debug messages.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
