### PR TITLE
Fix error handling on strdup

### DIFF
--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -923,8 +923,7 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 	}
 
 	if (args->label) {
-		if (p15card->tokeninfo->label)
-			free(p15card->tokeninfo->label);
+		free(p15card->tokeninfo->label);
 		p15card->tokeninfo->label = strdup(args->label);
 	}
 	if (p15card->tokeninfo->label)

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -927,7 +927,10 @@ sc_pkcs15init_add_app(struct sc_card *card, struct sc_profile *profile,
 			free(p15card->tokeninfo->label);
 		p15card->tokeninfo->label = strdup(args->label);
 	}
-	app->label = strdup(p15card->tokeninfo->label);
+	if (p15card->tokeninfo->label)
+		app->label = strdup(p15card->tokeninfo->label);
+	else
+		app->label = strdup("Token");
 
 	/* See if we've set an SO PIN */
 	r = sc_pkcs15init_add_object(p15card, profile, SC_PKCS15_AODF, pin_obj);


### PR DESCRIPTION
I have reviewed all issues that were brought up by CodeQL. Unfortunately, almost everyone of them was a false positive. It seems that CodeQL doesn't understand it when we're correctly handling some error in the line of the following:
```
p = calloc(5);
if (p == NULL)
   LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
```
Anyway, one CodeQL issue at least led me to harden some other error handling around the referenced code.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
