### PR TITLE
Fix disable flag for application conf block

### DIFF
--- a/src/libopensc/dir.c
+++ b/src/libopensc/dir.c
@@ -98,8 +98,8 @@ parse_dir_record(sc_card_t *card, u8 ** buf, size_t *buflen, int rec_nr)
 		sc_bin_to_hex(aid.value, aid.len, aid_str, sizeof(aid_str), 0);
 		blocks = scconf_find_blocks(card->ctx->conf, conf_block, "application", aid_str);
 		if (blocks)   {
-			ignore_app = (blocks[0] && scconf_get_str(blocks[0], "disable", 0));
-                        free(blocks);
+			ignore_app = (blocks[0] && scconf_get_bool(blocks[0], "disable", 0));
+			free(blocks);
 		 }
 
 		if (ignore_app)   {


### PR DESCRIPTION
Currently the mere presence of 'disable=xx' disables the application. Even the 'disable=false', which imho can be confusing. 
Treat it as a boolan instead...

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
