### PR TITLE
Configure.ac - --enable-piv-sm now test for --enable_sm and --enable-openssl 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -861,7 +861,11 @@ else
 fi
 
 if  test "${enable_piv_sm}" = "yes"; then
-	AC_DEFINE([ENABLE_PIV_SM], [1], [Enable PIV SM])
+	if test "${enable_sm}" = "yes" -a "${enable_openssl}" = "yes" ; then
+		AC_DEFINE([ENABLE_PIV_SM], [1], [Enable PIV SM])
+	else
+		AC_MSG_ERROR([ENABLE_PIV_SM requires ENABLE_SM and ENABLE_OPENSSL])
+	fi
 fi
 
 if test "${enable_openct}" = "yes"; then

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -49,18 +49,14 @@
 #endif
 #endif
 
-/* 800-73-4 SM and VCI need: ECC, SM and real OpenSSL >= 1.1 */
-#if defined(ENABLE_OPENSSL) && defined(ENABLE_SM) && !defined(OPENSSL_NO_EC) && !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-#else
-#undef ENABLE_PIV_SM
-#endif
+#include "internal.h"
 
-#ifdef ENABLE_PIV_SM
+/* 800-73-4 SM and VCI need: ECC, SM and OpenSSL or LibreSSL */
+#if defined(ENABLE_PIV_SM)
 #include <openssl/cmac.h>
 #include "compression.h"
 #endif
 
-#include "internal.h"
 #include "asn1.h"
 #include "cardctl.h"
 #include "simpletlv.h"


### PR DESCRIPTION
card-piv.c now relies on configure tests for SM and OpenSSL which are needed for PIV-SM.   

--enable-piv-sm can also use LibreSSL as well as OpenSSL.

 Changes to be committed:
	modified:   configure.ac
	modified:   src/libopensc/card-piv.c

Tested with Idemia test PIV card and the PIV SM works with OpenSSL-3.4.1 and Libressl-4.0.0



