### PR TITLE
Do not require repeated authentication in the pkcs15init layer when checking ACLs

### DIFF
--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -307,6 +307,7 @@ sc_pkcs15_verify_pin(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *pi
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_PIN_REFERENCE);
 	auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 
+	/* Check the provided pin matches pin requirements */
 	r = _validate_pin(p15card, auth_info, pinlen);
 
 	if (r)


### PR DESCRIPTION
As discussed in the #2903 this basically moves the check out of the libopensc to prevent zero-lenght pin bypass there, but allow checking login status in the pkcs15init layer, which happens usually during card enrollment (key generation, ...).

Fixes: #2903

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested