### PR TITLE
Epass2003 sm new -  fails for RSA2048 but works with EC

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -1125,7 +1125,7 @@ construct_mac_tlv(struct sc_card *card, unsigned char *apdu_buf, size_t data_tlv
 	return 0;
 }
 
-/* MAC(TLV case 1 */
+/* MAC(TLV case 1) */
 static int
 construct_mac_tlv_case1(struct sc_card *card, unsigned char *apdu_buf, size_t data_tlv_len, size_t le_tlv_len,
 	unsigned char *mac_tlv, size_t * mac_tlv_len, const unsigned char key_type)

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2759,7 +2759,6 @@ epass2003_create_file(struct sc_card *card, sc_file_t * file)
 	apdu.lc = len;
 	apdu.datalen = len;
 	apdu.data = sbuf;
-
 	r = sc_transmit_apdu_t(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -3122,6 +3121,7 @@ epass2003_erase_card(struct sc_card *card)
 	static const unsigned char mf_path[2] = { 0x3f, 0x00 };
 	sc_apdu_t apdu;
 	int r;
+	int saved_sm_mode = 0;
 
 	LOG_FUNC_CALLED(card->ctx);
 	sc_invalidate_cache(card);
@@ -3131,7 +3131,13 @@ epass2003_erase_card(struct sc_card *card)
 	apdu.cla = 0x80;
 	apdu.data = install_magic_pin;
 	apdu.datalen = apdu.lc = sizeof(install_magic_pin);
+
+	saved_sm_mode = card->sm_ctx.sm_mode;
+        card->sm_ctx.sm_mode = 0;
+
 	r = sc_transmit_apdu(card, &apdu);
+	card->sm_ctx.sm_mode = saved_sm_mode;
+
 	LOG_TEST_RET(card->ctx, r, "APDU install magic pin failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "install magic pin failed");

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -404,6 +404,8 @@ aes128_encrypt_cmac_ft(struct sc_card *card, const unsigned char *key, int keysi
 	for (int i = 0; i < 16; i++) {
 		data2[i] = data2[i] ^ k2Bin[offset + i];
 	}
+	sc_evp_cipher_free(alg);
+	alg = sc_evp_cipher(card->ctx, "AES-128-CBC");
 	r = openssl_enc(alg, key, iv, data2, 16, output);
 	sc_evp_cipher_free(alg);
 	if (r != SC_SUCCESS)

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -37,8 +37,10 @@ static int epass2003_pkcs15_erase_card(struct sc_profile *profile,
 {
 	SC_FUNC_CALLED(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	if (sc_select_file(p15card->card, sc_get_mf_path(), NULL) < 0)
-		return SC_SUCCESS;
+	if (sc_select_file(p15card->card, sc_get_mf_path(), NULL) < 0) {
+		sc_do_log(p15card->card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL,NULL,0,NULL,
+			"epass2003_pkcs15__erase_card failed calling sc_select_file, continue with erase. \n");
+	}
 
 	return sc_card_ctl(p15card->card, SC_CARDCTL_ERASE_CARD, 0);
 }


### PR DESCRIPTION
As suggested  in https://github.com/OpenSC/OpenSC/pull/3196 

> @dengert Regarding the cifuzz crash please open a seperate issue if you believe the problem is reliably reproducible or you have some idea how to fix that. I don't think it is related to these changes

I am pushing all the epass2003 changes I have, including changes for newer cards (I have 2) and a possible fix for cifuzz ec171220ccf4cb8a23e776d36c5e599869ba3975 "epass2003- improved SM handling" and debugging SM calls, and fixes to SM for newer cards.  (My old epass2003 does not use SM.) 

But newer epass2003 cards with RSA 2048 sign SHA256-RSA-PKCS  does not work, but EC:nistp256 ECDSA-SHA256 does work. 
RSA  returns: `99 02 6F 83 8E 08 C0 57 56 04 B0 8D 61 FD 6F 83` and  6F 83 is not known to the card driver. 

I suspect it is caused by using extended APDUs. Or with the newer cards for RSA something else is going on. Extended APDUs are part of the original card driver from 2012. 

Also see #3034 #2843 and search issues using filter:  is:issue epass2003

With a lack of documentation and unresponsive vendor support very little progress in the last year with the cards being sold these days.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
