### PR TITLE
pkcs11: perform driver matching with invalid card only once while card is present in reader

### DIFF
--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -242,7 +242,7 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 	sc_card_t *card;
 	sc_context_t *ctx;
 	struct sc_card_driver *driver;
-	int i, r = 0, idx, connected = 0;
+	int i, r = 0, idx;
 
 	if (card_out == NULL || reader == NULL)
 		return SC_ERROR_INVALID_ARGUMENTS;
@@ -258,7 +258,6 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 	if (r)
 		goto err;
 
-	connected = 1;
 	card->reader = reader;
 	card->ctx = ctx;
 
@@ -392,10 +391,7 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 err:
-	if (connected)
-		reader->ops->disconnect(reader);
-	if (card != NULL)
-		sc_card_free(card);
+	*card_out = card;
 	LOG_FUNC_RETURN(ctx, r);
 }
 

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7173,6 +7173,7 @@ static DWORD associate_card(PCARD_DATA pCardData)
 	r = sc_connect_card(vs->reader, &(vs->card));
 	if (r != SC_SUCCESS) {
 		logprintf(pCardData, 0, "Cannot connect card in reader '%s'\n", NULLSTR(vs->reader->name));
+		sc_disconnect_card(vs->card);
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
 	}
 	logprintf(pCardData, 3, "Connected card in '%s'\n", NULLSTR(vs->reader->name));

