### PR TITLE
Fix for OSS-Fuzz issues

### DIFF
--- a/src/pkcs15init/pkcs15-authentic.c
+++ b/src/pkcs15init/pkcs15-authentic.c
@@ -169,8 +169,10 @@ authentic_pkcs15_erase_card(struct sc_profile *profile, struct sc_pkcs15_card *p
 			rv = sc_pkcs15_get_objects(p15card, obj_type, objs, 32);
 			LOG_TEST_RET(ctx, rv, "Failed to get PKCS#15 objects to remove");
 
-			for (ii=0; ii<rv; ii++)
+			for (ii=0; ii<rv; ii++) {
 				sc_pkcs15_remove_object(p15card, objs[ii]);
+				sc_pkcs15_free_object(objs[ii]);
+			}
 		}
 
 		rv = sc_select_file(p15card->card, &df->path, &file);

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -156,6 +156,7 @@ iasecc_pkcs15_erase_card(struct sc_profile *profile, struct sc_pkcs15_card *p15c
 			}
 
 			sc_pkcs15_remove_object(p15card, objs[ii]);
+			sc_pkcs15_free_object(objs[ii]);
 		}
 
 		rv = sc_select_file(p15card->card, &df->path, &file);


### PR DESCRIPTION
Recently found memory leak by OSS-Fuzz.

##### Checklist
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
