### PR TITLE
Fix coverity issues in dtrust driver

### DIFF
--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -314,7 +314,7 @@ dtrust_init(sc_card_t *card)
 	if (can_value != NULL) {
 		size_t can_len;
 
-		can_len = strlen(can_env);
+		can_len = strlen(can_value);
 		drv_data->can_value = sc_mem_secure_alloc(can_len + 1);
 		if (drv_data->can_value == NULL) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);

--- a/src/tests/fuzzing/fuzz_pkcs11_uri.c
+++ b/src/tests/fuzzing/fuzz_pkcs11_uri.c
@@ -44,8 +44,10 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	memcpy(input_string, Data, Size);
 	input_string[Size] = 0;
 
-	if ((uri = pkcs11_uri_new()) == NULL)
+	if ((uri = pkcs11_uri_new()) == NULL) {
+		free(input_string);
 		return 0;
+	}
 	parse_pkcs11_uri(input_string, uri);
 
 	pkcs11_uri_free(uri);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9297,7 +9297,7 @@ p11_utf8_to_string(CK_UTF8CHAR *string, size_t len)
 	while (len && string[len - 1] == ' ')
 		len--;
 
-	if (len < 1 || !(buffer = calloc(len, sizeof(char)))) {
+	if (len < 1 || !(buffer = calloc(len + 1, sizeof(char)))) {
 		return NULL;
 	}
 

--- a/src/tools/pkcs11_uri.c
+++ b/src/tools/pkcs11_uri.c
@@ -119,6 +119,10 @@ parse_string(char *argument, char **out, int *out_len, int max_len)
 {
 	int rv = 0, len = 0;
 	char *tmp = NULL;
+	if (out == NULL) {
+		fprintf(stderr, "Wrong parameters provided\n");
+		return 1;
+	}
 	if (*out != NULL) {
 		rv = 1;
 		fprintf(stderr, "Attribute already set\n");


### PR DESCRIPTION
This PR fixes coverity issued in the `dtrust` driver. It already contains the fixes of @Jakuje in #3469 and furthermore fixes the issue which was left open there.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
