### PR TITLE
pgp: fixed internal data handling when overwriting key/cert

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2558,8 +2558,8 @@ pgp_update_new_algo_attr(sc_card_t *card, sc_cardctl_openpgp_keygen_info_t *key_
 		}
 
 		pgp_set_blob(algo_blob, data, data_len);
+		r = pgp_put_data(card, tag, data, data_len);
 		free(data);
-		r = pgp_put_data(card, tag, algo_blob->data, data_len);
 		/* Note: Don't use pgp_set_blob to set data, because it won't touch the real DO */
 		LOG_TEST_RET(card->ctx, r, "Cannot set new algorithm attributes");
 	} else {


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/3094

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
