### PR TITLE
pkcs11-register: Don't show terminal on Windows Autostart

### DIFF
--- a/src/tools/Makefile.mak
+++ b/src/tools/Makefile.mak
@@ -49,7 +49,7 @@ opensc-asn1.exe: opensc-asn1-cmdline.obj fread_to_eof.obj versioninfo-tools.res 
 
 pkcs11-register.exe: pkcs11-register-cmdline.obj fread_to_eof.obj $(LIBS)
 	cl $(COPTS) /c $*.c
-	link $(LINKFLAGS) /pdb:$*.pdb /out:$@ $*.obj pkcs11-register-cmdline.obj fread_to_eof.obj versioninfo-tools.res $(LIBS) gdi32.lib shell32.lib User32.lib ws2_32.lib shlwapi.lib
+	link $(LINKFLAGS) /subsystem:windows /pdb:$*.pdb /out:$@ $*.obj pkcs11-register-cmdline.obj fread_to_eof.obj versioninfo-tools.res $(LIBS) gdi32.lib shell32.lib User32.lib ws2_32.lib shlwapi.lib
 	mt -manifest exe.manifest -outputresource:$@;1
 
 pkcs15-tool.exe: pkcs15-tool.obj $(TOPDIR)\src\pkcs11\pkcs11-display.obj

--- a/src/tools/pkcs11-register.c
+++ b/src/tools/pkcs11-register.c
@@ -345,3 +345,11 @@ main(int argc, char **argv)
 
 	return 0;
 }
+
+#ifdef _WIN32
+int WINAPI
+WinMain(HINSTANCE hInstance, HINSTANCE prevInstance, LPSTR lpCmdLine, int nShowCmd)
+{
+	return main(__argc, __argv);
+}
+#endif


### PR DESCRIPTION
This PR is an alternate approach to #3218 suggested in https://github.com/OpenSC/OpenSC/pull/3218#issuecomment-2447863759. It sets the subsystem of `pkcs11-register` to `windows` to detach the application from the terminal.

This approach disables the terminal output at all, even if invoked from a command shell. To solve this issue one might compile `pkcs11-register.c` twice, one time with `/subsystem:windows` for the autostart usage and another time with `/subsystem:console` for command line usage.

Fixes #3217

##### Checklist

No items apply