### PR TITLE
padding: don't add digest info OID when no padding is required

### DIFF
--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -572,7 +572,7 @@ int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
 		pad_algo = SC_ALGORITHM_RSA_PAD_NONE;
 	sc_log(ctx, "hash algorithm 0x%X, pad algorithm 0x%X", hash_algo, pad_algo);
 
-	if ((pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 || pad_algo == SC_ALGORITHM_RSA_PAD_NONE) &&
+	if (pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 &&
 	    hash_algo != SC_ALGORITHM_RSA_HASH_NONE) {
 		i = sc_pkcs1_add_digest_info_prefix(hash_algo, in, in_len, out, &tmp_len);
 		if (i != SC_SUCCESS) {


### PR DESCRIPTION
If PKCS#1 padding scheme is used, a digest info OID has to be prepended in front of the message digest before padding is performed. This digest info shouldn't be prepended if no padding is requested i.e. SC_ALGORITHM_RSA_HASH_NONE is set.

I came across this issue during implementing a driver to solve #2784. This card supports PKCS#1 padding as well as PSS padding. In PKCS#1 mode the card expects the application to send the digest info OID together with the message digest. The card won't prepend the OID on it's own. This means `SC_ALGORITHM_RSA_PAD_PKCS1` is set and `SC_ALGORITHM_RSA_HASH_NONE` is the only permissible hash algorithm flag for this card. No other RSA hash flags are allowed. Otherwise OpenSC would expect the card to add the digest info OID before performing the padding and the signature operation.

In PSS mode the card only expects only the message digest so the following capability flags are defined

 * `SC_ALGORITHM_RSA_PAD_PSS`
 * `SC_ALGORITHM_MGF1_SHA256`
 * `SC_ALGORITHM_MGF1_SHA384`
 * `SC_ALGORITHM_MGF1_SHA512`

When now creating a PSS signature (say `SHA384-RSA-PKCS-PSS`) OpenSC requests the following flags `SC_ALGORITHM_RSA_PAD_PSS | SC_ALGORITHM_RSA_HASH_SHA384 | SC_ALGORITHM_MGF1_SHA384`. In `sc_get_encoding_flags()` the flags `SC_ALGORITHM_RSA_PAD_PSS` and `SC_ALGORITHM_MGF1_SHA384` are assigned to `sflags` (expected to be performed by the card) and `SC_ALGORITHM_RSA_HASH_SHA384` is assigned to `pflags` (to be done in software).

During the signature creation the function `sc_pkcs1_encode()` is called with the flags in `pflags`. It determines, that no padding has to be performed `pad_algo == 0` and the message digest SHA384 was applied `hash_algo == SC_ALGORITHM_RSA_HASH_SHA384`.

Now `pad_algo` becomes `SC_ALGORITHM_RSA_PAD_NONE` in

```c
        if (pad_algo == 0) 
                pad_algo = SC_ALGORITHM_RSA_PAD_NONE;
```

As a consequence this leads to prepending the PKCS#1 digest info OID to the message, although PSS padding is used instead of PKCS#1 padding.

```c
        if ((pad_algo == SC_ALGORITHM_RSA_PAD_PKCS1 || pad_algo == SC_ALGORITHM_RSA_PAD_NONE) &&
            hash_algo != SC_ALGORITHM_RSA_HASH_NONE) {
                i = sc_pkcs1_add_digest_info_prefix(hash_algo, in, in_len, out, &tmp_len);
                /* ... */
        }
```

The effectively creates an invalid signature. By applying this patch, the signature will become valid and the behavior for PKCS#1 signatures is kept.

I think this is a bug, which was introduced in e5707b545e5a2dc33b0ca52a8bf63f36f71b3d85 or d517d8e18d9c7f918e38de7e613e34f6b3d21f09. The former commit introduced the PSS signature scheme. The latter one seems just to fix a logic glitch.

##### Checklist

- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
