### PR TITLE
idprime: IDPrime 940 supports 3072 RSA keys

### DIFF
--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -694,6 +694,9 @@ static int idprime_init(sc_card_t *card)
 
 	_sc_card_add_rsa_alg(card, 1024, flags, 0);
 	_sc_card_add_rsa_alg(card, 2048, flags, 0);
+	if (card->type == SC_CARD_TYPE_IDPRIME_940) {
+		_sc_card_add_rsa_alg(card, 3072, flags, 0);
+	}
 	if (card->type == SC_CARD_TYPE_IDPRIME_930
 	    || card->type == SC_CARD_TYPE_IDPRIME_940) {
 		_sc_card_add_rsa_alg(card, 4096, flags, 0);


### PR DESCRIPTION
Such is the key on the Gemalto IDPrime 940B card
I got from the bulgarian eID provider B-Trust [1]. Tested and confirmed to work.

Its ATR is as follows:
3b:7f:96:00:00:80:31:80:65:b0:85:05:00:39:12:0f:fe:82:90:00

I.e. identical to the one already defined for IDPrime 940.

[1] https://www.b-trust.bg/en/electronic-signatures/cards-and-readers

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
