### PR TITLE
pkcs11: improve logging of mechanism setup

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -64,6 +64,9 @@ else
 	if [ "$1" == "no-shared" ]; then
 		CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-shared"
 	fi
+	if [ "$1" == "no-openssl" ]; then
+		CONFIGURE_FLAGS="$CONFIGURE_FLAGS --disable-openssl"
+	fi
 	export CFLAGS="-DDEBUG_PROFILE=1 $CFLAGS"
 	./configure $CONFIGURE_FLAGS
 	make -j 4 V=1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,6 +66,13 @@ jobs:
       - run: .github/setup-linux.sh
       - run: .github/build.sh no-shared valgrind
 
+  build-no-openssl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: .github/setup-linux.sh
+      - run: .github/build.sh no-openssl valgrind
+
   build-ix86:
     runs-on: ubuntu-20.04
     steps:

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -6681,6 +6681,11 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 		if (rc != CKR_OK)
 			return rc;
 
+#ifdef ENABLE_OPENSSL
+		/* sc_pkcs11_register_sign_and_hash_mechanism expects software hash */
+		/* All hashes are in OpenSSL
+		 * Either the card set the hashes or we helped it above */
+
 		if (rsa_flags & SC_ALGORITHM_RSA_HASH_SHA1) {
 			rc = sc_pkcs11_register_sign_and_hash_mechanism(p11card,
 				CKM_SHA1_RSA_PKCS_PSS, CKM_SHA_1, registered_mt);
@@ -6711,6 +6716,7 @@ register_mechanisms(struct sc_pkcs11_card *p11card)
 			if (rc != CKR_OK)
 				return rc;
 		}
+#endif /* ENABLE_OPENSSL */
 		mech_info.flags = old_flags;
 	}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,14 +42,17 @@ TESTS = \
         test-duplicate-symbols.sh \
         test-pkcs11-tool-test.sh \
         test-pkcs11-tool-test-threads.sh \
-        test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-allowed-mechanisms.sh \
-        test-pkcs11-tool-sym-crypt-test.sh \
+        test-pkcs11-tool-sym-crypt-test.sh
+if ENABLE_OPENSSL
+TESTS += \
+        test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-unwrap-wrap-test.sh \
         test-pkcs11-tool-import.sh
 if ENABLE_TESTS
 if ENABLE_SHARED
 TESTS += test-p11test.sh
+endif
 endif
 endif
 XFAIL_TESTS = \


### PR DESCRIPTION
There is no logging in the mechanism setup, which is causing confusing and hard to debug issues. This should help us to debug #3087.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested