### PR TITLE
Fix Edwards and Montgomery "field_length"

### DIFF
--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1524,17 +1524,18 @@ static struct ec_curve_info {
 
 		/* OpenPGP extensions by Yubikey and GNUK are not defined in RFCs but we know the oid written to card */
 
-		{"edwards25519",	"1.3.6.1.4.1.11591.15.1", {(u8 *)"\x06\x09\x2B\x06\x01\x04\x01\xDA\x47\x0F\x01", 11}, 255, SC_ALGORITHM_EDDSA},
-		{"curve25519",		"1.3.6.1.4.1.3029.1.5.1", {(u8 *)"\x06\x0A\x2B\x06\x01\x04\x01\x97\x55\x01\x05\x01", 12}, 255, SC_ALGORITHM_XEDDSA},
+		{"edwards25519",	"1.3.6.1.4.1.11591.15.1", {(u8 *)"\x06\x09\x2B\x06\x01\x04\x01\xDA\x47\x0F\x01", 11}, 256, SC_ALGORITHM_EDDSA},
+		{"curve25519",		"1.3.6.1.4.1.3029.1.5.1", {(u8 *)"\x06\x0A\x2B\x06\x01\x04\x01\x97\x55\x01\x05\x01", 12}, 256, SC_ALGORITHM_XEDDSA},
 
 		/* RFC 8410 defined curves */
-		{"X25519",              "1.3.101.110", {(u8 *)"\x06\x03\x2b\x65\x6e", 5}, 255, SC_ALGORITHM_XEDDSA},
+		{"X25519",              "1.3.101.110", {(u8 *)"\x06\x03\x2b\x65\x6e", 5}, 256, SC_ALGORITHM_XEDDSA},
 		{"X448",		"1.3.101.111", {(u8 *)"\x06\x03\x2b\x65\x6f", 5}, 448, SC_ALGORITHM_XEDDSA},
-		{"Ed25519",             "1.3.101.112", {(u8 *)"\x06\x03\x2b\x65\x70", 5}, 255, SC_ALGORITHM_EDDSA},
-		{"Ed448",		"1.3.101.113", {(u8 *)"\x06\x03\x2b\x65\x71", 5}, 448, SC_ALGORITHM_EDDSA},
+		{"Ed25519",             "1.3.101.112", {(u8 *)"\x06\x03\x2b\x65\x70", 5}, 256, SC_ALGORITHM_EDDSA},
+		/* Ed448 needs extra byte thus 456 */
+		{"Ed448",		"1.3.101.113", {(u8 *)"\x06\x03\x2b\x65\x71", 5}, 456, SC_ALGORITHM_EDDSA},
 		/* GnuPG openpgp curves as used in gnupg-card are equivalent to RFC8410 OIDs */
-		{"cv25519",		"1.3.101.110", {(u8 *)"\x06\x03\x2b\x65\x6e", 5}, 255, SC_ALGORITHM_XEDDSA},
-		{"ed25519",		"1.3.101.112", {(u8 *)"\x06\x03\x2b\x65\x70", 5}, 255, SC_ALGORITHM_EDDSA},
+		{"cv25519",		"1.3.101.110", {(u8 *)"\x06\x03\x2b\x65\x6e", 5}, 256, SC_ALGORITHM_XEDDSA},
+		{"ed25519",		"1.3.101.112", {(u8 *)"\x06\x03\x2b\x65\x70", 5}, 256, SC_ALGORITHM_EDDSA},
 
 		{NULL, NULL, {NULL, 0}, 0, 0}, /* Do not touch this */
 };

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -2866,15 +2866,15 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 	}
 
 	if (key_type == CKK_EC_EDWARDS) {
-		if (ec->ecpointQ.len == BYTES4BITS(255))
+		if (ec->ecpointQ.len == BYTES4BITS(256))
 			ec->params.id = oid_ED25519;
-		else if (ec->ecpointQ.len == BYTES4BITS(448))
+		else if (ec->ecpointQ.len == BYTES4BITS(456)) /* note extra byte */
 			ec->params.id = oid_ED448;
 		else
 			return CKR_ATTRIBUTE_VALUE_INVALID;
 
 	} else if (key_type == CKK_EC_MONTGOMERY) {
-		if (ec->ecpointQ.len == BYTES4BITS(255))
+		if (ec->ecpointQ.len == BYTES4BITS(256))
 			ec->params.id = oid_X25519;
 		else if (ec->ecpointQ.len == BYTES4BITS(448))
 			ec->params.id = oid_X448;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -154,19 +154,19 @@ static struct ec_curve_info {
 	/* Some of the following may not yet be supported by the OpenSC module, but may be by other modules */
 	/* OpenPGP extensions by Yubikey and GNUK are not defined in RFCs, so pass by printable string */
 	/* See PKCS#11 3.0 2.3.7 */
-	{"edwards25519", "1.3.6.1.4.1.11591.15.1", (unsigned char*)"\x13\x0c\x65\x64\x77\x61\x72\x64\x73\x32\x35\x35\x31\x39", 14, 255, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* send by curve name */
-	{"curve25519",   "1.3.6.1.4.1.3029.1.5.1", (unsigned char*)"\x13\x0a\x63\x75\x72\x76\x65\x32\x35\x35\x31\x39", 12, 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* send by curve name */
+	{"edwards25519", "1.3.6.1.4.1.11591.15.1", (unsigned char*)"\x13\x0c\x65\x64\x77\x61\x72\x64\x73\x32\x35\x35\x31\x39", 14, 256, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* send by curve name */
+	{"curve25519",   "1.3.6.1.4.1.3029.1.5.1", (unsigned char*)"\x13\x0a\x63\x75\x72\x76\x65\x32\x35\x35\x31\x39", 12, 256, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* send by curve name */
 
 	/* RFC8410, EDWARDS and MONTGOMERY curves are used by GnuPG and also by OpenSSL */
 
-	{"X25519",  "1.3.101.110", (unsigned char*)"\x06\x03\x2b\x65\x6e", 5, 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+	{"X25519",  "1.3.101.110", (unsigned char*)"\x06\x03\x2b\x65\x6e", 5, 256, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
 	{"X448",    "1.3.101.111", (unsigned char*)"\x06\x03\x2b\x65\x6f", 5, 448, CKM_EC_MONTGOMERY_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
 	{"Ed25519", "1.3.101.112", (unsigned char*)"\x06\x03\x2b\x65\x70", 5, 255, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
-	{"Ed448",   "1.3.101.113", (unsigned char*)"\x06\x03\x2b\x65\x71", 5, 448, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
+	{"Ed448",   "1.3.101.113", (unsigned char*)"\x06\x03\x2b\x65\x71", 5, 456, CKM_EC_EDWARDS_KEY_PAIR_GEN}, /* RFC 4810 send by OID */
 
 	/* GnuPG openpgp curves as used in gnupg-card are equivalent to RFC8410 OIDs */
-	{"cv25519", "1.3.101.110", (unsigned char*)"\x06\x03\x2b\x65\x6e", 5, 255, CKM_EC_MONTGOMERY_KEY_PAIR_GEN},
-	{"ed25519", "1.3.101.112", (unsigned char*)"\x06\x03\x2b\x65\x70", 5, 255, CKM_EC_EDWARDS_KEY_PAIR_GEN},
+	{"cv25519", "1.3.101.110", (unsigned char*)"\x06\x03\x2b\x65\x6e", 5, 256, CKM_EC_MONTGOMERY_KEY_PAIR_GEN},
+	{"ed25519", "1.3.101.112", (unsigned char*)"\x06\x03\x2b\x65\x70", 5, 256, CKM_EC_EDWARDS_KEY_PAIR_GEN},
 	/* OpenSC card-openpgp.c will map these to what is need on the card */
 
 	{NULL, NULL, NULL, 0, 0, 0},
@@ -2452,7 +2452,7 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		}
 
 		/* Ed448: need the params defined but default to false */
-		if (curve->size == 448) {
+		if (curve->size == 456) {
 			mech.pParameter = &eddsa_params;
 			mech.ulParameterLen = (CK_ULONG)sizeof(eddsa_params);
 		}
@@ -2607,7 +2607,7 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		}
 
 		/* Ed448: need the params defined but default to false */
-		if (curve->size == 448) {
+		if (curve->size == 456) {
 			mech.pParameter = &eddsa_params;
 			mech.ulParameterLen = (CK_ULONG)sizeof(eddsa_params);
 		}
@@ -6589,14 +6589,15 @@ static int read_object(CK_SESSION_HANDLE session)
 					}
 				}
 
-				if (type == CKK_EC_EDWARDS && os->length == BYTES4BITS(255))
+				if (type == CKK_EC_EDWARDS && os->length == BYTES4BITS(256))
 					raw_pk = EVP_PKEY_ED25519;
 #if defined(EVP_PKEY_ED448)
-				else if (type == CKK_EC_EDWARDS && os->length == BYTES4BITS(448))
+				/* note extra byte */
+				else if (type == CKK_EC_EDWARDS && os->length == BYTES4BITS(456))
 					raw_pk = EVP_PKEY_ED448;
 #endif /* EVP_PKEY_ED448 */
 #if defined(EVP_PKEY_X25519)
-				else if (type == CKK_EC_MONTGOMERY && os->length == BYTES4BITS(255))
+				else if (type == CKK_EC_MONTGOMERY && os->length == BYTES4BITS(256))
 					raw_pk = EVP_PKEY_X25519;
 #endif /*EVP_PKEY_X25519 */
 #if defined(EVP_PKEY_X448)

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -730,15 +730,15 @@ static const struct alg_spec alg_types_asym[] = {
 	{ "gost2001",	SC_ALGORITHM_GOSTR3410,	SC_PKCS15_GOSTR3410_KEYSIZE },
 	{ "ec",		SC_ALGORITHM_EC,	0 }, /* keybits derived from curve */
 	/*  RFC 8410 */
-	{ "Ed25519",	SC_ALGORITHM_EDDSA,	255 }, /* RFC 8410 and gunpg */
-	{ "Ed448",	SC_ALGORITHM_EDDSA,	448 },
-	{ "X25519",	SC_ALGORITHM_XEDDSA,	255 },
+	{ "Ed25519",	SC_ALGORITHM_EDDSA,	256 }, /* RFC 8410 and gunpg */
+	{ "Ed448",	SC_ALGORITHM_EDDSA,	456 }, /* note extra btye */
+	{ "X25519",	SC_ALGORITHM_XEDDSA,	256 },
 	{ "X448",	SC_ALGORITHM_XEDDSA,	448 },
 	/* used by Yubikey and GNUK */
-	{ "edwards25519", SC_ALGORITHM_EDDSA,	255 },
-	{ "curve25519", SC_ALGORITHM_XEDDSA,	255 },
+	{ "edwards25519", SC_ALGORITHM_EDDSA,	256 },
+	{ "curve25519", SC_ALGORITHM_XEDDSA,	256 },
 	/* gnupg */
-	{ "cv25519",	SC_ALGORITHM_XEDDSA,	255 },
+	{ "cv25519",	SC_ALGORITHM_XEDDSA,	256 },
 
 	{ NULL, -1, 0 }
 };


### PR DESCRIPTION
The Edwards and Montgomery "field_length" is changed from 255 to 256 and for Ed448, 448 is changed to 456 as it needs an extra byte.

The field_length in bits, and is used to caculate number of bytes.

The BYTES4BITS(255) returns 32 and happens to work but should be BTYES4BITS(256) so the 25519 curves have been working but not as expected. But BYTES4BITS(448) returns 56, but Ed448 needed an extra byte so will use BYTES4BITS(456) to return 57 as required in the RFCs.

 On branch ED448-X448-fix
 Changes to be committed:
	modified:   src/libopensc/pkcs15-pubkey.c
	modified:   src/pkcs11/framework-pkcs15.c
	modified:   src/tools/pkcs11-tool.c
	modified:   src/tools/pkcs15-init.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
