### PR TITLE
ci: Unbreak macos build

### DIFF
--- a/.github/setup-macos.sh
+++ b/.github/setup-macos.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-brew install automake gengetopt help2man pkgconfig libtool
+brew install automake gengetopt help2man libtool
 
 # openSCToken
 export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Seem like the pkg-config is already installed on the github images

inspired by latchset/pkcs11-provider#476