### PR TITLE
Add full ECC Support for D-Trust Card 4.1/4.4

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -14,7 +14,7 @@ noinst_HEADERS = cards.h ctbcs.h internal.h muscle.h muscle-filesystem.h \
 	pace.h cwa14890.h cwa-dnie.h card-gids.h aux-data.h \
 	jpki.h sc-ossl-compat.h card-npa.h card-openpgp.h \
 	card-eoi.h ccid-types.h reader-tr03119.h \
-	card-cac-common.h
+	card-cac-common.h card-cardos-common.h
 
 AM_CPPFLAGS = -D'OPENSC_CONF_PATH="$(sysconfdir)/opensc.conf"' \
      -D'DEFAULT_SM_MODULE_PATH="$(DEFAULT_SM_MODULE_PATH)"' \
@@ -38,7 +38,7 @@ libopensc_la_SOURCES_BASE = \
 	ctbcs.c reader-ctapi.c reader-pcsc.c reader-openct.c reader-tr03119.c \
 	\
 	card-setcos.c card-flex.c \
-	card-cardos.c card-tcos.c card-default.c \
+	card-cardos.c card-cardos-common.c card-tcos.c card-default.c \
 	card-mcrd.c card-starcos.c card-openpgp.c \
 	card-oberthur.c card-belpic.c card-atrust-acos.c \
 	card-entersafe.c card-epass2003.c card-coolkey.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -15,7 +15,7 @@ OBJECTS			= \
 	ctbcs.obj reader-ctapi.obj reader-pcsc.obj reader-openct.obj reader-tr03119.obj \
 	\
 	card-setcos.obj card-flex.obj \
-	card-cardos.obj card-tcos.obj card-default.obj \
+	card-cardos.obj card-cardos-common.obj card-tcos.obj card-default.obj \
 	card-mcrd.obj card-starcos.obj card-openpgp.obj \
 	card-oberthur.obj card-belpic.obj card-atrust-acos.obj \
 	card-entersafe.obj card-epass2003.obj card-coolkey.obj \

--- a/src/libopensc/card-cardos-common.c
+++ b/src/libopensc/card-cardos-common.c
@@ -1,0 +1,85 @@
+/*
+ * card-cardos-common.c: Common code for CardOS based cards
+ *
+ * Copyright (C) 2024 Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "card-cardos-common.h"
+#include "internal.h"
+
+int
+cardos_ec_compute_shared_value(struct sc_card *card,
+		const u8 *crgram, size_t crgram_len,
+		u8 *out, size_t outlen)
+{
+	int r;
+	struct sc_apdu apdu;
+	u8 *sbuf = NULL;
+
+	if (card == NULL || crgram == NULL || out == NULL) {
+		return SC_ERROR_INVALID_ARGUMENTS;
+	}
+	LOG_FUNC_CALLED(card->ctx);
+	sc_log(card->ctx, "CardOS compute shared value: in-len %" SC_FORMAT_LEN_SIZE_T "u, out-len %" SC_FORMAT_LEN_SIZE_T "u", crgram_len, outlen);
+
+	/* Ensure public key is provided in uncompressed format (indicator byte
+	 * 0x04 followed by X and Y coordinate. */
+	if (crgram_len % 2 == 0 || crgram[0] != 0x04) {
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+	}
+
+	/* strip indicator byte */
+	crgram++;
+	crgram_len--;
+
+	sbuf = malloc(crgram_len + 2);
+	if (sbuf == NULL)
+		return SC_ERROR_OUT_OF_MEMORY;
+
+	/* INS: 0x2A  PERFORM SECURITY OPERATION
+	 * P1:  0x80  Resp: Plain value
+	 * P2:  0xA6  Cmd: Control reference template for key agreement */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0x2A, 0x80, 0xA6);
+	apdu.resp = out;
+	apdu.resplen = outlen;
+	apdu.le = outlen;
+
+	sbuf[0] = 0x9c; /* context specific ASN.1 tag */
+	sbuf[1] = crgram_len;
+	memcpy(sbuf + 2, crgram, crgram_len);
+	apdu.data = sbuf;
+	apdu.lc = crgram_len + 2;
+	apdu.datalen = crgram_len + 2;
+
+	iso7816_fixup_transceive_length(card, &apdu);
+	r = sc_transmit_apdu(card, &apdu);
+	sc_mem_clear(sbuf, crgram_len + 2);
+	free(sbuf);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+		LOG_FUNC_RETURN(card->ctx, (int)apdu.resplen);
+	else
+		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+}

