### PR TITLE
feat(pkcs11-tool): add support for ChaCha20 Poly1305

### DIFF
--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -148,7 +148,7 @@
 					</term>
 					<listitem><para>Specify the type and (not always compulsory) flavour (byte-wise symmetric key length, bit-wise asymmetric key length,
 					elliptic curve identifier, etc.) of the key to create, for example RSA:2048, EC:prime256v1, EC:ED25519, EC:X448, GOSTR3410-2012-256:B,
-					DES:8, DES3:24, AES:16, AES: or GENERIC:64. If the key type was incompletely specified, possible values are listed.</para></listitem>
+					DES:8, DES3:24, AES:16, AES:, CHACHA20, POLY1305 or GENERIC:64. If the key type was incompletely specified, possible values are listed.</para></listitem>
 				</varlistentry>
 
 				<varlistentry>
@@ -845,7 +845,7 @@ pkcs11-tool --login --wrap --id 75 --mechanism AES-CBC-PAD \
 				<programlisting>
 pkcs11-tool --login --unwrap --mechanism RSA-PKCS --id 22 \
 	-i aes_wrapped.key --key-type AES: \
-	--application-id 90 --applicatin-label unwrapped-key
+	--application-id 90 --application-label unwrapped-key
 				</programlisting>
 
 			Use the SO-PIN to initialize or re-set the PIN:

--- a/doc/tools/tools.html
+++ b/doc/tools/tools.html
@@ -1491,7 +1491,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						<code class="option">--key-type</code> <em class="replaceable"><code>specification</code></em>
 					</span></dt><dd><p>Specify the type and (not always compulsory) flavour (byte-wise symmetric key length, bit-wise asymmetric key length,
 					elliptic curve identifier, etc.) of the key to create, for example RSA:2048, EC:prime256v1, EC:ED25519, EC:X448, GOSTR3410-2012-256:B,
-					DES:8, DES3:24, AES:16, AES: or GENERIC:64. If the key type was incompletely specified, possible values are listed.</p></dd><dt><span class="term">
+					DES:8, DES3:24, AES:16, AES:, CHACHA20, POLY1305 or GENERIC:64. If the key type was incompletely specified, possible values are listed.</p></dd><dt><span class="term">
 						<code class="option">--usage-sign</code>
 					</span></dt><dd><p>Specify 'sign' key usage flag (sets SIGN in privkey, sets VERIFY in pubkey).</p></dd><dt><span class="term">
 						<code class="option">--usage-decrypt</code>
@@ -1824,7 +1824,7 @@ pkcs11-tool --login --wrap --id 75 --mechanism AES-CBC-PAD \
 				</p><pre class="programlisting">
 pkcs11-tool --login --unwrap --mechanism RSA-PKCS --id 22 \
 	-i aes_wrapped.key --key-type AES: \
-	--application-id 90 --applicatin-label unwrapped-key
+	--application-id 90 --application-label unwrapped-key
 				</pre><p>
 
 			Use the SO-PIN to initialize or re-set the PIN:

--- a/src/pkcs11/pkcs11.h
+++ b/src/pkcs11/pkcs11.h
@@ -370,6 +370,8 @@ typedef unsigned long ck_key_type_t;
 #define CKK_GOSTR3410		(0x30UL)
 #define CKK_GOSTR3411		(0x31UL)
 #define CKK_GOST28147		(0x32UL)
+#define CKK_CHACHA20		(0x33UL)
+#define CKK_POLY1305		(0x34UL)
 #define CKK_EC_EDWARDS		(0x40UL)
 #define CKK_EC_MONTGOMERY	(0x41UL)
 #define CKK_HKDF		(0x42UL)
@@ -802,6 +804,10 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_GOST28147           (0x1222UL)
 #define CKM_GOST28147_MAC       (0x1223UL)
 #define CKM_GOST28147_KEY_WRAP  (0x1224UL)
+#define CKM_CHACHA20_KEY_GEN    (0x1225UL)
+#define CKM_CHACHA20            (0x1226UL)
+#define CKM_POLY1305_KEY_GEN    (0x1227UL)
+#define CKM_POLY1305            (0x1228UL)
 
 #define CKM_DSA_PARAMETER_GEN		(0x2000UL)
 #define CKM_DH_PKCS_PARAMETER_GEN	(0x2001UL)
@@ -813,6 +819,7 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_AES_CFB1			(0x2108UL)
 #define CKM_AES_KEY_WRAP		(0x2109UL)
 #define CKM_AES_KEY_WRAP_PAD		(0x210AUL)
+#define CKM_CHACHA20_POLY1305		(0x4021UL)
 #define CKM_XEDDSA			(0x4029UL)
 #define CKM_HKDF_DERIVE			(0x402AUL)
 #define CKM_HKDF_DATA			(0x402BUL)
@@ -961,6 +968,20 @@ typedef struct CK_XEDDSA_PARAMS {
 } CK_XEDDSA_PARAMS;
 
 typedef CK_XEDDSA_PARAMS *CK_XEDDSA_PARAMS_PTR;
+
+typedef struct CK_CHACHA20_PARAMS {
+	unsigned char *pBlockCounter;
+	unsigned long blockCounterBits;
+	unsigned char *pNonce;
+	unsigned long ulNonceBits;
+} CK_CHACHA20_PARAMS;
+
+typedef struct CK_SALSA20_CHACHA20_POLY1305_PARAMS {
+	unsigned char *pNonce;
+	unsigned long ulNonceLen;
+	unsigned char *pAAD;
+	unsigned long ulAADLen;
+} CK_SALSA20_CHACHA20_POLY1305_PARAMS;
 
 typedef struct CK_AES_CTR_PARAMS {
     unsigned long ulCounterBits;


### PR DESCRIPTION
Hi OpenSC team!

In this PR, I am adding the support for Chacha20 and Poly1305.
This is adding 2 new key types: CKK_CHACHA20 and CKK_POLY1305.
These keys can be either generated with CKM_CHACHA20_KEY_GEN and CKM_POLY1305_KEY_GEN or imported.
CKM_CHACHA20 is for encryption, CKK_POLY1305 is for message authentication and CKM_CHACHA20_POLY1305 is for authenticated encryption.
For CKM_CHACHA20, the nonce and initial counter value are passed via the IV option (128-bit).
I decided to use by default 64-bit for the nonce and 64-bit for the initial counter value (Bernstein's original variant), like it is done in OpenSSL.
For CKM_CHACHA20_POLY1305, the nonce is given via the IV option and the AAD via the AAD option like we did for AES GCM.

I could test the changes with the Trustonic TEE HSM and I could double check with OpenSSL3.

Regards,
Alexandre.
