### PR TITLE
Fix reader initialization without SCardControl

### DIFF
--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -263,8 +263,8 @@ static int pcsc_internal_transmit(sc_reader_t *reader,
 			rv = priv->gpriv->SCardControlOLD(card, sendbuf, dwSendLength,
 				  recvbuf, &dwRecvLength);
 		}
-		else if (!priv->gpriv->SCardControl) {
-			rv = priv->gpriv->SCardControl(card, (DWORD) control, sendbuf, dwSendLength,
+		} else if (!priv->gpriv->SCardControl) {
+			rv = priv->gpriv->SCardControl(card, (DWORD)control, sendbuf, dwSendLength,
 					recvbuf, dwRecvLength, &dwRecvLength);
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/3006

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
