### PR TITLE
Do not add CKA_ENCRYPT or CKA_DECRYPT for EC keys by default

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -3268,7 +3268,7 @@ static int gen_keypair(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 				n_privkey_attr++;
 			}
 
-			if (opt_key_usage_default || opt_key_usage_decrypt) {
+			if (opt_key_usage_decrypt) {
 				FILL_ATTR(publicKeyTemplate[n_pubkey_attr], CKA_ENCRYPT, &_true, sizeof(_true));
 				n_pubkey_attr++;
 				FILL_ATTR(privateKeyTemplate[n_privkey_attr], CKA_DECRYPT, &_true, sizeof(_true));


### PR DESCRIPTION
Setting CKA_ENCRYPT or CKA_DECRYPT by default for new keys in `pkcs11-tool` breaks the EC key generation.
With these changes, the CKA_ENCRYPT or CKA_DECRYPT can be set using `--usage-decrypt` option for `pkcs11-tool`.
Tested with NSS softokn.
