### PR TITLE
pkcs11: Fix constant-time regression in PKCS#1 v1.5 decrypt path

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4694,7 +4694,7 @@ pkcs15_prkey_decrypt(struct sc_pkcs11_session *session, void *obj,
 
 	/* only padding error must be handled in constant-time way,
 	 * other error can be returned straight away */
-	if ((~(size_t)constant_time_eq_i(rv, SC_ERROR_WRONG_PADDING) & constant_time_lt_s(sizeof(decrypted), (size_t)rv)))
+	if ((~constant_time_eq_s((size_t)rv, (size_t)SC_ERROR_WRONG_PADDING) & constant_time_lt_s(sizeof(decrypted), (size_t)rv)))
 		return sc_to_cryptoki_error(rv, "C_Decrypt");
 
 	/* check rv for padding error */


### PR DESCRIPTION
From 419a9d3553fa56a65fc4a0e90c9ed34f09a1cec4 Mon Sep 17 00:00:00 2001
From: "Pavel Kohout, Aisle Research, www.aisle.com" <pavel@aisle.com>
Date: Tue, 6 Jan 2026 13:17:21 +0000
Subject: [PATCH] pkcs11: Fix constant-time regression in PKCS#1 v1.5 decrypt
 path

A cast introduced in commit 767c340a489f17753bf137a12a9c579255c992ea causes
padding errors to return immediately on 64-bit platforms, breaking the
constant-time handling of PKCS#1 v1.5 decryption errors. On 64-bit systems,
casting the result of constant_time_eq_i() to size_t before applying bitwise
NOT produces 0xffffffff00000000 instead of zero when the values match, causing
the wrong branch to be taken. This timing discrepancy creates a padding oracle
that can be exploited for Bleichenbacher/Marvin-style attacks against PKCS#1
v1.5 decryption when software unpadding is used. The fix removes the cast
before the NOT operator to ensure proper constant-time behavior.

Reported-by: Pavel Kohout, Aisle Research, www.aisle.com
