### PR TITLE
ePass2003: Allow software implementation with more SHA2 hashes and ECDSA

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2200,16 +2200,10 @@ epass2003_set_security_env(struct sc_card *card, const sc_security_env_t * env, 
 			sbuf[2] = 0x92;
 			exdata->ecAlgFlags = SC_ALGORITHM_ECDSA_HASH_SHA256;
 		}
-		else if (env->algorithm_flags & SC_ALGORITHM_ECDSA_HASH_NONE)
+		else
 		{
 			sbuf[2] = 0x92;
 			exdata->ecAlgFlags = SC_ALGORITHM_ECDSA_HASH_NONE;
-		}
-		else
-		{
-			r = SC_ERROR_NOT_SUPPORTED;
-			sc_log(card->ctx, "%0lx Alg Not Support! ", env->algorithm_flags);
-			goto err;
 		}
 	}
 	else if(env->algorithm == SC_ALGORITHM_RSA)


### PR DESCRIPTION
This removes bogus check to allow ePass token working with the SHA2 hashes (in software) and ECDSA signatures (RAW).

This is likely the last thing before the ci for the ePass will be green.

@FeitianSmartcardReader any comments?

##### Checklist
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
