### PR TITLE
OpenSC 0.26.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.26.0.{build}
+version: 0.26.1.{build}
 
 platform:
   - x86

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,17 @@
 NEWS for OpenSC -- History of user visible changes
 
+# New in 0.26.1; 2025-01-14
+
+## General improvements
+* Align allocations of sc_mem_secure_alloc (#3281)
+* Fix -O3 gcc optimization failure on amd64 and ppc64el (#3299)
+
+## pkcs11-spy
+* Avoid crash while spying C_GetInterface() (#3275)
+
+## TCOS
+* Fix reading certificate (#3296)
+
 # New in 0.26.0; 2024-11-13
 
 ## Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ backport security fixes into them. Only the last release is supported.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 0.26.0   | :white_check_mark: |
-| < 0.26.0 | :x:                |
+| 0.26.1   | :white_check_mark: |
+| < 0.26.1 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ define([PRODUCT_BUGREPORT], [https://github.com/OpenSC/OpenSC/issues])
 define([PRODUCT_URL], [https://github.com/OpenSC/OpenSC])
 define([PACKAGE_VERSION_MAJOR], [0])
 define([PACKAGE_VERSION_MINOR], [26])
-define([PACKAGE_VERSION_FIX], [0])
+define([PACKAGE_VERSION_FIX], [1])
 define([PACKAGE_SUFFIX], [])
 
 define([VS_FF_LEGAL_COPYRIGHT], [OpenSC Project])
@@ -48,7 +48,7 @@ OPENSC_VS_FF_PRODUCT_URL="VS_FF_PRODUCT_URL"
 #   (Interfaces added:                  CURRENT++, REVISION=0)
 OPENSC_LT_CURRENT="12"
 OPENSC_LT_OLDEST="12"
-OPENSC_LT_REVISION="1"
+OPENSC_LT_REVISION="2"
 OPENSC_LT_AGE="$((${OPENSC_LT_CURRENT}-${OPENSC_LT_OLDEST}))"
 
 AC_CONFIG_SRCDIR([src/libopensc/sc.c])


### PR DESCRIPTION
The stable branch for 0.26.1: https://github.com/OpenSC/OpenSC/tree/0.26.1

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
