### PR TITLE
cert: Avoid use of uninitialized memory on errors

### DIFF
--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -39,7 +39,7 @@ static int
 parse_x509_cert(sc_context_t *ctx, struct sc_pkcs15_der *der, struct sc_pkcs15_cert *cert)
 {
 	int r;
-	struct sc_algorithm_id sig_alg;
+	struct sc_algorithm_id sig_alg = {0};
 	struct sc_pkcs15_pubkey *pubkey = NULL;
 	unsigned char *serial = NULL, *issuer = NULL, *subject = NULL, *buf =  der->value;
 	size_t serial_len = 0, issuer_len = 0, subject_len = 0, data_len = 0, buflen = der->len;


### PR DESCRIPTION
Thanks oss-fuzz and deengert for pointing the issue out.

This issue was introduced in
460a862ee043672b5114c1a0b8d429c587764c89

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66192

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
