### PR TITLE
Add Support for ECC Signatures on D-Trust Card 4.1/4.4

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -58,7 +58,7 @@ libopensc_la_SOURCES_BASE = \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
-	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c compression.c sm.c \
+	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c pkcs15-dtrust.c compression.c sm.c \
 	aux-data.c
 
 if ENABLE_CRYPTOTOKENKIT
@@ -140,7 +140,7 @@ TIDY_FILES = \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
-	pkcs15-starcos-esign.c pkcs15-skeid.c compression.c sm.c \
+	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-dtrust.c compression.c sm.c \
 	aux-data.c \
 	#$(SOURCES)
 

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -36,8 +36,8 @@ OBJECTS			= \
 	pkcs15-oberthur.obj pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
 	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-jpki.obj \
 	pkcs15-esteid2018.obj pkcs15-idprime.obj pkcs15-nqApplet.obj \
-	pkcs15-starcos-esign.obj pkcs15-skeid.obj pkcs15-eoi.obj compression.obj sm.obj \
-	aux-data.obj \
+	pkcs15-starcos-esign.obj pkcs15-skeid.obj pkcs15-eoi.obj pkcs15-dtrust.obj \
+	compression.obj sm.obj aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res
 LIBS = $(TOPDIR)\src\scconf\scconf.lib \
 	   $(TOPDIR)\src\common\common.lib \

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -256,12 +256,10 @@ dtrust_init(sc_card_t *card)
 		r = SC_SUCCESS;
 		break;
 
-	/* Untested due to lacking hardware */
 	case SC_CARD_TYPE_DTRUST_V4_1_MULTI:
 	case SC_CARD_TYPE_DTRUST_V4_1_M100:
 	case SC_CARD_TYPE_DTRUST_V4_4_MULTI:
-		flags |= SC_ALGORITHM_ECDH_CDH_RAW;
-		flags |= SC_ALGORITHM_ECDSA_HASH_SHA256;
+		flags |= SC_ALGORITHM_ECDSA_RAW;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE;
 		for (unsigned int i = 0; dtrust_curves[i].oid.value[0] >= 0; i++) {
 			_sc_card_add_ec_alg(card, dtrust_curves[i].size, flags, ext_flags, &dtrust_curves[i].oid);
@@ -372,6 +370,8 @@ dtrust_set_security_env(sc_card_t *card,
 			default:
 				return SC_ERROR_NOT_SUPPORTED;
 			}
+		} else if (env->algorithm_flags & SC_ALGORITHM_ECDSA_RAW) {
+			se_num = 0x21;
 		} else {
 			return SC_ERROR_NOT_SUPPORTED;
 		}

--- a/src/libopensc/pkcs15-dtrust.c
+++ b/src/libopensc/pkcs15-dtrust.c
@@ -1,0 +1,105 @@
+/*
+ * PKCS15 emulation layer for D-Trust card.
+ *
+ * Copyright (C) 2024, Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "internal.h"
+#include "pkcs15.h"
+
+static int
+_dtrust_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_object *pkobjs[32];
+	struct sc_pkcs15_prkey_info *prkey_info;
+	int rv, i, count;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!df)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (df->enumerated)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	rv = sc_pkcs15_parse_df(p15card, df);
+	LOG_TEST_RET(ctx, rv, "DF parse error");
+
+	if (df->type != SC_PKCS15_PRKDF)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	switch (p15card->card->type) {
+	/* Cards with EC keys, don't encode the curve size in the
+	 * private key directory file. We need to set the field_length
+	 * element after parsing the private key directory file. */
+	case SC_CARD_TYPE_DTRUST_V4_1_MULTI:
+	case SC_CARD_TYPE_DTRUST_V4_1_M100:
+	case SC_CARD_TYPE_DTRUST_V4_4_MULTI:
+		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY, pkobjs, sizeof(pkobjs) / sizeof(pkobjs[0]));
+		LOG_TEST_RET(ctx, rv, "Cannot get PRKEY objects list");
+
+		count = rv;
+		for (i = 0; i < count; i++) {
+			prkey_info = (struct sc_pkcs15_prkey_info *)pkobjs[i]->data;
+			prkey_info->field_length = 256;
+		}
+		break;
+	}
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+static int
+dtrust_pkcs15emu_detect_card(sc_pkcs15_card_t *p15card)
+{
+	if (p15card->card->type < SC_CARD_TYPE_DTRUST_V4_1_STD)
+		return SC_ERROR_WRONG_CARD;
+
+	if (p15card->card->type > SC_CARD_TYPE_DTRUST_V4_4_MULTI)
+		return SC_ERROR_WRONG_CARD;
+
+	return SC_SUCCESS;
+}
+
+static int
+sc_pkcs15emu_dtrust_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	int rv;
+
+	LOG_FUNC_CALLED(ctx);
+
+	rv = sc_pkcs15_bind_internal(p15card, aid);
+
+	p15card->ops.parse_df = _dtrust_parse_df;
+
+	LOG_FUNC_RETURN(ctx, rv);
+}
+
+int
+sc_pkcs15emu_dtrust_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	if (dtrust_pkcs15emu_detect_card(p15card))
+		return SC_ERROR_WRONG_CARD;
+
+	return sc_pkcs15emu_dtrust_init(p15card, aid);
+}

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -61,6 +61,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "nqapplet",   sc_pkcs15emu_nqapplet_init_ex },
 	{ "esign",      sc_pkcs15emu_starcos_esign_init_ex },
 	{ "eOI",        sc_pkcs15emu_eoi_init_ex },
+	{ "dtrust",     sc_pkcs15emu_dtrust_init_ex },
 	{ NULL, NULL }
 };
 
@@ -113,6 +114,11 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_SKEID_V3:
 		case SC_CARD_TYPE_EOI:
 		case SC_CARD_TYPE_EOI_CONTACTLESS:
+		case SC_CARD_TYPE_DTRUST_V4_1_STD:
+		case SC_CARD_TYPE_DTRUST_V4_4_STD:
+		case SC_CARD_TYPE_DTRUST_V4_1_MULTI:
+		case SC_CARD_TYPE_DTRUST_V4_1_M100:
+		case SC_CARD_TYPE_DTRUST_V4_4_MULTI:
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -56,6 +56,7 @@ int sc_pkcs15emu_nqapplet_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_starcos_esign_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_skeid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_eoi_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
+int sc_pkcs15emu_dtrust_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;


### PR DESCRIPTION
This PR adds support for ECDSA Signatures of the german D-Trust Signatures Cards 4.1/4.4 issued by the german Bundesdruckerei. To set the `field_length` attribute in the private key data structure, a PKCS#15 emulation wrapper for D-Trust Cards had to be introduced.

To use the authentication certificate for ECDH key derivation, there is still more work to do, which will be addressed eventually in its own PR.

Tested on:

* D-TRUST Card 4.1 M100 ECC 2ca
* D-TRUST Card 4.1 Multi ECC 2ca

* Fixes #3236

##### Checklist

- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested (unable to test, help needed)
