### PR TITLE
Fix new coverity issues 

### DIFF
--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -314,7 +314,7 @@ dtrust_init(sc_card_t *card)
 	if (can_value != NULL) {
 		size_t can_len;
 
-		can_len = strlen(can_env);
+		can_len = strlen(can_value);
 		drv_data->can_value = sc_mem_secure_alloc(can_len + 1);
 		if (drv_data->can_value == NULL) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);

--- a/src/tests/fuzzing/fuzz_pkcs11_uri.c
+++ b/src/tests/fuzzing/fuzz_pkcs11_uri.c
@@ -44,8 +44,10 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	memcpy(input_string, Data, Size);
 	input_string[Size] = 0;
 
-	if ((uri = pkcs11_uri_new()) == NULL)
+	if ((uri = pkcs11_uri_new()) == NULL) {
+		free(input_string);
 		return 0;
+	}
 	parse_pkcs11_uri(input_string, uri);
 
 	pkcs11_uri_free(uri);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9297,7 +9297,7 @@ p11_utf8_to_string(CK_UTF8CHAR *string, size_t len)
 	while (len && string[len - 1] == ' ')
 		len--;
 
-	if (len < 1 || !(buffer = calloc(len, sizeof(char)))) {
+	if (len < 1 || !(buffer = calloc(len + 1, sizeof(char)))) {
 		return NULL;
 	}
 

--- a/src/tools/pkcs11_uri.c
+++ b/src/tools/pkcs11_uri.c
@@ -119,6 +119,10 @@ parse_string(char *argument, char **out, int *out_len, int max_len)
 {
 	int rv = 0, len = 0;
 	char *tmp = NULL;
+	if (out == NULL) {
+		fprintf(stderr, "Wrong parameters provided\n");
+		return 1;
+	}
 	if (*out != NULL) {
 		rv = 1;
 		fprintf(stderr, "Attribute already set\n");


### PR DESCRIPTION
@hamarituc , can you check the dtrust change works as expected?

There is also one issue reported, which I am not completely sure how to fix:
```
*** CID 487695:           (FORWARD_NULL)
/src/tools/dtrust-tool.c: 875             in main()
869     		pin_resume = parse_pin(card, opt_resume, "Resume", NULL);
870     		if (pin_resume < 0)
871     			goto out;
872     	}
873     
874     	if (opt_unblock != NULL) {
>>>     CID 487695:           (FORWARD_NULL)
>>>     Passing null pointer "card" to "parse_pin", which dereferences it.
```
The tool is first reading the pins, but the function already needs to know the type of the card. But you delay the connect after that, which means it will likely not work as it is written.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
