### PR TITLE
Remove obsolete tokend support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@ run this command: `opensc-tool -n`
 - [ ] New files have a LGPL 2.1 license statement
 - [ ] PKCS#11 module is tested
 - [ ] Windows minidriver is tested
-- [ ] macOS tokend is tested
+- [ ] macOS token is tested

--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,6 @@ MacOSX/resources/Welcome.html
 
 *.dmg
 *.pkg
-OpenSC.tokend/
 build/
 engine_pkcs11/
 libp11/

--- a/MacOSX/Distribution.xml.in
+++ b/MacOSX/Distribution.xml.in
@@ -11,32 +11,15 @@ https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/I
     <welcome file="Welcome.html" mime-type="text/html"/>
     <title>@PACKAGE_STRING@</title>
     <options customize="allow" require-scripts="false" rootVolumeOnly="true"/>
-    <script>
-      <![CDATA[
-    function osx_before_catalina() {
-      return system.compareVersions(system.version.ProductVersion, '10.15') < 0;
-    }
-    function osx_after_catalina() {
-      return system.compareVersions(system.version.ProductVersion, '10.15') >= 0;
-    }
-    function osx_after_yosemite() {
-      return system.compareVersions(system.version.ProductVersion, '10.12') >= 0;
-    }
-      ]]>
-    </script>
     <choices-outline>
         <line choice="default" />
         <line choice="startup" />
-        <line choice="tokend" />
         <line choice="token" />
     </choices-outline>
     <choice id="default" title="PKCS#11 module and smart card tools" enabled="false">
         <pkg-ref id="org.opensc-project.mac">OpenSC.pkg</pkg-ref>
     </choice>
-    <choice id="tokend" title="TokenD-based smart card driver" start_selected="osx_before_catalina()">
-        <pkg-ref id="org.opensc-project.tokend">OpenSC-tokend.pkg</pkg-ref>
-    </choice>
-    <choice id="token" title="CryptoTokenKit-based smart card driver" visible="osx_after_yosemite()" start_selected="osx_after_catalina()">
+    <choice id="token" title="CryptoTokenKit-based smart card driver">
         <pkg-ref id="org.opensc-project.mac.opensctoken">OpenSCToken.pkg</pkg-ref>
     </choice>
     <choice id="startup" title="Automatic startup items">

--- a/MacOSX/Distribution_universal.xml.in
+++ b/MacOSX/Distribution_universal.xml.in
@@ -11,32 +11,15 @@ https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/I
     <welcome file="Welcome.html" mime-type="text/html"/>
     <title>@PACKAGE_STRING@</title>
     <options customize="allow" hostArchitectures="arm64,x86_64" require-scripts="false" rootVolumeOnly="true"/>
-    <script>
-      <![CDATA[
-    function osx_before_catalina() {
-      return system.compareVersions(system.version.ProductVersion, '10.15') < 0;
-    }
-    function osx_after_catalina() {
-      return system.compareVersions(system.version.ProductVersion, '10.15') >= 0;
-    }
-    function osx_after_yosemite() {
-      return system.compareVersions(system.version.ProductVersion, '10.12') >= 0;
-    }
-      ]]>
-    </script>
     <choices-outline>
         <line choice="default" />
         <line choice="startup" />
-        <line choice="tokend" />
         <line choice="token" />
     </choices-outline>
     <choice id="default" title="PKCS#11 module and smart card tools" enabled="false">
         <pkg-ref id="org.opensc-project.mac">OpenSC.pkg</pkg-ref>
     </choice>
-    <choice id="tokend" title="TokenD-based smart card driver" start_selected="osx_before_catalina()">
-        <pkg-ref id="org.opensc-project.tokend">OpenSC-tokend.pkg</pkg-ref>
-    </choice>
-    <choice id="token" title="CryptoTokenKit-based smart card driver" visible="osx_after_yosemite()" start_selected="osx_after_catalina()">
+    <choice id="token" title="CryptoTokenKit-based smart card driver">
         <pkg-ref id="org.opensc-project.mac.opensctoken">OpenSCToken.pkg</pkg-ref>
     </choice>
     <choice id="startup" title="Automatic startup items">

--- a/MacOSX/build-package.in
+++ b/MacOSX/build-package.in
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build the macOS installer for the tokend and command line tools.
+# Build the macOS installer for the token and command line tools.
 #
 # This is only tested and supported on macOS 10.10 or later, using Xcode 6.0.1.
 # Building should also work on older macOS versions with slight changes; YMMV.
