### PR TITLE
Fix -O3 gcc optimization failure on amd64 and ppc64el

### DIFF
--- a/src/libopensc/card-atrust-acos.c
+++ b/src/libopensc/card-atrust-acos.c
@@ -426,7 +426,7 @@ static int atrust_acos_select_file(struct sc_card *card,
 	else if (in_path->type == SC_PATH_TYPE_PATH)
 	{
 		u8 n_pathbuf[SC_MAX_PATH_SIZE];
-		int bMatch = -1;
+		size_t bMatch = 0;
 
 		/* Select with path (sequence of File-IDs) */
 		/* ACOS only supports one
@@ -463,8 +463,7 @@ static int atrust_acos_select_file(struct sc_card *card,
 					bMatch += 2;
 		}
 
-		if ( card->cache.valid && bMatch >= 0 )
-		{
+		if (card->cache.valid && bMatch > 2) {
 			if ( pathlen - bMatch == 2 )
 				/* we are in the right directory */
 				return atrust_acos_select_fid(card, path[bMatch], path[bMatch+1], file_out);
@@ -507,9 +506,7 @@ static int atrust_acos_select_file(struct sc_card *card,
 				/* nothing left to do */
 				return SC_SUCCESS;
 			}
-		}
-		else
-		{
+		} else {
 			/* no usable cache */
 			for ( i=0; i<pathlen-2; i+=2 )
 			{

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -582,7 +582,7 @@ static int entersafe_select_path(sc_card_t *card,
 	u8 n_pathbuf[SC_MAX_PATH_SIZE];
 	const u8 *path = pathbuf;
 	size_t pathlen = len;
-	int bMatch = -1;
+	size_t bMatch = 0;
 	unsigned int i;
 	int r;
 

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2009,7 +2009,7 @@ epass2003_select_path(struct sc_card *card, const u8 pathbuf[16], const size_t l
 	u8 n_pathbuf[SC_MAX_PATH_SIZE];
 	const u8 *path = pathbuf;
 	size_t pathlen = len;
-	int bMatch = -1;
+	size_t bMatch = 0;
 	unsigned int i;
 	int r;
 


### PR DESCRIPTION
convert int bMatch = -1 into size_t bMatch = 0, this fixes errors such as: card-entersafe.c: In function ‘entersafe_select_file’: card-entersafe.c:649:28: error: ‘__memcpy_chk’ writing between 18446744073709551608 and 18446744073709551613 bytes into a region of size 64 [-Werror=stringop-overflow=]
  649 |                            memcpy(new_path.value, &(path[bMatch+2]), new_path.len);
      |                            ^
card-entersafe.c:639:38: note: destination object ‘new_path’ of size 64
  639 |                            sc_path_t new_path;
      |                                      ^~~~~~~~
/bin/bash ../../libtool  --tag=CC --tag CC  --mode=compile gcc -DHAVE_CONFIG_H -I. -I../..  -D'OPENSC_CONF_PATH="/etc/opensc/opensc.conf"' -D'DEFAULT_SM_MODULE_PATH="/usr/lib/powerpc64le-linux-gnu"' -D'DEFAULT_SM_MODULE="libsmm-local.so"' -I../../src -Wdate-time -D_FORTIFY_SOURCE=3    -I/usr/include/PCSC   -Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 -g -O3 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-stack-clash-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/opensc-0.25.1-2 -Wno-error=maybe-uninitialized -c -o libopensc_la-card-coolkey.lo `test -f 'card-coolkey.c' || echo './'`card-coolkey.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -DOPENSC_CONF_PATH=\"/etc/opensc/opensc.conf\" -DDEFAULT_SM_MODULE_PATH=\"/usr/lib/powerpc64le-linux-gnu\" -DDEFAULT_SM_MODULE=\"libsmm-local.so\" -I../../src -Wdate-time -D_FORTIFY_SOURCE=3 -I/usr/include/PCSC -Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 -g -O3 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-stack-clash-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/opensc-0.25.1-2 -Wno-error=maybe-uninitialized -c card-coolkey.c  -fPIC -DPIC -o .libs/libopensc_la-card-coolkey.o
cc1: all warnings being treated as errors
make[4]: *** [Makefile:1756: libopensc_la-card-entersafe.lo] Error 1
make[4]: *** Waiting for unfinished jobs....
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -DOPENSC_CONF_PATH=\"/etc/opensc/opensc.conf\" -DDEFAULT_SM_MODULE_PATH=\"/usr/lib/powerpc64le-linux-gnu\" -DDEFAULT_SM_MODULE=\"libsmm-local.so\" -I../../src -Wdate-time -D_FORTIFY_SOURCE=3 -I/usr/include/PCSC -Wall -Wextra -Wno-unused-parameter -Werror -Wstrict-aliasing=2 -g -O3 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-stack-clash-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/opensc-0.25.1-2 -Wno-error=maybe-uninitialized -c card-coolkey.c -o libopensc_la-card-coolkey.o >/dev/null 2>&1
In file included from /usr/include/string.h:548,
                 from card-epass2003.c:30:
In function ‘memcpy’,
    inlined from ‘epass2003_select_path’ at card-epass2003.c:2080:4,
    inlined from ‘epass2003_select_file’ at card-epass2003.c:2148:10:
/usr/include/powerpc64le-linux-gnu/bits/string_fortified.h:29:10: error: ‘__memcpy_chk’ specified bound between 18446744073709551608 and 18446744073709551613 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[4]: *** [Makefile:1763: libopensc_la-card-epass2003.lo] Error 1
make[4]: Leaving directory '/<<PKGBUILDDIR>>/src/libopensc'
make[3]: *** [Makefile:483: all-recursive] Error 1
make[3]: Leaving directory '/<<PKGBUILDDIR>>/src'
make[2]: *** [Makefile:626: all-recursive] Error 1

Fix: #3243

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
