### PR TITLE
pkcs11: Use implicit type conversion to avoid build failure

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4694,7 +4694,7 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 
 	/* only padding error must be handled in constant-time way,
 	 * other error can be returned straight away */
-	if ((~constant_time_eq_i(rv, SC_ERROR_WRONG_PADDING) & constant_time_lt_s(sizeof(decrypted), (size_t)rv)))
+	if ((~(size_t)constant_time_eq_i(rv, SC_ERROR_WRONG_PADDING) & constant_time_lt_s(sizeof(decrypted), (size_t)rv)))
 		return sc_to_cryptoki_error(rv, "C_Decrypt");
 
 	/* check rv for padding error */


### PR DESCRIPTION
Without this windows build fails silently like this:

```
framework-pkcs15.c
Error: framework-pkcs15.c(4697): error C2220: the following warning is treated as an error
Warning: framework-pkcs15.c(4697): warning C4319: '~': zero extending 'unsigned int' to 'size_t' of greater size
```

For some reason, this started showing up in #3525 after rebase on current master.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested