### PR TITLE
Adjustments for wrap/unwrap tests

### DIFF
--- a/.github/setup-fedora.sh
+++ b/.github/setup-fedora.sh
@@ -3,7 +3,7 @@
 set -ex -o xtrace
 
 # Generic dependencies
-DEPS="make /usr/bin/xsltproc docbook-style-xsl autoconf automake libtool bash-completion vim-common softhsm openssl diffutils openpace openpace-devel gawk"
+DEPS="make /usr/bin/xsltproc docbook-style-xsl autoconf automake libtool bash-completion vim-common softhsm openssl diffutils openpace openpace-devel gawk nss-softokn nss-tools"
 
 if [ "$1" == "clang" ]; then
 	DEPS="$DEPS clang"

--- a/.github/workflows/external-pkcs11.yaml
+++ b/.github/workflows/external-pkcs11.yaml
@@ -90,3 +90,22 @@ jobs:
         env:
           LD_LIBRARY_PATH: /usr/local/lib
         run: tests/test-softhsm.sh
+  
+  test-interoperability:
+    runs-on: ubuntu-24.04
+    container:
+      image: fedora:latest
+    env:
+      SOURCE_PATH: ./
+      BUILD_PATH: ./
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Fedora
+        run: .github/setup-fedora.sh kryoptic
+      - name: Install OpenSC
+        run: .github/build.sh
+      - name: Setup Kryoptic
+        run: .github/setup-kryoptic.sh
+      - name: Interoperability tests
+        run: tests/test-pkcs11-tool-unwrap-wrap-interoperability-test.sh

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4660,6 +4660,10 @@ static CK_RV write_object(CK_SESSION_HANDLE session)
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_DERIVE, &_true, sizeof(_true));
 			n_privkey_attr++;
 		}
+		if (opt_key_usage_wrap) {
+			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_UNWRAP, &_true, sizeof(_true));
+			n_privkey_attr++;
+		}
 		if (opt_always_auth != 0) {
 			FILL_ATTR(privkey_templ[n_privkey_attr], CKA_ALWAYS_AUTHENTICATE,
 				&_true, sizeof(_true));
@@ -4769,6 +4773,10 @@ static CK_RV write_object(CK_SESSION_HANDLE session)
 		}
 		if (opt_key_usage_derive != 0) {
 			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_DERIVE, &_true, sizeof(_true));
+			n_pubkey_attr++;
+		}
+		if (opt_key_usage_wrap) {
+			FILL_ATTR(pubkey_templ[n_pubkey_attr], CKA_WRAP, &_true, sizeof(_true));
 			n_pubkey_attr++;
 		}
 

