### PR TITLE
add support for RSA4096 over pkcs11

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4583,6 +4583,7 @@ static int piv_validate_general_authentication(sc_card_t *card,
 			case 128: real_alg_id = 0x06; break;
 			case 256: real_alg_id = 0x07; break;
 			case 384: real_alg_id = 0x05; break;
+			case 512: real_alg_id = 0x16; break;
 			default:
 				SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_NO_CARD_SUPPORT);
 		}
@@ -5739,6 +5740,7 @@ static int piv_init(sc_card_t *card)
 	_sc_card_add_rsa_alg(card, 1024, flags, 0); /* mandatory */
 	_sc_card_add_rsa_alg(card, 2048, flags, 0); /* optional */
 	_sc_card_add_rsa_alg(card, 3072, flags, 0); /* optional */
+	_sc_card_add_rsa_alg(card, 4096, flags, 0); /* optional */
 
 	if (!(priv->card_issues & CI_NO_EC)) {
 		int i;


### PR DESCRIPTION
Hi, this PR adds support for RSA 4096 keys over the pkcs11 module.

I have tested this PR (used the pkcs11 module for signing) successfully in the following local environment:
* yubikey firmware 5.7.1 (Yubico [has announced](https://www.yubico.com/blog/now-available-for-purchase-yubikey-5-series-and-security-key-series-with-new-5-7-firmware/) the support of RSA4096 for firmware 5.7+ in May 2024)
    (the yubikey uses `0x16` as the identifier for RSA4096)
* ubuntu `24.04`, openssl `3.0.13`, p11tool (gnutls-bin package `3.8.3-1.1.ubuntu3.1`)

##### Checklist
- [x] PKCS#11 module is tested
