### PR TITLE
Add support for RSA D-Trust Card 4.1 & 4.4

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -50,7 +50,7 @@ libopensc_la_SOURCES_BASE = \
 	card-dnie.c cwa14890.c cwa-dnie.c \
 	card-isoApplet.c card-masktech.c card-gids.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
-	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c \
+	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
@@ -132,7 +132,7 @@ TIDY_FILES = \
 	cwa14890.c cwa-dnie.c \
 	card-isoApplet.c card-masktech.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
-	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c \
+	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
 	\
 	pkcs15-openpgp.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -28,7 +28,7 @@ OBJECTS			= \
 	card-sc-hsm.obj card-dnie.obj card-isoApplet.obj pkcs15-coolkey.obj \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-idprime.obj \
-	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj \
+	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj card-dtrust.obj \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj pkcs15-tcos.obj \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -311,7 +311,7 @@ dtrust_set_security_env(sc_card_t *card,
 
 	switch (env->operation) {
 	case SC_SEC_OPERATION_DECIPHER:
-		if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
+		if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1_TYPE_02) {
 			se_num = 0x31;
 		} else if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_OAEP) {
 			switch (env->algorithm_flags & SC_ALGORITHM_MGF1_HASHES) {
@@ -334,7 +334,7 @@ dtrust_set_security_env(sc_card_t *card,
 		break;
 
 	case SC_SEC_OPERATION_SIGN:
-		if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
+		if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1_TYPE_01) {
 			switch (env->algorithm_flags & SC_ALGORITHM_RSA_HASHES) {
 			case SC_ALGORITHM_RSA_HASH_SHA256:
 				se_num = 0x25;

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -310,7 +310,27 @@ static int dtrust_set_security_env(sc_card_t *card,
 	switch(env->operation)
 	{
 	case SC_SEC_OPERATION_DECIPHER:
-		return SC_ERROR_NOT_IMPLEMENTED;
+		if(env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1)
+		{
+			se_num = 0x31;
+		}
+		else if(env->algorithm_flags & SC_ALGORITHM_RSA_PAD_OAEP)
+		{
+			switch(env->algorithm_flags & SC_ALGORITHM_MGF1_HASHES)
+			{
+			case SC_ALGORITHM_MGF1_SHA256: se_num = 0x32; break;
+			case SC_ALGORITHM_MGF1_SHA384: se_num = 0x33; break;
+			case SC_ALGORITHM_MGF1_SHA512: se_num = 0x34; break;
+
+			default:
+				return SC_ERROR_NOT_SUPPORTED;
+			}
+		}
+		else
+		{
+			return SC_ERROR_NOT_SUPPORTED;
+		}
+		break;
 
 	case SC_SEC_OPERATION_SIGN:
 		if(env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1)

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -260,7 +260,14 @@ enum {
 
 	/* eOI cards */
 	SC_CARD_TYPE_EOI = 41000,
-	SC_CARD_TYPE_EOI_CONTACTLESS
+	SC_CARD_TYPE_EOI_CONTACTLESS,
+
+	/* D-Trust Signature cards */
+	SC_CARD_TYPE_DTRUST_V4_1_STD = 42000,
+	SC_CARD_TYPE_DTRUST_V4_1_MULTI,
+	SC_CARD_TYPE_DTRUST_V4_1_M100,
+	SC_CARD_TYPE_DTRUST_V4_4_STD,
+	SC_CARD_TYPE_DTRUST_V4_4_MULTI,
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);
@@ -303,6 +310,7 @@ extern sc_card_driver_t *sc_get_edo_driver(void);
 extern sc_card_driver_t *sc_get_nqApplet_driver(void);
 extern sc_card_driver_t *sc_get_skeid_driver(void);
 extern sc_card_driver_t *sc_get_eoi_driver(void);
+extern sc_card_driver_t *sc_get_dtrust_driver(void);
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -107,6 +107,10 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	 * In order to prevent the cardos driver from matching skeid cards, skeid driver
 	 * precedes cardos and matches no other CardOS 5.4 card. */
 	{ "skeid",	(void *(*)(void)) sc_get_skeid_driver },
+	/* The card handled by dtrust shares the ATR with other cards running CardOS 5.4.
+	 * In order to prevent the cardos driver from matching dtrust cards, dtrust driver
+	 * precedes cardos and matches no other CardOS 5.4 card. */
+	{ "dtrust",	(void *(*)(void)) sc_get_dtrust_driver },
 	{ "cardos",	(void *(*)(void)) sc_get_cardos_driver },
 	{ "gemsafeV1",	(void *(*)(void)) sc_get_gemsafeV1_driver },
 	{ "starcos",	(void *(*)(void)) sc_get_starcos_driver },


### PR DESCRIPTION
This PR adds support for the D-Trust RSA qualified signature and sealing cards.

The driver is a stripped down version of the CardOS driver similar to the Slovakian eID card driver, which deals with special behavior of this card type. Although the `skeid`, `dtrust` and `cardos` cards are all based on the CardOS platform, it seems easier to maintain different drivers in my judgment (see discussion in https://github.com/OpenSC/OpenSC/issues/2784#issuecomment-1567614104 and https://github.com/OpenSC/OpenSC/pull/2672#issuecomment-1371899002).

Fixes #2784

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested