### PR TITLE
Use X509_NAME_print_ex() instead of X509_NAME_print()

### DIFF
--- a/src/pkcs11/pkcs11-display.c
+++ b/src/pkcs11/pkcs11-display.c
@@ -201,7 +201,7 @@ print_dn(FILE *f, CK_LONG type, CK_VOID_PTR value, CK_ULONG size, CK_VOID_PTR ar
 			BIO *bio = BIO_new(BIO_s_file());
 			BIO_set_fp(bio, f, 0);
 			fprintf(f, "    DN: ");
-			X509_NAME_print(bio, name, XN_FLAG_RFC2253);
+			X509_NAME_print_ex(bio, name, 0, XN_FLAG_RFC2253);
 			fprintf(f, "\n");
 			BIO_free(bio);
 		}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5924,7 +5924,7 @@ static void show_cert(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 			BIO *bio = BIO_new(BIO_s_file());
 			BIO_set_fp(bio, stdout, BIO_NOCLOSE);
 			printf("  subject:    DN: ");
-			X509_NAME_print(bio, name, XN_FLAG_RFC2253);
+			X509_NAME_print_ex(bio, name, 0, XN_FLAG_RFC2253);
 			printf("\n");
 			BIO_free(bio);
 			X509_NAME_free(name);


### PR DESCRIPTION
The third argument of X509_NAME_print() is obase and is intended as indentation level. This never worked though. From the flag value XN_FLAG_RFC2253 it is clear that the use of X509_NAME_print_ex() was intended. Use this instead.

https://docs.openssl.org/3.4/man3/X509_NAME_print_ex/