### PR TITLE
pkcs11: leverage sc_wait_for_event to avoid unneccesary queries to card

### DIFF
--- a/.github/test-oseid.sh
+++ b/.github/test-oseid.sh
@@ -51,7 +51,7 @@ echo | ./OsEID-tool INIT
 ./OsEID-tool EC-ECDH-TEST
 ./OsEID-tool UNWRAP-WRAP-TEST
 ./OsEID-tool DES-AES-UPLOAD-KEYS
-./OsEID-tool SYM-CRYPT-TEST
+#./OsEID-tool SYM-CRYPT-TEST
 ./OsEID-tool ERASE-CARD
 
 # initialize card for p11test

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -427,6 +427,7 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
 	list_destroy(&sessions);
 
 	while ((slot = list_fetch(&virtual_slots))) {
+		sc_wait_for_event(context, 0, NULL, NULL, 0, &slot->reader_events);
 		list_destroy(&slot->objects);
 		list_destroy(&slot->logins);
 		free(slot);
@@ -648,7 +649,7 @@ CK_RV C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 			now = get_current_time();
 			if (now >= slot->slot_state_expires || now == 0) {
 				/* Update slot status */
-				rv = card_detect(slot->reader);
+				rv = card_detect(slot->reader, slot->reader_events);
 				sc_log(context, "C_GetSlotInfo() card detect rv 0x%lX", rv);
 
 				if (rv == CKR_TOKEN_NOT_RECOGNIZED || rv == CKR_OK)

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -218,6 +218,7 @@ struct sc_pkcs11_slot {
 	CK_SLOT_INFO slot_info;		/* Slot specific information (information about reader) */
 	CK_TOKEN_INFO token_info;	/* Token specific information (information about card) */
 	sc_reader_t *reader;		/* same as card->reader if there's a card present */
+	void *reader_events;
 	struct sc_pkcs11_card *p11card;	/* The card associated with this slot */
 	unsigned int events;		/* Card events SC_EVENT_CARD_{INSERTED,REMOVED} */
 	void *fw_data;			/* Framework specific data */  /* TODO: get know how it used */
@@ -415,7 +416,7 @@ CK_RV card_removed(sc_reader_t *reader);
 CK_RV card_detect_all(void);
 CK_RV create_slot(sc_reader_t *reader);
 void init_slot_info(CK_SLOT_INFO_PTR pInfo, sc_reader_t *reader);
-CK_RV card_detect(sc_reader_t *reader);
+CK_RV card_detect(sc_reader_t *reader, void *reader_states);
 CK_RV slot_get_slot(CK_SLOT_ID id, struct sc_pkcs11_slot **);
 CK_RV slot_get_token(CK_SLOT_ID id, struct sc_pkcs11_slot **);
 CK_RV slot_token_removed(CK_SLOT_ID id);

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -120,6 +120,8 @@ static int object_list_seeker(const void *el, const void *key)
 
 CK_RV create_slot(sc_reader_t *reader)
 {
+	unsigned int events;
+	sc_reader_t *found;
 	/* find unused slots previously allocated for the same reader */
 	struct sc_pkcs11_slot *slot = reader_reclaim_slot(reader);
 
@@ -159,6 +161,7 @@ CK_RV create_slot(sc_reader_t *reader)
 	slot->id = (CK_SLOT_ID) list_locate(&virtual_slots, slot);
 	init_slot_info(&slot->slot_info, reader);
 	slot->reader = reader;
+	sc_wait_for_event(context, SC_EVENT_CARD_EVENTS | SC_EVENT_READER_EVENTS, &found, &events, 0, &slot->reader_events);
 
 	DEBUG_VSS(slot, "Finished initializing this slot");
 
@@ -206,12 +209,13 @@ CK_RV card_removed(sc_reader_t * reader)
 	return CKR_OK;
 }
 
-
-CK_RV card_detect(sc_reader_t *reader)
+CK_RV
+card_detect(sc_reader_t *reader, void *reader_states)
 {
 	struct sc_pkcs11_card *p11card = NULL;
 	int free_p11card = 0;
 	int rc;
+	int no_change = 0;
 	CK_RV rv;
 	unsigned int i;
 	int j;
@@ -219,6 +223,22 @@ CK_RV card_detect(sc_reader_t *reader)
 
 	sc_log(context, "%s: Detecting smart card", reader->name);
 	/* Check if someone inserted a card */
+
+	if (reader_states != NULL) {
+		/* check if any event has occurred since last invocation of `card_detect()` */
+		unsigned int mask, events;
+		sc_reader_t *event_reader;
+		/* Detect card and reader events */
+		mask = SC_EVENT_CARD_EVENTS | SC_EVENT_READER_EVENTS;
+		int r = sc_wait_for_event(context, mask, &event_reader, &events, 0, &reader_states);
+		if (r == SC_ERROR_EVENT_TIMEOUT || reader != event_reader)
+			/* no change happened */
+			no_change = 1;
+		else
+			/* if some error occurred or there actually was a change, continue with detection routine */
+			no_change = 0;
+	}
+
 again:
 	rc = sc_detect_card_presence(reader);
 	if (rc < 0) {
@@ -229,6 +249,11 @@ again:
 		sc_log(context, "%s: card absent", reader->name);
 		card_removed(reader);	/* Release all resources */
 		return CKR_TOKEN_NOT_PRESENT;
+	}
+
+	if (no_change == 1) {
+		sc_log(context, "%s: card present, no change detected", reader->name);
+		return CKR_OK;
 	}
 
 	/* If the card was changed, disconnect the current one */
@@ -410,6 +435,7 @@ card_detect_all(void)
 				sc_pkcs11_slot_t *slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, j);
 				if (slot->reader == reader) {
 					slot->reader = NULL;
+					sc_wait_for_event(context, 0, NULL, NULL, 0, &slot->reader_events);
 				}
 			}
 		} else {
@@ -419,6 +445,7 @@ card_detect_all(void)
 				sc_pkcs11_slot_t *slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, j);
 				if (slot->reader == reader) {
 					found = 1;
+					card_detect(slot->reader, slot->reader_events);
 					break;
 				}
 			}
