### PR TITLE
pkcs11-tool: fix percent-encoding of id in pkcs11-uri

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -5861,9 +5861,9 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 	get_token_info(opt_slot, &info);
 	printf("  uri:        %s", get_uri(&info));
 	if (id != NULL && idsize) {
-		printf(";id=%%");
+		printf(";id=");
 		for (unsigned int n = 0; n < idsize; n++)
-			printf("%02x", id[n]);
+			printf("%%%02x", id[n]);
 		free(id);
 	}
 	if (label != NULL) {
@@ -5963,9 +5963,9 @@ static void show_cert(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 	get_token_info(opt_slot, &info);
 	printf("  uri:        %s", get_uri(&info));
 	if (id != NULL && size) {
-		printf(";id=%%");
+		printf(";id=");
 		for (unsigned int n = 0; n < size; n++)
-			printf("%02x", id[n]);
+			printf("%%%02x", id[n]);
 		free(id);
 	}
 	if (label != NULL) {


### PR DESCRIPTION
Fixes #3325

Tested with Rutoken ECP SC NFC

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
