### PR TITLE
pkcs11-tool: Add missing help message to avoid buffer overrun

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -425,6 +425,7 @@ static const char *option_help[] = {
 		"Specify the required length (in bits) for the authentication tag for AEAD ciphers",
 		"Specify the file containing the salt for HKDF (optional)",
 		"Specify the file containing the info for HKDF (optional)",
+		"When reading a public key, try to read PUBLIC_KEY_INFO (DER encoding of SPKI)",
 };
 
 static const char *	app_name = "pkcs11-tool"; /* for utils.c */


### PR DESCRIPTION
This was uninitentionally omitted in 175ac15c37817d0641ecd87066158365e49c6418 and later reported as #3418. The PR #3419 was stale so fixing this in separate PR.

Fixes: #3418
Supersedes: #3419

##### Checklist
- [X] Documentation is added or updated