### PR TITLE
Fix license identifier in Fedora specfile

### DIFF
--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -3,7 +3,7 @@ Version:        0.1.0
 Release:        1%{?dist}
 Summary:        Smart card library and applications
 
-License:        LGPLv2+
+License:        LGPL-2.1-or-later AND BSD-3-Clause
 URL:            https://github.com/OpenSC/OpenSC/wiki
 Source0:        opensc-0.1.0.tar.gz
 Source1:        opensc.module


### PR DESCRIPTION
According to SPDX licence identifier.
