### PR TITLE
edo2021: initial support for Polish eID v2.0 cards

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -234,7 +234,7 @@ app <em class="replaceable"><code>application</code></em> {
 							</p></li><li class="listitem"><p>
 									<code class="literal">dnie</code>: See <a class="xref" href="#dnie" title="Configuration Options for DNIe">the section called “Configuration Options for DNIe”</a>
 							</p></li><li class="listitem"><p>
-									<code class="literal">edo</code>: See <a class="xref" href="#edo" title="Configuration Options for Polish eID Card">the section called “Configuration Options for Polish eID Card”</a>
+									<code class="literal">edo</code>: See <a class="xref" href="#edo" title="Configuration Options for Polish eID Card (edo and edo2021)">the section called “Configuration Options for Polish eID Card (edo and edo2021)”</a>
 							</p></li><li class="listitem"><p>
 									<code class="literal">eoi</code>: See <a class="xref" href="#eoi" title="Configuration Options for Slovenian eID Card">the section called “Configuration Options for Slovenian eID Card”</a>
 							</p></li><li class="listitem"><p>
@@ -529,7 +529,7 @@ app <em class="replaceable"><code>application</code></em> {
 							<code class="literal">/usr/bin/pinentry</code>).
 							Only used if compiled with
 							<code class="option">--enable-dnie-ui</code>
-					</p></dd></dl></div></div><div class="refsect2"><a name="edo"></a><h3>Configuration Options for Polish eID Card</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+					</p></dd></dl></div></div><div class="refsect2"><a name="edo"></a><h3>Configuration Options for Polish eID Card (edo and edo2021)</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">can = <em class="replaceable"><code>value</code></em>;</code>
 					</span></dt><dd><p>
 							CAN (Card Access Number – 6 digit number
@@ -800,6 +800,7 @@ app <em class="replaceable"><code>application</code></em> {
 							<code class="literal">coolkey</code>,
 							<code class="literal">dnie</code>,
 							<code class="literal">edo</code>,
+							<code class="literal">edo2021</code>,
 							<code class="literal">esteid2018</code>,
 							<code class="literal">esteid2025</code>,
 							<code class="literal">flex</code> (deactivated driver),

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -783,7 +783,7 @@ app <replaceable>application</replaceable> {
 		</refsect2>
 
 		<refsect2 id="edo">
-			<title>Configuration Options for Polish eID Card</title>
+			<title>Configuration Options for Polish eID Card (edo and edo2021)</title>
 			<variablelist>
 				<varlistentry>
 					<term>
@@ -1241,6 +1241,7 @@ app <replaceable>application</replaceable> {
 							<literal>coolkey</literal>,
 							<literal>dnie</literal>,
 							<literal>edo</literal>,
+							<literal>edo2021</literal>,
 							<literal>esteid2018</literal>,
 							<literal>esteid2025</literal>,
 							<literal>flex</literal> (deactivated driver),

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -51,6 +51,7 @@ libopensc_la_SOURCES_BASE = \
 	card-isoApplet.c card-masktech.c card-gids.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-esteid2025.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
+	card-edo2021.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -29,6 +29,7 @@ OBJECTS			= \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-esteid2025.obj card-idprime.obj \
 	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj card-dtrust.obj \
+	card-edo2021.c \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj pkcs15-tcos.obj \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \

--- a/src/libopensc/card-edo.c
+++ b/src/libopensc/card-edo.c
@@ -23,6 +23,7 @@
 
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
 
+#include "libopensc/card-edo.h"
 #include "libopensc/internal.h"
 #include "libopensc/opensc.h"
 #include "libopensc/pace.h"
@@ -100,7 +101,7 @@ static int edo_get_can(sc_card_t* card, struct establish_pace_channel_input* pac
 }
 
 
-static int edo_unlock(sc_card_t* card) {
+int edo_unlock(sc_card_t* card) {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
 	struct establish_pace_channel_input pace_input;
@@ -302,7 +303,7 @@ static int edo_init(sc_card_t* card) {
 }
 
 
-static int edo_logout(sc_card_t* card) {
+int edo_logout(sc_card_t* card) {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
 	sc_sm_stop(card);
@@ -311,7 +312,7 @@ static int edo_logout(sc_card_t* card) {
 }
 
 
-static int edo_card_reader_lock_obtained(sc_card_t* card, int was_reset) {
+int edo_card_reader_lock_obtained(sc_card_t* card, int was_reset) {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
 	/* Re-establish CAN channel on demand after logout or concurrent non PACE access */

--- a/src/libopensc/card-edo.h
+++ b/src/libopensc/card-edo.h
@@ -1,0 +1,28 @@
+/*
+ * Common functions and constants for Polish eID cards.
+ *
+ * Copyright (C) 2025 Piotr Wegrzyn <piotro@piotro.eu>
+ *
+ * This file is part of OpenSC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "libopensc/opensc.h"
+#include "libopensc/pace.h"
+
+int edo_unlock(sc_card_t *card);
+int edo_logout(sc_card_t *card);
+int edo_card_reader_lock_obtained(sc_card_t *card, int was_reset);

--- a/src/libopensc/card-edo2021.c
+++ b/src/libopensc/card-edo2021.c
@@ -1,0 +1,206 @@
+/*
+ * Driver for Polish eID v2.0 cards issued from 2021.
+ *
+ * Copyright (C) 2025 Piotr Wegrzyn <piotro@piotro.eu>
+ *
+ * This file is part of OpenSC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
+
+#include "libopensc/asn1.h"
+#include "libopensc/card-edo.h"
+#include "libopensc/card-edo2021.h"
+#include "libopensc/internal.h"
+#include "libopensc/opensc.h"
+#include "libopensc/pace.h"
+#include "libopensc/sm.h"
+#include "sm/sm-eac.h"
+#include <openssl/sha.h>
+#include <stdlib.h>
+#include <string.h>
+
+static struct sc_card_operations edo2021_ops;
+
+static struct sc_card_driver edo2021_drv = {
+		"Polish eID card issued from 2021 (e-dowód, eDO)",
+		"edo2021",
+		&edo2021_ops,
+		NULL, 0, NULL};
+
+static const struct sc_atr_table edo2021_atrs[] = {
+		{"3b:89:80:01:02:4d:4b:4d:57:4b:53:4b:54:11", NULL, NULL, SC_CARD_TYPE_EDO2021, 0, NULL},
+		{NULL,					NULL, NULL, 0,		      0, NULL}
+};
+
+static struct {
+	int len;
+	struct sc_object_id oid;
+} edo2021_curves[] = {
+		// secp384r1
+		{384, {{1, 3, 132, 0, 34, -1}}}
+};
+
+static int
+edo2021_match_card(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	if (_sc_match_atr(card, edo2021_atrs, &card->type) >= 0) {
+		sc_log(card->ctx, "ATR recognized as Polish eID card (edo2021 driver).");
+		LOG_FUNC_RETURN(card->ctx, 1);
+	}
+	LOG_FUNC_RETURN(card->ctx, 0);
+}
+
+static int
+edo2021_set_security_env(struct sc_card *card, const struct sc_security_env *env, size_t data_len)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (!env)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+
+	if (env->algorithm != SC_ALGORITHM_EC || !(env->flags & SC_SEC_ENV_KEY_REF_PRESENT))
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
+	u8 payload[] = {0x91, 0x02, 0x00, 0x00};
+
+	if (data_len <= SHA_DIGEST_LENGTH) {
+		payload[2] = 0x11;
+	} else if (data_len <= SHA256_DIGEST_LENGTH) {
+		payload[2] = 0x21;
+	} else if (data_len <= SHA512_DIGEST_LENGTH) {
+		payload[2] = 0x22;
+	} else {
+		sc_log(card->ctx, "unsupported data length for signature (%ld)", data_len);
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+	}
+
+	payload[3] |= env->key_ref[0];
+
+	struct sc_apdu apdu;
+	sc_format_apdu_ex(&apdu, 0x00, 0x22, 0x81, 0xB6, payload, sizeof payload, NULL, 0);
+
+	LOG_TEST_RET(card->ctx, sc_transmit_apdu(card, &apdu), "APDU transmit failed");
+	LOG_TEST_RET(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2), "SW check failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+/*
+ * This function is a stub for driver calls, it caches data from for later execution of edo2021_set_security_env
+ * when signing.
+ */
+static int
+edo2021_set_security_env_driver_stub(struct sc_card *card, const struct sc_security_env *env, int se_num)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	struct edo2021_privdata *privdata = (struct edo2021_privdata *)card->drv_data;
+
+	if (!privdata)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+
+	if (env->operation != SC_SEC_OPERATION_SIGN || se_num > 0)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
+	memcpy(&privdata->sec_env, env, sizeof(struct sc_security_env));
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+edo2021_compute_signature(struct sc_card *card, const u8 *data, size_t data_len, u8 *out, size_t outlen)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	struct edo2021_privdata *privdata = (struct edo2021_privdata *)card->drv_data;
+
+	if (!privdata)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+
+	/* Now we know the data length (from hashed input), perform the true set_security_env. */
+	LOG_TEST_RET(card->ctx, edo2021_set_security_env(card, &privdata->sec_env, data_len), "set_security_env failed");
+
+	/* Call default iso7816 handler, we need this card op only for security_env. */
+	LOG_FUNC_RETURN(card->ctx, sc_get_iso7816_driver()->ops->compute_signature(card, data, data_len, out, outlen));
+
+	LOG_FUNC_CALLED(card->ctx);
+}
+
+static int
+edo2021_init(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	card->drv_data = calloc(1, sizeof(struct edo2021_privdata));
+	if (!card->drv_data)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+
+	memset(&card->sm_ctx, 0, sizeof card->sm_ctx);
+
+	card->max_send_size = SC_MAX_APDU_RESP_SIZE;
+	card->max_recv_size = SC_MAX_APDU_RESP_SIZE;
+
+	for (size_t i = 0; i < sizeof edo2021_curves / sizeof *edo2021_curves; ++i) {
+		LOG_TEST_RET(card->ctx, _sc_card_add_ec_alg(card, edo2021_curves[i].len, SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDSA_HASH_NONE, 0, &edo2021_curves[i].oid), "Add EC alg failed");
+	}
+
+	LOG_TEST_RET(card->ctx, sc_enum_apps(card), "Enumerate apps failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+edo2021_finish(sc_card_t *card)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	free(card->drv_data);
+	card->drv_data = NULL;
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+struct sc_card_driver *
+sc_get_edo2021_driver(void)
+{
+	edo2021_ops = *sc_get_iso7816_driver()->ops;
+	edo2021_ops.match_card = edo2021_match_card;
+	edo2021_ops.init = edo2021_init;
+	edo2021_ops.finish = edo2021_finish;
+	edo2021_ops.set_security_env = edo2021_set_security_env_driver_stub;
+	edo2021_ops.compute_signature = edo2021_compute_signature;
+	edo2021_ops.logout = edo_logout;
+	edo2021_ops.card_reader_lock_obtained = edo_card_reader_lock_obtained;
+
+	return &edo2021_drv;
+}
+
+#else
+
+#include "libopensc/opensc.h"
+
+struct sc_card_driver *
+sc_get_edo2021_driver(void)
+{
+	return NULL;
+}
+
+#endif

--- a/src/libopensc/card-edo2021.h
+++ b/src/libopensc/card-edo2021.h
@@ -1,0 +1,28 @@
+/*
+ * Driver for Polish eID v2.0 cards issued from 2021.
+ *
+ * Copyright (C) 2025 Piotr Wegrzyn <piotro@piotro.eu>
+ *
+ * This file is part of OpenSC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "pkcs15.h"
+
+struct edo2021_privdata {
+	/* Cached data for signing */
+	struct sc_security_env sec_env;
+};

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -251,6 +251,7 @@ enum {
 
 	/* eDO cards */
 	SC_CARD_TYPE_EDO = 38000,
+	SC_CARD_TYPE_EDO2021,
 
 	/* JCOP4 cards with NQ-Applet */
 	SC_CARD_TYPE_NQ_APPLET = 39000,
@@ -309,6 +310,7 @@ extern sc_card_driver_t *sc_get_esteid2018_driver(void);
 extern sc_card_driver_t *sc_get_esteid2025_driver(void);
 extern sc_card_driver_t *sc_get_idprime_driver(void);
 extern sc_card_driver_t *sc_get_edo_driver(void);
+extern sc_card_driver_t *sc_get_edo2021_driver(void);
 extern sc_card_driver_t *sc_get_nqApplet_driver(void);
 extern sc_card_driver_t *sc_get_skeid_driver(void);
 extern sc_card_driver_t *sc_get_eoi_driver(void);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -137,6 +137,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "idprime",	(void *(*)(void)) sc_get_idprime_driver },
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
 	{ "edo",        (void *(*)(void)) sc_get_edo_driver },
+	{ "edo2021",    (void *(*)(void)) sc_get_edo2021_driver },
 #endif
 
 /* Here should be placed drivers that need some APDU transactions in the

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -150,8 +150,8 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 	u8 last_update[32], profile_indication[SC_PKCS15_MAX_LABEL_SIZE];
 	size_t lupdate_len = sizeof(last_update) - 1, pi_len = sizeof(profile_indication) - 1;
 	size_t flags_len   = sizeof(ti->flags);
-	u8 preferred_language[3];
-	size_t lang_length = sizeof(preferred_language);
+	u8 preferred_language[18];
+	size_t lang_length = sizeof(preferred_language) - 1;
 	struct sc_asn1_entry asn1_supported_algorithms[SC_MAX_SUPPORTED_ALGORITHMS + 1],
 			asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7],
 			asn1_algo_infos_parameters[SC_MAX_SUPPORTED_ALGORITHMS][3];
@@ -169,6 +169,7 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 	memset(label, 0, sizeof(label));
 	memset(profile_indication, 0, sizeof(profile_indication));
 	memset(mnfid, 0, sizeof(mnfid));
+	memset(preferred_language, 0, sizeof(preferred_language));
 
 	sc_copy_asn1_entry(c_asn1_twlabel, asn1_twlabel);
 	sc_copy_asn1_entry(c_asn1_toki_attrs, asn1_toki_attrs);
@@ -265,9 +266,11 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 			sc_log(ctx, "LastUpdate.referencedTime present");
 		}
 	}
-	if (asn1_toki_attrs[12].flags & SC_ASN1_PRESENT) {
-		preferred_language[2] = 0;
-		ti->preferred_language = strdup((char *)preferred_language);
+	if (ti->preferred_language == NULL) {
+		if (asn1_toki_attrs[12].flags & SC_ASN1_PRESENT)
+			ti->preferred_language = strdup((char *)preferred_language);
+		else
+			ti->preferred_language = strdup("(unknown)");
 		if (ti->preferred_language == NULL)
 			return SC_ERROR_OUT_OF_MEMORY;
 	}


### PR DESCRIPTION
Hello,
This PR adds initial support for Polish eID v2.0 cards that are issued from 2021

Unfortunately there is still no published documentation for any version...

Verified with `pkcs15-tool` and `pkcs11-tool` - login and signing works with all `ECDSA*` mechanisms for keys 0 (Authorization) and 2 (Authentication).
Other feature support may be not ideal. 

Changes are based on card-edo v1 (PACE CAN authentication, unlock, and curves are the same). 
v2 cards use different chip and protocol (as mentioned in #1831), but more features seem to work with standard handles.
Security env APDU turned out to be similar as in `card-eoi` - it is dependent on hash length, so I used similar trick as there to call secure env from signing function, but a bit cleaner.

##### Checklist
- [x] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
