### PR TITLE
piv-tool: Fix RSA key generation

### DIFF
--- a/src/tools/piv-tool.c
+++ b/src/tools/piv-tool.c
@@ -423,7 +423,7 @@ static int gen_key(const char * key_info)
 			BN_free(newkey_e);
 			return -1;
 		}
-		params = OSSL_PARAM_BLD_to_param(bld);
+
 		BN_free(newkey_n);
 		BN_free(newkey_e);
 


### PR DESCRIPTION
`params = OSSL_PARAM_BLD_to_param(bld)` was called twice, once inside `if` condition and once after the `if`.  Removed the second one to resolve issue generating RSA keys with OpenSSL 3.0.

Someone else please verify this is the correct fix, I am far from understanding all the code and only did some preliminary tests to check if it is working after the fix. 

Also, maybe consider adding a test for `piv-tool` inside the piv test routine (with PivApplet)?

Fixes #3156
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
