### PR TITLE
pkcs11-tool: allocate for C_Sign/C_SignFinal

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2520,12 +2520,12 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		free(sig_buffer);
 		sig_buffer = NULL;
 		rv = p11->C_SignFinal(session, sig_buffer, &sig_len);
-		if (rv == CKR_OK) {
-			sig_buffer = malloc(sig_len);
-			if (!sig_buffer)
-				util_fatal("malloc() failure\n");
-			rv = p11->C_SignFinal(session, sig_buffer, &sig_len);
-		}
+		if (rv != CKR_OK)
+			p11_fatal("C_SignFinal", rv);
+		sig_buffer = malloc(sig_len);
+		if (!sig_buffer)
+			util_fatal("malloc() failure\n");
+		rv = p11->C_SignFinal(session, sig_buffer, &sig_len);
 		if (rv != CKR_OK)
 			p11_fatal("C_SignFinal", rv);
 	}

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2413,8 +2413,8 @@ parse_pss_params(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE key)
 {
-	unsigned char	in_buffer[1025];
-        CK_BYTE_PTR	sig_buffer = NULL;
+	unsigned char in_buffer[1025];
+	CK_BYTE_PTR sig_buffer = NULL;
 	CK_MECHANISM	mech;
 	CK_RSA_PKCS_PSS_PARAMS pss_params;
 	CK_MAC_GENERAL_PARAMS mac_gen_param;
@@ -2422,7 +2422,7 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			.phFlag = CK_FALSE,
 	};
 	CK_RV		rv;
-	CK_ULONG	sig_len = 0;
+	CK_ULONG sig_len = 0;
 	int		fd;
 	ssize_t sz;
 	unsigned long	hashlen;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -2570,7 +2570,7 @@ static void sign_data(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE key)
 {
-	unsigned char	in_buffer[1025];
+	unsigned char in_buffer[1025];
 	CK_BYTE_PTR sig_buffer = NULL;
 	CK_MECHANISM	mech;
 	CK_RSA_PKCS_PSS_PARAMS pss_params;
@@ -2579,7 +2579,7 @@ static void verify_signature(CK_SLOT_ID slot, CK_SESSION_HANDLE session,
 			.phFlag = CK_FALSE,
 	};
 	CK_RV		rv;
-	CK_ULONG	sig_len = 0;
+	CK_ULONG sig_len = 0;
 	int		fd, fd2;
 	struct stat sig_st;
 	ssize_t sz, sz2;


### PR DESCRIPTION
Addresses issue 3425.  Quantum resistant algorithms like LMS and ML-DSA have large signature sizes.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
