### PR TITLE
Constant time RSA PKCS#1 v1.5 depadding

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -8,7 +8,8 @@ dist_noinst_DATA = \
 	LICENSE.compat_getopt compat_getopt.txt \
 	compat_getopt_main.c \
 	README.compat_strlcpy compat_strlcpy.3
-noinst_HEADERS = compat_strlcat.h compat_strlcpy.h compat_strnlen.h compat_getpass.h compat_getopt.h simclist.h libpkcs11.h libscdl.h compat_overflow.h
+noinst_HEADERS = compat_strlcat.h compat_strlcpy.h compat_strnlen.h compat_getpass.h \
+	compat_getopt.h simclist.h libpkcs11.h libscdl.h compat_overflow.h constant-time.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
@@ -43,7 +44,8 @@ TIDY_FILES = \
 	compat___iob_func.c \
 	compat_overflow.h compat_overflow.c \
 	simclist.c simclist.h \
-	libpkcs11.c libscdl.c
+	libpkcs11.c libscdl.c \
+	constant-time.h
 
 check-local:
 	if [ -x "$(CLANGTIDY)" ]; then clang-tidy -config='' --checks='$(TIDY_CHECKS)' --warnings-as-errors='$(TIDY_CHECKS)' -header-filter=.* $(addprefix $(srcdir)/,$(TIDY_FILES)) -- $(TIDY_FLAGS); fi

--- a/src/common/constant-time.h
+++ b/src/common/constant-time.h
@@ -1,0 +1,128 @@
+/* Original source: https://github.com/openssl/openssl/blob/9890cc42daff5e2d0cad01ac4bf78c391f599a6e/include/internal/constant_time.h */
+
+#ifndef CONSTANT_TIME_H
+#define CONSTANT_TIME_H
+
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(inline)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define constant_inline inline
+#elif defined(__GNUC__) && __GNUC__ >= 2
+#elif defined(__GNUC__) && __GNUC__ >= 2
+#elif defined(_MSC_VER)
+#define constant_inline __inline
+#else
+#define constant_inline
+#endif
+#else			       /* use what caller wants as inline  may be from config.h */
+#define constant_inline inline /* inline */
+#endif
+
+/*-
+ * The boolean methods return a bitmask of all ones (0xff...f) for true
+ * and 0 for false. For example,
+ *      if (a < b) {
+ *        c = a;
+ *      } else {
+ *        c = b;
+ *      }
+ * can be written as
+ *      unsigned int lt = constant_time_lt(a, b);
+ *      c = constant_time_select(lt, a, b);
+ */
+
+static constant_inline unsigned int
+value_barrier(unsigned int a)
+{
+	volatile unsigned int r = a;
+	return r;
+}
+
+static constant_inline size_t
+value_barrier_s(size_t a)
+{
+	volatile size_t r = a;
+	return r;
+}
+
+/* MSB */
+static constant_inline size_t
+constant_time_msb_s(size_t a)
+{
+	return 0 - (a >> (sizeof(a) * 8 - 1));
+}
+
+static constant_inline unsigned int
+constant_time_msb(unsigned int a)
+{
+	return 0 - (a >> (sizeof(a) * 8 - 1));
+}
+
+/* Select */
+static constant_inline unsigned int
+constant_time_select(unsigned int mask, unsigned int a, unsigned int b)
+{
+	return (value_barrier(mask) & a) | (value_barrier(~mask) & b);
+}
+
+static constant_inline unsigned char
+constant_time_select_8(unsigned char mask, unsigned char a, unsigned char b)
+{
+	return (unsigned char)constant_time_select(mask, a, b);
+}
+
+static constant_inline size_t
+constant_time_select_s(size_t mask, size_t a, size_t b)
+{
+	return (value_barrier_s(mask) & a) | (value_barrier_s(~mask) & b);
+}
+
+/* Zero */
+static constant_inline unsigned int
+constant_time_is_zero(unsigned int a)
+{
+	return constant_time_msb(~a & (a - 1));
+}
+
+static constant_inline size_t
+constant_time_is_zero_s(size_t a)
+{
+	return constant_time_msb_s(~a & (a - 1));
+}
+
+/* Comparison*/
+static constant_inline size_t
+constant_time_lt_s(size_t a, size_t b)
+{
+	return constant_time_msb_s(a ^ ((a ^ b) | ((a - b) ^ b)));
+}
+
+static constant_inline unsigned int
+constant_time_lt(unsigned int a, unsigned int b)
+{
+	return constant_time_msb(a ^ ((a ^ b) | ((a - b) ^ b)));
+}
+
+static constant_inline unsigned int
+constant_time_ge(unsigned int a, unsigned int b)
+{
+	return ~constant_time_lt(a, b);
+}
+
+/* Equality*/
+
+static constant_inline unsigned int
+constant_time_eq(unsigned int a, unsigned int b)
+{
+	return constant_time_is_zero(a ^ b);
+}
+
+static constant_inline size_t
+constant_time_eq_s(size_t a, size_t b)
+{
+	return constant_time_is_zero_s(a ^ b);
+}
+
+#endif /* CONSTANT_TIME_H */

