### PR TITLE
openpgp: Fix retry counter of encryption PIN in SC_PIN_CMD_GET_INFO e…

### DIFF
--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2468,6 +2468,14 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 			LOG_TEST_RET(card->ctx, SC_ERROR_OBJECT_NOT_VALID,
 				"CHV status bytes have unexpected length");
 
+		/* The definition of fields of DO C4 changed between OpenPGP
+		 * card specification v1.1 and v2.0. There is no longer a separate
+		 * CHV2 retry counter but only one retry counter for both PW1 mode 1
+		 * and mode 2 at byte 5 (count from 1) of the DO.
+		 */
+		if (priv->bcd_version >= OPENPGP_CARD_2_0 && data->pin_reference == 0x82)
+			data->pin_reference = 0x81;
+
 		data->pin1.tries_left = c4data[3 + (data->pin_reference & 0x0F)];
 		data->pin1.max_tries = 3;
 		data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;


### PR DESCRIPTION
…mulation for card supporting OpenPGP card spec v2.0 and later

The meaning of byte 6 of DO C4 has changed from the retry counter of the encryption PIN (CHV2) to that of resetting code since OpenPGP card spec v2.0, and PW1 now serves as both the signature and encryption PIN. Map PIN reference from 82 to 81 to correct retry counter of encryption PIN for these cards.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS token is tested
