### PR TITLE
Add wolfProvider support for OpenSC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,13 @@ AS_IF([test $enable_openssl_secure_malloc != no],
 	[AC_DEFINE_UNQUOTED([OPENSSL_SECURE_MALLOC_SIZE],[$enable_openssl_secure_malloc],[Size of OpenSSL secure memory in bytes, must be a power of 2])])
 
 AC_ARG_ENABLE(
+	[wolfprov],
+	[AS_HELP_STRING([--enable-wolfprov],[enable wolfProvider support for FIPS and non-FIPS modes @<:@disabled@:>@])],
+	,
+	[enable_wolfprov="no"]
+)
+
+AC_ARG_ENABLE(
 	[openpace],
 	[AS_HELP_STRING([--enable-openpace],[enable OpenPACE linkage @<:@detect@:>@])],
 	,
@@ -749,6 +756,13 @@ else
 	OPENSSL_LIBS=""
 fi
 
+if test "${enable_wolfprov}" = "yes"; then
+	if test "${enable_openssl}" != "yes"; then
+		AC_MSG_ERROR([wolfProvider support requires OpenSSL to be enabled])
+	fi
+	AC_DEFINE([ENABLE_WOLFPROV], [1], [Enable wolfProvider support for OpenSSL 3.0+])
+fi
+
 if test "${enable_cmocka}" = "detect"; then
 	if test "${have_cmocka}" = "yes" -a "${have_openssl}" = "yes"; then
 		enable_cmocka="yes"
@@ -1058,6 +1072,9 @@ if test "${enable_openssl}" = "yes"; then
 	OPTIONAL_OPENSSL_CFLAGS="${OPENSSL_CFLAGS}"
 	OPTIONAL_OPENSSL_LIBS="${OPENSSL_LIBS}"
 fi
+if test "${enable_wolfprov}" = "yes"; then
+	OPENSC_FEATURES="${OPENSC_FEATURES} wolfprov"
+fi
 if test "${enable_openct}" = "yes"; then
 	OPENSC_FEATURES="${OPENSC_FEATURES} openct"
 	OPTIONAL_OPENCT_CFLAGS="${OPENCT_CFLAGS}"
@@ -1148,6 +1165,7 @@ AM_CONDITIONAL([ENABLE_THREAD_LOCKING], [test "${enable_thread_locking}" = "yes"
 AM_CONDITIONAL([ENABLE_ZLIB], [test "${enable_zlib}" = "yes"])
 AM_CONDITIONAL([ENABLE_READLINE], [test "${enable_readline}" = "yes"])
 AM_CONDITIONAL([ENABLE_OPENSSL], [test "${enable_openssl}" = "yes"])
+AM_CONDITIONAL([ENABLE_WOLFPROV], [test "${enable_wolfprov}" = "yes"])
 AM_CONDITIONAL([ENABLE_OPENPACE], [test "${enable_openpace}" = "yes"])
 AM_CONDITIONAL([ENABLE_NOTIFY], [test "${enable_notify}" = "yes"])
 AM_CONDITIONAL([ENABLE_CRYPTOTOKENKIT], [test "${enable_cryptotokenkit}" = "yes"])
@@ -1249,6 +1267,7 @@ zlib support:            ${enable_zlib}
 readline support:        ${enable_readline}
 OpenSSL support:         ${enable_openssl}
 OpenSSL secure memory:   ${enable_openssl_secure_malloc}
+wolfProvider support:    ${enable_wolfprov}
 PC/SC support:           ${enable_pcsc}
 CryptoTokenKit support:  ${enable_cryptotokenkit}
 OpenCT support:          ${enable_openct}

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -838,6 +838,16 @@ static int sc_openssl3_init(sc_context_t *ctx)
 	if (ctx->ossl3ctx->libctx == NULL) {
 		return SC_ERROR_INTERNAL;
 	}
+#ifdef ENABLE_WOLFPROV
+	ctx->ossl3ctx->defprov = OSSL_PROVIDER_load(ctx->ossl3ctx->libctx,
+						    "libwolfprov");
+	if (ctx->ossl3ctx->defprov == NULL) {
+		OSSL_LIB_CTX_free(ctx->ossl3ctx->libctx);
+		free(ctx->ossl3ctx);
+		ctx->ossl3ctx = NULL;
+		return SC_ERROR_INTERNAL;
+	}
+#else
 	ctx->ossl3ctx->defprov = OSSL_PROVIDER_load(ctx->ossl3ctx->libctx,
 						    "default");
 	if (ctx->ossl3ctx->defprov == NULL) {
@@ -851,6 +861,7 @@ static int sc_openssl3_init(sc_context_t *ctx)
 	if (ctx->ossl3ctx->legacyprov == NULL) {
 		sc_log(ctx, "Failed to load OpenSSL Legacy provider");
 	}
+#endif
 	return SC_SUCCESS;
 }
 
@@ -858,8 +869,10 @@ static void sc_openssl3_deinit(sc_context_t *ctx)
 {
 	if (ctx->ossl3ctx == NULL)
 		return;
+#ifndef ENABLE_WOLFPROV
 	if (ctx->ossl3ctx->legacyprov)
 		OSSL_PROVIDER_unload(ctx->ossl3ctx->legacyprov);
+#endif
 	if (ctx->ossl3ctx->defprov)
 		OSSL_PROVIDER_unload(ctx->ossl3ctx->defprov);
 	if (ctx->ossl3ctx->libctx)

--- a/src/tests/unittests/Makefile.am
+++ b/src/tests/unittests/Makefile.am
@@ -54,11 +54,14 @@ compression_LDADD = $(LDADD) $(OPTIONAL_ZLIB_LIBS)
 endif
 
 if ENABLE_OPENSSL
+# SM tests rely on DES which is not available in wolfProvider FIPS mode
+if !ENABLE_WOLFPROV
 noinst_PROGRAMS += sm
 TESTS += sm
 
 sm_SOURCES = sm.c
 sm_LDADD = $(top_builddir)/src/sm/libsm.la $(LDADD)
+endif
 endif
 
 

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -820,10 +820,16 @@ int main(int argc, char * argv[])
 	if (!(osslctx = OSSL_LIB_CTX_new())) {
 		util_fatal("Failed to create OpenSSL OSSL_LIB_CTX\n");
 	}
+#ifdef ENABLE_WOLFPROV
+	if (!(default_provider = OSSL_PROVIDER_load(osslctx, "libwolfprov"))) {
+		util_fatal("Failed to load wolfProvider \"libwolfprov\" provider\n");
+	}
+#else
 	if (!(default_provider = OSSL_PROVIDER_load(osslctx, "default"))) {
 		util_fatal("Failed to load OpenSSL \"default\" provider\n");
 	}
 	legacy_provider = OSSL_PROVIDER_try_load(NULL, "legacy", 1);
+#endif
 #endif
 
 	while (1) {
@@ -6963,7 +6969,7 @@ static int test_digest(CK_SESSION_HANDLE session)
 #else
 	i = 0;
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFPROV)
 		if (!legacy_provider) {
 			printf("Failed to load legacy provider\n");
 			return errors;
@@ -7436,7 +7442,7 @@ static int sign_verify_openssl(CK_SESSION_HANDLE session,
 		EVP_sha256(),
 	};
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(OPENSSL_NO_RIPEMD)
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(OPENSSL_NO_RIPEMD) && !defined(ENABLE_WOLFPROV)
 	if (!legacy_provider) {
 		printf("Failed to load legacy provider");
 		return errors;

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -32,6 +32,19 @@ function assert() {
 	fi
 }
 
+# Helper function to get OpenSSL provider arguments
+function get_openssl_provider_args() {
+	if [ "${ENABLE_WOLFPROV}" = "1" ]; then
+		if [ -n "${WOLFPROV_PATH}" ]; then
+			echo "-provider-path ${WOLFPROV_PATH} -provider libwolfprov"
+		else
+			echo "-provider libwolfprov"
+		fi
+	else
+		echo "-provider default"
+	fi
+}
+
 function generate_key() {
 	TYPE="$1"
 	ID="$2"
@@ -53,12 +66,13 @@ function generate_key() {
 	fi
 
 	# convert it to more digestible PEM format
+	PROVIDER_ARGS=$(get_openssl_provider_args)
 	if [[ ${TYPE:0:3} == "RSA" ]]; then
-		openssl rsa -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
+		openssl rsa -inform DER -outform PEM $PROVIDER_ARGS -in $ID.der -pubin > $ID.pub
 	elif [[ $TYPE == "EC:edwards25519" ]]; then
-		openssl pkey -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
+		openssl pkey -inform DER -outform PEM $PROVIDER_ARGS -in $ID.der -pubin > $ID.pub
 	else
-		openssl ec -inform DER -outform PEM -in $ID.der -pubin > $ID.pub
+		openssl ec -inform DER -outform PEM $PROVIDER_ARGS -in $ID.der -pubin > $ID.pub
 	fi
 	rm $ID.der
 }

--- a/tests/test-pkcs11-tool-import.sh
+++ b/tests/test-pkcs11-tool-import.sh
@@ -33,7 +33,8 @@ for KEYTYPE in "RSA" "EC"; do
         ID="0200"
         OPTS="-pkeyopt ec_paramgen_curve:P-256"
     fi
-    openssl genpkey -out "${KEYTYPE}_private.der" -outform DER -algorithm $KEYTYPE $OPTS
+    PROVIDER_ARGS=$(get_openssl_provider_args)
+    openssl genpkey -algorithm $KEYTYPE $OPTS $PROVIDER_ARGS -out "${KEYTYPE}_private.der" -outform DER
 
     assert $? "Failed to generate private $KEYTYPE key"
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object "${KEYTYPE}_private.der" --id "$ID" \
@@ -41,7 +42,7 @@ for KEYTYPE in "RSA" "EC"; do
     assert $? "Failed to write private $KEYTYPE key"
     echo "Private key written"
 
-    openssl pkey -in "${KEYTYPE}_private.der" -out "${KEYTYPE}_public.der" -pubout -inform DER -outform DER
+    openssl pkey $PROVIDER_ARGS -in "${KEYTYPE}_private.der" -out "${KEYTYPE}_public.der" -pubout -inform DER -outform DER
     assert $? "Failed to convert private $KEYTYPE key to public"
     $PKCS11_TOOL "${PRIV_ARGS[@]}" --write-object "${KEYTYPE}_public.der" --id "$ID" --type pubkey --label "$KEYTYPE"
     assert $? "Failed to write public $KEYTYPE key"

--- a/tests/test-pkcs11-tool-sym-crypt-test.sh
+++ b/tests/test-pkcs11-tool-sym-crypt-test.sh
@@ -52,7 +52,8 @@ dd if=/dev/urandom bs=200 count=1 >aes_plain.data 2>/dev/null
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --encrypt --id "$ID2" -m AES-CBC-PAD --iv "${VECTOR}" \
 	--input-file aes_plain.data --output-file aes_ciphertext_pkcs11.data 2>/dev/null
 assert $? "Fail/pkcs11-tool encrypt"
-openssl enc -aes-128-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+    PROVIDER_ARGS=$(get_openssl_provider_args)
+    openssl enc -aes-128-cbc $PROVIDER_ARGS -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
 cmp aes_ciphertext_pkcs11.data aes_ciphertext_openssl.data >/dev/null 2>/dev/null
 assert $? "Fail, AES-CBC-PAD (C_Encrypt) - wrong encrypt"
 
@@ -65,7 +66,7 @@ assert $? "Fail, AES-CBC-PAD (C_Decrypt) - wrong decrypt"
 
 echo "C_DecryptUpdate"
 dd if=/dev/urandom bs=8131 count=3 >aes_plain.data 2>/dev/null
-openssl enc -aes-128-cbc -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+    openssl enc -aes-128-cbc $PROVIDER_ARGS -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
 assert $? "Fail, OpenSSL"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt --id "$ID2" -m AES-CBC-PAD --iv "${VECTOR}" \
 	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
@@ -99,7 +100,7 @@ echo " OpenSSL encrypt, pkcs11-tool decrypt"
 echo " pkcs11-tool encrypt, compare to openssl encrypt"
 echo "======================================================="
 
-openssl enc -aes-128-ecb -nopad -in aes_plain.data -out aes_ciphertext_openssl.data  -K "70707070707070707070707070707070"
+    openssl enc -aes-128-ecb -nopad $PROVIDER_ARGS -in aes_plain.data -out aes_ciphertext_openssl.data  -K "70707070707070707070707070707070"
 assert $? "Fail/OpenSSL"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt --id "$ID2" -m AES-ECB --input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
 assert $? "Fail/pkcs11-tool decrypt"
@@ -117,7 +118,7 @@ echo " OpenSSL encrypt, pkcs11-tool decrypt"
 echo " pkcs11-tool encrypt, compare to openssl encrypt"
 echo "======================================================="
 
-openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+openssl enc -aes-128-cbc -nopad $PROVIDER_ARGS -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
 assert $? "Fail/OpenSSL"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
 	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null
@@ -138,7 +139,7 @@ echo " OpenSSL encrypt, pkcs11-tool decrypt"
 echo " pkcs11-tool encrypt, compare to openssl encrypt"
 echo "======================================================="
 
-openssl enc -aes-128-cbc -nopad -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
+openssl enc -aes-128-cbc -nopad $PROVIDER_ARGS -in aes_plain.data -out aes_ciphertext_openssl.data -iv "${VECTOR}" -K "70707070707070707070707070707070"
 assert $? "Fail/Openssl"
 $PKCS11_TOOL "${PRIV_ARGS[@]}" --decrypt --id "$ID2" -m AES-CBC --iv "${VECTOR}" \
 	--input-file aes_ciphertext_openssl.data --output-file aes_plain_test.data 2>/dev/null


### PR DESCRIPTION
# Description 

- Adds OpenSC support for wolfSSL's wolfProvider which supplies underlying cryptography for openssl. This can supply FIPS 140-3 crypto for OpenSC using wolfcrypt and wolfcrypt FIPS. 
- You can enable wolfprovider using `--enable-wolfprov` while setting env variable `ENABLE_WOLFPROV=1`
- For FIPS we can set `WOLFSSL_ISFIPS=1` which is used when building wolfprovider with FIPS.

## Testing 

- Tested with `make check`
- Tested in wolfProvider [here](https://github.com/wolfSSL/wolfProvider/pull/226)