### PR TITLE
pkcs11-tool: Fix format string

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2447,7 +2447,7 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		util_fatal("Cannot read from %s: %m", opt_input);
 
 	if (opt_mechanism == CKM_RSA_PKCS_PSS && (size_t)sz != hashlen) {
-		util_fatal("For %s mechanism, message size (got %z bytes) "
+		util_fatal("For %s mechanism, message size (got %zd bytes) "
 			"must be equal to specified digest length (%lu)\n",
 			p11_mechanism_to_name(opt_mechanism), sz, hashlen);
 	} else if (opt_mechanism == CKM_AES_CMAC_GENERAL) {
@@ -2653,7 +2653,7 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		util_fatal("Cannot read from %s: %m", opt_input);
 
 	if (opt_mechanism == CKM_RSA_PKCS_PSS && (size_t)sz != hashlen) {
-		util_fatal("For %s mechanism, message size (got %z bytes)"
+		util_fatal("For %s mechanism, message size (got %zd bytes)"
 			" must be equal to specified digest length (%lu)\n",
 			p11_mechanism_to_name(opt_mechanism), sz, hashlen);
 	} else if (opt_mechanism == CKM_AES_CMAC_GENERAL) {


### PR DESCRIPTION
This is fixup of c3b4ecc5a1d58e02be44538e48a383f86e2eee80 where I did the formatting string of `ssize_t` wrong. Accidentally noticed today while using pkcs11-tool.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
