### PR TITLE
Add SafeNet 5110+ FIPS token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ src/tests/fuzzing/fuzz_pkcs15init
 src/tests/fuzzing/fuzz_scconf_parse_string
 
 version.m4.ci
+openssl_arm64
+openssl_bin

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -57,6 +57,10 @@ static const struct sc_atr_table idprime_atrs[] = {
 	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime 930/3930",
 	  SC_CARD_TYPE_IDPRIME_930, 0, NULL },
+	{ "3b:ff:96:00:00:81:31:fe:43:80:31:80:65:b0:84:65:66:fb:12:01:78:82:90:00:85",
+	  "ff:ff:00:ff:ff:ff:ff:00:ff:ff:ff:ff:ff:ff:00:00:00:00:ff:ff:ff:ff:ff:ff:00",
+	  "based Gemalto IDPrime 930",
+	  SC_CARD_TYPE_IDPRIME_930, 0, NULL },
 	{ "3b:7f:96:00:00:80:31:80:65:b0:85:59:56:fb:12:0f:fe:82:90:00",
 	  "ff:ff:00:ff:ff:ff:ff:ff:ff:ff:ff:00:00:00:ff:00:00:ff:ff:ff",
 	  "Gemalto IDPrime 940",
@@ -648,10 +652,8 @@ static int idprime_init(sc_card_t *card)
 	if (card->type == SC_CARD_TYPE_IDPRIME_930
 	    || card->type == SC_CARD_TYPE_IDPRIME_940) {
 		_sc_card_add_rsa_alg(card, 4096, flags, 0);
-	}
 
-	/* Set up algorithm info for EC */
-	if (card->type == SC_CARD_TYPE_IDPRIME_940) {
+		/* Set up algorithm info for EC */
 		flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDSA_HASH_NONE;
 		ext_flags = SC_ALGORITHM_EXT_EC_F_P
 			| SC_ALGORITHM_EXT_EC_ECPARAMETERS


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

Signed-off-by: Raul Metsma <raul@metsma.ee>