### PR TITLE
pkcs11-tool: add pure EdDSA support to sign/verify

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -147,8 +147,23 @@ static struct ec_curve_info {
 	{"secp256k1",		"1.3.132.0.10", "06052B8104000A", 256, 0},
 	{"secp521k1",		"1.3.132.0.35", "06052B81040023", 521, 0},
 
-	{"edwards25519","1.3.6.1.4.1159.15.1", "130c656477617264733235353139", 255, CKM_EC_EDWARDS_KEY_PAIR_GEN},
-	{"curve25519", "1.3.6.1.4.3029.1.5.1", "130b63757276653235353139", 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN},
+	/* Some of the following may not yet be supported by the OpenSC module, but may be by other modules */
+	/* OpenPGP extensions by Yubikey and GNUK are not defined in RFCs, so pass by printable string */
+	/* See PKCS#11 3.0 2.3.7 */
+	{"edwards25519", "1.3.6.1.4.1.11591.15.1", "130c656477617264733235353139", 255, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* send by curve name */
+	{"curve25519",   "1.3.6.1.4.1.3029.1.5.1", "130a63757276653235353139",     255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* send by curve name */
+
+	/* RFC8410, EDWARDS and MONTGOMERY curves are used by GnuPG and also by OpenSSL */
+
+	{"X25519",  "1.3.101.110", "06032b656e", 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+	{"X448",    "1.3.101.111", "06032b656f", 448, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+	{"Ed25519", "1.3.101.112", "06032b6570", 255, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+	{"Ed448",   "1.3.101.113", "06032b6571", 448, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+
+	/* GnuPG openpgp curves as used in gnupg-card are equivalent to RFC8410 OIDs */
+	{"cv25519", "1.3.101.110", "06032b656e", 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN},
+	{"ed25519", "1.3.101.112", "06032b6570", 255, CKM_EC_EDWARDS_KEY_PAIR_GEN},
+	/* OpenSC card-openpgp.c will map these to what is need on the card */
 
 	{NULL, NULL, NULL, 0, 0},
 };

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2201,7 +2201,6 @@ match_ec_curve_by_params(const unsigned char *ec_params, CK_ULONG ec_params_size
 	sc_bin_to_hex(ec_params, ec_params_size, ecpbuf, sizeof(ecpbuf), 0);
 
 	for (size_t i = 0; ec_curve_infos[i].name != NULL; ++i) {
-
 		if (strcmp(ec_curve_infos[i].ec_params, ecpbuf) == 0) {
 			return &ec_curve_infos[i];
 		}


### PR DESCRIPTION
Adding Pure EdDSA using ed25519 and ed448 keys to pkcs11-tool.

I used @dengert changes here to wire ed448 keys to be able to generate them using my custom soft hsm: https://github.com/dengert/OpenSC/commit/1b0d7c996471a2c9576a7e8798a153e560a9128a#diff-fcf954433b996121efbb3028d15e969537c35c7fd4bcd8b2a31bba29c4af18f7R160

Related #2952

```
# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --keypairgen --key-type EC:edwards25519 --usage-sign --label ed25519key --id 1
Using slot 0 with a present token (0x0)
Key pair generated:
Private Key Object; EC_EDWARDS
  label:      ed25519key
  ID:         01
  Usage:      sign
  Access:     sensitive, always sensitive, never extractable, local
Public Key Object; EC_EDWARDS  EC_POINT 255 bits
  EC_POINT:   fed9e24a03a7d163bc3e6b0275aba8bff92f13ad125c676faa4dfd7e131a5294
  EC_PARAMS:  130c656477617264733235353139 (OID 2.21.100.119.97.114.100.115.50.53.53.49.57)
  label:      ed25519key
  ID:         01
  Usage:      verify
  Access:     local

# echo -n "000102030405060708090a0b0c0d0e0f" > /data/sign.bin

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --sign --mechanism EDDSA --label ed25519key --input-file /data/sign.bin --output-file /data/sig.bin
Using slot 0 with a present token (0x0)
Using signature algorithm EDDSA

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --verify --mechanism EDDSA --label ed25519key --input-file /data/sign.bin --signature-file /data/sig.bin
Using slot 0 with a present token (0x0)
Using signature algorithm EDDSA
Signature is valid
```

```
# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --keypairgen --key-type EC:Ed448 --usage-sign --label ed448key --id 2
Using slot 0 with a present token (0x0)
Key pair generated:
Private Key Object; EC_EDWARDS
  label:      ed448key
  ID:         02
  Usage:      sign
  Access:     sensitive, always sensitive, never extractable, local
Public Key Object; EC_EDWARDS  EC_POINT 255 bits
  EC_POINT:   38dd2151d0a622417779b533524108442b537b6525cd11f6950a962b78267c4cdb17aab3df8561855c39bc4d33ecf20c2ba448482c50389100
  EC_PARAMS:  06032b6571 (OID 1.3.101.113)
  label:      ed448key
  ID:         02
  Usage:      verify
  Access:     local

# echo -n "000102030405060708090a0b0c0d0e0f" > /data/sign.bin

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --sign --mechanism EDDSA --label ed448key --input-file /data/sign.bin --output-file /data/sig.bin
Using slot 0 with a present token (0x0)
Using signature algorithm EDDSA

# pkcs11-tool --module=/system/lib/dll/pkcs11-qkeystore.so --verify --mechanism EDDSA --label ed448key --input-file /data/sign.bin --signature-file /data/sig.bin
Using slot 0 with a present token (0x0)
Using signature algorithm EDDSA
Signature is valid
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X ] PKCS#11 module is tested (custom softhsm)