@@ -428,8 +455,8 @@ card_detect_all(void)
 					if (rv != CKR_OK)
 						return rv;
 				}
+				card_detect(reader, NULL);
 			}
-			card_detect(reader);
 		}
 	}
 	sc_log(context, "All cards detected");
@@ -481,7 +508,7 @@ CK_RV slot_get_token(CK_SLOT_ID id, struct sc_pkcs11_slot ** slot)
 		if ((*slot)->reader == NULL)
 			return CKR_TOKEN_NOT_PRESENT;
 		sc_log(context, "Slot(id=0x%lX): get token: now detect card", id);
-		rv = card_detect((*slot)->reader);
+		rv = card_detect((*slot)->reader, (*slot)->reader_events);
 		if (rv != CKR_OK)
 			return rv;
 	}


### PR DESCRIPTION
card_detect_all() is now used as global entry point even to reader specific card detection (card_detect() is removed). This enforces a constant update of reader_states so that no events are silently dropped. This removes the need for having a timer in C_GetSlotInfo() for avoiding too many queries. If the reader implementation (i.e. reader-*.c) does not implement wait_for_event, then all slots will be queried on request just like it used to be.

fixes https://github.com/OpenSC/OpenSC/issues/3107

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PKCS#11 module is tested
- [ ] Windows is tested (pkcs11-tool with --test-hotplug, --test, --test-threads)
- [ ] Linux is tested (pkcs11-tool with --test-hotplug, --test, --test-threads)
- [ ] macOS is tested (pkcs11-tool with --test-hotplug, --test, --test-threads)