### PR TITLE
ci: Update upload/download-artifact to v4

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,7 @@ jobs:
        fuzz-seconds: 600
        dry-run: false
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -25,7 +25,7 @@ jobs:
       - run: .github/setup-fedora.sh
       - run: .github/build.sh dist
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: fedora-test-logs

--- a/.github/workflows/linux-strict.yml
+++ b/.github/workflows/linux-strict.yml
@@ -76,7 +76,7 @@ jobs:
           CC: ${{ matrix.compiler }}
           CFLAGS: ${{ env.CFLAGS }} ${{ matrix.compiler == 'clang' && env.CLANG_CFLAGS || '' }}
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.name }}-${{ matrix.compiler }}-strict-test-logs

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
       - run: .github/setup-linux.sh
       - run: .github/build.sh dist
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ubuntu-test-logs
@@ -56,7 +56,7 @@ jobs:
           path: ./*
           key: ${{ runner.os }}-${{ github.sha }}
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensc-build
           path:
@@ -74,7 +74,7 @@ jobs:
       - run: .github/setup-linux.sh debug
       - run: .github/build.sh valgrind
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ubuntu-valgrind-logs
@@ -125,7 +125,7 @@ jobs:
       - run: .github/setup-linux.sh mingw force-install
       - run: .github/build.sh mingw
       - name: Cache build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensc-build-mingw
           path:
@@ -143,7 +143,7 @@ jobs:
       - run: .github/setup-linux.sh mingw32
       - run: .github/build.sh mingw32
       - name: Cache build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensc-build-mingw32
           path:
@@ -161,7 +161,7 @@ jobs:
       - run: .github/setup-linux.sh
       - run: .github/build.sh piv-sm dist
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ubuntu-piv-sm-test-logs
@@ -394,7 +394,7 @@ jobs:
           execute_install_scripts: true
       - run: .github/setup-linux.sh
       - run: .github/build.sh dist valgrind
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ubuntu-22-test-logs
@@ -408,10 +408,10 @@ jobs:
           path: ./*
           key: ${{ runner.os }}-22-${{ github.sha }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ success() }}
         with:
-          name: opensc-build
+          name: opensc-22-build
           path:
             opensc*.tar.gz
 
@@ -426,7 +426,7 @@ jobs:
           execute_install_scripts: true
       - run: .github/setup-linux.sh
       - run: .github/build.sh piv-sm dist valgrind
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ubuntu-22-piv-sm-test-logs
@@ -524,7 +524,7 @@ jobs:
           key: libressl-${{ env.LIBRESSL_VERSION }}
       - run: .github/setup-linux.sh libressl
       - run: .github/build.sh dist libressl valgrind
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: libressl-logs
@@ -598,7 +598,7 @@ jobs:
           path: ./*
           key: ${{ runner.os }}-${{ github.sha }}
       - name: Pull mingw build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: opensc-build-mingw
       - run: git config --global user.email "builds@github.com"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,7 @@ jobs:
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           INSTALLER_SIGN_IDENTITY: ${{ secrets.INSTALLER_SIGN_IDENTITY }}
       - name: Cache build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensc-build-${{ matrix.os }}
           path:
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pull build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: opensc-build-macos-12
       - run: git config --global user.email "builds@github.com"

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -21,7 +21,7 @@ jobs:
               fetch-depth: 0
         - uses: packit/actions/srpm@main
         - name: Upload build artifacts
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
               name: opensc-srpm
               path:
@@ -35,7 +35,7 @@ jobs:
               fetch-depth: 0
         - uses: ./.github/actions/packit
         - name: Upload build artifacts
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
               name: opensc-rpm
               path:


### PR DESCRIPTION
The v3 will be deprecated in the end of 2024

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
