### PR TITLE
Workaround for unwrapping using 2K RSA key with MyEID. 

### DIFF
--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1383,7 +1383,8 @@ static int myeid_transmit_decipher(struct sc_card *card, u8 p1, u8 p2,
 		apdu.le = MIN(card->max_recv_size, crgram_len);
 	}
 
-	if (p2 == 0x86 && crgram_len == 256 && priv && !priv->cap_chaining) {
+	/* In MyEID 4.5.x, unwrapping with 2K RSA using APDU chaining doesn't work properly. Split the APDU in the old way in this case. */
+	if (p2 == 0x86 && crgram_len == 256 && priv && (!priv->cap_chaining || (card->version.fw_major == 45 && priv->sec_env != NULL && priv->sec_env->operation == SC_SEC_OPERATION_UNWRAP))) {
 		r = myeid_transmit_decipher_pi_split(card, &apdu, sbuf);
 	} else {
 		apdu.flags |= SC_APDU_FLAGS_CHAINING;


### PR DESCRIPTION
In MyEID 4.5.5 APDU chaining doesn't work correctly in the unwrap operation. This PR checks for MyEID version, and calls myeid_transmit_decipher_pi_split to use the pre 4.5 way of splitting 2048 bit data for the unwrap operation, if the version is 4..5.x.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PKCS#11 module is tested

