### PR TITLE
card-piv.c - fix history object

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5135,14 +5135,14 @@ piv_process_history(sc_card_t *card)
 			goto err;
 		}
 		fp++;
-		if (strlen(fp) != 64) {  /* ASCII-HEX encoded SHA-256 */
+		if (strlen(fp) != 64) { /* ASCII-HEX encoded SHA-256 */
 			r = SC_ERROR_INVALID_DATA;
 			goto err;
 		}
 		for (i = 0; i < 64; i++) {
 			if (isxdigit((unsigned char)fp[i]) == 0) {
-					r = SC_ERROR_INVALID_DATA;
-					goto err;
+				r = SC_ERROR_INVALID_DATA;
+				goto err;
 			}
 		}
 


### PR DESCRIPTION
Improve handling of History object
 On branch piv-history-fix
 Changes to be committed:
	modified:   card-piv.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
