### PR TITLE
ci: Detect expired github tokens

### DIFF
--- a/.github/push_artifacts.sh
+++ b/.github/push_artifacts.sh
@@ -6,6 +6,13 @@ if [ -z "$GH_TOKEN" ]; then
     exit 0
 fi
 
+# Check the GH_TOKEN is not expired
+curl --fail --silent -XGET -H "authorization: token $GH_TOKEN" 'https://api.github.com/repos/OpenSC/Nightly'
+if [ 0 -eq "$?" ]; then
+    echo "The GH_TOKEN is expired -- please renew it!"
+    exit 1
+fi
+
 BUILDPATH=${PWD}
 BRANCH="`git log --max-count=1 --date=short --abbrev=8 --pretty=format:"%cd_%h"`"
 


### PR DESCRIPTION
The GH tokens for pushing builds to nightly repositories expired some months ago and the errors are very far from being helpful so this is attempt to provide useful errors when the GH token expires so any maintainer can jump and generate new tokens.
