### PR TITLE
OpenSSL 1.1.1 is deprecated

### DIFF
--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -29,16 +29,16 @@ if test "$FORCE_OPENSSL_BUILD" == "1" || ! pkg-config libcrypto --atleast-versio
 	if ! test -e $BUILDPATH/openssl_bin/$PREFIX/lib/pkgconfig; then
 		# Build OpenSSL manually, because Apple's binaries are deprecated
 		if ! test -e openssl; then
-			git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1-stable
+			git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0
 		fi
 		cd openssl
-		MACHINE=x86_64 ./config no-shared --prefix=$PREFIX
+		./Configure darwin64-x86_64 no-shared --prefix=$PREFIX enable-ec_nistp_64_gcc_128
 		make clean
 		make -j 4
 		make DESTDIR=$BUILDPATH/openssl_bin install_sw
 		if test -n "${BUILD_ARM}"; then
 			make clean
-			MACHINE=arm64 KERNEL_BITS=64 ./config no-shared --prefix=$PREFIX
+			./Configure darwin64-arm64 no-shared --prefix=$PREFIX enable-ec_nistp_64_gcc_128
 			make -j 4
 			make DESTDIR=$BUILDPATH/openssl_arm64 install_sw
 			lipo -create $BUILDPATH/openssl_arm64/$PREFIX/lib/libcrypto.a $BUILDPATH/openssl_bin/$PREFIX/lib/libcrypto.a -output libcrypto.a


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

Signed-off-by: Raul Metsma <raul@metsma.ee>