### PR TITLE
Fix bash-completion function name

### DIFF
--- a/doc/tools/completion-template
+++ b/doc/tools/completion-template
@@ -5,7 +5,11 @@ _FUNCTION_NAME()
     local cur prev split=false
     _get_comp_words_by_ref -n : cur prev
 
-    _split_longopt && split=true
+    if type _init_completion &>/dev/null; then
+        _init_completion -s && split=true
+    else
+        _split_longopt && split=true
+    fi
 
     opts="ALLOPTS"
 


### PR DESCRIPTION
The `_split_longopt` is renamed to `_comp__split_longopt` from bash-completion v2.12.0.
