### PR TITLE
Allocate whole page(s) for each sc_mem_secure_alloc

### DIFF
--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2736,12 +2736,9 @@ sc_pkcs15_make_absolute_path(const struct sc_path *parent, struct sc_path *child
 
 void sc_pkcs15_free_object_content(struct sc_pkcs15_object *obj)
 {
-	if (obj->content.value && obj->content.len)   {
-		if (SC_PKCS15_TYPE_AUTH & obj->type
-			|| SC_PKCS15_TYPE_SKEY & obj->type
-			|| SC_PKCS15_TYPE_PRKEY & obj->type) {
-			/* clean everything that potentially contains a secret */
-			sc_mem_secure_clear_free(obj->content.value, obj->content.len);
+	if (obj->content.value && obj->content.len) {
+		if (obj->content_free) {
+			obj->content_free(obj->content.value, obj->content.len);
 		} else {
 			free(obj->content.value);
 		}
@@ -2772,6 +2769,7 @@ sc_pkcs15_allocate_object_content(struct sc_context *ctx, struct sc_pkcs15_objec
 			|| SC_PKCS15_TYPE_SKEY & obj->type
 			|| SC_PKCS15_TYPE_PRKEY & obj->type) {
 		tmp_buf = sc_mem_secure_alloc(len);
+		obj->content_free = sc_mem_secure_free;
 	} else {
 		tmp_buf = malloc(len);
 	}

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -486,6 +486,10 @@ struct sc_pkcs15_object {
 	struct sc_pkcs15_object *next, *prev; /* used only internally */
 
 	struct sc_pkcs15_der content;
+	/* Method for deallocating the object's content.value.
+	 * If no specific function for deallocation is given, then free() is used
+	 * to release content.value */
+	void (*content_free)(void *, size_t);
 
 	int session_object;	/* used internally. if nonzero, object is a session object. */
 };

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -902,14 +902,12 @@ void *sc_mem_secure_alloc(size_t len)
 
 #ifdef _WIN32
 	p = VirtualAlloc(NULL, len, MEM_COMMIT, PAGE_READWRITE);
-	if (p != NULL)
-	{
+	if (p != NULL) {
 		VirtualLock(p, len);
 	}
 #else
 	p = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	if (p != NULL)
-	{
+	if (p != NULL) {
 		mlock(p, len);
 	}
 #endif

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -54,7 +54,6 @@ static const char *sc_version = "(undef)";
 #define PAGESIZE 0
 #endif
 #endif
-static size_t page_size = PAGESIZE;
 
 const char *sc_get_version(void)
 {
@@ -897,40 +896,22 @@ int _sc_parse_atr(sc_reader_t *reader)
 	return SC_SUCCESS;
 }
 
-static void init_page_size()
-{
-	if (page_size == 0) {
-#ifdef _WIN32
-		SYSTEM_INFO system_info;
-		GetSystemInfo(&system_info);
-		page_size = system_info.dwPageSize;
-#else
-		page_size = sysconf(_SC_PAGESIZE);
-		if ((long) page_size < 0) {
-			page_size = 0;
-		}
-#endif
-	}
-}
-
 void *sc_mem_secure_alloc(size_t len)
 {
 	void *p;
 
-	init_page_size();
-	if (page_size > 0) {
-		size_t pages = (len + page_size - 1) / page_size;
-		len = pages * page_size;
-	}
-
-	p = calloc(1, len);
-	if (p == NULL) {
-		return NULL;
-	}
 #ifdef _WIN32
-	VirtualLock(p, len);
+	p = VirtualAlloc(NULL, len, MEM_COMMIT, PAGE_READWRITE);
+	if (p != NULL)
+	{
+		VirtualLock(p, len);
+	}
 #else
-	mlock(p, len);
+	p = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (p != NULL)
+	{
+		mlock(p, len);
+	}
 #endif
 
 	return p;
@@ -940,10 +921,11 @@ void sc_mem_secure_free(void *ptr, size_t len)
 {
 #ifdef _WIN32
 	VirtualUnlock(ptr, len);
+	VirtualFree(ptr, 0, MEM_RELEASE);
 #else
 	munlock(ptr, len);
+	munmap(ptr, len);
 #endif
-	free(ptr);
 }
 
 void sc_mem_clear(void *ptr, size_t len)


### PR DESCRIPTION
sc_mem_secure_alloc uses calloc to allocate memory, but then uses mlock to try to lock the allocated memory. calloc may not necessarily return a page-aligned pointer, even if we request a whole page of memory.

Instead of relying on the libc allocator behavior, we directly call mmap (VirtualAlloc on Windows) to ensure we get whole page(s) to ourselves for sc_mem_secure_alloc.

Fixes #3267

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
