### PR TITLE
Fix Heap-use-after-free in iasecc_delete_file

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -1544,7 +1544,6 @@ iasecc_delete_file(struct sc_card *card, const struct sc_path *path)
 	struct sc_apdu apdu;
 	struct sc_file *file = NULL;
 	int rv;
-	unsigned int file_id;
 
 	LOG_FUNC_CALLED(ctx);
 	sc_print_cache(card);
@@ -1555,19 +1554,17 @@ iasecc_delete_file(struct sc_card *card, const struct sc_path *path)
 	LOG_TEST_RET(ctx, rv, "Cannot select file to delete");
 
 	entry = sc_file_get_acl_entry(file, SC_AC_OP_DELETE);
-
-	file_id = file->id;
-	sc_file_free(file);
-
 	if (!entry)
 		LOG_TEST_RET(ctx, SC_ERROR_OBJECT_NOT_FOUND, "Cannot delete file: no 'DELETE' acl");
 
 	sc_log(ctx, "DELETE method/reference %X/%X", entry->method, entry->key_ref);
 	if (entry->method == SC_AC_SCB && (entry->key_ref & IASECC_SCB_METHOD_SM))   {
 		unsigned char se_num = entry->key_ref & IASECC_SCB_METHOD_MASK_REF;
-		rv = iasecc_sm_delete_file(card, se_num, file_id);
+		rv = iasecc_sm_delete_file(card, se_num, file->id);
+		sc_file_free(file);
 	}
 	else   {
+		sc_file_free(file);
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_1, 0xE4, 0x00, 0x00);
 
 		rv = sc_transmit_apdu(card, &apdu);


### PR DESCRIPTION
Patch 773fcc6bd0d047aa629dd297e87244ca3add5b16 unfortunately introduced a new bug.  Here is a fix for both the old and the new bug.

Thanks oss-fuzz

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65562
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65684
