### PR TITLE
Deactivate driver for MICARDO cards

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -797,7 +797,7 @@ app <em class="replaceable"><code>application</code></em> {
 								</p></li></ul></div><p>
 							(Default: <code class="literal">public</code>
 							for the following card drivers
-							<code class="literal">atrust-acos</code>,
+							<code class="literal">atrust-acos</code> (deactivated driver),
 							<code class="literal">belpic</code>,
 							<code class="literal">cac1</code>,
 							<code class="literal">cac</code>,
@@ -805,14 +805,14 @@ app <em class="replaceable"><code>application</code></em> {
 							<code class="literal">dnie</code>,
 							<code class="literal">edo</code>,
 							<code class="literal">esteid2018</code>,
-							<code class="literal">flex</code>,
-							<code class="literal">cyberflex</code>,
+							<code class="literal">flex</code> (deactivated driver),
+							<code class="literal">cyberflex</code> (deactivated driver),
 							<code class="literal">gemsafeV1</code>,
 							<code class="literal">idprime</code>,
 							<code class="literal">itacns</code>,
 							<code class="literal">jpki</code>,
 							<code class="literal">MaskTech</code>,
-							<code class="literal">mcrd</code>,
+							<code class="literal">mcrd</code> (deactivated driver),
 							<code class="literal">npa</code>,
 							<code class="literal">nqapplet</code>,
 							<code class="literal">tcos</code> and otherwise <code class="literal">no</code>).

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1240,7 +1240,7 @@ app <replaceable>application</replaceable> {
 							</itemizedlist>
 							(Default: <literal>public</literal>
 							for the following card drivers
-							<literal>atrust-acos</literal>,
+							<literal>atrust-acos</literal> (deactivated driver),
 							<literal>belpic</literal>,
 							<literal>cac1</literal>,
 							<literal>cac</literal>,
@@ -1248,14 +1248,14 @@ app <replaceable>application</replaceable> {
 							<literal>dnie</literal>,
 							<literal>edo</literal>,
 							<literal>esteid2018</literal>,
-							<literal>flex</literal>,
-							<literal>cyberflex</literal>,
+							<literal>flex</literal> (deactivated driver),
+							<literal>cyberflex</literal> (deactivated driver),
 							<literal>gemsafeV1</literal>,
 							<literal>idprime</literal>,
 							<literal>itacns</literal>,
 							<literal>jpki</literal>,
 							<literal>MaskTech</literal>,
-							<literal>mcrd</literal>,
+							<literal>mcrd</literal> (deactivated driver),
 							<literal>npa</literal>,
 							<literal>nqapplet</literal>,
 							<literal>tcos</literal> and otherwise <literal>no</literal>).

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -148,7 +148,6 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	 * put the muscle driver first to cope with this bug. */
 	{ "muscle",	(void *(*)(void)) sc_get_muscle_driver },
 	{ "sc-hsm",	(void *(*)(void)) sc_get_sc_hsm_driver },
-	{ "mcrd",	(void *(*)(void)) sc_get_mcrd_driver },
 	{ "setcos",	(void *(*)(void)) sc_get_setcos_driver },
 	{ "PIV-II",	(void *(*)(void)) sc_get_piv_driver },
 	{ "cac",	(void *(*)(void)) sc_get_cac_driver },
@@ -176,6 +175,7 @@ static const struct _sc_driver_entry old_card_drivers[] = {
 	{ "atrust-acos",(void *(*)(void)) sc_get_atrust_acos_driver },
 	{ "cyberflex",	(void *(*)(void)) sc_get_cyberflex_driver },
 	{ "flex",       (void *(*)(void)) sc_get_cryptoflex_driver },
+	{ "mcrd",       (void *(*)(void)) sc_get_mcrd_driver },
 	{ NULL, NULL }
 };
 // clang-format on


### PR DESCRIPTION
This PR deactivates `card-mcrd` driver due to no recent user or developer activity.
The only recent changes in the driver concerns EstEID card, which support was removed in https://github.com/OpenSC/OpenSC/commit/7c19a920d7c94efa3695967b61d6981900503218. For further usage, the driver can be enabled via `card_drivers` in configuration file.

