### PR TITLE
Locally found fuzzing issues

### DIFF
--- a/src/libopensc/card-eoi.c
+++ b/src/libopensc/card-eoi.c
@@ -291,6 +291,7 @@ static int eoi_init(sc_card_t* card) {
 					strlcpy(privdata->can, can, sizeof(privdata->can));
 			}
 		}
+		free(found_blocks);
 	}
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);


### PR DESCRIPTION
Memory leaks found during local fuzzing with `fuzz_pkcs11`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