--- a/tests/init-kryoptic.sh
+++ b/tests/init-kryoptic.sh
@@ -37,6 +37,7 @@ function initialize_token() {
 
 	export PUB_ARGS=("--module=${P11LIB}" "--token-label=${TOKENLABEL}")
 	export PRIV_ARGS=("${PUB_ARGS[@]}" "--login" "--pin=${PIN}")
+	export PRIV_ARGS_KRYOPTIC=("${PRIV_ARGS[@]}")
 }
 
 function token_cleanup() {

--- a/tests/init-kryoptic.sh
+++ b/tests/init-kryoptic.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # set paths
-KRYOPTIC_PWD="$BUILD_PATH/kryoptic/target/debug/libkryoptic_pkcs11.so"
-if test -f "$KRYOPTIC_PWD" ; then
-	echo "Using kryoptic path $KRYOPTIC_PWD"
-	P11LIB="$KRYOPTIC_PWD"
-else
-	echo "Kryoptic not found"
-	exit 0
+kryoptic_paths="$BUILD_PATH/kryoptic/target/debug/libkryoptic_pkcs11.so"
+
+for LIB in $kryoptic_paths; do
+	echo "Testing $LIB"
+	if [[ -f $LIB ]]; then
+		export P11LIB=$LIB
+		echo "Setting P11LIB=$LIB"
+		break
+	fi
+done
+if [[ -z "$P11LIB" ]]; then
+	echo "Warning: Could not find the Kryoptic PKCS#11 module"
 fi
 
 function initialize_token() {

--- a/tests/init-softhsm.sh
+++ b/tests/init-softhsm.sh
@@ -33,6 +33,7 @@ function initialize_token() {
 
 	export PUB_ARGS=("--module=${P11LIB}")
 	export PRIV_ARGS=("${PUB_ARGS[@]}" "--login" "--pin=${PIN}")
+	export PRIV_ARGS_SOFTHSM=("${PRIV_ARGS[@]}")
 }
 
 function token_cleanup() {

--- a/tests/init-softhsm.sh
+++ b/tests/init-softhsm.sh
@@ -2,8 +2,9 @@
 
 SOURCE_PATH=${SOURCE_PATH:-..}
 
+
 softhsm_paths="/usr/local/lib/softhsm/libsofthsm2.so \
-	/usr/lib/softhsm/libsofthsm2.so
+	/usr/lib/softhsm/libsofthsm2.so \
 	/usr/lib64/pkcs11/libsofthsm2.so \
 	/usr/lib/i386-linux-gnu/softhsm/libsofthsm2.so \
 	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"
@@ -17,7 +18,7 @@ for LIB in $softhsm_paths; do
 	fi
 done
 if [[ -z "$P11LIB" ]]; then
-	echo "Warning: Could not find the softhsm pkcs11 module"
+	echo "Warning: Could not find the SoftHSM PKCS#11 module"
 fi
 
 function initialize_token() {
@@ -26,9 +27,8 @@ function initialize_token() {
 		rm -rf ".tokens"
 	fi
 	mkdir ".tokens"
-	export SOFTHSM2_CONF=$(realpath ".softhsm2.conf")
-	# Init token
 
+	export SOFTHSM2_CONF=$(realpath ".softhsm2.conf")
 	softhsm2-util --init-token --slot 0 --label "SC test" --so-pin="$SOPIN" --pin="$PIN"
 
 	export PUB_ARGS=("--module=${P11LIB}")

--- a/tests/init-softokn.sh
+++ b/tests/init-softokn.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-softokn_paths=(
-    "/usr/lib64/libsoftokn3.so" # Fedora
-    "/usr/lib/x86_64-linux-gnu/libsoftokn3.so" # Ubuntu
-)
-P11LIB=""
-for lib in "${softokn_paths[@]}"; do
-    if [ -f "$lib" ]; then
-        echo "Using softokn path $lib"
-        P11LIB="$lib"
-        break
-    fi
+softokn_paths="/usr/lib64/libsoftokn3.so \
+	/usr/lib/x86_64-linux-gnu/libsoftokn3.so"
+
+for LIB in $softokn_paths; do
+	echo "Testing $LIB"
+	if [[ -f $LIB ]]; then
+		export P11LIB=$LIB
+		echo "Setting P11LIB=$LIB"
+		break
+	fi
 done
-if [ -z "$P11LIB" ]; then
-    echo "Unable to find softokn PKCS#11 library"
-    exit 1
+if [[ -z "$P11LIB" ]]; then
+	echo "Warning: Could not find the Softokn PKCS#11 module"
 fi
 
 function initialize_token() {
@@ -34,7 +32,6 @@ function initialize_token() {
 	certutil -N -d $TOKDIR -f $PINFILE
 
 	export NSS_LIB_PARAMS=configDir=$TMPPDIR/tokens
-	export PKCS11_TOOL="pkcs11-tool"
 	export PUB_ARGS=("--module=${P11LIB}" "--token-label=${TOKENLABEL}")
 	export PRIV_ARGS=("${PUB_ARGS[@]}" "--login" "--pin=${PINVALUE}")
 }

--- a/tests/init-softokn.sh
+++ b/tests/init-softokn.sh
@@ -34,6 +34,7 @@ function initialize_token() {
 	export NSS_LIB_PARAMS=configDir=$TMPPDIR/tokens
 	export PUB_ARGS=("--module=${P11LIB}" "--token-label=${TOKENLABEL}")
 	export PRIV_ARGS=("${PUB_ARGS[@]}" "--login" "--pin=${PINVALUE}")
+	export PRIV_ARGS_SOFTOKN=("${PRIV_ARGS[@]}")
 }
 
 function token_cleanup() {

--- a/tests/test-pkcs11-tool-unwrap-wrap-interoperability-test.sh
+++ b/tests/test-pkcs11-tool-unwrap-wrap-interoperability-test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+SOURCE_PATH=${SOURCE_PATH:-..}
+
+get_priv_args() {
+    local target=$1
+    case "$target" in
+        Kryoptic)
+            ARGS=("${PRIV_ARGS_KRYOPTIC[@]}")
+            ;;
+        Softokn)
+            ARGS=("${PRIV_ARGS_SOFTOKN[@]}")
+            ;;
+        SoftHSM)
+            ARGS=("${PRIV_ARGS_SOFTHSM[@]}")
+            ;;
+        *)
+            echo "Unknown target: $target" >&2
+            return 1
+            ;;
+    esac
+}
+
+function test_unwrapped_aes_encryption() {
+	TARGET=$1
+    AES_256_KEY=$2
+    KEY_ID=$3
+    IV="00000000000000000000000000000000"
+    (printf '\xAB%.0s' {1..64};) > aes_plain.data
+    get_priv_args "$TARGET"
+
+    echo "Testing unwrapped key with encryption"
+
+    # Encrypt with openssl
+    openssl enc -aes-256-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv $IV -K $AES_256_KEY
+    assert $? "AES CBC OpenSSL encryption failed"
+
+    # Encrypt with pkcs11-tool
+    $PKCS11_TOOL "${ARGS[@]}" --encrypt --id $KEY_ID -m AES-CBC-PAD --iv $IV \
+            --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data
+    assert $? "Fail/pkcs11-tool encrypt"
+
+    # Compare ciphertexts
+    cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+    assert $? "AES CBC encrypted ciphertexts do not match"
+
+    rm aes_ciphertext_openssl.data aes_ciphertext_pkcs11.data aes_plain.data
+}
+
+source $SOURCE_PATH/tests/help.sh
+# Initialize tokens with their custom pkcs11-tool arguments
+source $SOURCE_PATH/tests/common.sh softokn
+initialize_token
+source $SOURCE_PATH/tests/common.sh softhsm
+initialize_token
+source $SOURCE_PATH/tests/common.sh kryoptic
+initialize_token
+
+# Generate AES and RSA keys for wrapping/unwrapping
+ID_AES_WRAP="0100"
+ID_RSA_WRAP="0200"
+ID_RSA_WRAPPED="0201"
+ID_RSA_UNWRAPPED="0202"
+
+AES_WRAP_KEY="7070707070707070707070707070707070707070707070707070707070707070"
+echo -n $AES_WRAP_KEY | xxd -p -r > aes_wrap.key
+IV="00000000000000000000000000000000"
+
+openssl genpkey -out "rsa_private.der" -outform DER -algorithm RSA -pkeyopt rsa_keygen_bits:1024
+openssl pkey -in "rsa_private.der" -out "rsa_public.der" -pubout -inform DER -outform DER
+
+# import keys
+for TARGET in SoftHSM Kryoptic Softokn; do
+    get_priv_args "$TARGET"
+    # Write AES key for wrapping
+    $PKCS11_TOOL "${ARGS[@]}" --write-object aes_wrap.key --id $ID_AES_WRAP \
+        --type secrkey --key-type AES:32 --usage-wrap --extractable --label aes-32-wrapping-key
+    assert $? "Failed to write AES key to $TARGET"
+
+    # Write RSA private key for unwrapping
+    $PKCS11_TOOL "${ARGS[@]}" --write-object rsa_private.der --id $ID_RSA_WRAP \
+        --type privkey --usage-wrap --usage-decrypt --label rsa-wrapping-key
+    assert $? "Failed to write RSA private key to $TARGET"
+
+    # Write RSA public key  for wrapping
+    $PKCS11_TOOL "${ARGS[@]}" --write-object rsa_public.der --id $ID_RSA_WRAP \
+        --type pubkey --usage-wrap --usage-decrypt --label rsa-wrapping-key
+    assert $? "Failed to write RSA public key to $TARGET"
+
+    # Generate RSA key to be wrapped/unwrapped
+    $PKCS11_TOOL "${ARGS[@]}" --keypairgen --key-type rsa:2048 --id $ID_RSA_WRAPPED \
+        --usage-decrypt --extractable --label rsa-key
+    assert $? "Failed to Generate RSA key"
+done
+
+echo "======================================================="
+echo " Wrap/Unwrap of secret keys"
+echo "======================================================="
+# Generate key to be wrapped/unwrapped
+ID_AES="0101"
+AES_KEY="ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB"
+echo -n $AES_KEY | xxd -p -r > aes.key
+
+for MECH in AES-CBC AES-KEY-WRAP RSA-PKCS; do
+    echo "-------------------------------------------------------"
+    echo " $MECH Wrap/Unwrap of secret key test"
+    echo "-------------------------------------------------------"
+    ID_WRAP=$ID_AES_WRAP
+    if [ "$MECH" == "RSA-PKCS" ]; then
+        ID_WRAP=$ID_RSA_WRAP
+    fi
+    for WRAPPER in SoftHSM Kryoptic Softokn; do
+        for UNWRAPPER in SoftHSM Kryoptic Softokn; do
+            if [ "$WRAPPER" == "$UNWRAPPER" ]; then
+                continue;
+            fi
+            if [ "$UNWRAPPER" == "SoftHSM" ] && [ $MECH == "AES-CBC" ]; then
+                continue;
+            fi
+            echo "-------------------------------------------------------"
+            echo " $WRAPPER Wrap -> $UNWRAPPER Unwrap"
+            echo "-------------------------------------------------------"
+            get_priv_args "$WRAPPER"
+            # 1. Load key
+            $PKCS11_TOOL "${ARGS[@]}" --write-object aes.key --id $ID_AES --type secrkey --key-type AES:32 \
+                --usage-decrypt --extractable --label "stored-aes-32"
+            assert $? "Failed to write AES key on $WRAPPER"
+            # 2. Wrap 
+            $PKCS11_TOOL "${ARGS[@]}" --wrap -m $MECH --id $ID_WRAP --iv $IV --application-id $ID_AES \
+                --output-file wrapped_key.data
+            assert $? "Failed to wrap AES key with $MECH from $WRAPPER"
+            
+            get_priv_args "$UNWRAPPER"
+            #3. Unwrap
+            $PKCS11_TOOL "${ARGS[@]}" --unwrap -m $MECH --id $ID_WRAP --iv $IV --application-id $ID_AES \
+                --key-type AES: --input-file wrapped_key.data --usage-decrypt --extractable
+            assert $? "Failed to unwrap AES key with $MECH by $UNWRAPPER"
+
+            # 4. Test unwrapped key with encryption
+            test_unwrapped_aes_encryption $UNWRAPPER $AES_KEY $ID_AES
+
+            # 5. Clean up
+            $PKCS11_TOOL "${ARGS[@]}" --delete-object --type secrkey --id $ID_AES
+            get_priv_args "$WRAPPER"
+            $PKCS11_TOOL "${ARGS[@]}" --delete-object --type secrkey --id $ID_AES
+            rm wrapped_key.data
+        done
+    done
+done
+
+echo "======================================================="
+echo " Wrap/Unwrap of private keys"
+echo "======================================================="
+
+for MECH in AES-CBC-PAD; do
+    ID_WRAP=$ID_AES_WRAP
+
+    for WRAPPER in Kryoptic Softokn; do
+        for UNWRAPPER in Kryoptic Softokn; do
+            if [ "$WRAPPER" == "$UNWRAPPER" ]; then
+                continue;
+            fi
+            if { [[ "$MECH" == "AES-CBC-PAD" ]] && ([[ "$WRAPPER" == "SoftHSM" ]] || [[ "$UNWRAPPER" == "SoftHSM" ]]); } || \
+            { [[ "$MECH" == "AES-KEY-WRAP-PAD" ]] && ([[ "$WRAPPER" == "Kryoptic" ]] || [[ "$UNWRAPPER" == "Kryoptic" ]]); }; then
+                continue
+            fi
+            echo "-------------------------------------------------------"
+            echo " $MECH: $WRAPPER Wrap -> $UNWRAPPER Unwrap"
+            echo "-------------------------------------------------------"
+            # Wrap
+            get_priv_args "$WRAPPER"
+            $PKCS11_TOOL "${ARGS[@]}" --wrap -m $MECH --id $ID_AES_WRAP --iv $IV \
+                --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+            assert $? "Failed to wrap RSA key by $WRAPPER"
+            # Unwrap
+            get_priv_args "$UNWRAPPER"
+            $PKCS11_TOOL "${ARGS[@]}" --unwrap -m $MECH --id $ID_AES_WRAP --iv $IV \
+                --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+            assert $? "Failed to unwrap RSA key with $MECH by $UNWRAPPER"
+            rm rsa_wrapped_key.data
+
+            # Remove unwrapped RSA key
+            $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+        done
+    done
+done
+
+
+echo "======================================================="
+echo "Cleanup"
+echo "======================================================="
+rm aes_wrap.key rsa_private.der rsa_public.der aes.key
+
+exit $ERRORS

--- a/tests/test-pkcs11-tool-unwrap-wrap-test.sh
+++ b/tests/test-pkcs11-tool-unwrap-wrap-test.sh
@@ -63,7 +63,7 @@ AES_256_KEY="7070707070707070707070707070707070707070707070707070707070707070"
 echo -n $AES_256_KEY | xxd -p -r > aes.key
 
 echo "======================================================="
-echo " RSA Wrap/Unwrap tests"
+echo " RSA Wrap/Unwrap of secret key tests"
 echo "======================================================="
 ID_RSA_WRAP="85" # RSA wrapping key
 ID_GENERIC_UNWRAPPED_1="95" # GENERIC key
@@ -77,9 +77,9 @@ assert $? "Failed to Generate RSA key"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type pubkey --id $ID_RSA_WRAP -o rsa_pub.key
 assert $? "Failed to export public key"
 
-echo "======================================================="
+echo "-------------------------------------------------------"
 echo " RSA-PKCS Unwrap generic key test"
-echo "======================================================="
+echo "-------------------------------------------------------"
 
 # Wrap with OpenSSL
 openssl rsautl -encrypt -pubin -keyform der -inkey rsa_pub.key -in aes.key -out openssl_wrapped.data
@@ -94,9 +94,9 @@ assert $? "RSA-PKCS unwrap GENERIC key failed"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_GENERIC_UNWRAPPED_1 --read-object --type secrkey --output-file generic_extracted.key
 compare_keys $? generic_extracted.key aes.key
 
-echo "======================================================="
+echo "-------------------------------------------------------"
 echo " RSA-PKCS Unwrap AES key test"
-echo "======================================================="
+echo "-------------------------------------------------------"
 
 # Unwrap with pkcs11-tool as AES key
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type AES: \
@@ -112,9 +112,9 @@ compare_keys $? aes_extracted.key aes.key
 # Check if AES key was correctly unwrapped with encryption
 test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_1
 
-echo "======================================================="
+echo "-------------------------------------------------------"
 echo " RSA-PKCS Wrap AES key test"
-echo "======================================================="
+echo "-------------------------------------------------------"
 
 # Wrap with pkcs11-tool
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS --id $ID_RSA_WRAP --application-id $ID_AES_UNWRAPPED_1 --output-file pkcs11_wrapped.data
@@ -129,9 +129,9 @@ assert $? "Wrapped key after decipher does not match the original key"
 rm openssl_wrapped.data generic_extracted.key pkcs11_wrapped.data aes_wrapped_decrypted.key aes_extracted.key
 
 if [ "${TOKENTYPE}" != "softokn" ]; then
-    echo "======================================================="
+    echo "-------------------------------------------------------"
     echo " RSA-PKCS-OAEP Unwrap generic key test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
     # RSA-PKCS-OAEP mechanism takes both a hash algorithm and MGF algorithm as parameters.
     # For now we use SHA1, although it has been deprecated by NIST, because SoftHSM only supports SHA1 hash with OAEP currently.
     # Known issue: https://github.com/softhsm/SoftHSMv2/issues/474 . When this issue is fixed, we shall replace with SHA256 or higher.
@@ -157,9 +157,9 @@ if [ "${TOKENTYPE}" != "softokn" ]; then
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_GENERIC_UNWRAPPED_2 --read-object --type secrkey --output-file generic_extracted.key
     compare_keys $? generic_extracted.key aes.key
 
-    echo "======================================================="
+    echo "-------------------------------------------------------"
     echo " RSA-PKCS-OAEP Unwrap AES key test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
 
     # Unwrap with pkcs11-tool as AES key
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type AES: \
@@ -173,9 +173,9 @@ if [ "${TOKENTYPE}" != "softokn" ]; then
     # Check if AES key was correctly unwrapped with encryption
     test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_3
 
-    echo "======================================================="
-    echo " RSA-PKCS-OAEP Wrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo " RSA-PKCS-OAEP Wrap AES key test"
+    echo "-------------------------------------------------------"
 
     # Wrap with pkcs11-tool
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS-OAEP --id $ID_RSA_WRAP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --application-id $ID_GENERIC_UNWRAPPED_2 --output-file pkcs11_wrapped.data
@@ -194,7 +194,7 @@ fi
 rm rsa_pub.key
 
 echo "======================================================="
-echo " AES Wrap/Unwrap tests"
+echo " AES Wrap/Unwrap of secret key tests"
 echo "======================================================="
 ID_AES_WRAP="0101" # AES wrapping key
 ID_AES_UNWRAPPED_4="0102" # AES 256 CBC
@@ -215,9 +215,9 @@ if [[ "$TOKENTYPE" != "softhsm" || -n "$is_softhsm2_2_6_1" ]]; then
     # CKM_AES_CBC -- SoftHSM2 AES CBC wrapping currently has a bug, the IV is not correctly used. Only IV=0 will work --*
     IV="00000000000000000000000000000000"
 
-    echo "======================================================="
-    echo " AES 256 CBC Unwrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo " AES 256 CBC Unwrap AES key test"
+    echo "-------------------------------------------------------"
     # Wrap with OpenSSL
     openssl enc -aes-256-cbc -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data -nopad
     assert $? "OpenSSL / Failed to AES CBC encrypt AES key"
@@ -241,9 +241,9 @@ if [[ "$TOKENTYPE" != "softhsm" || -n "$is_softhsm2_2_6_1" ]]; then
         # Check if AES key was correctly unwrapped with encryption
         test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_4
     fi
-    echo "======================================================="
-    echo " AES 256 CBC Wrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo " AES 256 CBC Wrap AES key test"
+    echo "-------------------------------------------------------"
     # Wrap with OpenSSL
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_4 \
         --output-file pkcs11_wrapped.data
@@ -258,9 +258,9 @@ fi
 
 if [[ "$TOKENTYPE" != "softhsm" ]]; then
     # SoftHSM2 currently doesn't support CKM_AES_CBC_PAD as a wrapping
-    echo "======================================================="
-    echo " AES 256 CBC PAD Wrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo " AES 256 CBC PAD Wrap AES test"
+    echo "-------------------------------------------------------"
     IV="000102030405060708090A0B0C0D0E0F"
     # Wrap with OpenSSL
     openssl enc -aes-256-cbc -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data
@@ -276,9 +276,9 @@ if [[ "$TOKENTYPE" != "softhsm" ]]; then
 fi
 
 if [[ -n $is_openssl_3 ]]; then
-    echo "======================================================="
-    echo "AES-KEY-WRAP Wrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo "AES-KEY-WRAP Wrap AES test"
+    echo "-------------------------------------------------------"
     # RSA Key
     # --AES-KEY-WRAP is not suitable for asymmetric key wrapping since the length of the encoded private key is likely not aligned to 8 bytes
     IV="a6a6a6a6a6a6a6a6"
@@ -296,9 +296,9 @@ if [[ -n $is_openssl_3 ]]; then
     cmp pkcs11_wrapped.data openssl_wrapped.data 2>&1 >/dev/null
     assert $? "AES-KEY-WRAP wrapped keys do not match"
 
-    echo "======================================================="
-    echo "AES-KEY-WRAP Unwrap test"
-    echo "======================================================="
+    echo "-------------------------------------------------------"
+    echo "AES-KEY-WRAP Unwrap AES key test"
+    echo "-------------------------------------------------------"
     # Unwrap with pkcs11-tool
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_5 \
         --key-type AES: --input-file pkcs11_wrapped.data --extractable --application-label "unwrap-aes-with-aes-key-wrap"
@@ -314,9 +314,9 @@ if [[ -n $is_openssl_3 ]]; then
     test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_4
 
     if [[ "$TOKENTYPE" != "kryoptic" ]]; then
-        echo "======================================================="
-        echo "AES-KEY-WRAP-PAD Wrap test"
-        echo "======================================================="
+        echo "-------------------------------------------------------"
+        echo "AES-KEY-WRAP-PAD Wrap AES key test"
+        echo "-------------------------------------------------------"
         IV="a65959a6"
 
         # Wrap with OpenSSL
@@ -336,9 +336,9 @@ if [[ -n $is_openssl_3 ]]; then
             echo "Comparing OpenSSL and pkcs11-tool wrapped keys for softokn fails"
         fi
 
-        echo "======================================================="
-        echo "AES-KEY-WRAP-PAD Unwrap test"
-        echo "======================================================="
+        echo "-------------------------------------------------------"
+        echo "AES-KEY-WRAP-PAD Unwrap AES key test"
+        echo "-------------------------------------------------------"
         # Unwrap with pkcs11-tool
         $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_6 \
                 --key-type AES: --input-file pkcs11_wrapped.data --extractable --application-label "unwrap-aes-with-aes-key-wrap-pad"
@@ -356,6 +356,110 @@ if [[ -n $is_openssl_3 ]]; then
 fi
 
 rm -f aes.key aes_kek.key pkcs11_wrapped.data openssl_wrapped.data unwrapped.key
+
+echo "======================================================="
+echo " AES Wrap/Unwrap of private key tests"
+echo "======================================================="
+
+function test_unwrapped_rsa_pkcs_decryption() {
+    ID_RSA_WRAPPED=$1
+    ID_RSA_UNWRAPPED=$2
+
+    echo "Testing unwrapped key with decryption"
+
+    (printf '\xAB%.0s' {1..64};) > plaintext.data
+    # Encrypt with original RSA key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id $ID_RSA_WRAPPED -m RSA-PKCS \
+            --input-file plaintext.data --output-file ciphertext.data
+    assert $? "Fail/pkcs11-tool encrypt"
+    # Decrypt with unwrapped private key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt --id $ID_RSA_UNWRAPPED -m RSA-PKCS \
+            --input-file ciphertext.data > decrypted_plaintext.data
+    # Compare plaintexts
+    cmp plaintext.data decrypted_plaintext.data >/dev/null 2>/dev/null
+    assert $? "RSA decrypted plaintexts do not match"
+    rm plaintext.data decrypted_plaintext.data
+}
+
+ID_AES_WRAP="0200"
+ID_RSA_WRAPPED="0201"
+ID_RSA_UNWRAPPED="0202"
+IV="00000000000000000000000000000000"
+
+# Generate AES key for unwrap/wrap operation
+AES_WRAP=$(head /dev/urandom | sha256sum | head -c 64)
+echo -n $AES_WRAP | xxd -p -r > aes_kek.key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object aes_kek.key --id $ID_AES_WRAP --type secrkey \
+    --key-type AES:32 --usage-wrap --usage-decrypt --extractable --label aes-32-wrapping-key
+assert $? "Failed to write AES key"
+
+# Generate RSA key to be wrapped/unwrapped
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --keypairgen --key-type rsa:2048 --id $ID_RSA_WRAPPED --usage-decrypt --extractable --label rsa-key
+assert $? "Failed to Generate RSA key"
+
+# AES-KEY-WRAP, AES-KEY-WRAP-PAD, AES-CBC, AES-CBC-PAD
+if [[ "$TOKENTYPE" == "softhsm" ]]; then
+    echo "-------------------------------------------------------"
+    echo "AES-KEY-WRAP Wrap/Unwrap RSA key test"
+    echo "-------------------------------------------------------"
+    # Wrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+    assert $? "Failed to wrap RSA key"
+    # Unwrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+    assert $? "Failed to unwrap RSA key with $MECH"
+    rm rsa_wrapped_key.data
+
+    # Test with decryption
+    test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
+
+    # Remove unwrapped RSA keys
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+fi
+
+if [[ "$TOKENTYPE" != "kryoptic" ]]; then
+    echo "-------------------------------------------------------"
+    echo "AES-KEY-WRAP-PAD Wrap/Unwrap RSA key test"
+    echo "-------------------------------------------------------"
+    # Wrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+    assert $? "Failed to wrap RSA key"
+    # Unwrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+    assert $? "Failed to unwrap RSA key with $MECH"
+    rm rsa_wrapped_key.data
+
+    # Test with decryption
+    test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
+
+    # Remove unwrapped RSA key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+fi
+
+if [[ "$TOKENTYPE" != "softhsm" ]]; then
+    echo "-------------------------------------------------------"
+    echo "AES-CBC-PAD Wrap/Unwrap RSA key test"
+    echo "-------------------------------------------------------"
+    # Wrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC-PAD --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+    assert $? "Failed to wrap RSA key"
+    # Unwrap
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-CBC-PAD --id $ID_AES_WRAP --iv $IV \
+        --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+    assert $? "Failed to unwrap RSA key with $MECH"
+    rm rsa_wrapped_key.data
+
+    # Test with decryption
+    test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
+
+    # Remove unwrapped RSA key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+fi
 
 echo "======================================================="
 echo "Cleanup"

--- a/tests/test-pkcs11-tool-unwrap-wrap-test.sh
+++ b/tests/test-pkcs11-tool-unwrap-wrap-test.sh
@@ -10,16 +10,38 @@ function compare_keys() {
         cmp $EXTRACTED $PLAIN >/dev/null 2>/dev/null
         assert $? "Extracted key does not match the input key"
     else
+        # softokn and kryoptic keys are extractable but sensitive
         echo "Key cannot be read in plaintext"
     fi
 }
 
+function test_unwrapped_aes_encryption() {
+    AES_256_KEY=$1
+    KEY_ID=$2
+    IV="00000000000000000000000000000000"
+    (printf '\xAB%.0s' {1..64};) > aes_plain.data
+
+    echo "Testing unwrapped key with encryption"
+
+    # Encrypt with openssl
+    openssl enc -aes-256-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv $IV -K $AES_256_KEY
+    assert $? "AES CBC OpenSSL encryption failed"
+
+    # Encrypt with pkcs11-tool
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id $KEY_ID -m AES-CBC-PAD --iv $IV \
+            --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data
+    assert $? "Fail/pkcs11-tool encrypt"
+
+    # Compare ciphertexts
+    cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
+    assert $? "AES CBC encrypted ciphertexts do not match"
+
+    rm aes_ciphertext_openssl.data aes_ciphertext_pkcs11.data aes_plain.data
+}
+
 TOKENTYPE=$1
 
-if [ "${TOKENTYPE}" == "softokn" ]; then
-	echo "Wrap/unwrap test not supported"
-	exit 1
-elif [ "${TOKENTYPE}" == "" ]; then
+if [ "${TOKENTYPE}" == "" ]; then
     TOKENTYPE=softhsm
     echo "No tokentype provided, running with SoftHSM"
 fi
@@ -36,156 +58,158 @@ fi
 
 initialize_token
 
+# create AES key
+AES_256_KEY="7070707070707070707070707070707070707070707070707070707070707070"
+echo -n $AES_256_KEY | xxd -p -r > aes.key
+
 echo "======================================================="
-echo " RSA-PKCS Unwrap test"
+echo " RSA Wrap/Unwrap tests"
 echo "======================================================="
-ID1="85" # RSA key
-ID2="95" # GENERIC key
-ID3="96" # AES key
-# Generate RSA key (this key is used to unwrap/wrap operation)
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --keypairgen --key-type rsa:1024 --id $ID1 --usage-wrap --usage-decrypt --label wrap-rsa
+ID_RSA_WRAP="85" # RSA wrapping key
+ID_GENERIC_UNWRAPPED_1="95" # GENERIC key
+ID_AES_UNWRAPPED_1="96" # AES key
+
+# Generate RSA key for unwrap/wrap operation
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --keypairgen --key-type rsa:1024 --id $ID_RSA_WRAP --usage-wrap --usage-decrypt --label rsa-wrapping-key
 assert $? "Failed to Generate RSA key"
 
-# export public key
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type pubkey --id $ID1 -o rsa_pub.key
+# Export public key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type pubkey --id $ID_RSA_WRAP -o rsa_pub.key
 assert $? "Failed to export public key"
 
-# create AES key
-KEY="70707070707070707070707070707070"
-
-echo -n $KEY|xxd -p -r > aes_plain_key
-# wrap AES key
-openssl rsautl -encrypt -pubin -keyform der -inkey rsa_pub.key -in aes_plain_key -out aes_wrapped_key
-assert $? "Failed wrap AES key"
-
-# unwrap key as generic key by pkcs11 interface
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS --id $ID1 -i aes_wrapped_key --key-type GENERIC: \
-	--extractable --application-id $ID3 --application-label "unwrap-generic-ex" --extractable 2>/dev/null
-assert $? "Unwrap failed"
-
-# if extractable, there is no problem to compare key value with original key
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID3 --read-object --type secrkey --output-file generic_extracted_key
-compare_keys $? generic_extracted_key aes_plain_key
-
-# unwrap AES key, not extractable
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS --id $ID1 -i aes_wrapped_key --key-type AES: \
-	--application-id $ID2 --application-label "unwrap-aes" 2>/dev/null
-assert $? "Unwrap failed"
-
-# To check if AES key was correctly unwrapped (non extractable), we need to encrypt some data by pkcs11 interface and by openssl
-# (with same key). If result is same, key was correctly unwrapped.
-VECTOR="00000000000000000000000000000000"
-echo -n "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU" > aes_plain.data
-
-openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv $VECTOR -K $KEY
-assert $? "Fail/Openssl"
-
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id $ID2 -m AES-CBC --iv $VECTOR \
-        --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
-assert $? "Fail/pkcs11-tool encrypt"
-cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
-assert $? "Fail, AES-CBC - wrong encrypt"
-
 echo "======================================================="
-echo " RSA-PKCS Wrap test"
+echo " RSA-PKCS Unwrap generic key test"
 echo "======================================================="
 
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS --id $ID1 --application-id $ID3 --output-file wrapped.key
-assert $? "Fail, unable to wrap"
+# Wrap with OpenSSL
+openssl rsautl -encrypt -pubin -keyform der -inkey rsa_pub.key -in aes.key -out openssl_wrapped.data
+assert $? "OpenSSL failed wrap AES key"
 
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt -m RSA-PKCS --id $ID1 --input-file wrapped.key --output-file plain_wrapped.key
-assert $? "Fail, unable to decrypt wrapped key"
-cmp plain_wrapped.key aes_plain_key >/dev/null 2>/dev/null
-assert $? "wrapped key after decipher does not match the original key"
-echo "RSA-PKCS wrap test successful"
+# Unwrap with pkcs11-tool as generic key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type GENERIC: \
+	--application-id $ID_GENERIC_UNWRAPPED_1 --application-label "unwrap-generic-ex-with-rsa-pkcs" --extractable 2>/dev/null
+assert $? "RSA-PKCS unwrap GENERIC key failed"
 
-echo "======================================================="
-echo " RSA-PKCS-OAEP Unwrap test"
-echo "======================================================="
-# RSA-PKCS-OAEP mechanism takes both a hash algorithm and MGF algorithm as parameters. For now we use SHA1, although it has been deprecated by NIST, because SoftHSM only supports SHA1 hash with OAEP currently. Known issue: https://github.com/softhsm/SoftHSMv2/issues/474 . When this issue is fixed, we shall replace with SHA256 or higher.
-# OpenSSL rsa_oaep_md hash algorithm option
-OSSL_OAEP_HASH_ALG="sha1"
-# pkcs11-tool hash-algorithm option
-P11_OAEP_HASH_ALG="SHA-1"
-# pkcs11-tool mgf option
-P11_OAEP_MGF_ALG="MGF1-SHA1"
-
-# Identifiers (pkcs11-tool --application-id argument) of PKCS11 key objects to be created
-ID4="97"
-ID5="98"
-
-# Reusing AES key and RSA key for unwrap/wrap operation already generated with ID1 in previous RSA-PKCS Unwrap test
-# Cleanup previously generated output
-rm aes_wrapped_key generic_extracted_key aes_ciphertext_openssl.data aes_ciphertext_pkcs11.data wrapped.key plain_wrapped.key
-
-# wrap AES key with RSA OAEP mode 
-openssl pkeyutl -encrypt -pubin -keyform DER -inkey rsa_pub.key -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$OSSL_OAEP_HASH_ALG -pkeyopt rsa_mgf1_md:$OSSL_OAEP_HASH_ALG -in aes_plain_key -out aes_wrapped_key
-assert $? "Failed wrap AES key"
-
-# unwrap key by pkcs11 interface, extractable
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID1 -i aes_wrapped_key --key-type GENERIC: \
-	--extractable --application-id $ID4 --application-label "unwrap-aes-ex-with-rsa-oaep" 2>/dev/null
-assert $? "Unwrap failed"
-
-# because key is extractable, there is no problem to compare key value with original key
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID4 --read-object --type secrkey --output-file generic_extracted_key
-compare_keys $? generic_extracted_key aes_plain_key
-
-# unwrap AES key, not extractable
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID1 -i aes_wrapped_key --key-type AES: \
-	--application-id $ID5 --application-label "unwrap-aes-non-ex-with-rsa-oaep" 2>/dev/null
-assert $? "Unwrap failed"
-
-# To check if AES key was correctly unwrapped (non extractable), we do the same as in the RSA-PKCS test.
-openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv $VECTOR -K $KEY
-assert $? "Fail/Openssl"
-
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id $ID5 -m AES-CBC --iv $VECTOR \
-        --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
-assert $? "Fail/pkcs11-tool encrypt"
-cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
-assert $? "Fail, AES-CBC - wrong encrypt"
-
+# Compare original and unwrapped key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_GENERIC_UNWRAPPED_1 --read-object --type secrkey --output-file generic_extracted.key
+compare_keys $? generic_extracted.key aes.key
 
 echo "======================================================="
-echo " RSA-PKCS-OAEP Wrap test"
+echo " RSA-PKCS Unwrap AES key test"
 echo "======================================================="
 
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS-OAEP --id $ID1 --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --application-id $ID4 --output-file wrapped.key
-assert $? "Fail, unable to wrap"
+# Unwrap with pkcs11-tool as AES key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type AES: \
+	--application-id $ID_AES_UNWRAPPED_1  --application-label "unwrap-aes-with-rsa-pkcs" --extractable 2>/dev/null
+assert $? "RSA-PKCS unwrap AES key failed"
 
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID1 --input-file wrapped.key --output-file plain_wrapped.key
-assert $? "Fail, unable to decrypt wrapped key"
-cmp plain_wrapped.key aes_plain_key >/dev/null 2>/dev/null
-assert $? "wrapped key after decipher does not match the original key"
-echo "RSA-PKCS-OAEP wrap test successful"
+# Read value of unwrapped key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_AES_UNWRAPPED_1 --read-object --type secrkey --output-file aes_extracted.key
+
+# Compare original and unwrapped key
+compare_keys $? aes_extracted.key aes.key
+
+# Check if AES key was correctly unwrapped with encryption
+test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_1
 
 echo "======================================================="
-echo " RSA-PKCS / RSA-PKCS-OAEP Cleanup"
+echo " RSA-PKCS Wrap AES key test"
 echo "======================================================="
 
-rm rsa_pub.key aes_plain_key aes_wrapped_key aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data aes_plain.data generic_extracted_key wrapped.key plain_wrapped.key
+# Wrap with pkcs11-tool
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS --id $ID_RSA_WRAP --application-id $ID_AES_UNWRAPPED_1 --output-file pkcs11_wrapped.data
+assert $? "Unable to wrap with RSA-PKCS"
+
+# Compare keys with decryption
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt -m RSA-PKCS --id $ID_RSA_WRAP --input-file pkcs11_wrapped.data --output-file aes_wrapped_decrypted.key
+assert $? "Unable to decrypt wrapped key"
+cmp aes_wrapped_decrypted.key aes.key >/dev/null 2>/dev/null
+assert $? "Wrapped key after decipher does not match the original key"
+
+rm openssl_wrapped.data generic_extracted.key pkcs11_wrapped.data aes_wrapped_decrypted.key aes_extracted.key
+
+if [ "${TOKENTYPE}" != "softokn" ]; then
+    echo "======================================================="
+    echo " RSA-PKCS-OAEP Unwrap generic key test"
+    echo "======================================================="
+    # RSA-PKCS-OAEP mechanism takes both a hash algorithm and MGF algorithm as parameters.
+    # For now we use SHA1, although it has been deprecated by NIST, because SoftHSM only supports SHA1 hash with OAEP currently.
+    # Known issue: https://github.com/softhsm/SoftHSMv2/issues/474 . When this issue is fixed, we shall replace with SHA256 or higher.
+
+    OSSL_OAEP_HASH_ALG="sha1"
+    P11_OAEP_HASH_ALG="SHA-1"
+    P11_OAEP_MGF_ALG="MGF1-SHA1"
+
+    # Identifiers (pkcs11-tool --application-id argument) of PKCS11 key objects to be created
+    ID_GENERIC_UNWRAPPED_2="97"
+    ID_AES_UNWRAPPED_3="98"
+
+    # Wrap with OpenSSL
+    openssl pkeyutl -encrypt -pubin -keyform DER -inkey rsa_pub.key -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$OSSL_OAEP_HASH_ALG -pkeyopt rsa_mgf1_md:$OSSL_OAEP_HASH_ALG -in aes.key -out openssl_wrapped.data
+    assert $? "OpenSSL failed wrap AES key"
+
+    # Unwrap with pkcs11-tool as generic key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type GENERIC: \
+        --extractable --application-id $ID_GENERIC_UNWRAPPED_2 --application-label "unwrap-aes-ex-with-rsa-oaep" 2>/dev/null
+    assert $? "RSA-PKCS-OAEP unwrap GENERIC key failed"
+
+    # Compare original and unwrapped key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_GENERIC_UNWRAPPED_2 --read-object --type secrkey --output-file generic_extracted.key
+    compare_keys $? generic_extracted.key aes.key
+
+    echo "======================================================="
+    echo " RSA-PKCS-OAEP Unwrap AES key test"
+    echo "======================================================="
+
+    # Unwrap with pkcs11-tool as AES key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID_RSA_WRAP -i openssl_wrapped.data --key-type AES: \
+        --extractable --application-id $ID_AES_UNWRAPPED_3 --application-label "unwrap-aes-non-ex-with-rsa-oaep" 2>/dev/null
+    assert $? "RSA-PKCS-OAEP unwrap AES key failed"
+
+    # Compare original and unwrapped key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --id $ID_AES_UNWRAPPED_1 --read-object --type secrkey --output-file aes_extracted.key
+    compare_keys $? aes_extracted.key aes.key
+
+    # Check if AES key was correctly unwrapped with encryption
+    test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_3
+
+    echo "======================================================="
+    echo " RSA-PKCS-OAEP Wrap test"
+    echo "======================================================="
+
+    # Wrap with pkcs11-tool
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m RSA-PKCS-OAEP --id $ID_RSA_WRAP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --application-id $ID_GENERIC_UNWRAPPED_2 --output-file pkcs11_wrapped.data
+    assert $? "Unable to wrap with RSA-PKCS-OAEP"
+
+    # Compare keys with decryption
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt -m RSA-PKCS-OAEP --hash-algorithm $P11_OAEP_HASH_ALG --mgf $P11_OAEP_MGF_ALG --id $ID_RSA_WRAP --input-file pkcs11_wrapped.data --output-file aes_wrapped_decrypted.key
+    assert $? "Fail, unable to decrypt wrapped key"
+    cmp aes_wrapped_decrypted.key aes.key >/dev/null 2>/dev/null
+    assert $? "Wrapped key after decipher does not match the original key"
+
+    rm  openssl_wrapped.data generic_extracted.key pkcs11_wrapped.data aes_wrapped_decrypted.key aes_extracted.key
+
+fi
+
+rm rsa_pub.key
 
 echo "======================================================="
-echo " AES wrap/unwrap"
+echo " AES Wrap/Unwrap tests"
 echo "======================================================="
+ID_AES_WRAP="0101" # AES wrapping key
+ID_AES_UNWRAPPED_4="0102" # AES 256 CBC
+ID_AES_UNWRAPPED_5="0103" # AES-KEY-WRAP
+ID_AES_UNWRAPPED_6="0104" # AES-KEY-WRAP-PAD
 
 is_openssl_3=$(openssl version | grep "OpenSSL 3.")
 is_softhsm2_2_6_1=$(softhsm2-util -version | grep "2.6.1")
 
-$PKCS11_TOOL "${PRIV_ARGS[@]}" -O
-
-ID_KEK="0101"
-ID_UNWRAPPED="0102"
-
-AES_KEY="7070707070707070707070707070707070707070707070707070707070707070"
-echo -n $AES_KEY | xxd -p -r > aes.key
-
-AES_KEK=$(head /dev/urandom | sha256sum | head -c 64)
-echo -n $AES_KEK | xxd -p -r > aes_kek.key
-$PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object aes_kek.key --id $ID_KEK --type secrkey \
-    --key-type AES:32 --usage-wrap --extractable --label wrap-aes-32
-assert $? "PKCS11 / Failed to write AES KEK"
+# Generate AES key for unwrap/wrap operation
+AES_WRAP=$(head /dev/urandom | sha256sum | head -c 64)
+echo -n $AES_WRAP | xxd -p -r > aes_kek.key
+$PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object aes_kek.key --id $ID_AES_WRAP --type secrkey \
+    --key-type AES:32 --usage-wrap --extractable --label aes-32-wrapping-key
+assert $? "Failed to write AES key"
 
 if [[ "$TOKENTYPE" != "softhsm" || -n "$is_softhsm2_2_6_1" ]]; then
     # CKM_AES_CBC -- SoftHSM2 AES CBC wrapping currently has a bug, the IV is not correctly used. Only IV=0 will work --*
@@ -194,139 +218,142 @@ if [[ "$TOKENTYPE" != "softhsm" || -n "$is_softhsm2_2_6_1" ]]; then
     echo "======================================================="
     echo " AES 256 CBC Unwrap test"
     echo "======================================================="
-    # wrapping AES Key with openssl
-    openssl enc -aes-256-cbc -e -K $AES_KEK -iv $IV -in aes.key -out openssl_wrapped.data -nopad
+    # Wrap with OpenSSL
+    openssl enc -aes-256-cbc -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data -nopad
     assert $? "OpenSSL / Failed to AES CBC encrypt AES key"
 
     if [ "${TOKENTYPE}" == "softhsm" ]; then
         echo "SoftHSM2 currently does not support CKM_AES_CBC unwrapping"
-        # SoftHSM does not have the wrapped key already, write it for wrap test
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object aes.key --id $ID_UNWRAPPED --type secrkey --key-type AES:32 \
-            --usage-decrypt --extractable --label "aes-stored"
+        # SoftHSM does not have the wrapped key already, write it for the wrap test
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object aes.key --id $ID_AES_UNWRAPPED_4 --type secrkey --key-type AES:32 \
+            --usage-decrypt --extractable --label "stored-aes-32-cbc"
         assert $? "PKCS11 / Failed to write AES key"
     else
-        # unwrap key
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-CBC --id $ID_KEK --iv $IV --application-id $ID_UNWRAPPED \
-            --key-type AES: --input-file openssl_wrapped.data --extractable --application-label "unwrap-aes-with-aes"
+        # Unwrap with pkcs11-tool
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-CBC --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_4 \
+            --key-type AES: --input-file openssl_wrapped.data --extractable --application-label "unwrap-aes-with-aes-32-cbc"
         assert $? "PKCS11 / Failed to AES CBC unwrap AES key"
 
-        # compare keys
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID_UNWRAPPED --output-file unwrapped.key
+        # Compare original and unwrapped key
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID_AES_UNWRAPPED_4 --output-file unwrapped.key
         compare_keys $? aes.key unwrapped.key
 
-        # check if AES key was correctly unwrapped with encryption
-        # encrypt with openssl
-        echo -n "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" > aes_plain.data
-        openssl enc -aes-256-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv $IV -K $AES_KEY
-        assert $? "Fail/Openssl"
-        # decrypt with pkcs11-tool
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id $ID_UNWRAPPED -m AES-CBC-PAD --iv $IV \
-                --input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data
-        assert $? "Fail/pkcs11-tool encrypt"
-        cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
-        assert $? "Fail, AES-CBC - wrong encrypt"
-        rm aes_ciphertext_openssl.data aes_ciphertext_pkcs11.data aes_plain.data
+        # Check if AES key was correctly unwrapped with encryption
+        test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_4
     fi
     echo "======================================================="
     echo " AES 256 CBC Wrap test"
     echo "======================================================="
-    # Wrapping AES Key with pkcs11-tool
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC --id $ID_KEK --iv $IV --application-id $ID_UNWRAPPED \
+    # Wrap with OpenSSL
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_4 \
         --output-file pkcs11_wrapped.data
     assert $? "Fail, unable to wrap"
 
-    # Compare wrapped keys
+    # Compare OpenSSL and pkcs11-tool wrapped keys
     cmp pkcs11_wrapped.data openssl_wrapped.data >/dev/null 2>/dev/null
     assert $? "Fail, AES-CBC - wrapped key incorrect"
-
-    # clean up
-    #$PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type secrkey --id $ID_UNWRAPPED
-    #assert $? "PKCS11 / Failed to delete unwrapped AES key"
 else
     echo "Not supported"
 fi
 
 if [[ "$TOKENTYPE" != "softhsm" ]]; then
-    # CKM_AES_CBC_PAD -- SoftHSM2 currently doesn't support CKM_AES_CBC_PAD as a wrapping mechanism --
-    IV="000102030405060708090A0B0C0D0E0F"
+    # SoftHSM2 currently doesn't support CKM_AES_CBC_PAD as a wrapping
     echo "======================================================="
     echo " AES 256 CBC PAD Wrap test"
     echo "======================================================="
-    # Wrapping AES key
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC-PAD --id $ID_KEK --iv $IV --application-id $ID_UNWRAPPED --output-file pkcs11_wrapped.data
-    assert $? "PKCS11 / Failed to AES CBC PAD wrap AES key"
-    openssl enc -aes-256-cbc -e -K $AES_KEK -iv $IV -in aes.key -out openssl_wrapped.data
+    IV="000102030405060708090A0B0C0D0E0F"
+    # Wrap with OpenSSL
+    openssl enc -aes-256-cbc -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data
     assert $? "OpenSSL / Failed to AES CBC encrypt AES key"
+
+    # Wrap with pkcs11-tool
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-CBC-PAD --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_4 --output-file pkcs11_wrapped.data
+    assert $? "PKCS11 / Failed to AES CBC PAD wrap AES key"
+
+    # Compare OpenSSL and pkcs11-tool wrapped keys
     cmp pkcs11_wrapped.data openssl_wrapped.data 2>&1 >/dev/null
-    assert $? "AES CBC PAD wrong AES key wrap"
+    assert $?  "AES 256 CBC PAD wrapped keys do not match"
 fi
 
 if [[ -n $is_openssl_3 ]]; then
-    # CKM_AES_KEY_WRAP
-    IV="a6a6a6a6a6a6a6a6"
-    ID7="0103"
     echo "======================================================="
     echo "AES-KEY-WRAP Wrap test"
     echo "======================================================="
     # RSA Key
     # --AES-KEY-WRAP is not suitable for asymmetric key wrapping since the length of the encoded private key is likely not aligned to 8 bytes
+    IV="a6a6a6a6a6a6a6a6"
 
-    # AES Key
-    openssl enc -id-aes256-wrap -e -K $AES_KEK -iv $IV -in aes.key -out openssl_wrapped.data
+    # Wrap with OpenSSL
+    openssl enc -id-aes256-wrap -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data
     assert $? "OpenSSL / Failed to AES KEY WRAP wrap AES key"
     
-    # Wrapping
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP --id $ID_KEK --iv $IV --application-id $ID_UNWRAPPED \
+    # Wrap with pkcs11-tool
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_4 \
         --output-file pkcs11_wrapped.data
     assert $? "PKCS11 / Failed to AES KEY WRAP wrap AES key"
+
+    # Compare OpenSSL and pkcs11-tool wrapped keys
     cmp pkcs11_wrapped.data openssl_wrapped.data 2>&1 >/dev/null
-    assert $? "AES KEY WRAP wrong AES key wrap"
+    assert $? "AES-KEY-WRAP wrapped keys do not match"
 
     echo "======================================================="
     echo "AES-KEY-WRAP Unwrap test"
     echo "======================================================="
-    # Unwrapping
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_KEK --iv $IV --application-id $ID7 \
-        --key-type AES: --input-file openssl_wrapped.data --extractable
+    # Unwrap with pkcs11-tool
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_5 \
+        --key-type AES: --input-file pkcs11_wrapped.data --extractable --application-label "unwrap-aes-with-aes-key-wrap"
     assert $? "PKCS11 / Failed to AES KEY WRAP wrap unwrap AES key"
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID7 --output-file unwrapped.key
+
+    # Read value of unwrapped key
+    $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID_AES_UNWRAPPED_5 --output-file unwrapped.key
+
+    # Compare original and unwrapped key
     compare_keys $? aes.key unwrapped.key
-    # Cleanup
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type secrkey --id $ID_UNWRAPPED
-    assert $? "PKCS11 / Failed to delete unwrapped AES key"
+
+    # Check if AES key was correctly unwrapped with encryption
+    test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_4
 
     if [[ "$TOKENTYPE" != "kryoptic" ]]; then
         echo "======================================================="
         echo "AES-KEY-WRAP-PAD Wrap test"
         echo "======================================================="
-        # CKM_AES_KEY_WRAP_PAD
         IV="a65959a6"
-        ID8="0104"
-        # AES Key
-        openssl enc -id-aes256-wrap-pad -e -K $AES_KEK -iv $IV -in aes.key -out openssl_wrapped.data
-        assert $? "OpenSSL / Failed to AES KEY WRAP PAD encrypt AES key"
-        # Wrapping
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP-PAD --id $ID_KEK --iv $IV --application-id $ID7 --output-file pkcs11_wrapped.data
+
+        # Wrap with OpenSSL
+        openssl enc -aes256-wrap-pad -e -K $AES_WRAP -iv $IV -in aes.key -out openssl_wrapped.data
+        assert $? "OpenSSL failed wrap AES key"
+
+        # Wrap with pkcs11-tool
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
+                --application-id $ID_AES_UNWRAPPED_4 --output-file pkcs11_wrapped.data
         assert $? "PKCS11 / Failed to AES KEY WRAP PAD wrap AES key"
-        cmp pkcs11_wrapped.data openssl_wrapped.data 2>&1 >/dev/null
-        assert $? "AES KEY WRAP PAD wrong AES key wrap"
+
+        # Compare OpenSSL and pkcs11-tool wrapped keys
+        if [[ "$TOKENTYPE" != "softokn" ]]; then
+            cmp pkcs11_wrapped.data openssl_wrapped.data 2>&1 >/dev/null
+            assert $? "AES-KEY-WRAP-PAD wrapped keys do not match"
+        else
+            echo "Comparing OpenSSL and pkcs11-tool wrapped keys for softokn fails"
+        fi
 
         echo "======================================================="
         echo "AES-KEY-WRAP-PAD Unwrap test"
         echo "======================================================="
-        # Unwrapping
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_KEK --iv $IV --application-id $ID8 --key-type AES: --input-file openssl_wrapped.data --extractable
+        # Unwrap with pkcs11-tool
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV --application-id $ID_AES_UNWRAPPED_6 \
+                --key-type AES: --input-file pkcs11_wrapped.data --extractable --application-label "unwrap-aes-with-aes-key-wrap-pad"
         assert $? "PKCS11 / Failed to AES KEY WRAP PAD wrap unwrap AES key"
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID8 --output-file unwrapped.key
-        assert $? "PKCS11 / Failed to read unwrapped AES key"
-        cmp aes.key unwrapped.key
-        assert $? "AES KEY WRAP PAD wrong AES key unwrap"
-        # Cleanup
-        $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type secrkey --id $ID8
-        assert $? "PKCS11 / Failed to delete unwrapped AES key"
+
+        # Read value of unwrapped key
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --read-object --type secrkey --id $ID_AES_UNWRAPPED_6 --output-file unwrapped.key
+
+        # Compare original and unwrapped key
+        compare_keys $? aes.key unwrapped.key
+        
+        # Check if AES key was correctly unwrapped with encryption
+        test_unwrapped_aes_encryption $AES_256_KEY $ID_AES_UNWRAPPED_4
     fi
 fi
-$PKCS11_TOOL "${PRIV_ARGS[@]}" -O
 
 rm -f aes.key aes_kek.key pkcs11_wrapped.data openssl_wrapped.data unwrapped.key
 

--- a/tests/test-pkcs11-tool-unwrap-wrap-test.sh
+++ b/tests/test-pkcs11-tool-unwrap-wrap-test.sh
@@ -398,46 +398,48 @@ $PKCS11_TOOL "${PRIV_ARGS[@]}" --keypairgen --key-type rsa:2048 --id $ID_RSA_WRA
 assert $? "Failed to Generate RSA key"
 
 # AES-KEY-WRAP, AES-KEY-WRAP-PAD, AES-CBC, AES-CBC-PAD
-if [[ "$TOKENTYPE" == "softhsm" ]]; then
-    echo "-------------------------------------------------------"
-    echo "AES-KEY-WRAP Wrap/Unwrap RSA key test"
-    echo "-------------------------------------------------------"
-    # Wrap
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
-        --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
-    assert $? "Failed to wrap RSA key"
-    # Unwrap
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
-        --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
-    assert $? "Failed to unwrap RSA key with $MECH"
-    rm rsa_wrapped_key.data
+if [[ -n $is_openssl_3 ]]; then
+    if [[ "$TOKENTYPE" == "softhsm" ]]; then
+        echo "-------------------------------------------------------"
+        echo "AES-KEY-WRAP Wrap/Unwrap RSA key test"
+        echo "-------------------------------------------------------"
+        # Wrap
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
+            --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+        assert $? "Failed to wrap RSA key"
+        # Unwrap
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP --id $ID_AES_WRAP --iv $IV \
+            --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+        assert $? "Failed to unwrap RSA key with $MECH"
+        rm rsa_wrapped_key.data
 
-    # Test with decryption
-    test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
+        # Test with decryption
+        test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
 
-    # Remove unwrapped RSA keys
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
-fi
+        # Remove unwrapped RSA keys
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+    fi
 
-if [[ "$TOKENTYPE" != "kryoptic" ]]; then
-    echo "-------------------------------------------------------"
-    echo "AES-KEY-WRAP-PAD Wrap/Unwrap RSA key test"
-    echo "-------------------------------------------------------"
-    # Wrap
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
-        --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
-    assert $? "Failed to wrap RSA key"
-    # Unwrap
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
-        --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
-    assert $? "Failed to unwrap RSA key with $MECH"
-    rm rsa_wrapped_key.data
+    if [[ "$TOKENTYPE" != "kryoptic" ]]; then
+        echo "-------------------------------------------------------"
+        echo "AES-KEY-WRAP-PAD Wrap/Unwrap RSA key test"
+        echo "-------------------------------------------------------"
+        # Wrap
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --wrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
+            --application-id $ID_RSA_WRAPPED --output-file rsa_wrapped_key.data
+        assert $? "Failed to wrap RSA key"
+        # Unwrap
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --unwrap -m AES-KEY-WRAP-PAD --id $ID_AES_WRAP --iv $IV \
+            --application-id $ID_RSA_UNWRAPPED --key-type RSA:2048 --input-file rsa_wrapped_key.data
+        assert $? "Failed to unwrap RSA key with $MECH"
+        rm rsa_wrapped_key.data
 
-    # Test with decryption
-    test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
+        # Test with decryption
+        test_unwrapped_rsa_pkcs_decryption $ID_RSA_WRAPPED $ID_RSA_UNWRAPPED
 
-    # Remove unwrapped RSA key
-    $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+        # Remove unwrapped RSA key
+        $PKCS11_TOOL "${PRIV_ARGS[@]}" --delete-object --type privkey --id $ID_RSA_UNWRAPPED
+    fi
 fi
 
 if [[ "$TOKENTYPE" != "softhsm" ]]; then

--- a/tests/test-softokn.sh
+++ b/tests/test-softokn.sh
@@ -5,3 +5,4 @@ echo "Running all supported tests for NSS Softokn token..."
 
 $SOURCE_PATH/tests/test-pkcs11-tool-sign-verify.sh softokn
 $SOURCE_PATH/tests/test-pkcs11-tool-import.sh softokn
+$SOURCE_PATH/tests/test-pkcs11-tool-unwrap-wrap-test.sh softokn


### PR DESCRIPTION
- Enabled wrap/unwrap tests with NSS Softokn
- Added tests for wrapping RSA private key
- Enable wrap/unwrap usage when writing object by `pkcs11-tool`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
