### PR TITLE
pkcs11: Fix onepin for thunderbird

### DIFF
--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -467,7 +467,8 @@ static int is_nss_browser(sc_context_t * ctx)
 		basename += sizeof(char);
 
 	if (strstr(basename, "chromium") || strstr(basename, "chrome")
-			|| strstr(basename, "firefox") || strstr(basename, "msedge"))
+			|| strstr(basename, "firefox") || strstr(basename, "msedge")
+			|| strstr(basename, "thunderbird"))
 		return 1;
 
 	return 0;


### PR DESCRIPTION
I did some tests on current master (0.24.0-rc1) to make sure that all of my use cases are covered by the next release. There is one fallout due to the removal of onepin-opensc-pkcs11.so:

Thunderbird is quite similar to Firefox and asked several times for the same pin. Adding "thunderbird" to the list of NSS browsers fixes that issue.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

Tested with:

```
opensc-tool -n       
Using reader with a card: Alcor Micro AU9540 00 00
Atos CardOS
``` 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
