### PR TITLE
Allow OpenSSL engine header only for version <3.0

### DIFF
--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -33,6 +33,7 @@
 #include <openssl/conf.h>
 #include <openssl/opensslconf.h> /* for OPENSSL_NO_* */
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define OPENSSL_NO_ENGINE
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #endif
@@ -258,7 +259,6 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
  * Engine support is being deprecated in 3.0. OpenSC loads GOST as engine.
  * When GOST developers convert to provider, we can load the provider
  */
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
 #if !defined(OPENSSL_NO_ENGINE)
 	ENGINE *e;
 /* crypto locking removed in 1.1 */
@@ -304,7 +304,6 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 		CRYPTO_set_locking_callback(locking_cb);
 #endif
 #endif /* !defined(OPENSSL_NO_ENGINE) */
-#endif /* OPENSSL_VERSION_NUMBER < 0x30000000L */
 
 	openssl_sha1_mech.mech_data = sc_evp_md(context, "sha1");
 	openssl_sha1_mech.free_mech_data = ossl_md_free;


### PR DESCRIPTION
This PR adds check for OpenSSL version when including `engine.h` and `OPENSSL_NO_ENGINE` is not defined.

In Fedora rawhide, the engine related files were moved to separate subpackage `devel-engine`, so the include for `engine.h` is problematic.
However, in OpenSC `openssl.c` is engine API used only for OpenSSL version < 3.0, so the version check is added also to include directive (this particular include of `engine.h` is there probably for https://github.com/OpenSC/OpenSC/blob/master/src/pkcs11/openssl.c#L261-L307 which is also already wrapped in `#if OPENSSL_VERSION_NUMBER < 0x30000000L` and `#if !defined(OPENSSL_NO_ENGINE)`). 

##### Checklist
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
