### PR TITLE
Add check for the optional member app, fix #3084

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -513,9 +513,12 @@ get_pin_by_name(PCARD_DATA pCardData, struct sc_pkcs15_card *p15card, int role, 
 	if (!conf_block)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_F_INTERNAL_ERROR);
 
-	memset(str_path, 0, sizeof(str_path));
-	sc_bin_to_hex(p15card->app->path.value, p15card->app->path.len, str_path, sizeof(str_path), 0);
-	blocks = scconf_find_blocks(p15card->card->ctx->conf, conf_block, "application", str_path);
+	if ( p15card->app != NULL ) {
+		memset(str_path, 0, sizeof(str_path));
+		sc_bin_to_hex(p15card->app->path.value, p15card->app->path.len, str_path, sizeof(str_path), 0);
+		blocks = scconf_find_blocks(p15card->card->ctx->conf, conf_block, "application", str_path);
+	}
+	
 	if (blocks)   {
 		if (blocks[0]) {
 			pin = (char *)scconf_get_str(blocks[0], pin_type, NULL);

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -513,12 +513,12 @@ get_pin_by_name(PCARD_DATA pCardData, struct sc_pkcs15_card *p15card, int role, 
 	if (!conf_block)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_F_INTERNAL_ERROR);
 
-	if ( p15card->app != NULL ) {
+	if (p15card->app != NULL) {
 		memset(str_path, 0, sizeof(str_path));
 		sc_bin_to_hex(p15card->app->path.value, p15card->app->path.len, str_path, sizeof(str_path), 0);
 		blocks = scconf_find_blocks(p15card->card->ctx->conf, conf_block, "application", str_path);
 	}
-	
+
 	if (blocks)   {
 		if (blocks[0]) {
 			pin = (char *)scconf_get_str(blocks[0], pin_type, NULL);


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
Fixes #3084 : If the card is using a PKCS15 Emulator where the optional pointer to the sc_app_info in the sc_pkcs15_card structure is not set then the minidriver crashes.

In this PR, the checking of pointer p15card->app was added to minidriver.c

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Windows minidriver is tested
