### PR TITLE
Support uncompressed certificates on IDPrime 940

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -58,7 +58,7 @@ static const struct sc_atr_table idprime_atrs[] = {
 	  "Gemalto IDPrime 930/3930",
 	  SC_CARD_TYPE_IDPRIME_930, 0, NULL },
 	{ "3b:7f:96:00:00:80:31:80:65:b0:85:59:56:fb:12:0f:fe:82:90:00",
-	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:00:00:ff:ff:ff",
+	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:00:00:00:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime 940",
 	  SC_CARD_TYPE_IDPRIME_940, 0, NULL },
 	{ "3b:7f:96:00:00:80:31:80:65:b0:85:03:00:ef:12:0f:fe:82:90:00",

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -844,10 +844,8 @@ static int idprime_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 
 static int idprime_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file_out)
 {
-	int r, len;
+	int r;
 	idprime_private_data_t * priv = card->drv_data;
-	u8 data[HEADER_LEN];
-	size_t data_len = HEADER_LEN;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -861,13 +859,8 @@ static int idprime_select_file(sc_card_t *card, const sc_path_t *in_path, sc_fil
 
 	r = iso_ops->select_file(card, in_path, file_out);
 	if (r == SC_SUCCESS && file_out != NULL) {
-		/* Try to read first bytes of the file to fix FCI in case of
-		 * compressed certififcate */
-		len = iso_ops->read_binary(card, 0, data, data_len, 0);
-		if (len == HEADER_LEN && data[0] == 0x01 && data[1] == 0x00) {
-			/* Cache the real file size for the caching read_binary() */
-			priv->file_size = (*file_out)->size;
-		}
+ 	 	/* Cache the real file size for the caching read_binary() */
+ 	 	priv->file_size = (*file_out)->size;
 	}
 	/* Return the exit code of the select command */
 	return r;

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -905,7 +905,9 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 			r = priv->file_size - 4;
 			if (flags)
 				*flags |= SC_FILE_FLAG_COMPRESSED_AUTO;
-		}
+		} else {
+ 	 	 	r = priv->file_size;
+ 	 	}
 		priv->cache_buf = malloc(r);
 		if (priv->cache_buf == NULL) {
 			return SC_ERROR_OUT_OF_MEMORY;


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

This PR intends to fix handling of uncompressed certificates in Gemalto IDPrime cards. I'm currently testing this on a 940 (applet version 4), but other card variants may be affected.

Specifically, the PR fixes a bug with the data caching when reading binary data from the card, as well as ensuring that the on-card file sizes are known regardless of the compression state of the file.

Fixes #2956.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
