### PR TITLE
jpki/iso7816: explicitly check for PIN length != 0 on VERIFY

### DIFF
--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -243,7 +243,7 @@ jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	switch (data->cmd) {
 	case SC_PIN_CMD_VERIFY:
 		/* detect overloaded APDU with SC_PIN_CMD_GET_INFO */
-		if (data->pin1.len == 0)
+		if (data->pin1.len == 0 && !(data->flags & SC_PIN_CMD_USE_PINPAD))
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_PIN_LENGTH);
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3, 0x20, 0x00, 0x80);
 		apdu.data = data->pin1.data;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1202,7 +1202,7 @@ iso7816_build_pin_apdu(struct sc_card *card, struct sc_apdu *apdu,
 	case SC_PIN_CMD_VERIFY:
 		ins = 0x20;
 		/* detect overloaded APDU with SC_PIN_CMD_GET_INFO */
-		if (data->pin1.len == 0)
+		if (data->pin1.len == 0 && !use_pin_pad)
 			return SC_ERROR_INVALID_PIN_LENGTH;
 		if ((r = sc_build_pin(buf, buf_len, &data->pin1, pad)) < 0)
 			return r;


### PR DESCRIPTION
If we want to verify the PIN, we don't want the status request, which results in an almost identical APDU (VERIFY APDU with no data). However, as the request for verifying the PIN results in a CASE 3 APDU, `sc_check_apdu()` will check for missing data for the verification so that an error is returned and no PIN bypass is possible.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
