### PR TITLE
feat(pkcs11-tool): add support for AES CTR

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2819,6 +2819,7 @@ typedef union
 	CK_GCM_PARAMS gcm;
 	CK_CHACHA20_PARAMS chacha20;
 	CK_SALSA20_CHACHA20_POLY1305_PARAMS chacha20poly1305;
+	CK_AES_CTR_PARAMS ctr;
 } params_t;
 
 static void
@@ -2859,6 +2860,16 @@ build_params(
 		params->gcm.ulTagBits = opt_tag_bits;
 		mech->pParameter = &params->gcm;
 		mech->ulParameterLen = sizeof(params->gcm);
+		break;
+	case CKM_AES_CTR:
+		*iv = hex_string_to_byte_array(opt_iv, &iv_size, "IV");
+		if (iv_size != 16U) {
+			util_fatal("Invalid IV length %zu", iv_size);
+		}
+		memcpy(&params->ctr.cb[0], *iv, sizeof(params->ctr.cb));
+		params->ctr.ulCounterBits = 128U;
+		mech->pParameter = &params->ctr;
+		mech->ulParameterLen = sizeof(params->ctr);
 		break;
 	case CKM_CHACHA20:
 		*iv = hex_string_to_byte_array(opt_iv, &iv_size, "IV");

--- a/tests/test-pkcs11-tool-sym-crypt-test.sh
+++ b/tests/test-pkcs11-tool-sym-crypt-test.sh
@@ -182,6 +182,26 @@ cmp gcm_vector_plain.data gcm_test_plain.data >/dev/null 2>&1
 assert $? "Fail, AES-GCM - wrong decrypt"
 
 echo "======================================================="
+echo " AES-CTR"
+echo " OpenSSL encrypt, pkcs11-tool decrypt"
+echo " pkcs11-tool encrypt, compare to openssl encrypt"
+echo "======================================================="
+
+openssl enc -aes-128-ctr -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+assert $? "Fail/OpenSSL"
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --decrypt --id "$ID2" -m AES-CTR --iv "${VECTOR}" \
+	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
+assert $? "Fail/pkcs11-tool decrypt"
+cmp aes_plain.data aes_plain_test.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CTR - wrong decrypt"
+
+$PKCS11_TOOL --module="$P11LIB" --pin "$PIN" --encrypt --id "$ID2" -m AES-CTR --iv "${VECTOR}" \
+	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
+assert $? "Fail/pkcs11-tool encrypt"
+cmp  aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+assert $? "Fail, AES-CTR - wrong encrypt"
+
+echo "======================================================="
 echo "Cleanup"
 echo "======================================================="
 softhsm_cleanup


### PR DESCRIPTION
Hi OpenSC team!

In this PR, I am adding the support for CKM_AES_CTR for the encrypt and decrypt options.
As you will see, the ulCounterBits is hard coded to 128 bits which is the only value supported by the HSM that I am using.
I could test the changes with the Trustonic TEE HSM and I could double check with OpenSSL3.

Regards,
Alexandre.