### PR TITLE
Fixes for uninitialized memory issues

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -68,7 +68,7 @@ int sc_asn1_read_tag(const u8 ** buf, size_t buflen, unsigned int *cla_out,
 
 	*buf = NULL;
 
-	if (left == 0 || !p)
+	if (left == 0 || !p || buflen == 0)
 		return SC_ERROR_INVALID_ASN1_OBJECT;
 	if (*p == 0xff || *p == 0) {
 		/* end of data reached */
@@ -83,6 +83,8 @@ int sc_asn1_read_tag(const u8 ** buf, size_t buflen, unsigned int *cla_out,
 	 */
 	cla = (*p & SC_ASN1_TAG_CLASS) | (*p & SC_ASN1_TAG_CONSTRUCTED);
 	tag = *p & SC_ASN1_TAG_PRIMITIVE;
+	if (left < 1)
+		return SC_ERROR_INVALID_ASN1_OBJECT;
 	p++;
 	left--;
 	if (tag == SC_ASN1_TAG_PRIMITIVE) {

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -252,7 +252,7 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 	size_t * recvbuflen)
 {
 	int r;
-	sc_apdu_t apdu;
+	sc_apdu_t apdu = {0};
 	u8 rbufinitbuf[CAC_MAX_SIZE];
 	u8 *rbuf;
 	size_t rbuflen;
@@ -389,13 +389,13 @@ fail:
 static int cac_read_file(sc_card_t *card, int file_type, u8 **out_buf, size_t *out_len)
 {
 	u8 params[2];
-	u8 count[2];
+	u8 count[2] = {0};
 	u8 *out = NULL;
-	u8 *out_ptr;
+	u8 *out_ptr = NULL;
 	size_t offset = 0;
 	size_t size = 0;
 	size_t left = 0;
-	size_t len;
+	size_t len = 0;
 	int r;
 
 	params[0] = file_type;
@@ -458,7 +458,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 	const u8 *tl_ptr, *val_ptr, *tl_start;
 	u8 *tlv_ptr;
 	const u8 *cert_ptr;
-	size_t tl_len, val_len, tlv_len;
+	size_t tl_len = 0, val_len = 0, tlv_len;
 	size_t len, tl_head_len, cert_len;
 	u8 cert_type, tag;
 
@@ -1519,7 +1519,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 static int cac_process_CCC(sc_card_t *card, cac_private_data_t *priv, int depth)
 {
 	u8 *tl = NULL, *val = NULL;
-	size_t tl_len, val_len;
+	size_t tl_len = 0, val_len = 0;
 	int r;
 
 	if (depth > CAC_MAX_CCC_DEPTH) {

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1293,10 +1293,10 @@ static int cac_parse_aid(sc_card_t *card, cac_private_data_t *priv, const u8 *ai
 	/* Call without OID set will just select the AID without subsequent
 	 * OID selection, which we need to figure out just now
 	 */
-	cac_select_file_by_type(card, &new_object.path, NULL);
+	r = cac_select_file_by_type(card, &new_object.path, NULL);
+	LOG_TEST_RET(card->ctx, r, "Cannot select AID");
 	r = cac_get_properties(card, &prop);
-	if (r < 0)
-		return SC_ERROR_INTERNAL;
+	LOG_TEST_RET(card->ctx, r, "Cannot get CAC properties");
 
 	for (i = 0; i < prop.num_objects; i++) {
 		/* don't fail just because we have more certs than we can support */

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -92,12 +92,12 @@ static int cac_cac1_get_certificate(sc_card_t *card, u8 **out_buf, size_t *out_l
 		if (apdu.sw1 != 0x63 || apdu.sw2 < 1)  {
 			/* we've either finished reading, or hit an error, break */
 			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-			left -= len;
+			left -= apdu.resplen;
 			break;
 		}
 		/* Adjust the lengths */
-		left -= len;
-		out_ptr += len;
+		left -= apdu.resplen;
+		out_ptr += apdu.resplen;
 		len = MIN(left, apdu.sw2);
 	}
 	if (r < 0) {

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -1281,7 +1281,7 @@ cardos_lifecycle_get(sc_card_t *card, int *mode)
 	LOG_TEST_RET(card->ctx, r, "Card returned error");
 
 	if (apdu.resplen < 1) {
-		LOG_TEST_RET(card->ctx, r, "Lifecycle byte not in response");
+		LOG_TEST_RET(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Lifecycle byte not in response");
 	}
 
 	r = SC_SUCCESS;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -94,14 +94,14 @@ static void fixup_transceive_length(const struct sc_card *card,
 
 static int cardos_match_card(sc_card_t *card)
 {
-	unsigned char atr[SC_MAX_ATR_SIZE];
+	unsigned char atr[SC_MAX_ATR_SIZE] = { 0 };
 	int i;
 
 	i = _sc_match_atr(card, cardos_atrs, &card->type);
 	if (i < 0)
 		return 0;
 
-	memcpy(atr, card->atr.value, sizeof(atr));
+	memcpy(atr, card->atr.value, card->atr.len);
 
 	/* Do not change card type for CIE! */
 	if (card->type == SC_CARD_TYPE_CARDOS_CIE_V1)
@@ -114,8 +114,8 @@ static int cardos_match_card(sc_card_t *card)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_2) {
 		int rv;
-		sc_apdu_t apdu;
-		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+		sc_apdu_t apdu = { 0 };
+		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE] = { 0 };
 		/* first check some additional ATR bytes */
 		if ((atr[4] != 0xff && atr[4] != 0x02) ||
 		    (atr[6] != 0x10 && atr[6] != 0x0a) ||

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -94,7 +94,7 @@ static void fixup_transceive_length(const struct sc_card *card,
 
 static int cardos_match_card(sc_card_t *card)
 {
-	unsigned char atr[SC_MAX_ATR_SIZE] = { 0 };
+	unsigned char atr[SC_MAX_ATR_SIZE] = {0};
 	int i;
 
 	i = _sc_match_atr(card, cardos_atrs, &card->type);
@@ -114,8 +114,8 @@ static int cardos_match_card(sc_card_t *card)
 		return 1;
 	if (card->type == SC_CARD_TYPE_CARDOS_M4_2) {
 		int rv;
-		sc_apdu_t apdu = { 0 };
-		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE] = { 0 };
+		sc_apdu_t apdu = {0};
+		u8 rbuf[SC_MAX_APDU_BUFFER_SIZE] = {0};
 		/* first check some additional ATR bytes */
 		if ((atr[4] != 0xff && atr[4] != 0x02) ||
 		    (atr[6] != 0x10 && atr[6] != 0x0a) ||
@@ -131,7 +131,7 @@ static int cardos_match_card(sc_card_t *card)
 		apdu.lc = 0;
 		rv = sc_transmit_apdu(card, &apdu);
 		LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
-		if (apdu.sw1 != 0x90 || apdu.sw2 != 0x00)
+		if (apdu.sw1 != 0x90 || apdu.sw2 != 0x00 || apdu.resplen < 2)
 			return 0;
 		if (apdu.resp[0] != atr[10] ||
 		    apdu.resp[1] != atr[11])

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -1424,6 +1424,8 @@ static int entersafe_get_serialnr(sc_card_t *card, sc_serial_number_t *serial)
 	r = entersafe_transmit_apdu(card, &apdu, 0, 0, 0, 0);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	LOG_TEST_RET(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2), "EnterSafe get SN failed");
+	if (apdu.resplen != 8)
+		LOG_TEST_RET(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Invalid length of SN");
 
 	card->serialnr.len = serial->len = 8;
 	memcpy(card->serialnr.value, rbuf, 8);

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -250,7 +250,7 @@ static int gids_get_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	LOG_TEST_RET(card->ctx, r, "gids get data failed");
 	LOG_TEST_RET(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2), "invalid return");
 
-	p = sc_asn1_find_tag(card->ctx, buffer, sizeof(buffer), dataObjectIdentifier, &datasize);
+	p = sc_asn1_find_tag(card->ctx, buffer, apdu.resplen, dataObjectIdentifier, &datasize);
 	if (!p) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_FILE_NOT_FOUND);
 	}

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -230,6 +230,7 @@ static int gids_get_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	size_t datasize = 0;
 	const u8* p;
 	u8 buffer[MAX_GIDS_FILE_SIZE];
+	size_t buffer_len = sizeof(buffer);
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 	sc_log(card->ctx,
@@ -243,14 +244,15 @@ static int gids_get_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	apdu.data = data;
 	apdu.datalen = 04;
 	apdu.resp = buffer;
-	apdu.resplen = sizeof(buffer);
+	apdu.resplen = buffer_len;
 	apdu.le = 256;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "gids get data failed");
 	LOG_TEST_RET(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2), "invalid return");
+	buffer_len = apdu.resplen;
 
-	p = sc_asn1_find_tag(card->ctx, buffer, apdu.resplen, dataObjectIdentifier, &datasize);
+	p = sc_asn1_find_tag(card->ctx, buffer, buffer_len, dataObjectIdentifier, &datasize);
 	if (!p) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_FILE_NOT_FOUND);
 	}

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -195,6 +195,8 @@ jpki_select_file(struct sc_card *card,
 		u8 buf[4];
 		rc = sc_read_binary(card, 0, buf, 4, 0);
 		LOG_TEST_RET(card->ctx, rc, "SW Check failed");
+		if (rc < 4)
+			LOG_TEST_RET(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Received data too short");
 		file = sc_file_new();
 		if (!file) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -587,20 +587,23 @@ do_select(sc_card_t * card, u8 kind,
 		}
 	}
 
-	if (p2 == 0x04 && apdu.resp[0] == 0x62) {
+	if (p2 == 0x04 && apdu.resplen > 2 && apdu.resp[0] == 0x62) {
 		*file = sc_file_new();
 		if (!*file)
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		if (apdu.resp[1] > apdu.resplen - 2)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		process_fcp(card, *file, apdu.resp + 2, apdu.resp[1]);
 		return SC_SUCCESS;
 	}
 
-	if (p2 != 0x0C && apdu.resp[0] == 0x6F) {
+	if (p2 != 0x0C && apdu.resplen > 2 && apdu.resp[0] == 0x6F) {
 		*file = sc_file_new();
 		if (!*file)
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
-		if (apdu.resp[1] <= apdu.resplen)
-			process_fcp(card, *file, apdu.resp + 2, apdu.resp[1]);
+		if (apdu.resp[1] > apdu.resplen - 2)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
+		process_fcp(card, *file, apdu.resp + 2, apdu.resp[1]);
 		return SC_SUCCESS;
 	}
 	return SC_SUCCESS;

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -145,7 +145,7 @@ auth_select_aid(struct sc_card *card)
 {
 	struct sc_apdu apdu;
 	unsigned char apdu_resp[SC_MAX_APDU_BUFFER_SIZE];
-	struct auth_private_data *data =  (struct auth_private_data *) card->drv_data;
+	struct auth_private_data *data = (struct auth_private_data *)card->drv_data;
 	int rv, ii;
 	struct sc_path tmp_path;
 
@@ -162,6 +162,9 @@ auth_select_aid(struct sc_card *card)
 
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+	if (apdu.resplen < 20) {
+		LOG_TEST_RET(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Serial number has incorrect length");
+	}
 	card->serialnr.len = 4;
 	memcpy(card->serialnr.value, apdu.resp+15, 4);
 

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4428,7 +4428,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	const u8 *p;
 	size_t out_len = 0;
 	int r;
-	unsigned int tag_out, cla_out;
+	unsigned int tag_out = 0, cla_out = 0;
 	piv_private_data_t * priv = PIV_DATA(card);
 
 	LOG_FUNC_CALLED(card->ctx);

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -760,6 +760,9 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 
 	LOG_FUNC_CALLED(ctx);
 
+	if (data == NULL || data_len < 2)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+
 	if (*data == IASECC_SDO_TEMPLATE_TAG)   {
 		size_size = iasecc_parse_size(data + 1, data_len - 1, &size);
 		LOG_TEST_RET(ctx, size_size, "parse error: invalid size data of IASECC_SDO_TEMPLATE");

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -318,15 +318,24 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 
 	LOG_FUNC_CALLED(ctx);
 
+	if (data_len < 1)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+
 	if (*data == IASECC_SDO_TEMPLATE_TAG)   {
 		size_size = iasecc_parse_size(data + 1, data_len - 1, &size);
 		LOG_TEST_RET(ctx, size_size, "parse error: invalid size data of IASECC_SDO_TEMPLATE");
+
+		if (data_len - 1 < size)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 
 		data += size_size + 1;
 		data_len = size;
 		sc_log(ctx,
 		       "IASECC_SDO_TEMPLATE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %d",
 		       size, size_size);
+
+		if (data_len < 3)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 
 		if (*data != IASECC_SDO_TAG_HEADER)
 			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);

--- a/src/libopensc/pkcs15-cert.c
+++ b/src/libopensc/pkcs15-cert.c
@@ -169,7 +169,7 @@ sc_pkcs15_get_name_from_dn(struct sc_context *ctx, const u8 *dn, size_t dn_len,
 	for (next_ava = rdn, next_ava_len = rdn_len; next_ava_len; ) {
 		const u8 *ava, *dummy, *oidp;
 		struct sc_object_id oid;
-		size_t ava_len, dummy_len, oid_len;
+		size_t ava_len = 0, dummy_len, oid_len = 0;
 
 		/* unwrap the set and point to the next ava */
 		ava = sc_asn1_skip_tag(ctx, &next_ava, &next_ava_len, SC_ASN1_TAG_SET | SC_ASN1_CONS, &ava_len);

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -386,7 +386,7 @@ int sc_pkcs15emu_sc_hsm_decode_cvc(sc_pkcs15_card_t * p15card,
 	struct sc_asn1_entry asn1_cvcert[C_ASN1_CVCERT_SIZE];
 	struct sc_asn1_entry asn1_cvc_body[C_ASN1_CVC_BODY_SIZE];
 	struct sc_asn1_entry asn1_cvc_pubkey[C_ASN1_CVC_PUBKEY_SIZE];
-	unsigned int cla,tag;
+	unsigned int cla = 0, tag = 0;
 	size_t taglen;
 	const u8 *tbuf;
 	int r;

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -62,7 +62,8 @@ static int insert_cert(
 			"Select(%s) failed\n", path);
 		return 1;
 	}
-	if(sc_read_binary(card, 0, cert, sizeof(cert), 0)<0){
+	r = sc_read_binary(card, 0, cert, sizeof(cert), 0);
+	if (r <= 0){
 		sc_log(ctx, 
 			"ReadBinary(%s) failed\n", path);
 		return 2;

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -531,10 +531,15 @@ int sc_pkcs15emu_tcos_init_ex(
 	/* get the card serial number */
 	r = sc_card_ctl(card, SC_CARDCTL_GET_SERIALNR, &serialnr);
 	if (r < 0) {
-		sc_log(ctx,  "unable to get ICCSN\n");
+		sc_log(ctx, "unable to get ICCSN");
 		return SC_ERROR_WRONG_CARD;
 	}
-	sc_bin_to_hex(serialnr.value, serialnr.len , serial, sizeof(serial), 0);
+	r = sc_bin_to_hex(serialnr.value, serialnr.len, serial, sizeof(serial), 0);
+	if (r != SC_SUCCESS) {
+		sc_log(ctx, "serial number invalid");
+		return SC_ERROR_INTERNAL;
+	}
+
 	serial[19] = '\0';
 	set_string(&p15card->tokeninfo->serial_number, serial);
 

--- a/src/libopensc/pkcs15-tcos.c
+++ b/src/libopensc/pkcs15-tcos.c
@@ -45,6 +45,7 @@ static int insert_cert(
 	struct sc_pkcs15_cert_info cert_info;
 	struct sc_pkcs15_object cert_obj;
 	unsigned char cert[20];
+	size_t cert_len = 0;
 	int r;
 
 	memset(&cert_info, 0, sizeof(cert_info));
@@ -57,25 +58,31 @@ static int insert_cert(
 	strlcpy(cert_obj.label, label, sizeof(cert_obj.label));
 	cert_obj.flags = writable ? SC_PKCS15_CO_FLAG_MODIFIABLE : 0;
 
-	if(sc_select_file(card, &cert_info.path, NULL)!=SC_SUCCESS){
-		sc_log(ctx, 
-			"Select(%s) failed\n", path);
+	if (sc_select_file(card, &cert_info.path, NULL) != SC_SUCCESS) {
+		sc_log(ctx, "Select(%s) failed", path);
 		return 1;
 	}
 	r = sc_read_binary(card, 0, cert, sizeof(cert), 0);
-	if (r <= 0){
-		sc_log(ctx, 
-			"ReadBinary(%s) failed\n", path);
+	if (r <= 0) {
+		sc_log(ctx, "ReadBinary(%s) failed\n", path);
 		return 2;
 	}
-	if(cert[0]!=0x30 || cert[1]!=0x82){
-		sc_log(ctx, 
-			"Invalid Cert: %02X:%02X:...\n", cert[0], cert[1]);
+	cert_len = r; /* actual number of read bytes */
+	if (cert_len < 7 || (size_t)(7 + cert[5]) > cert_len) {
+		sc_log(ctx, "Invalid certificate length");
+		return 3;
+	}
+	if (cert[0] != 0x30 || cert[1] != 0x82) {
+		sc_log(ctx, "Invalid Cert: %02X:%02X:...\n", cert[0], cert[1]);
 		return 3;
 	}
 
 	/* some certificates are prefixed by an OID */
-	if(cert[4]==0x06 && cert[5]<10 && cert[6+cert[5]]==0x30 && cert[7+cert[5]]==0x82){
+	if (cert[4] == 0x06 && cert[5] < 10 && cert[6 + cert[5]] == 0x30 && cert[7 + cert[5]] == 0x82) {
+		if ((size_t)(9 + cert[5]) > cert_len) {
+			sc_log(ctx, "Invalid certificate length");
+			return 3;
+		}
 		cert_info.path.index=6+cert[5];
 		cert_info.path.count=(cert[8+cert[5]]<<8) + cert[9+cert[5]] + 4;
 	} else {
@@ -83,12 +90,12 @@ static int insert_cert(
 		cert_info.path.count=(cert[2]<<8) + cert[3] + 4;
 	}
 
-	r=sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
-	if(r!=SC_SUCCESS){
-		sc_log(ctx,  "sc_pkcs15emu_add_x509_cert(%s) failed\n", path);
+	r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+	if (r != SC_SUCCESS) {
+		sc_log(ctx, "sc_pkcs15emu_add_x509_cert(%s) failed", path);
 		return 4;
 	}
-	sc_log(ctx,  "%s: OK, Index=%d, Count=%d\n", path, cert_info.path.index, cert_info.path.count);
+	sc_log(ctx, "%s: OK, Index=%d, Count=%d", path, cert_info.path.index, cert_info.path.count);
 	return 0;
 }
 

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3831,13 +3831,15 @@ sc_pkcs15init_get_transport_key(struct sc_profile *profile, struct sc_pkcs15_car
 	if (callbacks.get_key)   {
 		rv = callbacks.get_key(profile, type, reference, defbuf, defsize, pinbuf, pinsize);
 		LOG_TEST_RET(ctx, rv, "Cannot get key");
-	}
-	else if (rv >= 0)  {
+	} else if (rv >= 0) {
 		if (*pinsize < defsize)
 			LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "Get transport key error");
 
 		memcpy(pinbuf, data.key_data, data.len);
 		*pinsize = data.len;
+	} else {
+		/* pinbuf and pinsize were not filled */
+		LOG_TEST_RET(ctx, SC_ERROR_INTERNAL, "Get transport key error");
 	}
 
 	memset(&auth_info, 0, sizeof(auth_info));

--- a/src/pkcs15init/pkcs15-sc-hsm.c
+++ b/src/pkcs15init/pkcs15-sc-hsm.c
@@ -140,7 +140,7 @@ static int sc_hsm_determine_free_id(struct sc_pkcs15_card *p15card, u8 range)
 	LOG_TEST_RET(card->ctx, filelistlength, "Could not enumerate file and key identifier");
 
 	for (j = 0; j < 256; j++) {
-		for (i = 0; i < filelistlength; i += 2) {
+		for (i = 0; i + 1 < filelistlength; i += 2) {
 			if ((filelist[i] == range) && (filelist[i + 1] == j)) {
 				break;
 			}

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -507,6 +507,9 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		r = sc_card_ctl(p15card->card, SC_CARDCTL_SETCOS_GETDATA, &data_obj);
 		LOG_TEST_RET(ctx, r, "Cannot get key modulus: 'SETCOS_GETDATA' failed");
 
+		if (data_obj.DataLen < 3 || data_obj.DataLen < pubkey->u.rsa.modulus.len)
+			LOG_TEST_RET(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED, "Cannot get key modulus: wrong length of raw key");
+
 		keybits = ((raw_pubkey[0] * 256) + raw_pubkey[1]);  /* modulus bit length */
 		if (keybits != key_info->modulus_length)  {
 			sc_log(ctx,
@@ -514,7 +517,7 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 				 keybits, key_info->modulus_length);
 			LOG_TEST_RET(ctx, SC_ERROR_PKCS15INIT, "Failed to generate key");
 		}
-		memcpy (pubkey->u.rsa.modulus.data, &raw_pubkey[2], pubkey->u.rsa.modulus.len);
+		memcpy(pubkey->u.rsa.modulus.data, &raw_pubkey[2], pubkey->u.rsa.modulus.len);
 	} else {
 		sc_file_free(file);
 	}

--- a/src/pkcs15init/pkcs15-starcos.c
+++ b/src/pkcs15init/pkcs15-starcos.c
@@ -670,6 +670,8 @@ static int starcos_write_pukey(sc_profile_t *profile, sc_card_t *card,
 		return r;
 	len = tfile->size;
 	sc_file_free(tfile);
+	if (len == 0)
+		return SC_ERROR_INTERNAL;
 	buf = malloc(len);
 	if (!buf)
 		return SC_ERROR_OUT_OF_MEMORY;
@@ -684,7 +686,7 @@ static int starcos_write_pukey(sc_profile_t *profile, sc_card_t *card,
 	if (num_keys == 0xff)
 		num_keys = 0;
 	/* encode public key */
-	keylen  = starcos_encode_pukey(rsa, NULL, kinfo);
+	keylen = starcos_encode_pukey(rsa, NULL, kinfo);
 	if (!keylen) {
 		free(buf);
 		return SC_ERROR_INTERNAL;

--- a/src/pkcs15init/profile.c
+++ b/src/pkcs15init/profile.c
@@ -1809,7 +1809,7 @@ do_pin_storedlength(struct state *cur, int argc, char **argv)
 static int
 do_pin_flags(struct state *cur, int argc, char **argv)
 {
-	unsigned int	flags;
+	unsigned int	flags = 0;
 	int		i, r;
 
 	if (cur->pin->pin.auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)

--- a/src/pkcs15init/profile.c
+++ b/src/pkcs15init/profile.c
@@ -1809,7 +1809,7 @@ do_pin_storedlength(struct state *cur, int argc, char **argv)
 static int
 do_pin_flags(struct state *cur, int argc, char **argv)
 {
-	unsigned int	flags = 0;
+	unsigned int flags = 0;
 	int		i, r;
 
 	if (cur->pin->pin.auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)


### PR DESCRIPTION
33 new use-of-uninitialized-memory bugs were found while testing fuzzing harnesses. The bugs were found in these functions:
- cac_read_file()
- cardos_match_card()
- sc_bin_to_hex()
- strcmp(), from gids_get_identifiers()
- do_select()
- bcmp(), from cac_list_compare_path()
- insert_cert()
- cardos_lifecycle_get()
- gids_read_masterfile()
- sc_pkcs15init_parse_info()
- piv_get_challenge()
- asn1_decode()
- malloc(), from cac_read_file()
- sc_asn1_decode_object_id()
- sc_pkcs15emu_sc_hsm_decode_cvc()
- gemsafe_get_cert_len()
- process_fcp()
- dnie_process_fci()
- iso7816_process_fci()
- sc_pkcs15_read_file()
- strlen(), from set_string()
- asn1_encode_path()
- msc_extract_rsa_public_key()
- sc_build_pin()
- DES_set_key_unchecked(), from openssl_enc()
- starcos_write_pukey()
- iasecc_sdo_parse()
- setcos_generate_key()
- iasecc_parse_size()
- iasecc_se_parse()
- sc_hsm_determine_free_id()
- asn1_encode_entry()
- coolkey_rsa_op()

Reported by Matteo Marini (@Heinzeen)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
