### PR TITLE
doc: Correctly forward IO to xsltproc to correctly replace paths in manual pages

### DIFF
--- a/doc/files/Makefile.am
+++ b/doc/files/Makefile.am
@@ -26,7 +26,7 @@ files.html: $(srcdir)/files.xml $(wildcard $(srcdir)/*.5.xml) opensc.conf.5.xml
 
 %.5: $(srcdir)/%.5.xml
 	$(AM_V_GEN)sed -e 's|@pkgdatadir[@]|$(pkgdatadir)|g' < $< \
-	| $(XSLTPROC) --nonet --path "$(srcdir)/..:$(xslstylesheetsdir)/manpages" --xinclude -o $@ man.xsl $< 2>/dev/null
+	| $(XSLTPROC) --nonet --path "$(srcdir)/..:$(xslstylesheetsdir)/manpages" --xinclude -o $@ man.xsl - 2>/dev/null
 
 clean-local:
 	-rm -rf $(html_DATA) $(man5_MANS) opensc.conf.5.xml

--- a/doc/tools/Makefile.am
+++ b/doc/tools/Makefile.am
@@ -18,7 +18,7 @@ tools.html: $(srcdir)/tools.xml $(wildcard $(srcdir)/*.1.xml)
 
 %.1: $(srcdir)/%.1.xml
 	$(AM_V_GEN)sed -e 's|@pkgdatadir[@]|$(pkgdatadir)|g' < $< \
-	| $(XSLTPROC) --nonet --path "$(srcdir)/..:$(xslstylesheetsdir)/manpages" --xinclude -o $@ man.xsl $< 2>/dev/null
+	| $(XSLTPROC) --nonet --path "$(srcdir)/..:$(xslstylesheetsdir)/manpages" --xinclude -o $@ man.xsl - 2>/dev/null
 
 %: $(srcdir)/%.1.xml
 	$(AM_V_GEN)cat $(srcdir)/completion-template \


### PR DESCRIPTION
I accidentally noticed that some of the generated manual pages had non-translated replacement strings, which was caused by wrong invocation of the xsltproc.

##### Checklist
- [X] Documentation is added or updated