### PR TITLE
fixed overwriting global module functions, e.g. C_Initialize

### DIFF
--- a/src/common/libscdl.c
+++ b/src/common/libscdl.c
@@ -70,7 +70,11 @@ int sc_dlclose(void *handle)
 
 void *sc_dlopen(const char *filename)
 {
-	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL);
+	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL
+#ifdef RTLD_DEEPBIND
+			| RTLD_DEEPBIND
+#endif
+			);
 }
 
 void *sc_dlsym(void *handle, const char *symbol)


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2875

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
