### PR TITLE
ci: Try to use debuginfod instead of manual download of ddebs

### DIFF
--- a/.github/setup-valgrind.sh
+++ b/.github/setup-valgrind.sh
@@ -13,4 +13,7 @@ if [ "$1" == "valgrind" -o "$2" == "valgrind" ]; then
 	export VALGRIND="valgrind -q --error-exitcode=1 --leak-check=full --keep-debuginfo=yes --trace-children=yes --gen-suppressions=all --suppressions=$PWD/tests/opensc.supp"
 	# this should help us getting better traces as some of pcsclite and avoid false positives
 	export LD_PRELOAD=$(ldconfig -p | grep libpcsclite.so.1 |  tr ' ' '\n' | grep /)
+
+	# The valgrind should be able to find the debuginfo on the fly
+	export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com"
 fi


### PR DESCRIPTION
... which is fragile given that ubuntu does not have predictable naming pattern for the debuginfo packages and the repositories are most of the time being updated which results in random failures in CI installing these packages.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
