### PR TITLE
Add OpenPACE to dependencies on Fedora CI

### DIFF
--- a/.github/setup-fedora.sh
+++ b/.github/setup-fedora.sh
@@ -3,7 +3,7 @@
 set -ex -o xtrace
 
 # Generic dependencies
-DEPS="make /usr/bin/xsltproc docbook-style-xsl autoconf automake libtool bash-completion vim-common softhsm openssl diffutils"
+DEPS="make /usr/bin/xsltproc docbook-style-xsl autoconf automake libtool bash-completion vim-common softhsm openssl diffutils openpace openpace-devel"
 
 if [ "$1" == "clang" ]; then
 	DEPS="$DEPS clang"


### PR DESCRIPTION
OpenPACE is available for Fedora 41 used in CI.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
