### PR TITLE
Rename configuration option `private_certificate` to `pin_protected_certificate`

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -874,7 +874,7 @@ app <em class="replaceable"><code>application</code></em> {
 							<code class="literal">use_pin_caching</code> option for OpenSC
 							to be able to provide PIN for the card when needed.
 					</p></dd><dt><span class="term">
-						<code class="option">private_certificate = <em class="replaceable"><code>value</code></em>;</code>
+						<code class="option">pin_protected_certificate = <em class="replaceable"><code>value</code></em>;</code>
 					</span></dt><dd><p>
 							How to handle a PIN-protected certificate. Known
 							parameters:

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1350,7 +1350,7 @@ app <replaceable>application</replaceable> {
 				</varlistentry>
 				<varlistentry>
 					<term>
-						<option>private_certificate = <replaceable>value</replaceable>;</option>
+						<option>pin_protected_certificate = <replaceable>value</replaceable>;</option>
 					</term>
 					<listitem><para>
 							How to handle a PIN-protected certificate. Known

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -948,7 +948,7 @@ app default {
 		# How to handle a PIN-protected certificate
 		# Valid values: protect, declassify, ignore.
 		# Default: ignore in tokend, protect otherwise
-		# private_certificate = declassify;
+		# pin_protected_certificate = declassify;
 
 		# Enable pkcs15 emulation.
 		# Default: yes

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -501,7 +501,7 @@ sc_pkcs15_decode_cdf_entry(struct sc_pkcs15_card *p15card, struct sc_pkcs15_obje
 	}
 	sc_log(ctx, "Certificate path '%s'", sc_print_path(&info.path));
 
-	switch (p15card->opts.private_certificate) {
+	switch (p15card->opts.pin_protected_certificate) {
 		case SC_PKCS15_CARD_OPTS_PRIV_CERT_DECLASSIFY:
 			sc_log(ctx, "Declassifying certificate");
 			obj->flags &= ~SC_PKCS15_CO_FLAG_PRIVATE;

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -586,7 +586,7 @@ typedef struct sc_pkcs15_card {
 		int use_pin_cache;
 		int pin_cache_counter;
 		int pin_cache_ignore_user_consent;
-		int private_certificate;
+		int pin_protected_certificate;
 	} opts;
 
 	unsigned int magic;
@@ -612,7 +612,7 @@ typedef struct sc_pkcs15_card {
 #define SC_PKCS15_OPTS_CACHE_PUBLIC_FILES		1
 #define SC_PKCS15_OPTS_CACHE_ALL_FILES			2
 
-/* suitable for struct sc_pkcs15_card.opts.private_certificate */
+/* suitable for struct sc_pkcs15_card.opts.pin_protected_certificate */
 #define SC_PKCS15_CARD_OPTS_PRIV_CERT_PROTECT		0
 #define SC_PKCS15_CARD_OPTS_PRIV_CERT_IGNORE		1
 #define SC_PKCS15_CARD_OPTS_PRIV_CERT_DECLASSIFY	2


### PR DESCRIPTION
Fixes #2597

After adding the configuration option for caching private data from card #2588, the configuration option `private_certificate` for handling PIN-protected certificates might be misleading with the caching of private data.
The option `private_certificate` is renamed to `pin_protected_certificate`.

It would also be good to modify `ignore_private_certificate` to `ignore_pin_protected_certificate` when integrating this change.