### PR TITLE
openpgp: Oss-fuzz fixes

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2903,6 +2903,9 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 
 		/* RSA modulus */
 		if (tag == 0x0081) {
+			if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA) {
+				LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
+			}
 			if ((BYTES4BITS(key_info->u.rsa.modulus_len) < len)  /* modulus_len is in bits */
 				|| key_info->u.rsa.modulus == NULL) {
 
@@ -2918,6 +2921,9 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 		}
 		/* RSA public exponent */
 		else if (tag == 0x0082) {
+			if (key_info->algorithm != SC_OPENPGP_KEYALGO_RSA) {
+				LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
+			}
 			if ((BYTES4BITS(key_info->u.rsa.exponent_len) < len)  /* exponent_len is in bits */
 				|| key_info->u.rsa.exponent == NULL) {
 
@@ -2933,6 +2939,10 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 		}
 		/* ECC public key */
 		else if (tag == 0x0086) {
+			if (key_info->algorithm != SC_OPENPGP_KEYALGO_ECDSA &&
+					key_info->algorithm != SC_OPENPGP_KEYALGO_ECDH) {
+				LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
+			}
 			/* set the output data */
 			/* len is ecpoint length + format byte
 			 * see section 7.2.14 of 3.3.1 specs */

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2785,7 +2785,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 		r = SC_ERROR_OUT_OF_MEMORY;
 		LOG_TEST_GOTO_ERR(card->ctx, r, "Cannot find blob 00C5");
 	}
-	if (20 * key_info->key_id > fpseq_blob->len) {
+	if (20U * key_info->key_id > fpseq_blob->len) {
 		r = SC_ERROR_OBJECT_NOT_VALID;
 		LOG_TEST_GOTO_ERR(card->ctx, r, "The 00C5 blob is not large enough");
 	}

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2961,6 +2961,7 @@ pgp_parse_and_set_pubkey_output(sc_card_t *card, u8* data, size_t data_len,
 					LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_ENOUGH_MEMORY);
 			}
 			memcpy(key_info->u.ec.ecpoint, part + 1, len - 1);
+			key_info->u.ec.ecpoint_len = len - 1;
 		}
 
 		/* go to next part to parse */


### PR DESCRIPTION
When generating RSA key pair using PKCS#15 init, the driver could accept responses relevant to ECC keys, which made further processing in the pkcs15-init failing/accessing invalid parts of structures.

and

Avoid buffer overflow when writing fingerprint 

Thanks oss-fuzz!

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71010

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=70933

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
