### PR TITLE
pkcs11-tool: add support for AES/GCM encryption and decryption

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -700,6 +700,22 @@
 					</para></listitem>
 				</varlistentry>
 
+				<varlistentry>
+					<term>
+						<option>--aad-file</option> <replaceable>filename</replaceable>
+					</term>
+					<listitem><para>Optional file containing additional authenticated data
+					for AEAD methods.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--tag-len</option> <replaceable>bytes</replaceable>
+					</term>
+					<listitem><para>Length of the authentication tag appended to the end
+					of the ciphertext when using AEAD methods.</para></listitem>
+				</varlistentry>
+
 			</variablelist>
 		</para>
 	</refsect1>

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -212,7 +212,7 @@ enum {
 	OPT_LIST_INTERFACES,
 	OPT_IV,
 	OPT_AAD_FILE,
-	OPT_TAG_SIZE
+	OPT_TAG_LEN
 };
 
 static const struct option options[] = {
@@ -300,7 +300,7 @@ static const struct option options[] = {
 	{ "allow-sw",		0, NULL,		OPT_ALLOW_SW },
 	{ "iv",			1, NULL,			OPT_IV },
 	{ "aad-file",		1, NULL,		OPT_AAD_FILE },
-	{ "tag-size",	1, NULL,			OPT_TAG_SIZE },
+	{ "tag-len",	1, NULL,			OPT_TAG_LEN },
 
 	{ NULL, 0, NULL, 0 }
 };
@@ -390,7 +390,7 @@ static const char *option_help[] = {
 	"Allow using software mechanisms (without CKF_HW)",
 	"Initialization vector",
 	"Additional authenticated data for AEAD methods",
-	"Authentication tag size in bytes (default: 16)",
+	"Authentication tag length in bytes (default: 16)",
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */
@@ -451,7 +451,7 @@ static int		opt_always_auth = 0;
 static CK_FLAGS		opt_allow_sw = CKF_HW;
 static const char *	opt_iv = NULL;
 static const char *	opt_aad_file = NULL;
-static int		opt_tag_size = 16;
+static int		opt_tag_len = 16;
 
 static void *module = NULL;
 static CK_FUNCTION_LIST_3_0_PTR p11 = NULL;
@@ -1158,8 +1158,8 @@ int main(int argc, char * argv[])
 		case OPT_AAD_FILE:
 			opt_aad_file = optarg;
 			break;
-		case OPT_TAG_SIZE:
-			opt_tag_size = strtoul(optarg, NULL, 0);
+		case OPT_TAG_LEN:
+			opt_tag_len = strtoul(optarg, NULL, 0);
 			break;
 		default:
 			util_print_usage_and_die(app_name, options, option_help, NULL);
@@ -2615,7 +2615,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		gcm_params.pAAD = aad;
 		gcm_params.ulAADLen = aad_size;
 
-		gcm_params.ulTagBits = opt_tag_size * 8;
+		gcm_params.ulTagBits = opt_tag_len * 8;
 
 		mech.pParameter = &gcm_params;
 		mech.ulParameterLen = sizeof(gcm_params);
@@ -2785,7 +2785,7 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		gcm_params.pAAD = aad;
 		gcm_params.ulAADLen = aad_size;
 
-		gcm_params.ulTagBits = opt_tag_size * 8;
+		gcm_params.ulTagBits = opt_tag_len * 8;
 
 		mech.pParameter = &gcm_params;
 		mech.ulParameterLen = sizeof(gcm_params);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -390,6 +390,7 @@ static const char *option_help[] = {
 	"Allow using software mechanisms (without CKF_HW)",
 	"Initialization vector",
 	"Additional authenticated data for AEAD methods",
+	"GCM tag size in bytes (default: 16)",
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */
@@ -2599,7 +2600,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		iv = get_iv(opt_iv, &iv_size);
 		gcm_params.pIv = iv;
 		gcm_params.ulIvLen = iv_size;
-		gcm_params.ulIvBits = iv_size * 8;
+		gcm_params.ulIvBits = iv_size * 8; // no one seems to know what this is for
 
 		aad_size = 0;
 		aad = get_aad(opt_aad_file, &aad_size);
@@ -2742,7 +2743,7 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		iv = get_iv(opt_iv, &iv_size);
 		gcm_params.pIv = iv;
 		gcm_params.ulIvLen = iv_size;
-		gcm_params.ulIvBits = iv_size * 8;
+		gcm_params.ulIvBits = iv_size * 8; // no one seems to know what this is for
 
 		aad_size = 0;
 		aad = get_aad(opt_aad_file, &aad_size);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -212,7 +212,7 @@ enum {
 	OPT_LIST_INTERFACES,
 	OPT_IV,
 	OPT_AAD_FILE,
-	OPT_GCM_TAG_SIZE
+	OPT_TAG_SIZE
 };
 
 static const struct option options[] = {
@@ -298,9 +298,9 @@ static const struct option options[] = {
 #endif
 	{ "generate-random",	1, NULL,		OPT_GENERATE_RANDOM },
 	{ "allow-sw",		0, NULL,		OPT_ALLOW_SW },
-	{ "iv",			1, NULL,		OPT_IV },
+	{ "iv",			1, NULL,			OPT_IV },
 	{ "aad-file",		1, NULL,		OPT_AAD_FILE },
-	{ "gcm-tag-size",	1, NULL,		OPT_GCM_TAG_SIZE },
+	{ "tag-size",	1, NULL,			OPT_TAG_SIZE },
 
 	{ NULL, 0, NULL, 0 }
 };
@@ -390,7 +390,7 @@ static const char *option_help[] = {
 	"Allow using software mechanisms (without CKF_HW)",
 	"Initialization vector",
 	"Additional authenticated data for AEAD methods",
-	"GCM tag size in bytes (default: 16)",
+	"Authentication tag size in bytes (default: 16)",
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */
@@ -451,7 +451,7 @@ static int		opt_always_auth = 0;
 static CK_FLAGS		opt_allow_sw = CKF_HW;
 static const char *	opt_iv = NULL;
 static const char *	opt_aad_file = NULL;
-static int		opt_gcm_tag_size = 16;
+static int		opt_tag_size = 16;
 
 static void *module = NULL;
 static CK_FUNCTION_LIST_3_0_PTR p11 = NULL;
@@ -1158,8 +1158,8 @@ int main(int argc, char * argv[])
 		case OPT_AAD_FILE:
 			opt_aad_file = optarg;
 			break;
-		case OPT_GCM_TAG_SIZE:
-			opt_gcm_tag_size = strtoul(optarg, NULL, 0);
+		case OPT_TAG_SIZE:
+			opt_tag_size = strtoul(optarg, NULL, 0);
 			break;
 		default:
 			util_print_usage_and_die(app_name, options, option_help, NULL);
@@ -2615,7 +2615,7 @@ static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		gcm_params.pAAD = aad;
 		gcm_params.ulAADLen = aad_size;
 
-		gcm_params.ulTagBits = opt_gcm_tag_size * 8;
+		gcm_params.ulTagBits = opt_tag_size * 8;
 
 		mech.pParameter = &gcm_params;
 		mech.ulParameterLen = sizeof(gcm_params);
@@ -2785,7 +2785,7 @@ static void encrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		gcm_params.pAAD = aad;
 		gcm_params.ulAADLen = aad_size;
 
-		gcm_params.ulTagBits = opt_gcm_tag_size * 8;
+		gcm_params.ulTagBits = opt_tag_size * 8;
 
 		mech.pParameter = &gcm_params;
 		mech.ulParameterLen = sizeof(gcm_params);


### PR DESCRIPTION
Adds support for `--encrypt` and `--decrypt` when using `-m AES-GCM`.

Note that due to AES-GCM being a cipher method with authenticated data, multipart decryption doesn't return any data until C_DecryptFinal. This implementation decrypts the entire ciphertext in memory and uses a single C_Decrypt call for inputs of all sizes.

Tested (manually) on the latest version of SoftHSMv2
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
