### PR TITLE
Workaround Yubikey bug with SELECT DATA

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -539,6 +539,8 @@ struct sc_reader_operations {
 #define SC_CARD_FLAG_RNG		0x00000002
 #define SC_CARD_FLAG_KEEP_ALIVE	0x00000004
 
+#define SC_CARD_FLAG_YUBIKEY_SELECT	0x00010000
+
 /*
  * Card capabilities
  */


### PR DESCRIPTION
There is a known issue with Yubikey tokens, that they're requiring another length byte in APDU for SELECT DATA:
https://github.com/Yubico/yubikey-manager/issues/403

Let's workaround this, by checking return value of SELECT DATA, and if error indicates that parameters are wrong, let's try Yubikey-specific ones.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
