### PR TITLE
setup-linux.sh - get package name  to load the -dbgsym libs for OpenSSL 

### DIFF
--- a/.github/setup-linux.sh
+++ b/.github/setup-linux.sh
@@ -91,7 +91,9 @@ deb http://ddebs.ubuntu.com $(lsb_release -cs 2> /dev/null)-proposed main restri
 	$SUDO apt-get update -qq
 	DEP="libssl1.1-dbgsym"
 	if [ -f "/usr/lib/x86_64-linux-gnu/libssl.so.3" ]; then
-		DEP="libssl3t64-dbgsym"
+#		libcrypto is in same package as libssl
+		DEPX=`dpkg -S "/usr/lib/x86_64-linux-gnu/libssl.so.3"`
+		DEP="${DEPX%%:*}-dbgsym"
 	fi
 	$SUDO apt-get install -y openssl-dbgsym "$DEP" softhsm2-dbgsym libsofthsm2-dbgsym
 fi


### PR DESCRIPTION
Use the same OpenSSL package names as installed for libs. Newer versions of debian based OS use a different naming convention for libs then older versions. 

`dpkg -S` is used to find the package name for the OpenSSL libs to load the `<package>-dbgsym` files.
The libcrypto and libssl are both in the same package. 

This also fixes the other actions that depend on setup-linux.sh  loading the dbgsym libs.
 
The `test-oseid-libressl` still fails but this appears to be problem within libressl with PSS saltlen 

 On branch github-setup
 Changes to be committed:
	modified:   setup-linux.sh

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
