### PR TITLE
pkcs15-piv.c placeholder for Yubikey key Attestation certificate CK_ID

### DIFF
--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -370,7 +370,8 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		{"22", "Retired Certificate for Key Management 18", "1012cece", 0, 0},
 		{"23", "Retired Certificate for Key Management 19", "1013cece", 0, 0},
 		{"24", "Retired Certificate for Key Management 20", "1014cece", 0, 0},
-		{"25", "Secure Messaging Certificate Signer",   "1017cece", 0, 0} /* no keys on card */
+		/* Yubikey Attestation uses "25" but not read via GET_DATA */
+		{"81", "Secure Messaging Certificate Signer",   "1017cece", 0, 0} /* no keys on card */
 	};
 	// clang-format on
 


### PR DESCRIPTION
Yubikey PKCS11 module uses CKA_ID "25" for its Attestation certificate which is read using a Yubikey APDU. Other PIV certificates are stored in PIV objects and the certificate is extracted from the object.

OpenSC code was using the same CKA_ID for "Secure Messaging Certificate Signer" which is used with PIV SM.

 So to avoid any confusion, the "Secure Messaging Certificate Signer"
 will now use "81".

 On branch placeholer-for-Attestation
 Changes to be committed:
	modified:   pkcs15-piv.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
