### PR TITLE
Silence a Microsoft linker warning

### DIFF
--- a/win32/Make.rules.mak
+++ b/win32/Make.rules.mak
@@ -165,7 +165,7 @@ COPTS = /O1 /$(BUILD_TYPE) $(COPTS)
 	rc $(DEFS) /l 0x0409 /I$(TOPDIR)\win32 $<
 
 .exports.def:
-	echo LIBRARY $* > $*.def
+	echo LIBRARY > $*.def
 	echo EXPORTS >> $*.def
 	type $*.exports >> $*.def
 


### PR DESCRIPTION
The library name within pkcs11.def matched neither of the two DLLs where the definition file was used, this resulted in warning LNK4070. The linker gets the output filename as a parameter. Drop it from the definition files, where it is optional.

(as instructed by @Jakuje: https://github.com/OpenSC/OpenSC/pull/3524#discussion_r2578890777)