@@ -129,42 +129,6 @@ if test -n "${CODE_SIGN_IDENTITY}"; then
 fi
 
 
-# Build OpenSC.tokend when XCode version < 10
-if (( $(xcodebuild -version | sed -En 's/Xcode[[:space:]]+([0-9]+)(\.[0-9]*)*/\1/p') < 10 )); then
-	# Check out OpenSC.tokend, if not already fetched.
-	if ! test -e OpenSC.tokend; then
-		git clone https://github.com/OpenSC/OpenSC.tokend.git
-	fi
-
-	# Create the symlink to OpenSC sources
-	test -L OpenSC.tokend/build/opensc-src || ln -sf ${BUILDPATH}/src OpenSC.tokend/build/opensc-src
-
-	# Build and copy OpenSC.tokend
-	if test -n "${CODE_SIGN_IDENTITY}" -a -n "${DEVELOPMENT_TEAM}"; then
-		xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj install DSTROOT=${BUILDPATH}/target_tokend \
-		CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}" DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}" OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO CODE_SIGN_STYLE=Manual
-	else
-		xcodebuild -target OpenSC -configuration Deployment -project OpenSC.tokend/Tokend.xcodeproj install DSTROOT=${BUILDPATH}/target_tokend
-	fi
-
-	TOKEND="-tokend"
-else
-	# https://github.com/OpenSC/OpenSC.tokend/issues/33
-	mkdir -p ${BUILDPATH}/target_tokend
-	TOKEND=""
-fi
-
-#if ! test -e $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications/terminal-notifier.app; then
-	#if ! test -e terminal-notifier-1.7.1.zip; then
-		#curl -L https://github.com/julienXX/terminal-notifier/releases/download/1.7.1/terminal-notifier-1.7.1.zip > terminal-notifier-1.7.1.zip
-	#fi
-	#if ! test -e terminal-notifier-1.7.1; then
-		#unzip terminal-notifier-1.7.1.zip
-	#fi
-	#mkdir -p $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
-	#cp -r terminal-notifier-1.7.1/terminal-notifier.app $BUILDPATH/target/Library/Security/tokend/OpenSC.tokend/Contents/Resources/Applications
-#fi
-
 imagedir=$(mktemp -d)
 
 # Prepare target root
@@ -221,7 +185,6 @@ fi
 
 # Build package
 pkgbuild --root ${BUILDPATH}/target --component-plist MacOSX/target.plist --scripts MacOSX/scripts --identifier org.opensc-project.mac --version @PACKAGE_VERSION@ --install-location / OpenSC.pkg
-pkgbuild --root ${BUILDPATH}/target_tokend --component-plist MacOSX/target_tokend.plist --identifier org.opensc-project.tokend --version @PACKAGE_VERSION@ --install-location / OpenSC-tokend.pkg
 pkgbuild --root ${BUILDPATH}/target_token $COMPONENT_TOKEN --identifier org.opensc-project.mac.opensctoken --version @PACKAGE_VERSION@ --install-location / OpenSCToken.pkg
 pkgbuild --root ${BUILDPATH}/target_startup --component-plist MacOSX/target_startup.plist --identifier org.opensc-project.startup --version @PACKAGE_VERSION@ --install-location / OpenSC-startup.pkg
 
@@ -241,9 +204,9 @@ if test -n "${CODE_SIGN_IDENTITY}"; then
 fi
 
 # Create .dmg
-rm -f OpenSC-@PACKAGE_VERSION@$TOKEND.dmg
+rm -f OpenSC-@PACKAGE_VERSION@.dmg
 i=0
-while ! hdiutil create -srcfolder "${imagedir}" -volname "@PACKAGE_NAME@" -fs JHFS+ OpenSC-@PACKAGE_VERSION@$TOKEND.dmg
+while ! hdiutil create -srcfolder "${imagedir}" -volname "@PACKAGE_NAME@" -fs JHFS+ OpenSC-@PACKAGE_VERSION@.dmg
 do
 	i=$[$i+1]
 	if [ $i -gt 2 ]

