### PR TITLE
fixed usage of free() on data that was created with sc_mem_secure_alloc

### DIFF
--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2736,12 +2736,9 @@ sc_pkcs15_make_absolute_path(const struct sc_path *parent, struct sc_path *child
 
 void sc_pkcs15_free_object_content(struct sc_pkcs15_object *obj)
 {
-	if (obj->content.value && obj->content.len)   {
-		if (SC_PKCS15_TYPE_AUTH & obj->type
-			|| SC_PKCS15_TYPE_SKEY & obj->type
-			|| SC_PKCS15_TYPE_PRKEY & obj->type) {
-			/* clean everything that potentially contains a secret */
-			sc_mem_secure_clear_free(obj->content.value, obj->content.len);
+	if (obj->content.value && obj->content.len) {
+		if (obj->content_free) {
+			obj->content_free(obj->content.value, obj->content.len);
 		} else {
 			free(obj->content.value);
 		}
@@ -2772,6 +2769,7 @@ sc_pkcs15_allocate_object_content(struct sc_context *ctx, struct sc_pkcs15_objec
 			|| SC_PKCS15_TYPE_SKEY & obj->type
 			|| SC_PKCS15_TYPE_PRKEY & obj->type) {
 		tmp_buf = sc_mem_secure_alloc(len);
+		obj->content_free = sc_mem_secure_free;
 	} else {
 		tmp_buf = malloc(len);
 	}

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -486,6 +486,10 @@ struct sc_pkcs15_object {
 	struct sc_pkcs15_object *next, *prev; /* used only internally */
 
 	struct sc_pkcs15_der content;
+	/* Method for deallocating the object's content.value.
+	 * If no specific function for deallocation is given, then free() is used
+	 * to release content.value */
+	void (*content_free)(void *, size_t);
 
 	int session_object;	/* used internally. if nonzero, object is a session object. */
 };


### PR DESCRIPTION
This will crash applications, which, for example are importing a private key as reported here
https://github.com/OpenSC/OpenSC/pull/3269#issuecomment-2495074344

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
