### PR TITLE
Disable the Applet V1.8 ATR

### DIFF
--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -146,8 +146,8 @@ static long t1, t2, tot_read = 0, tot_dur = 0, dur;
 static size_t next_idx = (size_t)-1;
 
 static const struct sc_atr_table belpic_atrs[] = {
-	/* Applet V1.8 */
-	{ "3B:7F:96:00:00:80:31:80:65:B0:85:04:01:20:12:0F:FF:82:90:00", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
+	/* Applet V1.8 -- disabled, as it requires driver updates which are not yet implemented */
+	/* { "3B:7F:96:00:00:80:31:80:65:B0:85:04:01:20:12:0F:FF:82:90:00", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL }, */
 	/* Applet V1.1 */
 	{ "3B:98:13:40:0A:A5:03:01:01:01:AD:13:11", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
 	/* Applet V1.0 with new EMV-compatible ATR */


### PR DESCRIPTION
The V1.8 applet has a few differences to the older applets. This causes the OpenSC PKCS#11 module to not be able to sign anything with the Belpic driver on this card.

While the best solution is to implement the required changes to make this work correctly, for the time being it's better to not confuse users by claiming we support the card when in reality we don't.

Not tested, but trivial enough.
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
