### PR TITLE
ci: Verify the HTML documentation is up-to-date

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,40 @@
+---
+name: Make sure HTML files are updated
+
+on:
+  pull_request:
+    paths:
+      - '**.xml'
+      - '**.xml.in'
+      - .github/workflows/doc.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      # Do this before checkout otherwise we will not have a git repository
+      - run: dnf install -y git
+      - uses: actions/checkout@v3
+      - run: .github/setup-fedora.sh
+      # git checkout to revert changes to tests/Makefile.am done by the setup
+      - run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE &&
+          git checkout tests/Makefile.am &&
+          ./bootstrap &&
+          ./configure --prefix="/usr" --enable-doc &&
+          cd doc/tools &&
+          rm tools.html &&
+          make tools.html &&
+          cd ../files &&
+          rm files.html &&
+          make files.html &&
+          cd ../../ &&
+          git diff --exit-code --color || (
+          echo "The documentation files were changed!"
+          echo -n "Regenerate the HTML files with "
+          echo -n "\`make tools.html\` in \`doc/tools\` and "
+          echo -n "\`make files.html\`in \`doc/files\` or apply the above patch"
+          exit 1
+          )

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -47,11 +47,11 @@ TESTS = \
         test-pkcs11-tool-sym-crypt-test.sh \
         test-pkcs11-tool-unwrap-wrap-test.sh \
         test-pkcs11-tool-import.sh
-XFAIL_TESTS = \
-        test-pkcs11-tool-test-threads.sh \
-        test-pkcs11-tool-test.sh
 if ENABLE_TESTS
 if ENABLE_SHARED
 TESTS += test-p11test.sh
 endif
 endif
+XFAIL_TESTS = \
+        test-pkcs11-tool-test-threads.sh \
+        test-pkcs11-tool-test.sh


### PR DESCRIPTION
Fixes: #3056

Similar to the spellcheck or clang-format, this attemtpts to regenerate HTML pages and if they are not up to date, fail

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
