### PR TITLE
pkcs15-prkey.c: correctly check for presence of ECC parameters

### DIFF
--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -240,7 +240,7 @@ int sc_pkcs15_decode_prkdf_entry(struct sc_pkcs15_card *p15card,
 	else if (asn1_prkey[1].flags & SC_ASN1_PRESENT) {
 		obj->type = SC_PKCS15_TYPE_PRKEY_EC;
 #ifdef ENABLE_OPENSSL
-		if (!info.field_length && ec_domain_len) {
+		if (!(asn1_ecckey_attr[1].flags & SC_ASN1_PRESENT) && (asn1_ecckey_attr[3].flags & SC_ASN1_PRESENT)) {
 			const unsigned char *p = ec_domain;
 			ASN1_OBJECT *object = d2i_ASN1_OBJECT(NULL, &p, ec_domain_len);
 			int nid;


### PR DESCRIPTION
This PR changes the condition to check for special handling of ~~Slovakian~~ Slovenian eID more general. Previous the existence of such parameters was tested if the values are still have their default value. Now existence is tested by parser specific flags. At least it solves #3031. But I don't have access to a Slovakian eID, but it should be checked against such a device.

Mentioning @llogar and @jurajsarinay as they were involved in the implementation of that driver and asking them kindly to check against their hardware.

closes #3031

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested