### PR TITLE
build: fix linking of opensc-notify.exe on Windows

### DIFF
--- a/src/ui/invisible_window.h
+++ b/src/ui/invisible_window.h
@@ -20,7 +20,7 @@
 
 #include <windows.h>
 
-HWND create_invisible_window(LPCTSTR lpszClassName,
+static HWND create_invisible_window(LPCTSTR lpszClassName,
 		LRESULT (CALLBACK* WndProc)(HWND, UINT, WPARAM, LPARAM),
 		HINSTANCE hInstance)
 {

--- a/src/ui/notify.c
+++ b/src/ui/notify.c
@@ -104,7 +104,7 @@ err:
 	return 100;
 }
 
-LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) {
 		case WM_COMMAND:


### PR DESCRIPTION
With Visual Studio 2022 I get:
```
FAILED: src/tools/opensc-notify.exe src/tools/opensc-notify.pdb
"link"  /MACHINE:x64 /OUT:src/tools/opensc-notify.exe src/tools/src_tools_versioninfo-opensc-notify.rc_versioninfo-opensc-notify.res src/tools/opensc-notify.exe.p/meson-generated_.._opensc-notify-cmdline.c.obj src/tools/opensc-notify.exe.p/opensc-notify.c.obj "/release" "/nologo" "/DEBUG" "/PDB:src/tools\opensc-notify.pdb" "src/common/libcompat.a" "src/libopensc/libopensc.a" "src/common/libscdl.a" "src/scconf/libscconf.a" "src/ui/libstrings.a" "src/ui/libnotify.a" "src/pkcs15init/libpkcs15init.a" "src/sm/libsmeac.a" "src/sm/libsmiso.a" "winscard.lib" "/SUBSYSTEM:CONSOLE" "advapi32.lib" "comctl32.lib" "gdi32.lib" "shell32.lib" "shlwapi.lib" "user32.lib" "ws2_32.lib"
libnotify.a(notify.c.obj) : error LNK2005: create_invisible_window already defined in opensc-notify.c.obj
libnotify.a(notify.c.obj) : error LNK2005: WndProc already defined in opensc-notify.c.obj
src\tools\opensc-notify.exe : fatal error LNK1169: one or more multiply defined symbols found
```