### PR TITLE
authentic: Avoid potential double free

### DIFF
--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -1937,13 +1937,12 @@ authentic_manage_sdo(struct sc_card *card, struct sc_authentic_sdo *sdo, unsigne
 
 	rv = sc_transmit_apdu(card, &apdu);
 	card->max_send_size = save_max_send;
+	free(data);
 	if (rv != SC_SUCCESS) {
-		free(data);
 		LOG_TEST_RET(ctx, rv, "APDU transmit failed");
 	}
 
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	free(data);
 	LOG_TEST_RET(ctx, rv, "authentic_sdo_create() SDO put data error");
 
 	LOG_FUNC_RETURN(ctx, rv);


### PR DESCRIPTION
introduced in 54b496a8c133bc898b03cb37929cc5cd15dbc0fb

Thanks coverity

CID 403732

##### Checklist

- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
