### PR TITLE
feat(pkcs11-tool): an invalid signature is a fatal error

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2541,9 +2541,9 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 	if (rv == CKR_OK)
 		printf("Signature is valid\n");
 	else if (rv == CKR_SIGNATURE_INVALID)
-		printf("Invalid signature\n");
+		util_fatal("Invalid signature");
 	else
-		printf("Cryptoki returned error: %s\n", CKR2Str(rv));
+		util_fatal("Signature verification failed: rv = %s (0x%0x)\n", CKR2Str(rv), (unsigned int)rv);
 }
 
 static void decrypt_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,


### PR DESCRIPTION
Hi,
We are using the pkcs11-tool for the validation of the Trustonic HSM.
I noticed that the tool is not returning an error when a signature is invalid or when something bad happens during the signature verification.
I would expect something more than just a print.
This is why I am proposing to call util_fatal() which will exit with an error code different than 0.
I checked the patch with the Trustonic TEE HSM.
Regards,
Alexandre.
