### PR TITLE
Fixes for issues found by static analysis

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -3408,11 +3408,11 @@ piv_put_data(sc_card_t *card, int tag, const u8 *buf, size_t buf_len)
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
 	tag_len = piv_objects[tag].tag_len;
-	sbuflen = sc_asn1_put_tag(0x5c, piv_objects[tag].tag_value, tag_len, NULL, 0, NULL);
-	if (sbuflen <= 0) {
+	r = sc_asn1_put_tag(0x5c, piv_objects[tag].tag_value, tag_len, NULL, 0, NULL);
+	if (r <= 0) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 	}
-	sbuflen += buf_len;
+	sbuflen = r + buf_len;
 	if (!(sbuf = malloc(sbuflen))) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 	}

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1003,7 +1003,7 @@ iso7816_set_security_env(struct sc_card *card,
 		*p++ = env->algorithm_ref & 0xFF;
 	}
 	if (env->flags & SC_SEC_ENV_FILE_REF_PRESENT) {
-		if (env->file_ref.len > 0xFF)
+		if (env->file_ref.len > SC_MAX_PATH_SIZE)
 			return SC_ERROR_INVALID_ARGUMENTS;
 		if (sizeof(sbuf) - (p - sbuf) < env->file_ref.len + 2)
 			return SC_ERROR_OFFSET_TOO_LARGE;

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1021,7 +1021,7 @@ iso7816_set_security_env(struct sc_card *card,
 			*p++ = 0x83;
 		else
 			*p++ = 0x84;
-		if (env->key_ref_len > 0xFF)
+		if (env->key_ref_len > SC_MAX_KEYREF_SIZE)
 			return SC_ERROR_INVALID_ARGUMENTS;
 		*p++ = env->key_ref_len & 0xFF;
 		memcpy(p, env->key_ref, env->key_ref_len);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -251,7 +251,7 @@ typedef struct sc_security_env {
 
 	unsigned long algorithm_ref;
 	struct sc_path file_ref;
-	unsigned char key_ref[8];
+	unsigned char key_ref[SC_MAX_KEYREF_SIZE];
 	size_t key_ref_len;
 	struct sc_path target_file_ref; /* target key file in unwrap operation */
 

--- a/src/libopensc/types.h
+++ b/src/libopensc/types.h
@@ -50,6 +50,7 @@ typedef unsigned char u8;
 #define SC_MAX_CRTS_IN_SE		12
 #define SC_MAX_SE_NUM			8
 #define SC_MAX_PKCS15_EMULATORS	48
+#define SC_MAX_KEYREF_SIZE		8
 
 /* When changing this value, pay attention to the initialization of the ASN1
  * static variables that use this macro, like, for example,


### PR DESCRIPTION
Fixes for following bugs:
1. _integer overflow_ in `piv_put_data()`, when return value of `sc_asn1_put_tag()` function of type `int` was stored into variable of type `size_t`
2. _buffer overflow_ in `iso7816_set_security_env()`, when `file_ref.len` is checked against `0xFF` instead of `SC_MAX_PATH_SIZE`
3. _buffer overflow_ in `iso7816_set_security_env()`, when `key_ref_len` is checked against `0xFF` instead of `8` (`SC_MAX_KEYREF_SIZE`)

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
