### PR TITLE
Fix some recent CI issues 

### DIFF
--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -2,7 +2,8 @@
 
 set -ex -o xtrace
 
-V=libressl-3.8.1
+# WARNING: Change this also in .github/workflows/linux.yml
+V=libressl-4.0.0
 
 sudo apt-get remove -y libssl-dev
 

--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -83,10 +83,10 @@ if [ "$1" == "libressl" -o "$2" == "libressl" ]; then
 	fi
 elif [ "$1" == "debug" -o "$2" == "debug" ]; then
 	# install debug symbols
-	$SUDO apt-get install -y lsb-core ubuntu-dbgsym-keyring
+	$SUDO apt-get install -y lsb-release ubuntu-dbgsym-keyring
 	echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
+deb http://ddebs.ubuntu.com $(lsb_release -cs 2> /dev/null)-updates main restricted universe multiverse
+deb http://ddebs.ubuntu.com $(lsb_release -cs 2> /dev/null)-proposed main restricted universe multiverse" | \
 	$SUDO tee -a /etc/apt/sources.list.d/ddebs.list
 	$SUDO apt-get update -qq
 	DEP="libssl1.1-dbgsym"

--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -91,9 +91,9 @@ deb http://ddebs.ubuntu.com $(lsb_release -cs 2> /dev/null)-proposed main restri
 	$SUDO apt-get update -qq
 	DEP="libssl1.1-dbgsym"
 	if [ -f "/usr/lib/x86_64-linux-gnu/libssl.so.3" ]; then
-		DEP="libssl3-dbgsym"
+		DEP="libssl3t64-dbgsym"
 	fi
-	$SUDO apt-get install -y openssl-dbgsym "$DEP" softhsm2-dbgsym
+	$SUDO apt-get install -y openssl-dbgsym "$DEP" softhsm2-dbgsym libsofthsm2-dbgsym
 fi
 
 if [ "$1" == "mingw" -o "$1" == "mingw32" ]; then

--- a/.github/test-cac.sh
+++ b/.github/test-cac.sh
@@ -23,6 +23,7 @@ sudo make install
 popd
 
 # prepare pcscd
+PCSCD_DEBUG="-d -a"
 . .github/restart-pcscd.sh
 
 # virt_cacard

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ env:
   JAVA_DEPS: |
     ant openjdk-8-jdk maven cmake
   JCARDSIM: https://github.com/Jakuje/jcardsim.git
-  LIBRESSL_VERSION: 3.8.1
+  LIBRESSL_VERSION: 4.0.0
 
 jobs:
   build:

--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -15,13 +15,21 @@ BuildRequires:  openssl-devel
 BuildRequires:  /usr/bin/xsltproc
 BuildRequires:  docbook-style-xsl
 BuildRequires:  autoconf automake libtool gcc
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
+BuildRequires:  bash-completion-devel
+%else
 BuildRequires:  bash-completion
+%endif
 BuildRequires:  zlib-ng-devel
 # For tests
 BuildRequires:  libcmocka-devel
 BuildRequires:  vim-common
+%if ! 0%{?rhel}
 BuildRequires:  softhsm
 BuildRequires:  openssl
+BuildRequires:  openpace-devel
+%endif
+Requires:       %{name}-libs = %{version}-%{release}
 Requires:       pcsc-lite-libs%{?_isa}
 Requires:       pcsc-lite
 Obsoletes:      mozilla-opensc-signer < 0.12.0
@@ -38,6 +46,13 @@ digital signatures. OpenSC implements the PKCS#11 API so applications
 supporting this API (such as Mozilla Firefox and Thunderbird) can use it. On
 the card OpenSC implements the PKCS#15 standard and aims to be compatible with
 every software/card that does so, too.
+
+%package        libs
+Requires:       pcsc-lite-libs%{?_isa}
+Summary:        OpenSC libraries
+
+%description    libs
+OpenSC libraries.
 
 
 %prep
@@ -56,7 +71,6 @@ sed -i -e "/XFAIL_TESTS/,$ {
   s/XFAIL_TESTS.*/XFAIL_TESTS=$XFAIL_TESTS/
   q
 }" tests/Makefile.am
-
 
 cp -p src/pkcs15init/README ./README.pkcs15init
 cp -p src/scconf/README.scconf .