--- a/src/libopensc/internal.h
+++ b/src/libopensc/internal.h
@@ -175,8 +175,8 @@ int _sc_card_add_xeddsa_alg(struct sc_card *card, size_t key_length,
 
 int sc_pkcs1_strip_01_padding(struct sc_context *ctx, const u8 *in_dat, size_t in_len,
 		u8 *out_dat, size_t *out_len);
-int sc_pkcs1_strip_02_padding(struct sc_context *ctx, const u8 *data, size_t len,
-		u8 *out_dat, size_t *out_len);
+int sc_pkcs1_strip_02_padding_constant_time(sc_context_t *ctx, unsigned int n, const u8 *data,
+		unsigned int data_len, u8 *out, unsigned int *out_len);
 int sc_pkcs1_strip_digest_info_prefix(unsigned int *algorithm,
 		const u8 *in_dat, size_t in_len, u8 *out_dat, size_t *out_len);
 #ifdef ENABLE_OPENSSL

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -308,10 +308,10 @@ int sc_pkcs15_decipher(struct sc_pkcs15_card *p15card,
 
 	/* Strip any padding */
 	if (pad_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
-		int s = r;
-		int key_size = alg_info->key_length;
+		unsigned int s = r;
+		unsigned int key_size = (unsigned int)alg_info->key_length;
 		r = sc_pkcs1_strip_02_padding_constant_time(ctx, key_size / 8, out, s, out, &s);
-		LOG_TEST_RET(ctx, r, "Invalid PKCS#1 padding");
+		/* for keeping PKCS#1 v1.5 depadding constant-time, do not log error here */
 	}
 #ifdef ENABLE_OPENSSL
 	if (pad_flags & SC_ALGORITHM_RSA_PAD_OAEP)
@@ -333,7 +333,8 @@ int sc_pkcs15_decipher(struct sc_pkcs15_card *p15card,
 		LOG_TEST_RET(ctx, r, "Invalid OAEP padding");
 	}
 #endif
-	LOG_FUNC_RETURN(ctx, r);
+	/* do not log error code to prevent side channel attack */
+	return r;
 }
 
 /* derive one key from another. RSA can use decipher, so this is for only ECDH

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -308,8 +308,9 @@ int sc_pkcs15_decipher(struct sc_pkcs15_card *p15card,
 
 	/* Strip any padding */
 	if (pad_flags & SC_ALGORITHM_RSA_PAD_PKCS1) {
-		size_t s = r;
-		r = sc_pkcs1_strip_02_padding(ctx, out, s, out, &s);
+		int s = r;
+		int key_size = alg_info->key_length;
+		r = sc_pkcs1_strip_02_padding_constant_time(ctx, key_size / 8, out, s, out, &s);
 		LOG_TEST_RET(ctx, r, "Invalid PKCS#1 padding");
 	}
 #ifdef ENABLE_OPENSSL

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4653,9 +4653,9 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 					  "sc_pkcs15_decipher: DECRYPT-INFO dwVersion=%lu\n",
 					  (unsigned long)pInfo->dwVersion);
 				if (pInfo->dwPaddingType == CARD_PADDING_PKCS1)   {
-					size_t temp = pInfo->cbData;
+					unsigned int temp = pInfo->cbData;
 					logprintf(pCardData, 2, "sc_pkcs15_decipher: stripping PKCS1 padding\n");
-					r = sc_pkcs1_strip_02_padding(vs->ctx, pbuf2, pInfo->cbData, pbuf2, &temp);
+					r = sc_pkcs1_strip_02_padding_constant_time(vs->ctx, prkey_info->modulus_length / 8, pbuf2, pInfo->cbData, pbuf2, &temp);
 					pInfo->cbData = (DWORD) temp;
 					if (r < 0)   {
 						logprintf(pCardData, 2, "Cannot strip PKCS1 padding: %i\n", r);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -44,6 +44,7 @@
 #endif
 
 #include "common/compat_strlcpy.h"
+#include "common/constant-time.h"
 #include "libopensc/asn1.h"
 #include "libopensc/cardctl.h"
 #include "libopensc/opensc.h"
@@ -4534,13 +4535,15 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 
 {
 	DWORD dwret;
-	int r, opt_crypt_flags = 0;
+	int r, opt_crypt_flags = 0, good = 0;
 	unsigned ui;
 	VENDOR_SPECIFIC *vs;
 	struct sc_pkcs15_prkey_info *prkey_info;
 	BYTE *pbuf = NULL, *pbuf2 = NULL;
 	struct sc_pkcs15_object *pkey = NULL;
 	struct sc_algorithm_info *alg_info = NULL;
+	unsigned int wrong_padding = 0;
+	unsigned int pbufLen = 0;
 
 	MD_FUNC_CALLED(pCardData, 1);
 
@@ -4641,11 +4644,11 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		goto err;
 	}
 
+	pbufLen = pInfo->cbData;
 	if (alg_info->flags & SC_ALGORITHM_RSA_RAW)   {
 		logprintf(pCardData, 2, "sc_pkcs15_decipher: using RSA-RAW mechanism\n");
 		r = sc_pkcs15_decipher(vs->p15card, pkey, opt_crypt_flags | SC_ALGORITHM_RSA_RAW, pbuf, pInfo->cbData, pbuf2, pInfo->cbData, NULL);
-		logprintf(pCardData, 2, "sc_pkcs15_decipher returned %d\n", r);
-
+		/* do not log return value to not leak it */
 		if (r > 0) {
 			/* Need to handle padding */
 			if (pInfo->dwVersion >= CARD_RSA_KEY_DECRYPT_INFO_VERSION_TWO) {
@@ -4657,13 +4660,9 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 					logprintf(pCardData, 2, "sc_pkcs15_decipher: stripping PKCS1 padding\n");
 					r = sc_pkcs1_strip_02_padding_constant_time(vs->ctx, prkey_info->modulus_length / 8, pbuf2, pInfo->cbData, pbuf2, &temp);
 					pInfo->cbData = (DWORD) temp;
-					if (r < 0)   {
-						logprintf(pCardData, 2, "Cannot strip PKCS1 padding: %i\n", r);
-						pCardData->pfnCspFree(pbuf);
-						pCardData->pfnCspFree(pbuf2);
-						dwret = SCARD_F_INTERNAL_ERROR;
-						goto err;
-					}
+					wrong_padding = constant_time_eq_s(r, SC_ERROR_WRONG_PADDING);
+					/* continue without returning error to not leak that padding is wrong
+					   to prevent time side-channel leak for Marvin attack*/
 				}
 				else if (pInfo->dwPaddingType == CARD_PADDING_OAEP)   {
 					/* TODO: Handle OAEP padding if present - can call PFN_CSP_UNPAD_DATA */
@@ -4711,28 +4710,38 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		goto err;
 	}
 
-	if ( r < 0)   {
+	good = constant_time_eq_s(r, 0);
+	/* if no error or padding error, do not return here to prevent Marvin attack */
+	if (!(good | wrong_padding) && r < 0)   {
 		logprintf(pCardData, 2, "sc_pkcs15_decipher error(%i): %s\n", r, sc_strerror(r));
 		pCardData->pfnCspFree(pbuf);
 		pCardData->pfnCspFree(pbuf2);
 		dwret = md_translate_OpenSC_to_Windows_error(r, SCARD_E_INVALID_VALUE);
 		goto err;
 	}
+	dwret = constant_time_select_s(good, SCARD_S_SUCCESS, SCARD_F_INTERNAL_ERROR);
 
 	logprintf(pCardData, 2, "decrypted data(%lu):\n",
 		  (unsigned long)pInfo->cbData);
 	loghex(pCardData, 7, pbuf2, pInfo->cbData);
 
 	/*inversion donnees */
-	for(ui = 0; ui < pInfo->cbData; ui++)
-		pInfo->pbData[ui] = pbuf2[pInfo->cbData-ui-1];
+	/* copy data in constant-time way to prevent leak */
+	for (ui = 0; ui < pbufLen; ui++) {
+		unsigned int mask, msg_index, inv_ui;
+		mask = good & constant_time_lt_s(ui, pInfo->cbData); /* ui should be in the bounds of pbuf2 */
+		inv_ui = pInfo->cbData - ui - 1;
+		msg_index = constant_time_select_s(mask, inv_ui, 0);
+		pInfo->pbData[ui] = constant_time_select_8(mask, pbuf2[msg_index], pInfo->pbData[ui]);
+	}
 
 	pCardData->pfnCspFree(pbuf);
 	pCardData->pfnCspFree(pbuf2);
 
 err:
 	unlock(pCardData);
-	MD_FUNC_RETURN(pCardData, 1, dwret);
+	/* do not log return value to not leak it */
+	return dwret;
 }
 
 

--- a/src/pkcs11/misc.c
+++ b/src/pkcs11/misc.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/constant-time.h"
 #include "sc-pkcs11.h"
 
 #define DUMP_TEMPLATE_MAX	32
@@ -174,7 +175,7 @@ CK_RV reset_login_state(struct sc_pkcs11_slot *slot, CK_RV rv)
 			slot->p11card->framework->logout(slot);
 		}
 
-		if (rv == CKR_USER_NOT_LOGGED_IN) {
+		if (constant_time_eq_s(rv, CKR_USER_NOT_LOGGED_IN)) {
 			slot->login_user = -1;
 			pop_all_login_states(slot);
 		}

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -1034,7 +1034,8 @@ C_Decrypt(CK_SESSION_HANDLE hSession,	     /* the session's handle */
 		rv = reset_login_state(session->slot, rv);
 	}
 
-	SC_LOG_RV("C_Decrypt() = %s", rv);
+	/* do not log error code to prevent side channel attack */
+	SC_LOG("C_Decrypt()");
 	sc_pkcs11_unlock();
 	return rv;
 }
@@ -1058,7 +1059,8 @@ C_DecryptUpdate(CK_SESSION_HANDLE hSession,  /* the session's handle */
 		rv = sc_pkcs11_decr_update(session, pEncryptedPart, ulEncryptedPartLen,
 				pPart, pulPartLen);
 
-	SC_LOG_RV("C_DecryptUpdate() = %s", rv);
+	/* do not log error code to prevent side channel attack */
+	SC_LOG("C_DecryptUpdate()");
 	sc_pkcs11_unlock();
 	return rv;
 }
@@ -1086,7 +1088,8 @@ C_DecryptFinal(CK_SESSION_HANDLE hSession,   /* the session's handle */
 		rv = reset_login_state(session->slot, rv);
 	}
 
-	SC_LOG_RV("C_DecryptFinal() = %s", rv);
+	/* do not log error code to prevent side channel attack */
+	SC_LOG("C_DecryptFinal()");
 	sc_pkcs11_unlock();
 	return rv;
 }

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -246,6 +246,11 @@ do {\
         }\
 } while(0)
 
+#define SC_LOG(fmt) \
+	do { \
+		sc_log(context, (fmt)); \
+	} while (0)
+
 /* Debug virtual slots. S is slot to be highlighted or NULL
  * C is a comment format string and args It will be preceded by "VSS " */
 #define DEBUG_VSS(S, ...) do { sc_log(context,"VSS " __VA_ARGS__); _debug_virtual_slots(S); } while (0)

--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -14,8 +14,10 @@ VALGRIND_FLAGS = --num-callers=30 -q --keep-debuginfo=yes --gen-suppressions=all
 TESTS_ENVIRONMENT = LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libpcsclite.so.1'
 endif
 
-noinst_PROGRAMS = asn1 simpletlv cachedir pkcs15filter openpgp-tool hextobin decode_ecdsa_signature check_macro_reference_loop
-TESTS = asn1 simpletlv cachedir pkcs15filter openpgp-tool hextobin decode_ecdsa_signature check_macro_reference_loop
+noinst_PROGRAMS = asn1 simpletlv cachedir pkcs15filter openpgp-tool hextobin \
+	decode_ecdsa_signature check_macro_reference_loop strip_pkcs1_2_padding
+TESTS = asn1 simpletlv cachedir pkcs15filter openpgp-tool hextobin \
+	decode_ecdsa_signature check_macro_reference_loop strip_pkcs1_2_padding
 
 noinst_HEADERS = torture.h
 
@@ -37,6 +39,7 @@ openpgp_tool_SOURCES = openpgp-tool.c $(top_builddir)/src/tools/openpgp-tool-hel
 hextobin_SOURCES = hextobin.c
 decode_ecdsa_signature_SOURCES = decode_ecdsa_signature.c
 check_macro_reference_loop = check_macro_reference_loop.c
+strip_pkcs1_2_padding = strip_pkcs1_2_padding.c
 
 if ENABLE_ZLIB
 noinst_PROGRAMS += compression

--- a/src/tests/unittests/Makefile.mak
+++ b/src/tests/unittests/Makefile.mak
@@ -1,11 +1,12 @@
 TOPDIR = ..\..\..
 
-TARGETS = asn1 compression pkcs15filter check_macro_reference_loop
+TARGETS = asn1 compression pkcs15filter check_macro_reference_loop strip_pkcs1_2_padding
 
 OBJECTS = asn1.obj \
 	compression.obj \
 	pkcs15-emulator-filter.obj \
-	check_macro_reference_loop.obj
+	check_macro_reference_loop.obj \
+	strip_pkcs1_2_padding.obj \
 	$(TOPDIR)\win32\versioninfo.res
 
 all: $(TARGETS)

--- a/src/tests/unittests/strip_pkcs1_2_padding.c
+++ b/src/tests/unittests/strip_pkcs1_2_padding.c
@@ -1,0 +1,204 @@
+#include "common/compat_strlcpy.c"
+#include "libopensc/log.c"
+#include "libopensc/padding.c"
+#include "torture.h"
+#include <cmocka.h>
+
+static void
+torture_long_output_buffer(void **state)
+{
+	unsigned int n = 14;
+	unsigned int in_len = 14;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 3;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	unsigned char result_msg[] = {'m', 's', 'g'};
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, 3);
+	assert_memory_equal(out, result_msg, r);
+	free(out);
+}
+
+static void
+torture_short_output_buffer(void **state)
+{
+	unsigned int n = 14;
+	unsigned int in_len = 14;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 1;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_short_message_correct_padding(void **state)
+{
+	unsigned int n = 14;
+	unsigned int in_len = 14;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 3;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	unsigned char result_msg[] = {'m', 's', 'g'};
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, 3);
+	assert_memory_equal(out, result_msg, r);
+	free(out);
+}
+
+static void
+torture_missing_first_zero(void **state)
+{
+	unsigned int n = 13;
+	unsigned int in_len = 13;
+	unsigned char in[] = {0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 10;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_missing_two(void **state)
+{
+	unsigned int n = 13;
+	unsigned int in_len = 13;
+	unsigned char in[] = {0x00,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 10;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_short_padding(void **state)
+{
+	unsigned int n = 13;
+	unsigned int in_len = 13;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x00,
+			'm', 's', 'g'};
+	unsigned int out_len = 10;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_missing_second_zero(void **state)
+{
+	unsigned int n = 13;
+	unsigned int in_len = 13;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			'm', 's', 'g'};
+	unsigned int out_len = 10;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_missing_message(void **state)
+{
+	unsigned int n = 20;
+	unsigned int in_len = 11;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00};
+	unsigned int out_len = 11;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, SC_ERROR_WRONG_PADDING);
+	free(out);
+}
+
+static void
+torture_one_byte_message(void **state)
+{
+	unsigned int n = 12;
+	unsigned int in_len = 12;
+	unsigned char in[] = {0x00, 0x02,
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x00,
+			'm'};
+	unsigned int out_len = 1;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	unsigned char result_msg[] = {'m'};
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, 1);
+	assert_memory_equal(out, result_msg, r);
+	free(out);
+}
+
+static void
+torture_longer_padding(void **state)
+{
+	unsigned int n = 26;
+	unsigned int in_len = 26;
+	unsigned char in[] = {0x00, 0x02,
+			0x0e, 0x38, 0x97, 0x18, 0x16, 0x57, 0x9e, 0x30, 0xb6, 0xa5, 0x78, 0x13, 0x20, 0xca, 0x11,
+			0x00,
+			0x9d, 0x98, 0x3d, 0xca, 0xa9, 0xa7, 0x11, 0x0a};
+	unsigned int out_len = 8;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	unsigned char result_msg[] = {0x9d, 0x98, 0x3d, 0xca, 0xa9, 0xa7, 0x11, 0x0a};
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, 8);
+	assert_memory_equal(out, result_msg, r);
+	free(out);
+}
+
+static void
+torture_empty_message(void **state)
+{
+	unsigned int n = 18;
+	unsigned int in_len = 18;
+	unsigned char in[] = {0x00, 0x02,
+			0x0e, 0x38, 0x97, 0x18, 0x16, 0x57, 0x9e, 0x30, 0xb6, 0xa5, 0x78, 0x13, 0x20, 0xca, 0x11,
+			0x00};
+	unsigned int out_len = 8;
+	unsigned char *out = malloc(out_len * sizeof(unsigned char));
+	int r = sc_pkcs1_strip_02_padding_constant_time(NULL, n, in, in_len, out, &out_len);
+	assert_int_equal(r, 0);
+	free(out);
+}
+
+int
+main(void)
+{
+	const struct CMUnitTest tests[] = {
+			cmocka_unit_test(torture_long_output_buffer),
+			cmocka_unit_test(torture_short_output_buffer),
+			cmocka_unit_test(torture_short_message_correct_padding),
+			cmocka_unit_test(torture_missing_first_zero),
+			cmocka_unit_test(torture_missing_two),
+			cmocka_unit_test(torture_short_padding),
+			cmocka_unit_test(torture_missing_second_zero),
+			cmocka_unit_test(torture_missing_message),
+			cmocka_unit_test(torture_one_byte_message),
+			cmocka_unit_test(torture_longer_padding),
+			cmocka_unit_test(torture_empty_message)};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This PR implements constant-time PKCS#1 v1.5 depadding and return value handling after RSA decryption. The returned value and depadded message are handled in the same way, both for valid and invalid padding, not to disclose the result of the depadding operation in the time side-channel.

- The details on the related Marvin attack can be found on https://people.redhat.com/~hkario/marvin/. 
- CVE 2023 5992 (https://github.com/OpenSC/OpenSC/wiki/CVE-2023-5992)

##### Checklist
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
