### PR TITLE
card-iasecc.c - return SC_ERROR_INVALID_CARD

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -716,6 +716,7 @@ err:
 	if (rv < 0) {
 		free(private_data);
 		card->drv_data = old_drv_data;
+		rv = SC_ERROR_INVALID_CARD;
 	} else {
 		free(old_drv_data);
 	}

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -525,9 +525,6 @@ iasecc_init_oberthur(struct sc_card *card)
 
 	flags = IASECC_CARD_DEFAULT_FLAGS;
 
-	_sc_card_add_rsa_alg(card, 1024, flags, 0x10001);
-	_sc_card_add_rsa_alg(card, 2048, flags, 0x10001);
-
 	card->caps = IASECC_CARD_DEFAULT_CAPS;
 
 	iasecc_parse_ef_atr(card);
@@ -545,6 +542,9 @@ iasecc_init_oberthur(struct sc_card *card)
 
 	rv = iasecc_parse_ef_atr(card);
 	LOG_TEST_RET(ctx, rv, "EF.ATR read or parse error");
+
+	_sc_card_add_rsa_alg(card, 1024, flags, 0x10001);
+	_sc_card_add_rsa_alg(card, 2048, flags, 0x10001);
 
 	sc_log(ctx, "EF.ATR(aid:'%s')", sc_dump_hex(card->ef_atr->aid.value, card->ef_atr->aid.len));
 	LOG_FUNC_RETURN(ctx, rv);
@@ -588,9 +588,6 @@ iasecc_init_amos_or_sagem(struct sc_card *card)
 
 	flags = IASECC_CARD_DEFAULT_FLAGS;
 
-	_sc_card_add_rsa_alg(card, 1024, flags, 0x10001);
-	_sc_card_add_rsa_alg(card, 2048, flags, 0x10001);
-
 	card->caps = IASECC_CARD_DEFAULT_CAPS;
 
 	if (card->type == SC_CARD_TYPE_IASECC_MI)   {
@@ -609,6 +606,9 @@ iasecc_init_amos_or_sagem(struct sc_card *card)
 		rv = iasecc_parse_ef_atr(card);
 	}
 	LOG_TEST_RET(ctx, rv, "IASECC: ATR parse failed");
+
+	_sc_card_add_rsa_alg(card, 1024, flags, 0x10001);
+	_sc_card_add_rsa_alg(card, 2048, flags, 0x10001);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -640,14 +640,14 @@ iasecc_init_cpx(struct sc_card *card)
 
 	flags = IASECC_CARD_DEFAULT_FLAGS;
 
-	_sc_card_add_rsa_alg(card, 512, flags, 0);
-	_sc_card_add_rsa_alg(card, 1024, flags, 0);
-	_sc_card_add_rsa_alg(card, 2048, flags, 0);
-
 	rv = iasecc_parse_ef_atr(card);
 	if (rv)
 		sc_invalidate_cache(card); /* avoid memory leakage */
 	LOG_TEST_RET(ctx, rv, "Parse EF.ATR");
+
+	_sc_card_add_rsa_alg(card, 512, flags, 0);
+	_sc_card_add_rsa_alg(card, 1024, flags, 0);
+	_sc_card_add_rsa_alg(card, 2048, flags, 0);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }


### PR DESCRIPTION
If `iasecc_init` fails, return `SC_ERROR_INVALID_CARD` so `card.c` will try other drivers.

 On branch iasecc_init
 Changes to be committed:
	modified:   card-iasecc.c

Fixes #3265
  
 #3265  shows  `card-iasecc.c` matches an ATR, but the the same ATR may be for "Athena IDProtect Smart Card Logon Card" which may have an applet  supported by other drivers which use SELECT AID to identify applet.

Untested, as it requires a card with the  ATR  3B:DC:18:FF:81:91:FE:1F:C3:80:73:C8:21:13:66:01:0B:03:52:00:05:38  
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested

