### PR TITLE
minidriver set decipher flag SC_ALGORITHM_RSA_RAW

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4643,7 +4643,7 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 
 	if (alg_info->flags & SC_ALGORITHM_RSA_RAW)   {
 		logprintf(pCardData, 2, "sc_pkcs15_decipher: using RSA-RAW mechanism\n");
-		r = sc_pkcs15_decipher(vs->p15card, pkey, opt_crypt_flags, pbuf, pInfo->cbData, pbuf2, pInfo->cbData, NULL);
+		r = sc_pkcs15_decipher(vs->p15card, pkey, opt_crypt_flags | SC_ALGORITHM_RSA_RAW, pbuf, pInfo->cbData, pbuf2, pInfo->cbData, NULL);
 		logprintf(pCardData, 2, "sc_pkcs15_decipher returned %d\n", r);
 
 		if (r > 0) {


### PR DESCRIPTION
Some cards (cardos) may not return the leading zero when deciphering using RSA RAW. Set flag SC_ALGORITHM_RSA_RAW when calling sc_pkcs15_decipher like other callers do.

 On branch decipher-missing-leading-00
 Changes to be committed:
	modified:   minidriver/minidriver.c

Fixes #2925

Checklist:

- [x] Windows minidriver has needs testing by author of #2925

