### PR TITLE
Add Windows Build Option hint to disable asserts

### DIFF
--- a/win32/Make.rules.mak
+++ b/win32/Make.rules.mak
@@ -36,6 +36,8 @@ SM_DEF = /DENABLE_SM
 
 #Build with debugging support
 #DEBUG_DEF = /DDEBUG
+#Release build, disable asserts
+#DEBUG_DEF = /DNDEBUG
 
 !IF "$(BUILD_TYPE)" == ""
 !IF "$(DEBUG_DEF)" == "/DDEBUG"


### PR DESCRIPTION
I have recognized that the OpenSC Windows shared libraries or the minidriver.dll, which are built with Microsoft Visual C++, may produce Assert messages even if the build option "DEBUG_DEF = /DDEBUG" is not specified. According to the C Runtime documentation of Visual C++, only the define NDEBUG can deactivate asserts.

Imho, asserts should be used in Debug builds, but I don't want to break any build scripts, so I only added a hint in Make.rules.mak:
```c
#Release build, disable asserts
#DEBUG_DEF = /DNDEBUG
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
