### PR TITLE
AppVeyor: removed GH_TOKEN from configuration file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,6 @@ configuration:
   - Light
 
 environment:
-  GH_TOKEN:
-    secure: jeReA6BNx/dXVMGfroKadgE9ByKAE/tAGcb2z+dIVZGAN29X1Pu22wi1TuVOy9ZugqBzjvFV4knwHJSGi0+U6Yj1fTfa2CYpeCBym4JOXqPis/GpKfSeBV9IrmJGT/Av
   PATH: C:\cygwin\bin;%PATH%
   OPENPACE_VER: 1.1.3
   ZLIB_VER_DOT: 1.3.1


### PR DESCRIPTION
the regenewed token was directly added to the online project settings

fixes https://github.com/OpenSC/OpenSC/issues/3507

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
