### PR TITLE
sc_mem_secure_alloc: only lock requested length

### DIFF
--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -916,6 +916,7 @@ static void init_page_size()
 void *sc_mem_secure_alloc(size_t len)
 {
 	void *p;
+	size_t requested_len = len;
 
 	init_page_size();
 	if (page_size > 0) {
@@ -928,9 +929,9 @@ void *sc_mem_secure_alloc(size_t len)
 		return NULL;
 	}
 #ifdef _WIN32
-	VirtualLock(p, len);
+	VirtualLock(p, requested_len);
 #else
-	mlock(p, len);
+	mlock(p, requested_len);
 #endif
 
 	return p;


### PR DESCRIPTION
sc_mem_secure_alloc uses calloc to allocate memory, but then uses mlock to try to lock the allocated memory. calloc may not necessarily return a page-aligned pointer, even if we request a whole page of memory.

Instead of relying on the libc allocator behavior, we directly call mmap (VirtualAlloc on Windows) to ensure we get whole page(s) to ourselves for sc_mem_secure_alloc.

Fixes #3267

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS tokend is tested
