### PR TITLE
ctx: Introduce custom openssl configuration file to better support FIPS mode

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -275,6 +275,21 @@ app <em class="replaceable"><code>application</code></em> {
 							</p></li></ul></div><p>
 						(Default: <code class="literal">decipher</code>).
 				</p></dd><dt><span class="term">
+					<code class="option">openssl_config = <em class="replaceable"><code>path</code></em>;</code>
+				</span></dt><dd><p>
+						Specify a OpenSSL configuration file to be loaded into the
+						OpenSC's library context. This should not be needed for general
+						operation, but is needed if you need to confirure some
+						specifics of OpenSSL, without the need to rebuild OpenSC (for
+						example configure and load a FIPS provider).
+						For more information about configuring OpenSSL, see
+						<span class="citerefentry"><span class="refentrytitle">config</span>(5).
+						</span>
+						and
+						<span class="citerefentry"><span class="refentrytitle">fips_config</span>(5).
+						</span>.
+						(Default: <code class="literal">empty</code>).
+				</p></dd><dt><span class="term">
 					<code class="option">secure_messaging <em class="replaceable"><code>name</code></em> {
 						<em class="replaceable"><code>block_contents</code></em>
 						}

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -359,6 +359,29 @@ app <replaceable>application</replaceable> {
 			</varlistentry>
 			<varlistentry>
 				<term>
+					<option>openssl_config = <replaceable>path</replaceable>;</option>
+				</term>
+				<listitem><para>
+						Specify a OpenSSL configuration file to be loaded into the
+						OpenSC's library context. This should not be needed for general
+						operation, but is needed if you need to confirure some
+						specifics of OpenSSL, without the need to rebuild OpenSC (for
+						example configure and load a FIPS provider).
+						For more information about configuring OpenSSL, see
+						<citerefentry>
+							<refentrytitle>config</refentrytitle>
+							<manvolnum>5</manvolnum>.
+						</citerefentry>
+						and
+						<citerefentry>
+							<refentrytitle>fips_config</refentrytitle>
+							<manvolnum>5</manvolnum>.
+						</citerefentry>.
+						(Default: <literal>empty</literal>).
+				</para></listitem>
+			</varlistentry>
+			<varlistentry>
+				<term>
 					<option>secure_messaging <replaceable>name</replaceable> {
 						<replaceable>block_contents</replaceable>
 						}

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -895,6 +895,7 @@ typedef struct sc_context {
 	void *mutex;
 
 #ifdef ENABLE_OPENSSL
+	char *openssl_config;
 	ossl3ctx_t *ossl3ctx;
 #endif
 


### PR DESCRIPTION
Fixes: #3500

This attempts to simplify support for FIPS mode in OpenSC by loading a configuration file from `/etc/opensc/openssl.cnf` (if it exists) as it looks like the only sane way to support FIPS mode in application specific OpenSSL contexts.

By default the `/etc/opensc/openssl.cnf` does not exists and the OpenSC behaves as for now. But if the file is present, OpenSC loads it and assumes it configures the providers that need to be loaded by default (including legacy provider if needed).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested