### PR TITLE
fuzz_pkcs15init.c: Fix FTBFS on ppc64el with gcc and O3

### DIFF
--- a/src/tests/fuzzing/fuzz_pkcs15init.c
+++ b/src/tests/fuzzing/fuzz_pkcs15init.c
@@ -122,7 +122,7 @@ void do_init_app(struct sc_profile *profile, struct sc_pkcs15_card *p15card, sc_
                  unsigned char *so_pin, unsigned char *so_puk)
 {
     struct sc_pkcs15init_initargs init_args;
-    sc_pkcs15_auth_info_t         info;
+    sc_pkcs15_auth_info_t info = {0};
     int                           so_puk_disabled = 0;
 
     memset(&init_args, 0, sizeof(init_args));


### PR DESCRIPTION
libtool: link: gcc -g -O0 -Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 -g -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-stack-clash-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/opensc-0.25.1-2ubuntu1 -O2 -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -Wl,-z -Wl,relro -o .libs/fuzz_piv_tool fuzz_piv_tool.o fuzzer_reader.o fuzzer_tool.o fuzzer.o ../../tools/util.o  -lcrypto ../../../src/libopensc/.libs/libopensc.so ../../../src/common/.libs/libscdl.a -ldl ../../../src/pkcs15init/.libs/libpkcs15init.a ../../../src/common/.libs/libcompat.a -pthread fuzz_pkcs15init.c: In function ‘do_init_app’:
fuzz_pkcs15init.c:130:70: error: ‘BIT_FIELD_REF <info.attrs.pin, 64, 0>’ may be used uninitialized [-Werror=maybe-uninitialized]
  130 |     if ((info.attrs.pin.flags & SC_PKCS15_PIN_FLAG_UNBLOCK_DISABLED) &&
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  131 |         (info.attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
fuzz_pkcs15init.c:125:35: note: ‘BIT_FIELD_REF <info.attrs.pin, 64, 0>’ was declared here
  125 |     sc_pkcs15_auth_info_t         info;
      |                                   ^~~~
cc1: all warnings being treated as errors

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
