### PR TITLE
fixed Stack-buffer-overflow WRITE in GET RESPONSE

### DIFF
--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -184,9 +184,10 @@ static int nqapplet_finish(struct sc_card *card)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-static int nqapplet_get_response(struct sc_card *card, size_t *cb_resp, u8 *resp)
+static int
+nqapplet_get_response(struct sc_card *card, size_t *cb_resp, u8 *resp)
 {
-	struct sc_apdu apdu;
+	struct sc_apdu apdu = {0};
 	int rv;
 	size_t resplen;
 
@@ -198,12 +199,12 @@ static int nqapplet_get_response(struct sc_card *card, size_t *cb_resp, u8 *resp
 
 	rv = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
-	if (apdu.resplen == 0) {
-		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
-	}
 
 	*cb_resp = apdu.resplen;
 
+	if (apdu.resplen == 0) {
+		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+	}
 	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00) {
 		rv = SC_SUCCESS;
 	} else if (apdu.sw1 == 0x61) {

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -920,11 +920,12 @@ iso7816_get_response(struct sc_card *card, size_t *count, u8 *buf)
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-	if (apdu.resplen == 0)
-		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
 
 	*count = apdu.resplen;
 
+	if (apdu.resplen == 0) {
+		LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+	}
 	if (apdu.sw1 == 0x90 && apdu.sw2 == 0x00)
 		r = 0;					/* no more data to read */
 	else if (apdu.sw1 == 0x61)


### PR DESCRIPTION
The do-while loop in apdu.c requires the output data to be set in any case, otherwise non existent data may be copied to the output data.

fixes https://issues.oss-fuzz.com/issues/416351800 fixes https://issues.oss-fuzz.com/issues/416295951

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