--- a/src/libopensc/card-cardos-common.h
+++ b/src/libopensc/card-cardos-common.h
@@ -1,0 +1,43 @@
+/*
+ * card-cardos-common.c: Common code for CardOS based cards
+ *
+ * Copyright (C) 2024 Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef HAVE_CARD_CARDOS_COMMON_H
+#define HAVE_CARD_CARDOS_COMMON_H
+
+#include "libopensc/opensc.h"
+
+/**
+ * @brief compute a shared value from the peers public ECC key
+ *
+ * Key agreement on ECC keys requires a CardOS-specific command.
+ *
+ * @param  card[in]       struct sc_card object on which to issue the command
+ * @param  crgram[in]     public key point coordinates of the peer party in uncompressed format
+ * @param  crgram_len[in] size of the public key point
+ * @param  out[out]       output buffer for the shared value
+ * @param  outlen[in]     size of the output buffer
+ * @return number of bytes of the shared value or an error code
+ */
+int
+cardos_ec_compute_shared_value(struct sc_card *card,
+		const u8 *crgram, size_t crgram_len,
+		u8 *out, size_t outlen);
+
+#endif /* HAVE_CARD_CARDOS_COMMON_H */

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -72,26 +72,6 @@ typedef struct cardos_data {
 	const sc_security_env_t * sec_env;
 } cardos_data_t;
 
