### PR TITLE
pkcs11: Fix C_InitToken() pLabel past-end-of-buffer read

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -445,7 +445,7 @@ AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([ \
 	getpass gettimeofday getline memset mkdir \
 	strdup strerror memset_s explicit_bzero \
-	strnlen sigaction
+	strnlen strndup sigaction
 ])
 
 #

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -8,7 +8,7 @@ dist_noinst_DATA = \
 	LICENSE.compat_getopt compat_getopt.txt \
 	compat_getopt_main.c \
 	README.compat_strlcpy compat_strlcpy.3
-noinst_HEADERS = compat_strlcat.h compat_strlcpy.h compat_strnlen.h compat_getpass.h compat_getopt.h simclist.h libpkcs11.h libscdl.h compat_overflow.h
+noinst_HEADERS = compat_strlcat.h compat_strlcpy.h compat_strnlen.h compat_strndup.h compat_getpass.h compat_getopt.h simclist.h libpkcs11.h libscdl.h compat_overflow.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
@@ -17,6 +17,7 @@ libcompat_la_SOURCES = \
 	compat_strlcat.c \
 	compat_strlcpy.c \
 	compat_strnlen.c \
+	compat_strndup.c \
 	compat_getpass.c \
 	compat_getopt.c \
 	compat_report_rangecheckfailure.c \
@@ -37,6 +38,7 @@ TIDY_FILES = \
 	compat_strlcat.h compat_strlcat.c \
 	compat_strlcpy.h compat_strlcpy.c \
 	compat_strnlen.h compat_strnlen.c \
+	compat_strndup.h compat_strndup.c \
 	compat_getpass.h compat_getpass.c \
 	compat_getopt.h compat_getopt.c \
 	compat_report_rangecheckfailure.c \

--- a/src/common/compat_strndup.c
+++ b/src/common/compat_strndup.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Luka Logar <luka.logar@iname.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifndef HAVE_STRNDUP
+#include <stdlib.h>
+#include <string.h>
+#include "common/compat_strnlen.h"
+
+char *_strndup(const char *str, size_t n)
+{
+	char *dst;
+	if (!str)
+		return NULL;
+	n = strnlen(str, n);
+	dst = (char*)malloc(n + 1);
+	if (!dst)
+		return NULL;
+	memcpy(dst, str, n);
+	dst[n] = '\0';
+	return dst;
+};
+
+#endif

--- a/src/common/compat_strndup.h
+++ b/src/common/compat_strndup.h
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * @brief prototype of strndup()
+ */
+
+#ifndef __COMPAT_STRNDUP_H
+#define __COMPAT_STRNDUP_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifndef HAVE_STRNDUP
+#include <stddef.h>
+/* Workaround for mingw gcc nonnull-compare error */
+#define strndup _strndup
+char *_strndup(const char *str, size_t n);
+#else
+#include <string.h>
+#endif
+
+#endif


### PR DESCRIPTION
`C_InitToken()` `pLabel` parameter is not required to be NUL-terminated. But underlying functions use regular C string.h functions to manipulate a label which leads to random trailing characters being appended.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
