### PR TITLE
pkcs15init: Avoid buffer overrun

### DIFF
--- a/src/pkcs15init/pkcs15-cflex.c
+++ b/src/pkcs15init/pkcs15-cflex.c
@@ -539,6 +539,9 @@ cflex_create_pin_file(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 
 	/* Build the CHV path */
 	path = *df_path;
+	if (path.len > SC_MAX_PATH_SIZE - 2) {
+		return SC_ERROR_INVALID_ARGUMENTS;
+	}
 	path.value[path.len++] = ref - 1;
 	path.value[path.len++] = 0;
 


### PR DESCRIPTION
The maximum path length is 16 bytes and if we want to extend the path, we need to make sure its not too long.

Thanks oss-fuzz.

https://issues.oss-fuzz.com/issues/467161860

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
