### PR TITLE
openpgp: Fix retry counter for card does not support query PIN status…

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2172,9 +2172,9 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 			LOG_TEST_RET(card->ctx, SC_ERROR_OBJECT_NOT_VALID,
 				"CHV status bytes have unexpected length");
 
-                data->pin1.tries_left = c4data[4 + (data->pin_reference & 0x0F)];
-                data->pin1.max_tries = 3;
-                data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
+		data->pin1.tries_left = c4data[3 + (data->pin_reference & 0x0F)];
+		data->pin1.max_tries = 3;
+		data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
 		if (tries_left != NULL)
 			*tries_left = data->pin1.tries_left;
 


### PR DESCRIPTION
… by VERIFY command

According to OpenPGP spec, DO C4 is a simple DO which means response of GET DATA is not TLV encoded data. So retry counter bytes starts from byte 5 (count from 1) of buffer. Since 81 <= PIN reference <= 83, access to error counter would start from byte 6 of buffer and get wrong data.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

Tested with opensc-explorer
Before this change:
```
OpenSC Explorer version 0.26.1
Using reader with a card: Yubico YubiKey OTP+FIDO+CCID 00 00
OpenSC [3F00]> pin_info CHV1
Login status unknown.
3 tries left.
OpenSC [3F00]> pin_info CHV2
Login status unknown.
3 tries left.
OpenSC [3F00]> pin_info CHV3
Login status unknown.
113 tries left.
```

After this change:
```
OpenSC Explorer version 0.26.1
Using reader with a card: Yubico YubiKey OTP+FIDO+CCID 00 00
OpenSC [3F00]> pin_info CHV1
Login status unknown.
3 tries left.
OpenSC [3F00]> pin_info CHV2
Login status unknown.
3 tries left.
OpenSC [3F00]> pin_info CHV3
Login status unknown.
3 tries left.
```