@@ -116,9 +130,10 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libopensc.so
 rm -f $RPM_BUILD_ROOT%{_libdir}/pkgconfig/*.pc
 rm -f $RPM_BUILD_ROOT%{_libdir}/libsmm-local.so
 
-# the npa-tool builds to nothing since we do not have OpenPACE library
+%if 0%{?rhel}
 rm -rf %{buildroot}%{_bindir}/npa-tool
 rm -rf %{buildroot}%{_mandir}/man1/npa-tool.1*
+%endif
 
 # the pkcs11-register is not applicable to Fedora/RHEL where we use p11-kit
 rm -rf %{buildroot}%{_bindir}/pkcs11-register
@@ -134,24 +149,16 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 
 %{_datadir}/bash-completion/*
 
-%ifarch %{ix86}
-%{_mandir}/man5/opensc-%{_arch}.conf.5*
-%else
-%config(noreplace) %{_sysconfdir}/opensc.conf
-%{_mandir}/man5/opensc.conf.5*
-%endif
 
-%config(noreplace) %{_sysconfdir}/opensc-%{_arch}.conf
-# Co-owned with p11-kit so it is not hard dependency
-%dir %{_datadir}/p11-kit
-%dir %{_datadir}/p11-kit/modules
-%{_datadir}/p11-kit/modules/opensc.module
 %{_bindir}/cardos-tool
 %{_bindir}/cryptoflex-tool
 %{_bindir}/eidenv
 %{_bindir}/iasecc-tool
 %{_bindir}/gids-tool
 %{_bindir}/netkey-tool
+%if ! 0%{?rhel}
+%{_bindir}/npa-tool
+%endif
 %{_bindir}/openpgp-tool
 %{_bindir}/opensc-explorer
 %{_bindir}/opensc-tool
@@ -167,14 +174,6 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 %{_bindir}/egk-tool
 %{_bindir}/goid-tool
 %{_bindir}/dtrust-tool
-%{_libdir}/lib*.so.*
-%{_libdir}/opensc-pkcs11.so
-%{_libdir}/pkcs11-spy.so
-%{_libdir}/onepin-opensc-pkcs11.so
-%dir %{_libdir}/pkcs11
-%{_libdir}/pkcs11/opensc-pkcs11.so
-%{_libdir}/pkcs11/onepin-opensc-pkcs11.so
-%{_libdir}/pkcs11/pkcs11-spy.so
 %{_datadir}/opensc/
 %{_mandir}/man1/cardos-tool.1*
 %{_mandir}/man1/cryptoflex-tool.1*
@@ -183,6 +182,9 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 %{_mandir}/man1/goid-tool.1*
 %{_mandir}/man1/iasecc-tool.1*
 %{_mandir}/man1/netkey-tool.1*
+%if ! 0%{?rhel}
+%{_mandir}/man1/npa-tool.1*
+%endif
 %{_mandir}/man1/openpgp-tool.1*
 %{_mandir}/man1/opensc-explorer.*
 %{_mandir}/man1/opensc-tool.1*
@@ -198,3 +200,31 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 %{_mandir}/man1/egk-tool.1*
 %{_mandir}/man1/dtrust-tool.1*
 %{_mandir}/man5/pkcs15-profile.5*
+
+%files libs
+%ifarch %{ix86}
+%{_mandir}/man5/opensc-%{_arch}.conf.5*
+%else
+%config(noreplace) %{_sysconfdir}/opensc.conf
+%{_mandir}/man5/opensc.conf.5*
+%endif
+
+%config(noreplace) %{_sysconfdir}/opensc-%{_arch}.conf
+# Co-owned with p11-kit so it is not hard dependency
+%dir %{_datadir}/p11-kit
+%dir %{_datadir}/p11-kit/modules
+%{_datadir}/p11-kit/modules/opensc.module
+%{_libdir}/lib*.so.*
+%{_libdir}/opensc-pkcs11.so
+%{_libdir}/pkcs11-spy.so
+%{_libdir}/onepin-opensc-pkcs11.so
+%dir %{_libdir}/pkcs11
+%{_libdir}/pkcs11/opensc-pkcs11.so
+%{_libdir}/pkcs11/onepin-opensc-pkcs11.so
+%{_libdir}/pkcs11/pkcs11-spy.so
+
+# For OpenPACE
+%if ! 0%{?rhel}
+%config(noreplace) %{_sysconfdir}/eac/cvc/DESCHSMCVCA00001
+%config(noreplace) %{_sysconfdir}/eac/cvc/DESRCACC100001
+%endif


### PR DESCRIPTION
This is attempt to fix recent CI failures:
 * ubuntu changes broke valgrind builds
 * Fedora spec file is out of sync
 
Remaining issues look like related to libressl

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
