### PR TITLE
Configure --enable-piv-sm does not work with LibreSSL

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -49,18 +49,17 @@
 #endif
 #endif
 
+#include "internal.h"
+
 /* 800-73-4 SM and VCI need: ECC, SM and real OpenSSL >= 1.1 */
 #if defined(ENABLE_OPENSSL) && defined(ENABLE_SM) && !defined(OPENSSL_NO_EC) && !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+#include <openssl/cmac.h>
 #else
 #undef ENABLE_PIV_SM
 #endif
 
-#ifdef ENABLE_PIV_SM
-#include <openssl/cmac.h>
 #include "compression.h"
-#endif
 
-#include "internal.h"
 #include "asn1.h"
 #include "cardctl.h"
 #include "simpletlv.h"


### PR DESCRIPTION
Configuring with --enable-piv-sm and LibreSSL fails when compiling.

card-piv.c checks for this and other requirements and does "#undef ENABLE_PIV_SM" to turn off ENABLE_PIV_SM.
But config.h, is include a second time by internal.h which redefines ENABLE_PIV_SM.

The commit reorders the includes so the above does not happen.

 On branch PIV-SM-LibreSSL
 Changes to be committed:
	modified:   src/libopensc/card-piv.c

##### Checklist
Tested with and without --enable-piv-sm with OpenSSL-3.4.1 and LibreSSL-4.0.0 
