### PR TITLE
Update CI runners

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,11 +18,12 @@ environment:
   # not compatible with OpenSSL 1.1.1:
   # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
   #   VCVARSALL: "%VS120COMNTOOLS%/../../VC/vcvarsall.bat"
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    VCVARSALL: "%VS140COMNTOOLS%/../../VC/vcvarsall.bat"
-    DO_PUSH_ARTIFACT: yes
+  #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #VCVARSALL: "%VS140COMNTOOLS%/../../VC/vcvarsall.bat"
+    #DO_PUSH_ARTIFACT: yes
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     VCVARSALL: "%ProgramFiles(x86)%/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvarsall.bat"
+    DO_PUSH_ARTIFACT: yes
   # not compatible with WiX 3.11.2:
   # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
   #   VCVARSALL: "%ProgramFiles(x86)%/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-15, macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -45,14 +45,14 @@ jobs:
           PASS_SECRETS_TAR_ENC: ${{ secrets.PASS_SECRETS_TAR_ENC }}
 
   push-artifacts:
-    runs-on: macos-12
+    runs-on: macos-latest
     needs: [build]
     steps:
       - uses: actions/checkout@v4
       - name: Pull build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: opensc-build-macos-12
+          name: opensc-build-macos-15
       - run: git config --global user.email "builds@github.com"
       - run: git config --global user.name "Github Actions";
       - run: .github/push_artifacts.sh "Github Actions ${GITHUB_REF}"


### PR DESCRIPTION
Both, Github and Signpath updated the list of their supported build infrastructure.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
