### PR TITLE
card-piv.c - Card matching fix for unknown card

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5468,9 +5468,16 @@ static int piv_match_card_continued(sc_card_t *card)
 	 * Will fail for other reasons if wrong applet is selected or bad PIV implementation.
 	 */
 
-	/* first test if PIV is active applet without using AID If fails use the AID */
+	/*
+	* if ATR matched or user forced card type 
+	* test if PIV is active applet without using AID If fails use the AID 
+	*/
 
-	r = piv_find_discovery(card);
+	if (card->type != SC_CARD_TYPE_PIV_II_BASE)
+		r = piv_find_discovery(card);
+	else
+		r = SC_CARD_TYPE_UNKNOWN;
+
 	if (r < 0) {
 		piv_obj_cache_free_entry(card, PIV_OBJ_DISCOVERY, 0); /* don't cache  on failure */
 		r = piv_find_aid(card);


### PR DESCRIPTION
During card matching, only use GET DATA of Discovery object before or in place of SELECT AID, if the ATR matches a known card or user has forced the card type or forced the use of a PIV driver.

This avoids possible state change in the unknown card if used by other processes.

partial fox for #3108

 On branch piv-fix-#3108
 Changes to be committed:
	modified:   card-piv.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
