### PR TITLE
pkcs11/slot.c  If first  sc_card_connect fails, mark reader with SC_READER_CARD_INVALID

### DIFF
--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -377,6 +377,7 @@ struct sc_reader_driver {
 #define SC_READER_HAS_WAITING_AREA	0x00000010
 #define SC_READER_REMOVED			0x00000020
 #define SC_READER_ENABLE_ESCAPE		0x00000040
+#define SC_READER_CARD_INVALID			0x00000080
 
 /* reader capabilities */
 #define SC_READER_CAP_DISPLAY	0x00000001

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -424,6 +424,7 @@ static int refresh_attributes(sc_reader_t *reader)
 			} else {
 				reader->flags |= SC_READER_CARD_CHANGED;
 			}
+			reader->flags &= ~SC_READER_CARD_INVALID;
 			reader->flags &= ~SC_READER_CARD_PRESENT;
 			reader->flags |= SC_READER_REMOVED;
 			priv->gpriv->removed_reader = reader;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -1654,7 +1654,8 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 	}
 
 	/* Find out framework data corresponding to the given application */
-	fw_data = get_fw_data(p11card, app_info, &idx);
+	if (p11card)
+		fw_data = get_fw_data(p11card, app_info, &idx);
 	if (!fw_data)   {
 		if (p11card) {
 			sc_log(context, "Create slot for the non-binded card");
@@ -1664,14 +1665,14 @@ pkcs15_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app_inf
 	}
 	sc_log(context, "Use FW data with index %i; fw_data->p15_card %p", idx, fw_data->p15_card);
 
-	conf_block = sc_get_conf_block(p11card->card->ctx, "framework", "pkcs15", 1);
+	conf_block = sc_get_conf_block(context, "framework", "pkcs15", 1);
 	if (conf_block && app_info)   {
 		scconf_block **blocks = NULL;
 		char str_path[SC_MAX_AID_STRING_SIZE];
 
 		memset(str_path, 0, sizeof(str_path));
 		sc_bin_to_hex(app_info->path.value, app_info->path.len, str_path, sizeof(str_path), 0);
-		blocks = scconf_find_blocks(p11card->card->ctx->conf, conf_block, "application", str_path);
+		blocks = scconf_find_blocks(context->conf, conf_block, "application", str_path);
 		if (blocks)   {
 			if (blocks[0]) {
 				user_pin = (char *)scconf_get_str(blocks[0], "user_pin", NULL);
@@ -2113,7 +2114,7 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 	sc_log(context, "Get 'enable-InitToken' card configuration option");
 	if (!p11card)
 		return CKR_TOKEN_NOT_RECOGNIZED;
-	conf_block = sc_get_conf_block(p11card->card->ctx, "framework", "pkcs15", 1);
+	conf_block = sc_get_conf_block(context, "framework", "pkcs15", 1);
 	enable_InitToken = scconf_get_bool(conf_block, "pkcs11_enable_InitToken", 0);
 
 	memset(&args, 0, sizeof(args));
@@ -2441,7 +2442,7 @@ pkcs15_create_private_key(struct sc_pkcs11_slot *slot, struct sc_profile *profil
 				ec->params.der.value = NULL;
 				goto out;
 			}
-			if (sc_pkcs15_fix_ec_parameters(p11card->card->ctx, &ec->params) != SC_SUCCESS)
+			if (sc_pkcs15_fix_ec_parameters(context, &ec->params) != SC_SUCCESS)
 				return CKR_ATTRIBUTE_VALUE_INVALID;
 			break;
 		case CKA_SIGN:
@@ -2817,7 +2818,7 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 		case CKA_EC_POINT:
 			switch (key_type) {
 			case CKK_EC:
-				if (sc_pkcs15_decode_pubkey_ec(p11card->card->ctx, ec, attr->pValue, attr->ulValueLen) < 0) {
+				if (sc_pkcs15_decode_pubkey_ec(context, ec, attr->pValue, attr->ulValueLen) < 0) {
 					free(ec->ecpointQ.value);
 					ec->ecpointQ.value = NULL;
 					ec->ecpointQ.len = 0;
@@ -2891,7 +2892,7 @@ pkcs15_create_public_key(struct sc_pkcs11_slot *slot, struct sc_profile *profile
 	} else if (key_type == CKK_EC ||
 			key_type == CKK_EC_EDWARDS ||
 			key_type == CKK_EC_MONTGOMERY) {
-		rc = sc_pkcs15_fix_ec_parameters(p11card->card->ctx, &ec->params);
+		rc = sc_pkcs15_fix_ec_parameters(context, &ec->params);
 
 		if (rc || !ec->ecpointQ.len || !ec->params.der.value) {
 			sc_log(context, "Template to store the EC public key is incomplete");

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -160,7 +160,7 @@ sc_pkcs11_register_mechanism(struct sc_pkcs11_card *p11card,
 				return CKR_OK;
 			}
 		}
-		sc_log(p11card->card->ctx, "Too many key types in mechanism 0x%lx, more than %d", mt->mech, MAX_KEY_TYPES);
+		sc_log(context, "Too many key types in mechanism 0x%lx, more than %d", mt->mech, MAX_KEY_TYPES);
 		return CKR_BUFFER_TOO_SMALL;
 	}
 
@@ -1785,22 +1785,22 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 	CK_MECHANISM_INFO mech_info;
 	CK_RV rv;
 
-	LOG_FUNC_CALLED(p11card->card->ctx);
-	sc_log(p11card->card->ctx, "mech = %lx, hash_mech = %lx", mech, hash_mech);
+	LOG_FUNC_CALLED(context);
+	sc_log(context, "mech = %lx, hash_mech = %lx", mech, hash_mech);
 
 	if (!sign_type)
-		LOG_FUNC_RETURN(p11card->card->ctx, CKR_MECHANISM_INVALID);
+		LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
 	mech_info = sign_type->mech_info;
 
 	if (!(hash_type = sc_pkcs11_find_mechanism(p11card, hash_mech, CKF_DIGEST)))
-		LOG_FUNC_RETURN(p11card->card->ctx, CKR_MECHANISM_INVALID);
+		LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
 
 	/* These hash-based mechs can only be used for sign/verify */
 	mech_info.flags &= (CKF_SIGN | CKF_SIGN_RECOVER | CKF_VERIFY | CKF_VERIFY_RECOVER);
 
 	info = calloc(1, sizeof(*info));
 	if (!info)
-		LOG_FUNC_RETURN(p11card->card->ctx, CKR_HOST_MEMORY);
+		LOG_FUNC_RETURN(context, CKR_HOST_MEMORY);
 
 	info->mech = mech;
 	info->hash_type = hash_type;
@@ -1811,11 +1811,11 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 			info, free_info, copy_hash_signature_info);
 	if (!new_type) {
 		free_info(info);
-		LOG_FUNC_RETURN(p11card->card->ctx, CKR_HOST_MEMORY);
+		LOG_FUNC_RETURN(context, CKR_HOST_MEMORY);
 	}
 
 	rv = sc_pkcs11_register_mechanism(p11card, new_type, NULL);
 	sc_pkcs11_free_mechanism(&new_type);
 
-	LOG_FUNC_RETURN(p11card->card->ctx, (int)rv);
+	LOG_FUNC_RETURN(context, (int)rv);
 }

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -313,7 +313,7 @@ again:
 			scconf_block *conf_block = NULL;
 			int enable_InitToken = 0;
 
-			conf_block = sc_match_atr_block(p11card->card->ctx, NULL,
+			conf_block = sc_match_atr_block(context, NULL,
 				&p11card->reader->atr);
 			if (!conf_block) /* check default block */
 				conf_block = sc_get_conf_block(context,

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -227,12 +227,14 @@ again:
 	}
 	if (rc == 0) {
 		sc_log(context, "%s: card absent", reader->name);
+		reader->flags &= ~SC_READER_CARD_INVALID;
 		card_removed(reader);	/* Release all resources */
 		return CKR_TOKEN_NOT_PRESENT;
 	}
 
 	/* If the card was changed, disconnect the current one */
 	if (rc & SC_READER_CARD_CHANGED) {
+		reader->flags &= ~SC_READER_CARD_INVALID; /* try connect to new card */
 		sc_log(context, "%s: Card changed", reader->name);
 		/* The following should never happen - but if it
 		 * does we'll be stuck in an endless loop.
@@ -260,13 +262,26 @@ again:
 		p11card = (struct sc_pkcs11_card *)calloc(1, sizeof(struct sc_pkcs11_card));
 		if (!p11card)
 			return CKR_HOST_MEMORY;
-		free_p11card = 1;
+		free_p11card = 0;
 		p11card->reader = reader;
 	}
 
 	if (p11card->card == NULL) {
-		sc_log(context, "%s: Connecting ... ", reader->name);
-		rc = sc_connect_card(reader, &p11card->card);
+		if (reader->flags & SC_READER_CARD_INVALID) {
+			sc_log(context, "%s: Connecting to reader with invalid card", reader->name);
+			rc = SC_ERROR_INVALID_CARD;
+			free_p11card = 0;
+		} else {
+			sc_log(context, "%s: Connecting ... ", reader->name);
+			rc = sc_connect_card(reader, &p11card->card);
+			if (rc == SC_ERROR_INVALID_CARD) {
+				/* Reader has invalid card not try to connect to it again */
+				/* do not try to cconnect to the same card again */
+				reader->flags |= SC_READER_CARD_INVALID;
+				free_p11card = 0;
+			}
+		}
+
 		if (rc != SC_SUCCESS) {
 			sc_log(context, "%s: SC connect card error %i", reader->name, rc);
 			rv = sc_to_cryptoki_error(rc, NULL);
@@ -314,7 +329,7 @@ again:
 			int enable_InitToken = 0;
 
 			conf_block = sc_match_atr_block(context, NULL,
-				&p11card->reader->atr);
+					&p11card->reader->atr);
 			if (!conf_block) /* check default block */
 				conf_block = sc_get_conf_block(context,
 					"framework", "pkcs15", 1);

--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -262,7 +262,7 @@ again:
 		p11card = (struct sc_pkcs11_card *)calloc(1, sizeof(struct sc_pkcs11_card));
 		if (!p11card)
 			return CKR_HOST_MEMORY;
-		free_p11card = 0;
+		free_p11card = 1; /* Allocated it here not found in a slot */
 		p11card->reader = reader;
 	}
 
@@ -270,15 +270,13 @@ again:
 		if (reader->flags & SC_READER_CARD_INVALID) {
 			sc_log(context, "%s: Connecting to reader with invalid card", reader->name);
 			rc = SC_ERROR_INVALID_CARD;
-			free_p11card = 0;
 		} else {
 			sc_log(context, "%s: Connecting ... ", reader->name);
 			rc = sc_connect_card(reader, &p11card->card);
 			if (rc == SC_ERROR_INVALID_CARD) {
-				/* Reader has invalid card not try to connect to it again */
-				/* do not try to cconnect to the same card again */
+				/* Reader has invalid card do not try to connect to it again */
+				/* do not try to connect to the same card again */
 				reader->flags |= SC_READER_CARD_INVALID;
-				free_p11card = 0;
 			}
 		}
 

--- a/src/tests/fuzzing/fuzz_pkcs11.c
+++ b/src/tests/fuzzing/fuzz_pkcs11.c
@@ -107,7 +107,7 @@ static int fuzz_card_connect(const uint8_t *data, size_t size, sc_pkcs11_slot_t 
 	if (app_generic || !p11card->card->app_count) {
 		scconf_block *conf_block = NULL;
 
-		conf_block = sc_match_atr_block(p11card->card->ctx, NULL, &p11card->reader->atr);
+		conf_block = sc_match_atr_block(context, NULL, &p11card->reader->atr);
 		if (!conf_block) /* check default block */
 			conf_block = sc_get_conf_block(context, "framework", "pkcs15", 1);
 


### PR DESCRIPTION

Fixes #3471

With pkcs11, If a card in a reader fails in `sc_card_connect`, `reader->flags |= SC_READER_CARD_INVALID;`  is set. If at a later time `C_GetSlotList`  is called by the application like FireFox, and SC_READER_CARD_INVALID is set, OpenSC will not call sc_card_connect again and will avoid all the overhead of trying to connect to the same card.

The SC_READER_CARD_INVALID will be reset if the reader reports SC_READER_CARD_CHANGED as a different card may have been inserted.


 On branch pkcs11-invalid-card
 Changes to be committed:
	modified:   libopensc/opensc.h
	modified:   pkcs11/slot.c


Partially tested on Ubuntu 24.04 with FireFox ESR  simulating an invalid card, by 
`export OPENSC_DRIVER=openpgp`  was set so any non-openpgp card will be considered invalid. 
 
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
