### PR TITLE
From  Jakub Jelen <jakuje@gmail.com>

### DIFF
--- a/src/libopensc/card-atrust-acos.c
+++ b/src/libopensc/card-atrust-acos.c
@@ -456,7 +456,6 @@ static int atrust_acos_select_file(struct sc_card *card,
 		    && card->cache.current_path.len >= 2
 		    && card->cache.current_path.len <= pathlen )
 		{
-			bMatch = 0;
 			for (i=0; i < card->cache.current_path.len; i+=2)
 				if (card->cache.current_path.value[i] == path[i]
 				    && card->cache.current_path.value[i+1] == path[i+1] )

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -607,7 +607,6 @@ static int entersafe_select_path(sc_card_t *card,
 			card->cache.current_path.type == SC_PATH_TYPE_PATH &&
 			card->cache.current_path.len >= 2 &&
 			card->cache.current_path.len <= pathlen) {
-		bMatch = 0;
 		for (i = 0; i < card->cache.current_path.len; i += 2) {
 			if (card->cache.current_path.value[i] == path[i] &&
 					card->cache.current_path.value[i + 1] == path[i + 1]) {

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -2034,7 +2034,6 @@ epass2003_select_path(struct sc_card *card, const u8 pathbuf[16], const size_t l
 			&& card->cache.current_path.type == SC_PATH_TYPE_PATH
 			&& card->cache.current_path.len >= 2
 			&& card->cache.current_path.len <= pathlen) {
-		bMatch = 0;
 		for (i = 0; i < card->cache.current_path.len; i += 2)
 			if (card->cache.current_path.value[i] == path[i]
 					&& card->cache.current_path.value[i + 1] == path[i + 1])


### PR DESCRIPTION
on line 437 we assert the pathlen is 2 or 4 or 6
on line 440 we assert that if pathlen is 6, the first two bytes are 0x3F00 on line 444 we extend the 2 or 4 bytes paths to 4 or 6 bytes starting with 0x3F00 the line 459 is no-operation with your change. It should be removed if it keeps working as it should This line change semantics as previously we were heading here also when we had a cache, but first two bytes of path did not match. OTOH I think this should never happen as the path should always start with 0x3F00 so I believe this change is ok.

Just remove the line 459 to avoid confusion. Same in the other files, where similar construct exist.

https://github.com/OpenSC/OpenSC/pull/3299/files#r1899506106