### PR TITLE
minidriver: Fix wrong hash selection in CardSignData if pszAlgId is NULL

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4865,11 +4865,11 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 				opt_crypt_flags = SC_ALGORITHM_RSA_PAD_PKCS1;
 				BCRYPT_PKCS1_PADDING_INFO *pkcs1_pinf = (BCRYPT_PKCS1_PADDING_INFO *)pInfo->pPaddingInfo;
 
-				if (!pkcs1_pinf->pszAlgId || wcscmp(pkcs1_pinf->pszAlgId, L"SHAMD5") == 0) {
-					/* hashAlg = CALG_SSL3_SHAMD5; */
-					logprintf(pCardData, 3, "Using CALG_SSL3_SHAMD5  hashAlg\n");
+				if (!pkcs1_pinf->pszAlgId)
+					opt_crypt_flags |= SC_ALGORITHM_RSA_HASH_NONE;
+				else if (wcscmp(pkcs1_pinf->pszAlgId, L"SHAMD5") == 0)
 					opt_crypt_flags |= SC_ALGORITHM_RSA_HASH_MD5_SHA1;
-				} else if (wcscmp(pkcs1_pinf->pszAlgId, BCRYPT_MD5_ALGORITHM) == 0)
+				else if (wcscmp(pkcs1_pinf->pszAlgId, BCRYPT_MD5_ALGORITHM) == 0)
 					opt_crypt_flags |= SC_ALGORITHM_RSA_HASH_MD5;
 				else if (wcscmp(pkcs1_pinf->pszAlgId, BCRYPT_SHA1_ALGORITHM) == 0)
 					opt_crypt_flags |= SC_ALGORITHM_RSA_HASH_SHA1;


### PR DESCRIPTION
According to `CardSignData` docs, if `pszAlgId` is `NULL`, OID should not be added to signature, but minidriver erroneously selects `SC_ALGORITHM_RSA_HASH_MD5_SHA1`.

See: [BCRYPT_PKCS1_PADDING_INFO structure description](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_pkcs1_padding_info)

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested
