### PR TITLE
ci: Dump logs on error

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -11,17 +11,20 @@ fi
 if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
 	PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 	if [ "$GITHUB_BASE_REF" == "master" ]; then
-		./bootstrap.ci -s "-pr$PR_NUMBER"
+		SUFFIX="-pr$PR_NUMBER"
 	else
-		./bootstrap.ci -s "$GITHUB_BASE_REF-pr$PR_NUMBER"
+		SUFFIX="$GITHUB_BASE_REF-pr$PR_NUMBER"
 	fi
 else
 	BRANCH=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-	if [ "$BRANCH" == "master" ]; then
-		./bootstrap
-	else
-		./bootstrap.ci -s "$BRANCH"
+	if [ "$BRANCH" != "master" ]; then
+		SUFFIX="$BRANCH"
 	fi
+fi
+if [ -n "$SUFFIX" ]; then
+	./bootstrap.ci -s "$SUFFIX"
+else
+	./bootstrap
 fi
 
 if [ "$RUNNER_OS" == "macOS" ]; then
@@ -66,25 +69,36 @@ else
 	make -j 4 V=1
 	# 32b build has some issues to find openssl correctly
 	if [ "$1" == "valgrind" ]; then
+		set +e
 		make check-valgrind-memcheck
 		RV=$?
-		source .github/dump-logs.sh
 		if [ $RV -ne 0 ]; then
+			./.github/dump-logs.sh
 			exit $RV
 		fi
+		set -e
 	elif [ "$1" != "ix86" ]; then
+		set +e
 		make check
 		RV=$?
-		source .github/dump-logs.sh
 		if [ $RV -ne 0 ]; then
+			./.github/dump-logs.sh
 			exit $RV
 		fi
+		set -e
 	fi
 fi
 
 # this is broken in old ubuntu
 if [ "$1" == "dist" -o "$2" == "dist" ]; then
+	set +e
 	make distcheck
+	RV=$?
+	if [ $RV -ne 0 ]; then
+		./.github/dump-logs.sh $SUFFIX
+		exit $RV
+	fi
+	set -e
 	make dist
 fi
 

--- a/.github/dump-logs.sh
+++ b/.github/dump-logs.sh
@@ -1,10 +1,13 @@
+SUFFIX=$1
+if [ -n "$SUFFIX" ]; then
+	REL="opensc-*$SUFFIX/_build/sub/"
+fi
+
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-for F in tests/*.log src/tests/unittests/*.log; do
-	echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-	echo $F
-	echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+for F in ${REL}tests/*.log ${REL}src/tests/unittests/*.log; do
+	echo "::group::$F"
 	cat $F
-	echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+	echo "::endgroup::"
 done
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 

--- a/.github/workflows/linux-strict.yml
+++ b/.github/workflows/linux-strict.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: ${{ matrix.name }}-%{{ matrix.compiler }}-strict-test-logs
+          name: ${{ matrix.name }}-${{ matrix.compiler }}-strict-test-logs
           path: |
             config.log
             tests/*.log

--- a/tests/opensc.supp
+++ b/tests/opensc.supp
@@ -37,3 +37,41 @@
    fun:_cmocka_run_group_tests
    fun:main
 }
+{
+   SoftHSM provides us with uninitialized flags
+   Memcheck:Value8
+   fun:_itoa_word
+   fun:__vfprintf_internal
+   fun:buffered_vfprintf
+   fun:fprintf
+   fun:print_mech_info
+   fun:C_GetMechanismInfo
+   fun:supported_mechanisms_test
+   obj:/usr/lib/x86_64-linux-gnu/libcmocka.so.0.7.0
+   fun:_cmocka_run_group_tests
+   fun:main
+}
+{
+   SoftHSM provides us with uninitialized flags
+   Memcheck:Cond
+   fun:_itoa_word
+   fun:__vfprintf_internal
+   fun:buffered_vfprintf
+   fun:fprintf
+   fun:print_mech_info
+   fun:C_GetMechanismInfo
+   fun:supported_mechanisms_test
+   obj:/usr/lib/x86_64-linux-gnu/libcmocka.so.0.7.0
+   fun:_cmocka_run_group_tests
+   fun:main
+}
+{
+   SoftHSM provides us with uninitialized flags
+   Memcheck:Cond
+   fun:print_mech_info
+   fun:C_GetMechanismInfo
+   fun:supported_mechanisms_test
+   obj:/usr/lib/x86_64-linux-gnu/libcmocka.so.0.7.0
+   fun:_cmocka_run_group_tests
+   fun:main
+}


### PR DESCRIPTION
The logs should be grouped in expandable sections as described here for better readability:

https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines

This also attempts to dump the logs from make distcheck as they will be in different path.

Example of failed run:

https://github.com/Jakuje/OpenSC/actions/runs/7723818954/job/21054680420

This allows fast review of the failed logs. Unfortunately, loading of long sections takes some time in the webui ...