### PR TITLE
pkcs15-jpki.c -  minidriver problem with reading public key

### DIFF
--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -199,6 +199,11 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 			"User Authentication Public Key",
 			"Digital Signature Public Key"
 		};
+		static int jpki_pubkey_flags[2] = {
+			0,
+			SC_PKCS15_CO_FLAG_PRIVATE
+		};
+		static int jpki_pubkey_auth_id[2] = {0, 2};
 		struct sc_pkcs15_pubkey_info pubkey_info;
 		struct sc_pkcs15_object pubkey_obj;
 		static char const *jpki_pubkey_paths[2] = {
@@ -217,6 +222,9 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 
 		sc_format_path(jpki_pubkey_paths[i], &pubkey_info.path);
 		pubkey_info.path.type = SC_PATH_TYPE_FILE_ID;
+		pubkey_obj.flags = jpki_pubkey_flags[i];
+		pubkey_obj.auth_id.len = 1;
+		pubkey_obj.auth_id.value[0] = jpki_pubkey_auth_id[i];
 
 		rc = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
 		if (rc < 0) {

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -200,9 +200,8 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 			"Digital Signature Public Key"
 		};
 		static int jpki_pubkey_flags[2] = {
-			0,
-			SC_PKCS15_CO_FLAG_PRIVATE
-		};
+				0,
+				SC_PKCS15_CO_FLAG_PRIVATE};
 		static int jpki_pubkey_auth_id[2] = {0, 2};
 		struct sc_pkcs15_pubkey_info pubkey_info;
 		struct sc_pkcs15_object pubkey_obj;


### PR DESCRIPTION
Add SC_PKCS15_CO_FLAG_PRIVATE on "Digital Signature Public Key" and set `pubkey_obj.flags` and `pubkey_obj.auth_id` to use the `Sign KEY` so `minidriver.c` can request the PIN before reading the public key. Card enforces this as per specs.

Partially Fixes #3169 Only `pkcs15-jpki.c` is changed.

Not tested with any card.

In addition to changes in #3167 that address "user_consent" using "PinCacheAlwaysPrompt", The JPKI card forces the user to verify the `Sign PIN` before the public key is read. But to use the `Sign KEY`, Windows minidriver specs V7.07 says: the "CCP_CONTAINER_INFO" contains "cbSigPublicKey" and "pbSigPublicKey" which is needed before the key is selected.

It might be possible to add bogus information in these and substitute the real values at a later time. But this will require someone with a working card. 

Also possible to use code from `pkcs15-dnie.c` which had its own `dmie_ask_user_consent`.

 On branch minidriver-PinCacheAlwaysPrompt
 Changes to be committed:
	modified:   libopensc/pkcs15-jpki.c

 On branch JPKI-Improvements
 Changes to be committed:
	modified:   libopensc/pkcs15-jpki.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
