### PR TITLE
piv-tool.c - missing #else

### DIFF
--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -532,6 +532,7 @@ static int gen_key(const char * key_info)
 		EVP_PKEY_CTX_free(ctx);
 		OSSL_PARAM_free(params);
 #endif
+#else  /* OPENSSL_NO_EC */
 		fprintf(stderr, "This build of OpenSSL does not support EC keys\n");
 		r = 1;
 #endif /* OPENSSL_NO_EC */


### PR DESCRIPTION
Missing #else causes EC key creation to fail

 Changes to be committed:
	modified:   tools/piv-tool.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
