### PR TITLE
dtrust-tool: Fix NULL dereference with pinpad

### DIFF
--- a/src/tools/dtrust-tool.c
+++ b/src/tools/dtrust-tool.c
@@ -177,12 +177,11 @@ unlock_transport_protection(sc_card_t *card)
 			fprintf(stderr, "New signature PINs doesn't match.\n");
 			goto fail_qespin2;
 		}
+		data.pin1.data = (u8 *)tpin;
+		data.pin1.len = strlen(tpin);
+		data.pin2.data = (u8 *)qespin1;
+		data.pin2.len = strlen(qespin1);
 	}
-
-	data.pin1.data = (u8 *)tpin;
-	data.pin1.len = strlen(tpin);
-	data.pin2.data = (u8 *)qespin1;
-	data.pin2.len = strlen(qespin1);
 
 	r = sc_pin_cmd(card, &data, &tries_left);
 

--- a/src/tools/dtrust-tool.c
+++ b/src/tools/dtrust-tool.c
@@ -145,6 +145,10 @@ unlock_transport_protection(sc_card_t *card)
 	data.cmd = SC_PIN_CMD_CHANGE;
 	data.pin_type = SC_AC_CHV;
 	data.pin_reference = 0x87;
+	data.pin1.min_length = 5;
+	data.pin1.max_length = 5;
+	data.pin2.min_length = 6;
+	data.pin2.max_length = 12;
 
 	if (card->reader->capabilities & SC_READER_CAP_PIN_PAD) {
 		printf("Please enter PINs on the reader's pin pad.\n");


### PR DESCRIPTION
Thanks coverity:

CID 414970
CID 414971
CID 414972
CID 414973

Fixup #3026

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested