### PR TITLE
CI: remove SoftHSM from OpenSC CI tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,16 +39,6 @@ dist_noinst_SCRIPTS = common.sh \
 .NOTPARALLEL:
 TESTS = \
         test-manpage.sh \
-        test-duplicate-symbols.sh \
-        test-pkcs11-tool-test-threads.sh \
-        test-pkcs11-tool-allowed-mechanisms.sh \
-        test-pkcs11-tool-sym-crypt-test.sh
-if ENABLE_OPENSSL
-TESTS += \
-        test-pkcs11-tool-test.sh \
-        test-pkcs11-tool-sign-verify.sh \
-        test-pkcs11-tool-unwrap-wrap-test.sh \
-        test-pkcs11-tool-import.sh
-endif
+        test-duplicate-symbols.sh
 # no tests expected to fail
 #XFAIL_TESTS =

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,11 +49,6 @@ TESTS += \
         test-pkcs11-tool-sign-verify.sh \
         test-pkcs11-tool-unwrap-wrap-test.sh \
         test-pkcs11-tool-import.sh
-if ENABLE_TESTS
-if ENABLE_SHARED
-TESTS += test-p11test.sh
-endif
-endif
 endif
 # no tests expected to fail
 #XFAIL_TESTS =


### PR DESCRIPTION
SoftHSM suppressed errors show up as new errors in updated cmocka library

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
