### PR TITLE
regenerated AppVeyor token for OpenSC-Nightly access

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ configuration:
 
 environment:
   GH_TOKEN:
-    secure: jeReA6BNx/dXVMGfroKadgVyPPLNrGL1pvLfc+sizlOLebm/+chuB9AcOi5mTdqHIb3E+TGIR+9fZ+kJotsjCF63ElwE8oJni0Ugrrs16SFwHLAnLpzZBQ5uuIOTVh1X
+    secure: jeReA6BNx/dXVMGfroKadgE9ByKAE/tAGcb2z+dIVZGAN29X1Pu22wi1TuVOy9ZugqBzjvFV4knwHJSGi0+U6Yj1fTfa2CYpeCBym4JOXqPis/GpKfSeBV9IrmJGT/Av
   PATH: C:\cygwin\bin;%PATH%
   OPENPACE_VER: 1.1.3
   ZLIB_VER_DOT: 1.2.12


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
