### PR TITLE
Use 'BYTES4BITS' in all OpenSC code

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -654,7 +654,7 @@ static int encode_bit_string(const u8 * inbuf, size_t bits_left, u8 **outbuf,
 	u8 *out;
 	size_t bytes, skipped = 0;
 
-	bytes = (bits_left + 7)/8 + 1;
+	bytes = BYTES4BITS(bits_left) + 1;
 	*outbuf = out = malloc(bytes);
 	if (out == NULL)
 		return SC_ERROR_OUT_OF_MEMORY;

--- a/src/libopensc/card-eoi.c
+++ b/src/libopensc/card-eoi.c
@@ -457,7 +457,7 @@ static int eoi_set_security_env(struct sc_card *card, const struct sc_security_e
 
 	/* We don't know yet which hash is used. So just store the security_env data and return */
 	if (!(env->algorithm_flags & ALREADY_PROCESSED)) {
-		privdata->key_len = (env->algorithm_ref + 7)/8;
+		privdata->key_len = BYTES4BITS(env->algorithm_ref);
 		memcpy(&privdata->sec_env, env, sizeof(struct sc_security_env));
 		privdata->se_num = se_num;
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);

--- a/src/libopensc/card-isoApplet.c
+++ b/src/libopensc/card-isoApplet.c
@@ -1249,7 +1249,7 @@ isoApplet_compute_signature(struct sc_card *card,
 		}
 
 		/* Convert ASN.1 sequence of integers R,S to the raw concatenation of R,S for PKCS#11. */
-		size_t len = (drvdata->sec_env_ec_field_length + 7) / 8 * 2;
+		size_t len = BYTES4BITS(drvdata->sec_env_ec_field_length) * 2;
 		if (len > outlen)
 			LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
 

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1087,7 +1087,7 @@ myeid_convert_ec_signature(struct sc_context *ctx, size_t s_len, unsigned char *
 	    return SC_ERROR_INVALID_DATA;
 
 	/* test&fail early */
-	buflen = (s_len + 7)/8*2;
+	buflen = BYTES4BITS(s_len) * 2;
 	if (buflen > datalen)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 
@@ -1199,8 +1199,8 @@ myeid_compute_signature(struct sc_card *card, const u8 * data, size_t datalen,
 	    field_length = priv->sec_env->algorithm_ref;
 
 	    /* pad with zeros if needed */
-		if (datalen < (field_length + 7) / 8 ) {
-			pad_chars = ((field_length + 7) / 8) - datalen;
+		if (datalen < BYTES4BITS(field_length)) {
+			pad_chars = BYTES4BITS(field_length) - datalen;
 
 			memset(sbuf, 0, pad_chars);
 		}

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4635,7 +4635,7 @@ piv_compute_signature(sc_card_t *card, const u8 * data, size_t datalen,
 	 */
 
 	if (priv->alg_id == 0x11 || priv->alg_id == 0x14 ) {
-		nLen = (priv->key_size + 7) / 8;
+		nLen = BYTES4BITS(priv->key_size);
 		if (outlen < 2*nLen) {
 			sc_log(card->ctx,
 					" output too small for EC signature %"SC_FORMAT_LEN_SIZE_T"u < %"SC_FORMAT_LEN_SIZE_T"u",

--- a/src/libopensc/card-setcos.c
+++ b/src/libopensc/card-setcos.c
@@ -1064,18 +1064,18 @@ static int setcos_generate_store_key(sc_card_t *card,
 
 	sbuf[len++] = data->pubexp_len / 256;   /* 2 bytes for pubexp bitlength */
 	sbuf[len++] = data->pubexp_len % 256;
-	memcpy(sbuf + len, data->pubexp, (data->pubexp_len + 7) / 8);
-	len += (data->pubexp_len + 7) / 8;
+	memcpy(sbuf + len, data->pubexp, BYTES4BITS(data->pubexp_len));
+	len += BYTES4BITS(data->pubexp_len);
 
 	if (data->op_type == OP_TYPE_STORE) {
 		sbuf[len++] = data->primep_len / 256;
 		sbuf[len++] = data->primep_len % 256;
-		memcpy(sbuf + len, data->primep, (data->primep_len + 7) / 8);
-		len += (data->primep_len + 7) / 8;
+		memcpy(sbuf + len, data->primep, BYTES4BITS(data->primep_len));
+		len += BYTES4BITS(data->primep_len);
 		sbuf[len++] = data->primeq_len / 256;
 		sbuf[len++] = data->primeq_len % 256;
-		memcpy(sbuf + len, data->primeq, (data->primeq_len + 7) / 8);
-		len += (data->primeq_len + 7) / 8;
+		memcpy(sbuf + len, data->primeq, BYTES4BITS(data->primeq_len));
+		len += BYTES4BITS(data->primeq_len);
 	}
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x46, 0x00, 0x00);

--- a/src/libopensc/padding.c
+++ b/src/libopensc/padding.c
@@ -480,7 +480,7 @@ static int sc_pkcs1_add_pss_padding(sc_context_t *scctx, unsigned int hash, unsi
 	EVP_MD_CTX* ctx = NULL;
 	u8 buf[8];
 	u8 salt[PSS_MAX_SALT_SIZE], mask[EVP_MAX_MD_SIZE];
-	size_t mod_length = (mod_bits + 7) / 8;
+	size_t mod_length = BYTES4BITS(mod_bits);
 
 	if (*out_len < mod_length)
 		return SC_ERROR_BUFFER_TOO_SMALL;
@@ -614,7 +614,7 @@ int sc_pkcs1_encode(sc_context_t *ctx, unsigned long flags,
 	size_t tmp_len = *out_len;
 	const u8    *tmp = in;
 	unsigned int hash_algo, pad_algo;
-	size_t mod_len = (mod_bits + 7) / 8;
+	size_t mod_len = BYTES4BITS(mod_bits);
 #ifdef ENABLE_OPENSSL
 	size_t sLen;
 	EVP_MD* md = NULL;

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -828,8 +828,8 @@ sc_pkcs15_convert_prkey(struct sc_pkcs15_prkey *pkcs15_key, void *evp_key)
 #endif
 
 		/* Octetstring may need leading zeros if BN is to short */
-		if (dst->privateD.len < (dst->params.field_length + 7) / 8)   {
-			size_t d = (dst->params.field_length + 7) / 8 - dst->privateD.len;
+		if (dst->privateD.len < BYTES4BITS(dst->params.field_length))   {
+			size_t d = BYTES4BITS(dst->params.field_length) - dst->privateD.len;
 
 			dst->privateD.data = realloc(dst->privateD.data, dst->privateD.len + d);
 			if (!dst->privateD.data)

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1369,7 +1369,7 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 
 	if (pk.len == 0)
 		LOG_TEST_GOTO_ERR(ctx, SC_ERROR_INTERNAL, "Incorrect length of key");
-	pk.len = (pk.len + 7)/8;	/* convert number of bits to bytes */
+	pk.len = BYTES4BITS(pk.len);	/* convert number of bits to bytes */
 
 	if (pk_alg.algorithm == SC_ALGORITHM_EC)   {
 		/* EC public key is not encapsulated into BIT STRING -- it's a BIT STRING */

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -370,8 +370,8 @@ int sc_pkcs15_derive(struct sc_pkcs15_card *p15card,
 	switch (obj->type) {
 		case SC_PKCS15_TYPE_PRKEY_EC:
 		case SC_PKCS15_TYPE_PRKEY_XEDDSA:
-			if (out == NULL || *poutlen < (prkey->field_length + 7) / 8) {
-				*poutlen = (prkey->field_length + 7) / 8;
+			if (out == NULL || *poutlen < BYTES4BITS(prkey->field_length)) {
+				*poutlen = BYTES4BITS(prkey->field_length);
 				r = 0; /* say no data to return */
 				LOG_FUNC_RETURN(ctx, r);
 			}
@@ -624,15 +624,15 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 
 	switch (obj->type) {
 		case SC_PKCS15_TYPE_PRKEY_RSA:
-			modlen = (prkey->modulus_length + 7) / 8;
+			modlen = BYTES4BITS(prkey->modulus_length);
 			break;
 		case SC_PKCS15_TYPE_PRKEY_GOSTR3410:
-			modlen = (prkey->modulus_length + 7) / 8 * 2;
+			modlen = BYTES4BITS(prkey->modulus_length) * 2;
 			break;
 		case SC_PKCS15_TYPE_PRKEY_EC:
 		case SC_PKCS15_TYPE_PRKEY_EDDSA:
 		case SC_PKCS15_TYPE_PRKEY_XEDDSA:
-			modlen = ((prkey->field_length +7) / 8) * 2;  /* 2*nLen */
+			modlen = BYTES4BITS(prkey->field_length) * 2;  /* 2*nLen */
 			break;
 		default:
 			LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Key type not supported");

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -26,6 +26,7 @@
 #include "common/compat_overflow.h"
 #include "common/constant-time.h"
 #include "sc-pkcs11.h"
+#include "libopensc/internal.h"
 
 /* Also used for verification data */
 struct hash_signature_info {
@@ -631,7 +632,7 @@ sc_pkcs11_signature_size(sc_pkcs11_operation_t *operation, CK_ULONG_PTR pLength)
 				rv = key->ops->get_attribute(operation->session, key, &attr);
 				/* convert bits to bytes */
 				if (rv == CKR_OK)
-					*pLength = (*pLength + 7) / 8;
+					*pLength = BYTES4BITS(*pLength);
 				break;
 			case CKK_EC:
 			case CKK_EC_EDWARDS:
@@ -639,12 +640,12 @@ sc_pkcs11_signature_size(sc_pkcs11_operation_t *operation, CK_ULONG_PTR pLength)
 				/* TODO: -DEE we should use something other then CKA_MODULUS_BITS... */
 				rv = key->ops->get_attribute(operation->session, key, &attr);
 				if (rv == CKR_OK)
-					*pLength = ((*pLength + 7)/8) * 2 ; /* 2*nLen in bytes */
+					*pLength = BYTES4BITS(*pLength) * 2 ; /* 2*nLen in bytes */
 				break;
 			case CKK_GOSTR3410:
 				rv = key->ops->get_attribute(operation->session, key, &attr);
 				if (rv == CKR_OK)
-					*pLength = (*pLength + 7) / 8 * 2;
+					*pLength = BYTES4BITS(*pLength) * 2;
 				break;
 			default:
 				rv = CKR_MECHANISM_INVALID;

--- a/src/pkcs15init/pkcs15-isoApplet.c
+++ b/src/pkcs15init/pkcs15-isoApplet.c
@@ -488,7 +488,7 @@ isoApplet_generate_key_ec(const sc_pkcs15_prkey_info_t *key_info, sc_card_t *car
 	args.pubkey.ec.params.coFactor.len			= curve->coFactor.len;
 	/* The length of the public key point will be:
 	 * Uncompressed tag + 2 * field length in bytes. */
-	args.pubkey.ec.ecPointQ.len = 1 + (key_info->field_length + 7) / 8 * 2;
+	args.pubkey.ec.ecPointQ.len = 1 + BYTES4BITS(key_info->field_length) * 2;
 	args.pubkey.ec.ecPointQ.value = malloc(args.pubkey.ec.ecPointQ.len);
 	if(!args.pubkey.ec.ecPointQ.value)
 	{

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -27,6 +27,7 @@
 
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
+#include "libopensc/internal.h"
 #include "libopensc/log.h"
 #include "pkcs15-init.h"
 #include "profile.h"
@@ -848,7 +849,7 @@ myeid_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 
 		if (object->type == SC_PKCS15_TYPE_PRKEY_RSA) {
 			pubkey->algorithm = SC_ALGORITHM_RSA;
-			pubkey->u.rsa.modulus.len = (keybits + 7) / 8;
+			pubkey->u.rsa.modulus.len = BYTES4BITS(keybits);
 			pubkey->u.rsa.modulus.data = malloc(pubkey->u.rsa.modulus.len);
 			pubkey->u.rsa.exponent.len = MYEID_DEFAULT_PUBKEY_LEN;
 			pubkey->u.rsa.exponent.data = malloc(MYEID_DEFAULT_PUBKEY_LEN);

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -26,6 +26,7 @@
 
 #include "libopensc/opensc.h"
 #include "libopensc/cardctl.h"
+#include "libopensc/internal.h"
 #include "libopensc/log.h"
 #include "pkcs15-init.h"
 #include "profile.h"
@@ -488,7 +489,7 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	/* Key pair generation -> collect public key info */
 	if (pubkey != NULL) {
 		pubkey->algorithm		= SC_ALGORITHM_RSA;
-		pubkey->u.rsa.modulus.len	= (keybits + 7) / 8;
+		pubkey->u.rsa.modulus.len	= BYTES4BITS(keybits);
 		pubkey->u.rsa.modulus.data	= malloc(pubkey->u.rsa.modulus.len);
 		pubkey->u.rsa.exponent.len	= SETCOS_DEFAULT_PUBKEY_LEN;
 		pubkey->u.rsa.exponent.data	= malloc(SETCOS_DEFAULT_PUBKEY_LEN);

--- a/src/tests/fuzzing/fuzz_pkcs15init.c
+++ b/src/tests/fuzzing/fuzz_pkcs15init.c
@@ -243,7 +243,7 @@ void do_store_secret_key(struct sc_profile *profile, struct sc_pkcs15_card *p15c
     sc_pkcs15_format_id("02", &(args.auth_id));
 
     for (int i = 0; i < 3; i++) {
-        size_t keybytes = (keybits[i] + 7) / 8;
+        size_t keybytes = BYTES4BITS(keybits[i]);
         args.key.data = malloc(keybytes);
         memcpy(args.key.data, buf, keybytes);
         args.key.data_len = keybytes;

--- a/src/tests/p11test/p11test_case_ec_derive.c
+++ b/src/tests/p11test/p11test_case_ec_derive.c
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "p11test_case_ec_derive.h"
+#include "libopensc/internal.h"
 
 size_t
 pkcs11_derive(test_cert_t *o, token_info_t * info,
@@ -31,7 +32,7 @@ pkcs11_derive(test_cert_t *o, token_info_t * info,
 	CK_OBJECT_HANDLE newkey;
 	CK_OBJECT_CLASS newkey_class = CKO_SECRET_KEY;
 	CK_KEY_TYPE newkey_type = CKK_GENERIC_SECRET;
-	CK_ULONG newkey_len = (o->bits + 7) / 8;
+	CK_ULONG newkey_len = BYTES4BITS(o->bits);
 	CK_BYTE newkey_id[] = {0x00, 0xff, 0x31};
 	CK_BYTE newkey_label[] = {"Derived key"};
 	CK_BBOOL _true = TRUE;

--- a/src/tests/p11test/p11test_case_ec_sign.c
+++ b/src/tests/p11test/p11test_case_ec_sign.c
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "p11test_case_ec_sign.h"
+#include "libopensc/internal.h"
 
 void ec_sign_size_test(void **state) {
 	unsigned int i;
@@ -45,7 +46,7 @@ void ec_sign_size_test(void **state) {
 		case CKK_EC:
 			/* This tests just couple of sizes around the curve length
 			 * to verify they are properly truncated on input */
-			curve_len = (objects.data[i].bits + 7) / 8;
+			curve_len = BYTES4BITS(objects.data[i].bits);
 			min = curve_len - 2;
 			max = curve_len + 2;
 			inc = 1;

--- a/src/tests/p11test/p11test_case_pss_oaep.c
+++ b/src/tests/p11test/p11test_case_pss_oaep.c
@@ -493,7 +493,7 @@ int oaep_encrypt_decrypt_test(test_cert_t *o, token_info_t *info, test_mech_t *m
 	}
 
 	message_length = MIN((int)global_message_length,
-		(int)((o->bits+7)/8 - 2*get_hash_length(mech->hash) - 2));
+		(int)(BYTES4BITS(o->bits) - 2 * get_hash_length(mech->hash) - 2));
 
 	/* will not work for 1024b RSA key and SHA512 hash: It has max size -2 */
 	if (message_length < 0) {
@@ -541,7 +541,7 @@ int oaep_encrypt_decrypt_test(test_cert_t *o, token_info_t *info, test_mech_t *m
 static unsigned long
 get_max_salt_len(unsigned long bits, CK_MECHANISM_TYPE hash)
 {
-	return (bits + 7)/8 - get_hash_length(hash) - 2;
+	return BYTES4BITS(bits) - get_hash_length(hash) - 2;
 }
 
 int fill_pss_params(CK_RSA_PKCS_PSS_PARAMS *pss_params,

--- a/src/tests/p11test/p11test_case_readonly.c
+++ b/src/tests/p11test/p11test_case_readonly.c
@@ -26,6 +26,7 @@
 #include <openssl/ripemd.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>
+#include "libopensc/internal.h"
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 # include <openssl/provider.h>
 #endif
@@ -64,7 +65,7 @@ const unsigned char *const_message = (unsigned char *) MESSAGE_TO_SIGN;
 unsigned char *
 rsa_x_509_pad_message(const unsigned char *message, unsigned long *message_length, test_cert_t *o, int encrypt)
 {
-	unsigned long pad_message_length = (o->bits+7)/8;
+	unsigned long pad_message_length = BYTES4BITS(o->bits);
 	unsigned char *pad_message = NULL;
 	size_t padding_len = pad_message_length - (*message_length) - 3;
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -67,6 +67,7 @@
 #include "pkcs11/pkcs11-opensc.h"
 #include "libopensc/asn1.h"
 #include "libopensc/log.h"
+#include "libopensc/internal.h"
 #include "common/compat_strlcat.h"
 #include "common/compat_strlcpy.h"
 #include "common/libpkcs11.h"
@@ -2353,7 +2354,7 @@ parse_pss_params(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 		if (opt_salt_len_given == 1) { /* salt size explicitly given */
 			unsigned long modlen = 0;
 
-			modlen = (get_private_key_length(session, key) + 7) / 8;
+			modlen = BYTES4BITS(get_private_key_length(session, key));
 			if (modlen == 0)
 				util_fatal("Incorrect length of private key");
 			switch (opt_salt_len) {
@@ -5284,7 +5285,7 @@ derive_ec_key(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key, CK_MECHANISM_TYPE
 #endif
 
 	/* both eckeys must be same curve */
-	key_len = (EC_GROUP_get_degree(ecgroup) + 7) / 8;
+	key_len = BYTES4BITS(EC_GROUP_get_degree(ecgroup));
 	FILL_ATTR(newkey_template[n_attrs], CKA_VALUE_LEN, &key_len, sizeof(key_len));
 	n_attrs++;
 
@@ -7306,7 +7307,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 			continue;
 		}
 
-		modLenBytes = (get_private_key_length(sess, privKeyObject) + 7) / 8;
+		modLenBytes = BYTES4BITS(get_private_key_length(sess, privKeyObject));
 		if(!modLenBytes) {
 			printf(" -- can't be used for signature, skipping: can't obtain modulus\n");
 			continue;
@@ -7499,7 +7500,7 @@ static int test_signature(CK_SESSION_HANDLE sess)
 		}
 
 		modLenBits = get_private_key_length(sess, privKeyObject);
-		modLenBytes = (modLenBits + 7) / 8;
+		modLenBytes = BYTES4BITS(modLenBits);
 		if (!modLenBytes)   {
 			printf(" -- can't be used to sign/verify, skipping: can't obtain modulus\n");
 			continue;
@@ -7664,7 +7665,7 @@ static int test_verify(CK_SESSION_HANDLE sess)
 			continue;
 		}
 
-		key_len = (get_private_key_length(sess, priv_key) + 7) / 8;
+		key_len = BYTES4BITS(get_private_key_length(sess, priv_key));
 		if (!key_len || key_len > INT_MAX) {
 			printf(" -- can't get the modulus length, skipping\n");
 			continue;
@@ -7894,7 +7895,7 @@ static int encrypt_decrypt(CK_SESSION_HANDLE session,
 	}
 	size_t in_len;
 	size_t max_in_len;
-	CK_ULONG mod_len = (get_private_key_length(session, privKeyObject) + 7) / 8;
+	CK_ULONG mod_len = BYTES4BITS(get_private_key_length(session, privKeyObject));
 	switch (mech_type) {
 	case CKM_RSA_PKCS:
 		pad = RSA_PKCS1_PADDING;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -1256,7 +1256,7 @@ do_store_secret_key(struct sc_profile *profile)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
-	r = do_read_data_object(opt_infile, &args.key.data, &args.key.data_len, (keybits+7) / 8);
+	r = do_read_data_object(opt_infile, &args.key.data, &args.key.data_len, BYTES4BITS(keybits));
 	if (r < 0) {
 		free(args.key.data);
 		return r;


### PR DESCRIPTION
'BYTES4BITS' is defined in 'libopensc/internal.c'

As suggested,in https://github.com/OpenSC/OpenSC/pull/3090#issuecomment-2459547719

All places in OpenSC that need to get number of bytes needed to hold some data bits i.e. 'bytes = (bits + 7) / 8;' will now use 'bytes = BYTES4BITS(bits);'

`#include "libopensc/internal.h"' was added to 7 of these files.

This command was used to find the lines which needed to be changed: find . -type d -name .svn -prune , -name .git -prune , -type f -name \*.c -exec \
    grep -E -n -e '[(].*+[[:blank:]]?7[[:blank:]]?[)]?[[:blank:]]?[/][[:blank:]]?8' {} \; -print

There are two other files that use 'Y = (X + 7) / 8;' but these are to alloc multiples of 8 bytes for SM padding bytes. These where not changed.

 On branch BYTES4BITS
 Changes to be committed:
	modified:   src/libopensc/asn1.c
	modified:   src/libopensc/card-eoi.c
	modified:   src/libopensc/card-isoApplet.c
	modified:   src/libopensc/card-myeid.c
	modified:   src/libopensc/card-piv.c
	modified:   src/libopensc/card-setcos.c
	modified:   src/libopensc/padding.c
	modified:   src/libopensc/pkcs15-prkey.c
	modified:   src/libopensc/pkcs15-pubkey.c
	modified:   src/libopensc/pkcs15-sec.c
	modified:   src/pkcs11/mechanism.c
	modified:   src/pkcs15init/pkcs15-isoApplet.c
	modified:   src/pkcs15init/pkcs15-myeid.c
	modified:   src/pkcs15init/pkcs15-setcos.c
	modified:   src/tests/fuzzing/fuzz_pkcs15init.c
	modified:   src/tests/p11test/p11test_case_ec_derive.c
	modified:   src/tests/p11test/p11test_case_ec_sign.c
	modified:   src/tests/p11test/p11test_case_pss_oaep.c
	modified:   src/tests/p11test/p11test_case_readonly.c
	modified:   src/tools/pkcs11-tool.c
	modified:   src/tools/pkcs15-init.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
