### PR TITLE
minidriver.c pkcs15-piv.c - Support PinCacheAlwaysPrompt

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -1893,9 +1893,10 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 
 					/* set flag that at least one key that uses the sign key needs PinCacheAlwaysPrompt */
 					logprintf(pCardData, 7, "key_obj->user_consent: %d\n", (int) key_obj->user_consent);
-					if (key_obj->user_consent)
+					if (key_obj->user_consent) {
 						vs->need_pin_always = 1;
-					logprintf(pCardData, 7, "vs->need_pin_always %d\n", (int) vs->need_pin_always);
+						logprintf(pCardData, 7, "vs->need_pin_always %d\n", (int) vs->need_pin_always);
+					}
 
 					if (pin_mode < pin_mode_n) {
 						pin_mode = pin_mode_n;


### PR DESCRIPTION
(WIP may fix #3159 waiting to download the MSI artifacts for testing.)

PKCS11 supports CKA_ALWAYS_AUTHENTICATE and PKCS15 user_consent Windows minidriver supports PinCacheAlwaysPrompt

Mindriver has MD_ROLE_USER_SIGN for a pin which is taken to be a second user local pin to be used for signing.

A second user local pin was defined in pkcs15-piv.c which is a duplicate of the user pin except  the sc_pkcs15_auth_info_auth_method set is set SC_AC_CONTEXT_SPECIFIC So when a key is used that requires "ALWAYS" authentication it will be be handled like framework-pkcs15.c handles CKA_ALWAYS_AUTHENTICATE

 On branch minidriver-PinCacheAlwaysPrompt
 Changes to be committed:
	modified:   libopensc/pkcs15-piv.c
	modified:   minidriver/minidriver.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
