### PR TITLE
Update version and NEWS for 0.25.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.25.0.{build}
+version: 0.25.1.{build}
 
 platform:
   - x86

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 NEWS for OpenSC -- History of user visible changes
 
+# New in 0.25.0; 2024-04-05
+
+## General improvements
+* Add missing file to dist tarball to build documentation (#3063)
+
+## minidriver
+* Fix RSA decryption with PKCS#1 v1.5 padding (#3077)
+* Fix crash when app is not set (#3084)
+
 # New in 0.25.0; 2024-03-06
 ## Security
 * [CVE-2023-5992](https://github.com/OpenSC/OpenSC/wiki/CVE-2023-5992): Side-channel leaks while stripping encryption PKCS#1.5 padding in OpenSC (#2948)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ backport security fixes into them. Only the last release is supported.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 0.25.0   | :white_check_mark: |
-| < 0.25.0 | :x:                |
+| 0.25.1   | :white_check_mark: |
+| < 0.25.1 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ define([PRODUCT_BUGREPORT], [https://github.com/OpenSC/OpenSC/issues])
 define([PRODUCT_URL], [https://github.com/OpenSC/OpenSC])
 define([PACKAGE_VERSION_MAJOR], [0])
 define([PACKAGE_VERSION_MINOR], [25])
-define([PACKAGE_VERSION_FIX], [0])
+define([PACKAGE_VERSION_FIX], [1])
 define([PACKAGE_SUFFIX], [])
 
 define([VS_FF_LEGAL_COPYRIGHT], [OpenSC Project])
@@ -48,7 +48,7 @@ OPENSC_VS_FF_PRODUCT_URL="VS_FF_PRODUCT_URL"
 #   (Interfaces added:                  CURRENT++, REVISION=0)
 OPENSC_LT_CURRENT="11"
 OPENSC_LT_OLDEST="11"
-OPENSC_LT_REVISION="1"
+OPENSC_LT_REVISION="2"
 OPENSC_LT_AGE="$((${OPENSC_LT_CURRENT}-${OPENSC_LT_OLDEST}))"
 
 AC_CONFIG_SRCDIR([src/libopensc/sc.c])


### PR DESCRIPTION
Stable branch for 0.25.1: https://github.com/OpenSC/OpenSC/tree/stable-0.25