### PR TITLE
Fix corner case of counting duplicate symbols

### DIFF
--- a/tests/test-duplicate-symbols.sh
+++ b/tests/test-duplicate-symbols.sh
@@ -6,7 +6,7 @@ EXPORTS=`find "${SOURCE_PATH}" -name "*exports"`
 ERRORS=0
 for E in $EXPORTS; do
 	DUPES=`sort $E | uniq -d`
-	NUM_DUPES=`echo -n "$DUPES" | wc -l`
+	NUM_DUPES=`sort $E | uniq -d | wc -l`
 	if [ $NUM_DUPES -gt 0 ]; then
 		echo "There are $NUM_DUPES duplicate symbols in '$E': $DUPES"
 		ERRORS=1


### PR DESCRIPTION
This was working correctly until d5dea2dd1b3a412adace25ee8a9ff2e73a97508a.

Fixes: #3298
