### PR TITLE
Unbreak support for ed/curve25519 Gnuk on Nitrokey Start

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2184,7 +2184,8 @@ pgp_set_security_env(sc_card_t *card,
 	/* The SC_SEC_ENV_ALG_PRESENT is set always so let it pass for GNUK */
 	if ((env->flags & SC_SEC_ENV_ALG_PRESENT)
 		&& (env->algorithm != SC_ALGORITHM_RSA)
-		&& (priv->bcd_version < OPENPGP_CARD_3_0))
+		&& (priv->bcd_version < OPENPGP_CARD_3_0)
+		&& (card->type != SC_CARD_TYPE_OPENPGP_GNUK))
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS,
 				"only RSA algorithm supported");
 


### PR DESCRIPTION
This was broken since b83c358 which dropped this condition as unneeded.

The Gnuk is technically version 2, but has some specifics from newer standard versions (at least new algorithms) so this condition needs to stay.


##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
