### PR TITLE
pkcs11: Present profile object in every slot

### DIFF
--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -226,6 +226,7 @@ struct sc_pkcs11_slot {
 	struct sc_app_info *app_info;	/* Application associated to slot */
 	list_t logins;			/* tracks all calls to C_Login if atomic operations are requested */
 	int flags;
+	struct pkcs15_any_object *profile; /* keeps track of the profile object */
 };
 typedef struct sc_pkcs11_slot sc_pkcs11_slot_t;
 


### PR DESCRIPTION
This should likely fix PIN needless prompts on the slots that do not have any private objects, such as in #2920.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
