### PR TITLE
sc-hsm: Force use of Le = 0x00 for SELECT

### DIFF
--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -232,7 +232,7 @@ static int sc_hsm_select_file_ex(sc_card_t *card,
 		}
 	}
 	/* Force use of Le = 0x00 in iso7816_select_file as required by SC-HSM */
-	card->max_recv_size = card->reader->max_recv_size = 256;
+	card->max_recv_size = card->reader->max_recv_size = SC_READER_SHORT_APDU_MAX_RECV_SIZE;
 	rv = (*iso_ops->select_file)(card, in_path, file_out);
 	card->max_recv_size = card_max_recv_size;
 	card->reader->max_recv_size = reader_max_recv_size;


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2944

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
