### PR TITLE
pkcs11-spy.c check return code

### DIFF
--- a/src/pkcs11/pkcs11-spy.c
+++ b/src/pkcs11/pkcs11-spy.c
@@ -1672,7 +1672,7 @@ C_GetInterface(CK_UTF8CHAR_PTR pInterfaceName, CK_VERSION_PTR pVersion,
 		(flags & CKF_INTERFACE_FORK_SAFE ? "CKF_INTERFACE_FORK_SAFE" : ""));
 	if (po->version.major >= 3) {
 		rv = po->C_GetInterface(pInterfaceName, pVersion, ppInterface, flags);
-		if (ppInterface != NULL) {
+		if (rv == CKR_OK && ppInterface != NULL) {
 			spy_interface_function_list(*ppInterface);
 		}
 	} else {


### PR DESCRIPTION
The po->C_GetInterface is passed the callers ppInterface where *ppInterface may not be valid.

if the po->C_GetInterface may not update the *ppInterface and return an error. In this case  spy_interface_function_list should not be called, as it assumes the *ppInterface has been modified.

Found debugging FireFox version 121 where FireFox passes a ppInterface where *ppInterface is not a valid pointer, causing a segfault in spy_interface_function_list.

FireFox calls C_GetInterface twice with flags = CKF_INTERFACE_FORK_SAFE twice then on third time requests with flag = 0  where po->GetInterface can support and it updates the *ppInterface  with valid data.

Found with debugging #2987 

 On branch pkcs11-spy-segfault
 Changes to be committed:
	modified:   pkcs11-spy.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PKCS#11 module is tested
