### PR TITLE
pkcs11: Fix C_WaitForSlotEvent() not working in Windows

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1640,6 +1640,11 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 #else
 			rgReaderStates[num_watch].szReader = "\\\\?PnP?\\Notification";
 			rgReaderStates[num_watch].dwCurrentState = SCARD_STATE_UNAWARE;
+#ifdef _WIN32
+			/* Windows expects number of readers in HiWord of dwCurrentState.
+			 * See https://stackoverflow.com/questions/16370909. */
+			rgReaderStates[num_watch].dwCurrentState |= (num_watch << 16);
+#endif
 			rgReaderStates[num_watch].dwEventState = SCARD_STATE_UNAWARE;
 			num_watch++;
 			sc_log(ctx, "Trying to detect new readers");
@@ -1706,6 +1711,13 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 			prev_state = rsp->dwCurrentState;
 			state = rsp->dwEventState;
 			rsp->dwCurrentState = rsp->dwEventState;
+#ifdef _WIN32
+			if (!strcmp(rsp->szReader, "\\\\?PnP?\\Notification")) {
+				/* Windows expects number of readers in HiWord of dwCurrentState.
+				 * See https://stackoverflow.com/questions/16370909. */
+				rsp->dwCurrentState |= ((num_watch - 1) << 16);
+			}
+#endif
 			if (state & SCARD_STATE_CHANGED) {
 				/* check for hotplug events */
 				if (!strcmp(rsp->szReader, "\\\\?PnP?\\Notification")) {


### PR DESCRIPTION
If there are any readers present when `C_WaitForSlotEvent()` is called, `C_WaitForSlotEvent()` returns immediately and does not wait for the card/slot event to happen. Apparently the MSDN documentation for `SCardGetStatusChange()` is inaccurate/incomplete and the `dwCurrentState` for `\\?PnP?\Notification` reader should contain the number of readers in it's HiWord to work properly. See [https://stackoverflow.com/questions/16370909](https://stackoverflow.com/questions/16370909).
