### PR TITLE
Use zlib-ng for Fedora

### DIFF
--- a/.github/setup-fedora.sh
+++ b/.github/setup-fedora.sh
@@ -13,9 +13,9 @@ fi
 
 # 64bit or 32bit dependencies
 if [ "$1" == "ix86" ]; then
-	DEPS="$DEPS pcsc-lite-devel*.i686 readline-devel*.i686 openssl-devel*.i686 zlib-devel*.i686 libcmocka-devel*.i686 glibc-devel*i686"
+	DEPS="$DEPS pcsc-lite-devel*.i686 readline-devel*.i686 openssl-devel*.i686 zlib-ng-devel*.i686 libcmocka-devel*.i686 glibc-devel*i686"
 else
-	DEPS="$DEPS pcsc-lite-devel readline-devel openssl-devel zlib-devel libcmocka-devel"
+	DEPS="$DEPS pcsc-lite-devel readline-devel openssl-devel zlib-ng-devel libcmocka-devel"
 fi
 
 sudo dnf install -y $DEPS

--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -16,7 +16,7 @@ BuildRequires:  /usr/bin/xsltproc
 BuildRequires:  docbook-style-xsl
 BuildRequires:  autoconf automake libtool gcc
 BuildRequires:  bash-completion
-BuildRequires:  zlib-devel
+BuildRequires:  zlib-ng-devel
 # For tests
 BuildRequires:  libcmocka-devel
 BuildRequires:  vim-common


### PR DESCRIPTION
It should be ABI compatible with the old zlib

https://fedoraproject.org/wiki/Changes/ZlibNGTransition

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
