### PR TITLE
Update codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/.codeql.yml
@@ -39,6 +39,6 @@ jobs:
     - run: .github/build.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Fixes deprecation warnings.

`The following actions use a deprecated Node.js version and will be forced to run on node20: github/codeql-action/init@v2, github/codeql-action/analyze@v2.`
`CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3.`