### PR TITLE
Add supports for belpic applet version 1.8

### DIFF
--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -146,15 +146,15 @@ static long t1, t2, tot_read = 0, tot_dur = 0, dur;
 static size_t next_idx = (size_t)-1;
 
 static const struct sc_atr_table belpic_atrs[] = {
-	/* Applet V1.8 */
-	{ "3B:7F:96:00:00:80:31:80:65:B0:85:04:01:20:12:0F:FF:82:90:00", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
-	/* Applet V1.1 */
-	{ "3B:98:13:40:0A:A5:03:01:01:01:AD:13:11", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
-	/* Applet V1.0 with new EMV-compatible ATR */
-	{ "3B:98:94:40:0A:A5:03:01:01:01:AD:13:10", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
-	/* Applet beta 5 + V1.0 */
-	{ "3B:98:94:40:FF:A5:03:01:01:01:AD:13:10", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL },
-	{ NULL, NULL, NULL, 0, 0, NULL }
+		/* Applet V1.8 */
+		{"3B:7F:96:00:00:80:31:80:65:B0:85:04:01:20:12:0F:FF:82:90:00", NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL},
+		/* Applet V1.1 */
+		{"3B:98:13:40:0A:A5:03:01:01:01:AD:13:11",			   NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL},
+		/* Applet V1.0 with new EMV-compatible ATR */
+		{"3B:98:94:40:0A:A5:03:01:01:01:AD:13:10",			   NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL},
+		/* Applet beta 5 + V1.0 */
+		{"3B:98:94:40:FF:A5:03:01:01:01:AD:13:10",			   NULL, NULL, SC_CARD_TYPE_BELPIC_EID, 0, NULL},
+		{NULL,							  NULL, NULL, 0,			      0, NULL}
 };
 
 static struct sc_card_operations belpic_ops;


### PR DESCRIPTION
This version of the applet only supports ECDSA keys

Documentation of the applet can be found at:
https://github.com/Fedict/eid-mw/tree/master/doc/sdk/documentation/Applet%201.8%20eID%20Cards

Fixes: #3308

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