-/* copied from iso7816.c */
-static void fixup_transceive_length(const struct sc_card *card,
-		struct sc_apdu *apdu)
-{
-	if (card == NULL || apdu == NULL) {
-		return;
-	}
-
-	if (apdu->lc > sc_get_max_send_size(card)) {
-		/* The lower layers will automatically do chaining */
-		apdu->flags |= SC_APDU_FLAGS_CHAINING;
-	}
-
-	if (apdu->le > sc_get_max_recv_size(card)) {
-		/* The lower layers will automatically do a GET RESPONSE, if possible.
-		 * All other workarounds must be carried out by the upper layers. */
-		apdu->le = sc_get_max_recv_size(card);
-	}
-}
-
 static int cardos_match_card(sc_card_t *card)
 {
 	unsigned char atr[SC_MAX_ATR_SIZE] = {0};
@@ -1080,7 +1060,7 @@ do_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
 	apdu.data    = data;
 	apdu.lc      = datalen;
 	apdu.datalen = datalen;
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -70,6 +70,27 @@ static struct dtrust_supported_ec_curves {
 };
 // clang-format on
 
+/* copied from iso7816.c */
+static void
+fixup_transceive_length(const struct sc_card *card,
+		struct sc_apdu *apdu)
+{
+	if (card == NULL || apdu == NULL) {
+		return;
+	}
+
+	if (apdu->lc > sc_get_max_send_size(card)) {
+		/* The lower layers will automatically do chaining */
+		apdu->flags |= SC_APDU_FLAGS_CHAINING;
+	}
+
+	if (apdu->le > sc_get_max_recv_size(card)) {
+		/* The lower layers will automatically do a GET RESPONSE, if possible.
+		 * All other workarounds must be carried out by the upper layers. */
+		apdu->le = sc_get_max_recv_size(card);
+	}
+}
+
 static int
 _dtrust_match_cardos(sc_card_t *card)
 {
@@ -259,6 +280,7 @@ dtrust_init(sc_card_t *card)
 	case SC_CARD_TYPE_DTRUST_V4_1_MULTI:
 	case SC_CARD_TYPE_DTRUST_V4_1_M100:
 	case SC_CARD_TYPE_DTRUST_V4_4_MULTI:
+		flags |= SC_ALGORITHM_ECDH_CDH_RAW;
 		flags |= SC_ALGORITHM_ECDSA_RAW;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE;
 		for (unsigned int i = 0; dtrust_curves[i].oid.value[0] >= 0; i++) {
@@ -377,6 +399,14 @@ dtrust_set_security_env(sc_card_t *card,
 		}
 		break;
 
+	case SC_SEC_OPERATION_DERIVE:
+		if (env->algorithm_flags & SC_ALGORITHM_ECDH_CDH_RAW) {
+			se_num = 0x39;
+		} else {
+			return SC_ERROR_NOT_SUPPORTED;
+		}
+		break;
+
 	default:
 		return SC_ERROR_NOT_SUPPORTED;
 	}
@@ -439,6 +469,84 @@ err:
 }
 
 static int
+_dtrust_compute_shared_value(struct sc_card *card,
+		const u8 *crgram, size_t crgram_len,
+		u8 *out, size_t outlen)
+{
+	int r;
+	struct sc_apdu apdu;
+	u8 *sbuf = NULL;
+
+	if (card == NULL || crgram == NULL || out == NULL) {
+		return SC_ERROR_INVALID_ARGUMENTS;
+	}
+	LOG_FUNC_CALLED(card->ctx);
+	sc_log(card->ctx, "CardOS compute shared value: in-len %" SC_FORMAT_LEN_SIZE_T "u, out-len %" SC_FORMAT_LEN_SIZE_T "u", crgram_len, outlen);
+
+	/* Ensure public key is provided in uncompressed format (indicator byte
+	 * 0x04 followed by X and Y coordinate. */
+	if (crgram_len % 2 == 0 || crgram[0] != 0x04) {
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+	}
+
+	/* strip indicator byte */
+	crgram++;
+	crgram_len--;
+
+	sbuf = malloc(crgram_len + 2);
+	if (sbuf == NULL)
+		return SC_ERROR_OUT_OF_MEMORY;
+
+	/* INS: 0x2A  PERFORM SECURITY OPERATION
+	 * P1:  0x80  Resp: Plain value
+	 * P2:  0xA6  Cmd: Control reference template for key agreement */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0x2A, 0x80, 0xA6);
+	apdu.resp = out;
+	apdu.resplen = outlen;
+	apdu.le = outlen;
+
+	sbuf[0] = 0x9c; /* context specific ASN.1 tag */
+	sbuf[1] = crgram_len;
+	memcpy(sbuf + 2, crgram, crgram_len);
+	apdu.data = sbuf;
+	apdu.lc = crgram_len + 2;
+	apdu.datalen = crgram_len + 2;
+
+	fixup_transceive_length(card, &apdu);
+	r = sc_transmit_apdu(card, &apdu);
+	sc_mem_clear(sbuf, crgram_len + 2);
+	free(sbuf);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+
+	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
+		LOG_FUNC_RETURN(card->ctx, (int)apdu.resplen);
+	else
+		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+}
+
+static int
+dtrust_decipher(struct sc_card *card, const u8 *data,
+		size_t data_len, u8 *out, size_t outlen)
+{
+	switch (card->type) {
+	/* No special handling necessary for RSA cards. */
+	case SC_CARD_TYPE_DTRUST_V4_1_STD:
+	case SC_CARD_TYPE_DTRUST_V4_4_STD:
+		LOG_FUNC_RETURN(card->ctx, iso_ops->decipher(card, data, data_len, out, outlen));
+
+	/* Elliptic Curve cards cannot use PSO:DECIPHER command and need to
+	 * perform key agreement by a CardOS specific command. */
+	case SC_CARD_TYPE_DTRUST_V4_1_MULTI:
+	case SC_CARD_TYPE_DTRUST_V4_1_M100:
+	case SC_CARD_TYPE_DTRUST_V4_4_MULTI:
+		LOG_FUNC_RETURN(card->ctx, _dtrust_compute_shared_value(card, data, data_len, out, outlen));
+
+	default:
+		return SC_ERROR_NOT_SUPPORTED;
+	}
+}
+
+static int
 dtrust_logout(sc_card_t *card)
 {
 	sc_path_t path;
@@ -462,6 +570,7 @@ sc_get_dtrust_driver(void)
 	dtrust_ops.finish = dtrust_finish;
 	dtrust_ops.set_security_env = dtrust_set_security_env;
 	dtrust_ops.compute_signature = dtrust_compute_signature;
+	dtrust_ops.decipher = dtrust_decipher;
 	dtrust_ops.logout = dtrust_logout;
 
 	return &dtrust_drv;

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -70,27 +70,6 @@ static struct dtrust_supported_ec_curves {
 };
 // clang-format on
 
-/* copied from iso7816.c */
-static void
-fixup_transceive_length(const struct sc_card *card,
-		struct sc_apdu *apdu)
-{
-	if (card == NULL || apdu == NULL) {
-		return;
-	}
-
-	if (apdu->lc > sc_get_max_send_size(card)) {
-		/* The lower layers will automatically do chaining */
-		apdu->flags |= SC_APDU_FLAGS_CHAINING;
-	}
-
-	if (apdu->le > sc_get_max_recv_size(card)) {
-		/* The lower layers will automatically do a GET RESPONSE, if possible.
-		 * All other workarounds must be carried out by the upper layers. */
-		apdu->le = sc_get_max_recv_size(card);
-	}
-}
-
 static int
 _dtrust_match_cardos(sc_card_t *card)
 {
@@ -516,7 +495,7 @@ _dtrust_compute_shared_value(struct sc_card *card,
 	apdu.lc = crgram_len + 2;
 	apdu.datalen = crgram_len + 2;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	sc_mem_clear(sbuf, crgram_len + 2);
 	free(sbuf);

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -312,6 +312,8 @@ dtrust_set_security_env(sc_card_t *card,
 {
 	struct dtrust_drv_data_t *drv_data;
 
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
 	if (card == NULL || env == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
@@ -424,6 +426,8 @@ dtrust_compute_signature(struct sc_card *card, const u8 *data,
 	u8 *buf = NULL;
 	int r;
 
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
 	drv_data = card->drv_data;
 	flags = drv_data->env->algorithm_flags;
 
@@ -528,6 +532,8 @@ static int
 dtrust_decipher(struct sc_card *card, const u8 *data,
 		size_t data_len, u8 *out, size_t outlen)
 {
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
 	switch (card->type) {
 	/* No special handling necessary for RSA cards. */
 	case SC_CARD_TYPE_DTRUST_V4_1_STD:

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -155,25 +155,6 @@ struct gids_private_data {
 	size_t buffersize;
 };
 
-static void fixup_transceive_length(const struct sc_card *card,
-		struct sc_apdu *apdu)
-{
-	if (card == NULL || apdu == NULL) {
-		return;
-	}
-
-	if (apdu->lc > sc_get_max_send_size(card)) {
-		/* The lower layers will automatically do chaining */
-		apdu->flags |= SC_APDU_FLAGS_CHAINING;
-	}
-
-	if (apdu->le > sc_get_max_recv_size(card)) {
-		/* The lower layers will automatically do a GET RESPONSE, if possible.
-		 * All other workarounds must be carried out by the upper layers. */
-		apdu->le = sc_get_max_recv_size(card);
-	}
-}
-
 // LOW LEVEL API
 ///////////////////////////////////////////
 
@@ -879,7 +860,7 @@ gids_decipher(struct sc_card *card,
 	apdu.lc = crgram_len;
 	apdu.datalen = crgram_len;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -30,8 +30,8 @@
 #include "iso7816.h"
 #include "sm/sm-iso.h"
 
-
-static void fixup_transceive_length(const struct sc_card *card,
+void
+iso7816_fixup_transceive_length(const struct sc_card *card,
 		struct sc_apdu *apdu)
 {
 	if (card == NULL || apdu == NULL) {
@@ -152,7 +152,7 @@ iso7816_read_binary(struct sc_card *card, unsigned int idx, u8 *buf, size_t coun
 	apdu.resplen = count;
 	apdu.resp = buf;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(ctx, r, "APDU transmit failed");
 
@@ -254,7 +254,7 @@ iso7816_read_record(struct sc_card *card, unsigned int rec_nr, unsigned int idx,
 	if (flags & SC_RECORD_BY_REC_NR)
 		apdu.p2 |= 0x04;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_GOTO_ERR(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -295,7 +295,7 @@ iso7816_write_record(struct sc_card *card, unsigned int rec_nr,
 	if (flags & SC_RECORD_BY_REC_NR)
 		apdu.p2 |= 0x04;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -318,7 +318,7 @@ iso7816_append_record(struct sc_card *card,
 	apdu.data = buf;
 	apdu.p2 = (flags & SC_RECORD_EF_ID_MASK) << 3;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -358,7 +358,7 @@ iso7816_update_record(struct sc_card *card, unsigned int rec_nr, unsigned int id
 	if (flags & SC_RECORD_BY_REC_NR)
 		apdu.p2 |= 0x04;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_GOTO_ERR(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -388,7 +388,7 @@ iso7816_write_binary(struct sc_card *card,
 	apdu.datalen = count;
 	apdu.data = buf;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -415,7 +415,7 @@ iso7816_update_binary(struct sc_card *card,
 	apdu.datalen = count;
 	apdu.data = buf;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -1114,7 +1114,7 @@ iso7816_compute_signature(struct sc_card *card,
 	apdu.lc = datalen;
 	apdu.datalen = datalen;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
@@ -1162,7 +1162,7 @@ iso7816_decipher(struct sc_card *card,
 	apdu.lc = crgram_len + 1;
 	apdu.datalen = crgram_len + 1;
 
-	fixup_transceive_length(card, &apdu);
+	iso7816_fixup_transceive_length(card, &apdu);
 	r = sc_transmit_apdu(card, &apdu);
 	sc_mem_clear(sbuf, crgram_len + 1);
 	free(sbuf);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1673,6 +1673,18 @@ extern const char *sc_get_version(void);
 
 extern sc_card_driver_t *sc_get_iso7816_driver(void);
 
+/*
+ * @brief Request command chaining if needed.
+ *
+ * @param[in]     card  card
+ * @param[in,out] apdu  apdu structure to update
+ *
+ * @note Checks if the command payload or the expected response fits into the
+ * card transceive buffer. It requests command chaining from the lower levels
+ * if the data length exceeds the buffer size.
+ */
+void iso7816_fixup_transceive_length(const struct sc_card *card, struct sc_apdu *apdu);
+
 /**
  * @brief Read a complete EF by short file identifier.
  *


### PR DESCRIPTION
This PR adds support for ECDSA signatures and ECDH key agreement for D-Trust Signatures Cards 4.1/4.4 issued by the german Bundesdruckerei.

This PR supersedes #3240. But since @frankmorgner already reviewed that PR I wouldn't like to amend it afterwards. Feel free to continue reviewing #3240 and to postpone this one or just to review this PR instead. I am unsure which way do you prefer. Sorry the noise in case you preferred just amending an already reviewed PR.

Tested on:

* D-TRUST Card 4.1 M100 ECC 2ca
* D-TRUST Card 4.1 Multi ECC 2ca
* Fixes #3236

##### Checklist

- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested (only for signature, but not for key derivation)
- [ ] macOS tokend is tested (unable to test, help needed)