### PR TITLE
Check key references instead of container map for IDPrime 940

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -574,7 +574,7 @@ static int idprime_init(sc_card_t *card)
 		LOG_FUNC_RETURN(card->ctx, r);
 	}
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Index file found");
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Container file found");
 
 	r = idprime_process_containermap(card, priv, r);
 	if (r != SC_SUCCESS) {


### PR DESCRIPTION
The IDPrime 940 card in https://github.com/OpenSC/OpenSC/issues/3201 has an empty container map file, even with a private key on the card.

The IDPrime driver uses a container map to identify whether there is a corresponding key to the certificate on the card. When not, the certificate object is stored without a key reference. However, the IDPrime 940 card also has a key reference file containing key references and the certificate ID to which they belong. The reference file can be used instead of the container map to check the existence of the key, even when the container map file is, for some reason, empty.

This cannot be used for other IDPrime card types, as they do not have any key reference file, and so a container map still needs to be used.

Changes were tested only with IDPrime 940 with a non-empty container map file. It still needs to check with the card without a container map file whether the key references are correct.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