--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -99,8 +99,6 @@ app <em class="replaceable"><code>application</code></em> {
 				</p></li><li class="listitem"><p>
 						<code class="literal">cardmod</code>: Configuration block for Windows' minidriver (<code class="filename">opensc-minidriver.dll</code>)
 				</p></li><li class="listitem"><p>
-						<code class="literal">tokend</code>: Configuration block for macOS' tokend (<span class="application">OpenSC.tokend</span>)
-				</p></li><li class="listitem"><p>
 						<code class="literal">cardos-tool</code>,
 						<code class="literal">cryptoflex-tool</code>,
 						<code class="literal">dnie-tool</code>,
@@ -352,8 +350,6 @@ app <em class="replaceable"><code>application</code></em> {
 						Internal configuration options where <em class="replaceable"><code>name</code></em> is one of:
 						</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem"><p>
 									<code class="literal">pkcs15</code>: See <a class="xref" href="#framework%20pkcs15" title="Configuration of PKCS#15 Framework">the section called “Configuration of PKCS#15 Framework”</a>
-							</p></li><li class="listitem"><p>
-									<code class="literal">tokend</code>: See <a class="xref" href="#framework%20tokend" title="Configuration of Tokend">the section called “Configuration of Tokend”</a>
 							</p></li></ul></div><p>
 					</p></dd><dt><span class="term">
 					<code class="option">pkcs11 {
@@ -887,8 +883,7 @@ app <em class="replaceable"><code>application</code></em> {
 								</p></li><li class="listitem"><p>
 										<code class="literal">ignore</code>: Ignore PIN-protected certificates.
 								</p></li></ul></div><p>
-							(Default: <code class="literal">ignore</code> in Tokend,
-							<code class="literal">protect</code> otherwise).
+							(Default: <code class="literal">protect</code>.
 					</p></dd><dt><span class="term">
 						<code class="option">enable_pkcs15_emulation = <em class="replaceable"><code>bool</code></em>;</code>
 					</span></dt><dd><p>
@@ -991,13 +986,7 @@ app <em class="replaceable"><code>application</code></em> {
 									<code class="option">sign_pin = <em class="replaceable"><code>name</code></em>;</code>
 								</span></dt><dd><p>
 									Name of the PIN object that will be used for signing.
-								</p></dd></dl></div></dd></dl></div></div><div class="refsect2"><a name="framework%20tokend"></a><h3>Configuration of Tokend</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
-						<code class="option">score = <em class="replaceable"><code>num</code></em>;</code>
-					</span></dt><dd><p>
-							Score for <span class="application">OpenSC.tokend</span>
-							(Default: <code class="literal">300</code>).  The tokend with
-							the highest score shall be used.
-					</p></dd></dl></div></div><div class="refsect2"><a name="pkcs11"></a><h3>Configuration of PKCS#11</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+								</p></dd></dl></div></dd></dl></div></div><div class="refsect2"><a name="pkcs11"></a><h3>Configuration of PKCS#11</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">max_virtual_slots = <em class="replaceable"><code>num</code></em>;</code>
 					</span></dt><dd><p>
 							Maximum Number of virtual slots (Default:

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -89,9 +89,6 @@ app <replaceable>application</replaceable> {
 						<literal>cardmod</literal>: Configuration block for Windows' minidriver (<filename>opensc-minidriver.dll</filename>)
 				</para></listitem>
 				<listitem><para>
-						<literal>tokend</literal>: Configuration block for macOS' tokend (<application>OpenSC.tokend</application>)
-				</para></listitem>
-				<listitem><para>
 						<literal>cardos-tool</literal>,
 						<literal>cryptoflex-tool</literal>,
 						<literal>dnie-tool</literal>,
@@ -480,9 +477,6 @@ app <replaceable>application</replaceable> {
 						<itemizedlist>
 							<listitem><para>
 									<literal>pkcs15</literal>: See <xref linkend="framework pkcs15"/>
-							</para></listitem>
-							<listitem><para>
-									<literal>tokend</literal>: See <xref linkend="framework tokend"/>
 							</para></listitem>
 						</itemizedlist>
 					</para>
@@ -1368,8 +1362,7 @@ app <replaceable>application</replaceable> {
 										<literal>ignore</literal>: Ignore PIN-protected certificates.
 								</para></listitem>
 							</itemizedlist>
-							(Default: <literal>ignore</literal> in Tokend,
-							<literal>protect</literal> otherwise).
+							(Default: <literal>protect</literal>.
 					</para></listitem>
 				</varlistentry>
 				<varlistentry>
@@ -1541,22 +1534,6 @@ app <replaceable>application</replaceable> {
 							</varlistentry>
 						</variablelist>
 					</listitem>
-				</varlistentry>
-			</variablelist>
-		</refsect2>
-
-		<refsect2 id="framework tokend">
-			<title>Configuration of Tokend</title>
-			<variablelist>
-				<varlistentry>
-					<term>
-						<option>score = <replaceable>num</replaceable>;</option>
-					</term>
-					<listitem><para>
-							Score for <application>OpenSC.tokend</application>
-							(Default: <literal>300</literal>).  The tokend with
-							the highest score shall be used.
-					</para></listitem>
 				</varlistentry>
 			</variablelist>
 		</refsect2>

--- a/etc/opensc.conf.example.in
+++ b/etc/opensc.conf.example.in
@@ -947,7 +947,7 @@ app default {
 
 		# How to handle a PIN-protected certificate
 		# Valid values: protect, declassify, ignore.
-		# Default: ignore in tokend, protect otherwise
+		# Default: protect
 		# pin_protected_certificate = declassify;
 
 		# Enable pkcs15 emulation.
@@ -1164,27 +1164,6 @@ app opensc-pkcs11 {
 app "C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe" {
 	pkcs11 {
 		slots_per_card = 1;
-	}
-}
-
-# Used by OpenSC.tokend on Mac OS X only
-app tokend {
-	# The file to which debug log will be written
-	# Default: /tmp/opensc-tokend.log
-	#
-	# debug_file = /Library/Logs/OpenSC.tokend.log
-
-	framework tokend {
-		# Score for OpenSC.tokend
-		# The tokend with the highest score shall be used.
-		# Default: 300
-		#
-		# score = 10;
-
-		# Tokend ignore to read PIN protected certificate that is set SC_PKCS15_CO_FLAG_PRIVATE flag.
-		# Default: true
-		#
-		# ignore_private_certificate = false;
 	}
 }
 

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -319,13 +319,6 @@ static void set_defaults(sc_context_t *ctx, struct _sc_ctx_options *opts)
 		fclose(ctx->debug_file);
 	ctx->debug_file = stderr;
 	ctx->flags = 0;
-
-#ifdef __APPLE__
-	/* Override the default debug log for OpenSC.tokend to be different from PKCS#11.
-	 * TODO: Could be moved to OpenSC.tokend */
-	if (!strcmp(ctx->app_name, "tokend"))
-		ctx->debug_file = fopen("/tmp/opensc-tokend.log", "a");
-#endif
 	ctx->forced_driver = NULL;
 	add_internal_drvs(opts);
 }

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1288,11 +1288,7 @@ sc_pkcs15_bind(struct sc_card *card, struct sc_aid *aid,
 	p15card->opts.use_pin_cache = 1;
 	p15card->opts.pin_cache_counter = 10;
 	p15card->opts.pin_cache_ignore_user_consent = 0;
-	if (0 == strcmp(ctx->app_name, "tokend")) {
-		pin_protected_certificate = "ignore";
-	} else {
-		pin_protected_certificate = "protect";
-	}
+	pin_protected_certificate = "protect";
 	private_certificate = "";
 
 	conf_block = sc_get_conf_block(ctx, "framework", "pkcs15", 1);

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -644,14 +644,6 @@ static int pcsc_connect(sc_reader_t *reader)
 		rv = priv->gpriv->SCardConnect(priv->gpriv->pcsc_ctx, reader->name,
 				priv->gpriv->connect_exclusive ? SCARD_SHARE_EXCLUSIVE : SCARD_SHARE_SHARED,
 				protocol, &card_handle, &active_proto);
-#ifdef __APPLE__
-		if (rv == (LONG)SCARD_E_SHARING_VIOLATION) {
-			sleep(1); /* Try again to compete with Tokend probes */
-			rv = priv->gpriv->SCardConnect(priv->gpriv->pcsc_ctx, reader->name,
-					priv->gpriv->connect_exclusive ? SCARD_SHARE_EXCLUSIVE : SCARD_SHARE_SHARED,
-					protocol, &card_handle, &active_proto);
-		}
-#endif
 		if (rv != SCARD_S_SUCCESS) {
 			PCSC_TRACE(reader, "SCardConnect failed", rv);
 			return pcsc_to_opensc_error(rv);

--- a/src/tests/fuzzing/corpus/fuzz_scconf_parse_string/497025125e0dfab0b9e16155ce16d6e25ec8ec6d
+++ b/src/tests/fuzzing/corpus/fuzz_scconf_parse_string/497025125e0dfab0b9e16155ce16d6e25ec8ec6d
@@ -169,14 +169,6 @@ app onepin-opensc-pkcs11 {
 	}
 }
 
-# Used by OpenSC.tokend on Mac OS X only
-app tokend {
-	framework tokend {
-		score = 10;
-		ignore_private_certificate = false;
-	}
-}
-
 # Used by OpenSC minidriver on Windows only
 app cardmod {
 }


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
