### PR TITLE
build: use forward slashes to compile resources on Windows

### DIFF
--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -50,6 +50,7 @@
 
 #include "internal.h"
 
+
 static void sc_do_log_va(sc_context_t *ctx, int level, const char *file, int line, const char *func, int color, const char *format, va_list args);
 static int sc_color_fprintf_va(int colors, struct sc_context *ctx, FILE * stream, const char *format, va_list args);
 

--- a/src/minidriver/versioninfo-minidriver.rc.in
+++ b/src/minidriver/versioninfo-minidriver.rc.in
@@ -4,11 +4,7 @@
 /* defined twice: in resource file and in source code */
 #define IDI_SMARTCARD       102
 
-#ifndef __MINGW32__
-IDI_SMARTCARD          ICON                    "..\\..\\win32\\DDORes.dll_14_2302.ico"
-#else
 IDI_SMARTCARD          ICON                    "../../win32/DDORes.dll_14_2302.ico"
-#endif
 
 VS_VERSION_INFO VERSIONINFO
 	FILEVERSION @OPENSC_VERSION_MAJOR@,@OPENSC_VERSION_MINOR@,@OPENSC_VERSION_FIX@,@OPENSC_VERSION_REVISION@

--- a/src/tools/versioninfo-opensc-notify.rc.in
+++ b/src/tools/versioninfo-opensc-notify.rc.in
@@ -4,11 +4,7 @@
 /* defined twice: in resource file and in source code */
 #define IDI_SMARTCARD       102
 
-#ifndef __MINGW32__
-IDI_SMARTCARD          ICON                    "..\\..\\win32\\DDORes.dll_14_2302.ico"
-#else
 IDI_SMARTCARD          ICON                    "../../win32/DDORes.dll_14_2302.ico"
-#endif
 
 VS_VERSION_INFO VERSIONINFO
 	FILEVERSION @OPENSC_VERSION_MAJOR@,@OPENSC_VERSION_MINOR@,@OPENSC_VERSION_FIX@,@OPENSC_VERSION_REVISION@


### PR DESCRIPTION
Contains fake modification of `log.c` to trigger CI.