--- a/src/pkcs11/framework-pkcs15init.c
+++ b/src/pkcs11/framework-pkcs15init.c
@@ -36,7 +36,7 @@ static CK_RV pkcs15init_bind(struct sc_pkcs11_card *p11card, struct sc_app_info 
 	struct sc_profile *profile;
 	int		rc;
 
-	if (!p11card)
+	if (!p11card || (p11card->flags & SC_PKCS11_CARD_INVALID))
 		return CKR_TOKEN_NOT_RECOGNIZED;
 	card = p11card->card;
 	rc = sc_pkcs15init_bind(card, "pkcs15", NULL, NULL, &profile);
@@ -49,7 +49,7 @@ static CK_RV pkcs15init_unbind(struct sc_pkcs11_card *p11card)
 {
 	struct sc_profile *profile;
 
-	if (!p11card)
+	if (!p11card || (p11card->flags & SC_PKCS11_CARD_INVALID))
 		return CKR_TOKEN_NOT_RECOGNIZED;
 	profile = (struct sc_profile *) p11card->fws_data[0];
 	sc_pkcs15init_unbind(profile);
@@ -64,7 +64,7 @@ pkcs15init_create_tokens(struct sc_pkcs11_card *p11card, struct sc_app_info *app
 	struct sc_pkcs11_slot	*slot;
 	CK_RV rc;
 
-	if (!p11card)
+	if (!p11card || (p11card->flags & SC_PKCS11_CARD_INVALID))
 		return CKR_TOKEN_NOT_RECOGNIZED;
 	profile = (struct sc_profile *) p11card->fws_data[0];
 
@@ -140,7 +140,7 @@ pkcs15init_initialize(struct sc_pkcs11_slot *pslot, void *ptr,
     CK_RV rv;
 	int		rc, id;
 
-	if (!p11card)
+	if (!p11card || (p11card->flags & SC_PKCS11_CARD_INVALID))
 		return CKR_TOKEN_NOT_RECOGNIZED;
 	profile = (struct sc_profile *) p11card->fws_data[0];
 	memset(&args, 0, sizeof(args));

--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -226,8 +226,8 @@ sc_pkcs11_get_mechanism_list(struct sc_pkcs11_card *p11card,
 	unsigned int n, count = 0;
 	CK_RV rv;
 
-	if (!p11card)
-		return CKR_TOKEN_NOT_PRESENT;
+	if (!p11card || (p11card->flags & SC_PKCS11_CARD_INVALID))
+		return CKR_TOKEN_NOT_RECOGNIZED;
 
 	for (n = 0; n < p11card->nmechanisms; n++) {
 		if (!(mt = p11card->mechanisms[n]))

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -760,7 +760,7 @@ CK_RV C_InitToken(CK_SLOT_ID slotID,
 		goto out;
 	}
 
-	if (!slot->p11card || !slot->p11card->framework
+	if ((!slot->p11card || (slot->p11card->flags & SC_PKCS11_CARD_INVALID)) || !slot->p11card->framework
 		   || !slot->p11card->framework->init_token) {
 		sc_log(context, "C_InitToken() not supported by framework");
 		rv = CKR_FUNCTION_NOT_SUPPORTED;

--- a/src/pkcs11/pkcs11-object.c
+++ b/src/pkcs11/pkcs11-object.c
@@ -1174,7 +1174,8 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	}
 
 	slot = session->slot;
-	if (slot == NULL || slot->p11card == NULL || slot->p11card->framework == NULL
+	if (slot == NULL || (slot->p11card == NULL || (slot->p11card->flags & SC_PKCS11_CARD_INVALID))
+			|| slot->p11card->framework == NULL
 			|| slot->p11card->framework->gen_keypair == NULL)
 		rv = CKR_FUNCTION_NOT_SUPPORTED;
 	else {
@@ -1444,7 +1445,8 @@ CK_RV C_GenerateRandom(CK_SESSION_HANDLE hSession,	/* the session's handle */
 	rv = get_session(hSession, &session);
 	if (rv == CKR_OK) {
 		slot = session->slot;
-		if (slot == NULL || slot->p11card == NULL || slot->p11card->framework == NULL
+		if (slot == NULL || (slot->p11card == NULL || (slot->p11card->flags & SC_PKCS11_CARD_INVALID))
+				|| slot->p11card->framework == NULL
 				|| slot->p11card->framework->get_random == NULL)
 			rv = CKR_RANDOM_NO_RNG;
 		else

--- a/src/pkcs11/sc-pkcs11.h
+++ b/src/pkcs11/sc-pkcs11.h
@@ -47,6 +47,8 @@ extern "C" {
 
 #define SC_PKCS11_SLOT_FOR_PINS		(SC_PKCS11_SLOT_FOR_PIN_USER | SC_PKCS11_SLOT_FOR_PIN_SIGN)
 
+#define SC_PKCS11_CARD_INVALID 1
+
 #ifdef __cplusplus
 }
 #endif
@@ -204,6 +206,8 @@ struct sc_pkcs11_card {
 
 	/* Number of virtual slots the card occupies */
 	unsigned int num_slots;
+
+	int flags;
 };
 
 /* If the slot did already show with `C_GetSlotList`, then we need to keep this

--- a/src/tests/sc-test.c
+++ b/src/tests/sc-test.c
@@ -111,6 +111,7 @@ int sc_test_init(int *argc, char *argv[])
 	i = sc_connect_card(sc_ctx_get_reader(ctx, opt_reader), &card);
 	if (i != SC_SUCCESS) {
 		printf("Connecting to card failed: %s\n", sc_strerror(i));
+		sc_disconnect_card(card);
 		return i;
 	}
 	printf("connected.\n");

--- a/src/tools/netkey-tool.c
+++ b/src/tools/netkey-tool.c
@@ -580,6 +580,7 @@ int main(
 
 	if((r = sc_connect_card(sc_ctx_get_reader(ctx, 0), &card))<0){
 		fprintf(stderr,"Connect-Card failed: %s\n", sc_strerror(r));
+		sc_disconnect_card(card);
 		sc_release_context(ctx);
 		exit(1);
 	}

--- a/src/tools/opensc-tool.c
+++ b/src/tools/opensc-tool.c
@@ -294,8 +294,8 @@ static int list_readers(void)
 					fprintf(stderr, "     failed: %s\n", sc_strerror(r));
 				} else {
 					printf("     %s %s %s\n", tmp, c->name ? c->name : "", state & SC_READER_CARD_INUSE ? "[IN USE]" : "");
-					sc_disconnect_card(c);
 				}
+				sc_disconnect_card(c);
 			}
 		}
 	}

--- a/src/tools/sceac-example.c
+++ b/src/tools/sceac-example.c
@@ -75,6 +75,7 @@ main (int argc, char **argv)
 	ctx->flags |= SC_CTX_FLAG_ENABLE_DEFAULT_DRIVER;
 	if (sc_connect_card(reader, &card) < 0) {
 		fprintf(stderr, "Could not connect to card\n");
+		sc_disconnect_card(card);
 		sc_release_context(ctx);
 		exit(1);
 	}

--- a/src/tools/util.c
+++ b/src/tools/util.c
@@ -172,6 +172,7 @@ util_connect_card_ex(sc_context_t *ctx, sc_card_t **cardp,
 	r = sc_connect_card(reader, &card);
 	if (r < 0) {
 		fprintf(stderr, "Failed to connect to card: %s\n", sc_strerror(r));
+		sc_disconnect_card(card);
 		return r;
 	}
 


### PR DESCRIPTION
sc_connect_card is modified to allow invalid card to remain connected. Connection between unsupported card handle and pkcs11 slot is now preserved, allowing correct status detection. Side effect of this modification is that sc_disconnect_card is now required to be called later on to perform card cleanup.

On top of that SC_PKCS11_CARD_INVALID flag is introduced for sc_pkcs11_card structure. This flag is set in case sc_connect_card returns SC_ERROR_INVALID_CARD on card_detect allowing us to preserve info about card support for the duration of card presence in reader.

Set SC_PKCS11_CARD_INVALID flag prevents running additional unnecessary driver matching actions on unsupported cards.

Other pksc11 methods utilizing sc_pkcs11_card objects are updated to include SC_PKCS11_CARD_INVALID flag checks.

fixes #3471 , possibly also #3107 , #3108

@dengert @frankmorgner @Jakuje please have a look, would appreciate your feedback on this.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
