### PR TITLE
Lithuanian Identity Card driver

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -584,7 +584,19 @@ app <em class="replaceable"><code>application</code></em> {
 						directory <code class="literal">file_cache_dir</code>. The cached CAN is used
 						later to avoid interactively prompting for the CAN. This feature is
 						enabled by default.
-						</p></dd></dl></div></div><div class="refsect2"><a name="piv"></a><h3>Configuration Options for PIV Card</h3><div class="variablelist"><dl class="variablelist"></dl></div></div><div class="refsect2"><a name="card_atr"></a><h3>Configuration based on ATR</h3><p>
+						</p></dd></dl></div></div><div class="refsect2"><a name="piv"></a><h3>Configuration Options for PIV Card</h3><div class="variablelist"><dl class="variablelist"></dl></div></div><div class="refsect2"><a name="lteid"></a><h3>Configuration Options for Lithuanian ID Card</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+						<code class="option">can = <em class="replaceable"><code>value</code></em>;</code>
+					</span></dt><dd><p>
+							Lithuanian ID card requires the card access
+							number (CAN) to be verified before reading it or
+							performing any operation. It is printed on the
+							front side bottom right corner of the card.
+					</p><p>
+							Note that alternatively it can also be set by
+							<span class="application">lteid-tool</span>. For command
+							line tools it can also be provided via
+							<code class="literal">LTEID_CAN</code> environment variable.
+					</p></dd></dl></div></div><div class="refsect2"><a name="card_atr"></a><h3>Configuration based on ATR</h3><p>
 				</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 							<code class="option">atrmask = <em class="replaceable"><code>hexstring</code></em>;</code>
 						</span></dt><dd><p>

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -929,6 +929,28 @@ app <replaceable>application</replaceable> {
 			</variablelist>
 		</refsect2>
 
+		<refsect2 id="lteid">
+			<title>Configuration Options for Lithuanian ID Card</title>
+			<variablelist>
+				<varlistentry>
+					<term>
+						<option>can = <replaceable>value</replaceable>;</option>
+					</term>
+					<listitem><para>
+							Lithuanian ID card requires the card access
+							number (CAN) to be verified before reading it or
+							performing any operation. It is printed on the
+							front side bottom right corner of the card.
+					</para><para>
+							Note that alternatively it can also be set by
+							<application>lteid-tool</application>. For command
+							line tools it can also be provided via
+							<literal>LTEID_CAN</literal> environment variable.
+					</para></listitem>
+				</varlistentry>
+			</variablelist>
+		</refsect2>
+
 		<refsect2 id="card_atr">
 			<title>Configuration based on ATR</title>
 			<para>

--- a/doc/tools/lteid-tool.1.xml
+++ b/doc/tools/lteid-tool.1.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<refentry id="lteid-tool">
+	<refmeta>
+		<refentrytitle>lteid-tool</refentrytitle>
+		<manvolnum>1</manvolnum>
+		<refmiscinfo class="productname">OpenSC</refmiscinfo>
+		<refmiscinfo class="manual">OpenSC Tools</refmiscinfo>
+		<refmiscinfo class="source">opensc</refmiscinfo>
+	</refmeta>
+
+	<refnamediv>
+		<refname>lteid-tool</refname>
+		<refpurpose>Lithuanian National eID card (asmens tapatybės kortelė) utility</refpurpose>
+	</refnamediv>
+
+	<refsynopsisdiv>
+		<cmdsynopsis>
+			<command>lteid-tool</command>
+			<arg choice="opt"><replaceable class="option">OPTIONS</replaceable></arg>
+		</cmdsynopsis>
+	</refsynopsisdiv>
+
+	<refsect1>
+		<title>Description</title>
+		<para>
+			The <command>lteid-tool</command> utility is used to set up Lithuanian National eID card access;
+			unblock it after incorrect PIN entry attempts.
+		</para>
+		<para>
+			When invoked without any options, <command>lteid-tool</command> will try to determine if card is
+			ready for use or card access number (CAN) needs to be entered first. Card access number is a 6
+			digit number printed on the front side bottom right corner of the card. Type it in and it will
+			be persisted for subsequent uses of the card.
+		</para>
+	</refsect1>
+
+	<refsect1>
+		<title>Options</title>
+		<para>
+			<variablelist>
+				<varlistentry>
+					<term>
+						<option>--help</option>,
+						<option>-h</option>
+					</term>
+					<listitem><para>Display tool options.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--verbose</option>,
+						<option>-v</option>
+					</term>
+					<listitem><para>Causes <command>lteid-tool</command> to be more verbose.
+						Specify this flag several times to enable debug output.</para></listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--reader</option> <replaceable>arg</replaceable>,
+						<option>-r</option> <replaceable>arg</replaceable>
+					</term>
+					<listitem>
+						<para>
+							Number of the reader to use. By default, the first
+							reader with a present card is used. If
+							<replaceable>arg</replaceable> is an ATR, the
+							reader with a matching card will be chosen.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--wait</option>,
+						<option>-w</option>
+					</term>
+					<listitem><para>Causes <command>lteid-tool</command> to wait for the token
+						to be inserted into reader.</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--can</option> <replaceable>can</replaceable>
+						<option>-c</option> <replaceable>can</replaceable>
+					</term>
+					<listitem>
+						<para>
+							This option can be used to specify the CAN value
+							on the command line. If the value is set to
+							<literal>env:</literal><replaceable>VARIABLE</replaceable>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--pin</option> <replaceable>pin</replaceable>
+						<option>-p</option> <replaceable>pin</replaceable>
+					</term>
+					<listitem>
+						<para>
+							This option can be used to specify the PIN value
+							on the command line. If the value is set to
+							<literal>env:</literal><replaceable>VARIABLE</replaceable>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--puk</option> <replaceable>puk</replaceable>
+						<option>-u</option> <replaceable>puk</replaceable>
+					</term>
+					<listitem>
+						<para>
+							This option can be used to specify the PUK value
+							on the command line. If the value is set to
+							<literal>env:</literal><replaceable>VARIABLE</replaceable>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--change-pin</option>
+						<option>-C</option>
+					</term>
+					<listitem>
+						<para>
+							Change PIN.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--resume</option>
+						<option>-R</option>
+					</term>
+					<listitem>
+						<para>
+							Resume eID PIN use after 2 incorrect attempts using current PIN.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--unblock</option>
+						<option>-U</option>
+					</term>
+					<listitem>
+						<para>
+							Unblock eID PIN use after 3 incorrect attempts using PUK.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>
+						<option>--verify-can</option>
+						<option>-V</option>
+					</term>
+					<listitem>
+						<para>
+							Verify Card Access Number (CAN). Use with
+							<literal>--can=XXXXXX</literal> option to
+							non-interactively verify and store CAN.
+						</para>
+					</listitem>
+				</varlistentry>
+			</variablelist>
+		</para>
+	</refsect1>
+
+	<refsect1>
+		<title>See also</title>
+		<para>
+			<citerefentry>
+				<refentrytitle>opensc.conf</refentrytitle>
+				<manvolnum>5</manvolnum>
+			</citerefentry>
+		</para>
+	</refsect1>
+
+	<refsect1>
+		<title>Authors</title>
+		<para><command>lteid-tool</command> was written by
+		Tadas Sasnauskas <email>tadas@yoyo.lt</email>.</para>
+	</refsect1>
+
+</refentry>

--- a/doc/tools/tools.html
+++ b/doc/tools/tools.html
@@ -47,7 +47,7 @@ span.errortext {
 		</span></dt><dt><span class="refentrytitle"><a href="#cryptoflex-tool">cryptoflex-tool</a></span><span class="refpurpose"> — utility for manipulating Schlumberger Cryptoflex data structures</span></dt><dt><span class="refentrytitle"><a href="#dnie-tool">dnie-tool</a></span><span class="refpurpose"> — displays information about DNIe based security tokens</span></dt><dt><span class="refentrytitle"><a href="#egk-tool">egk-tool</a></span><span class="refpurpose"> — displays information on the German electronic health card (elektronische Gesundheitskarte, <abbr class="abbrev">eGK</abbr>)
 		</span></dt><dt><span class="refentrytitle"><a href="#eidenv">eidenv</a></span><span class="refpurpose"> — utility for accessing visible data from
 		electronic identity cards</span></dt><dt><span class="refentrytitle"><a href="#gids-tool">gids-tool</a></span><span class="refpurpose"> — smart card utility for GIDS cards</span></dt><dt><span class="refentrytitle"><a href="#cardos-tool">iasecc-tool</a></span><span class="refpurpose"> — displays information about IAS/ECC card
-		</span></dt><dt><span class="refentrytitle"><a href="#netkey-tool">netkey-tool</a></span><span class="refpurpose"> — administrative utility for Netkey E4 cards</span></dt><dt><span class="refentrytitle"><a href="#npa-tool">npa-tool</a></span><span class="refpurpose"> — displays information of an ID card or ePassport.
+		</span></dt><dt><span class="refentrytitle"><a href="#lteid-tool">lteid-tool</a></span><span class="refpurpose"> — Lithuanian National eID card (asmens tapatybės kortelė) utility</span></dt><dt><span class="refentrytitle"><a href="#netkey-tool">netkey-tool</a></span><span class="refpurpose"> — administrative utility for Netkey E4 cards</span></dt><dt><span class="refentrytitle"><a href="#npa-tool">npa-tool</a></span><span class="refpurpose"> — displays information of an ID card or ePassport.
 		</span></dt><dt><span class="refentrytitle"><a href="#openpgp-tool">openpgp-tool</a></span><span class="refpurpose"> — utility for accessing visible data OpenPGP smart cards
 		and compatible tokens</span></dt><dt><span class="refentrytitle"><a href="#opensc-asn1">opensc-asn1</a></span><span class="refpurpose"> — parse ASN.1 data
 		</span></dt><dt><span class="refentrytitle"><a href="#opensc-explorer">opensc-explorer</a></span><span class="refpurpose"> — 
@@ -376,11 +376,92 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>Causes <span class="command"><strong>iasecc-tool</strong></span> to wait for the token
 					to be inserted into reader.</p></dd></dl></div><p>
 		</p></div><div class="refsect1"><a name="id-1.8.6"></a><h2>Authors</h2><p><span class="command"><strong>iasecc-tool</strong></span> was written by
-		Viktor Tarasov <code class="email">&lt;<a class="email" href="mailto:viktor.tarasov@gmail.com">viktor.tarasov@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="netkey-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>netkey-tool — administrative utility for Netkey E4 cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">netkey-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>COMMAND</code></em>]</p></div></div><div class="refsect1"><a name="id-1.9.4"></a><h2>Description</h2><p>The <span class="command"><strong>netkey-tool</strong></span> utility can be used from the
+		Viktor Tarasov <code class="email">&lt;<a class="email" href="mailto:viktor.tarasov@gmail.com">viktor.tarasov@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="lteid-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>lteid-tool — Lithuanian National eID card (asmens tapatybės kortelė) utility</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">lteid-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.9.4"></a><h2>Description</h2><p>
+			The <span class="command"><strong>lteid-tool</strong></span> utility is used to set up Lithuanian National eID card access;
+			unblock it after incorrect PIN entry attempts.
+		</p><p>
+			When invoked without any options, <span class="command"><strong>lteid-tool</strong></span> will try to determine if card is
+			ready for use or card access number (CAN) needs to be entered first. Card access number is a 6
+			digit number printed on the front side bottom right corner of the card. Type it in and it will
+			be persisted for subsequent uses of the card.
+		</p></div><div class="refsect1"><a name="id-1.9.5"></a><h2>Options</h2><p>
+			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+						<code class="option">--help</code>,
+						<code class="option">-h</code>
+					</span></dt><dd><p>Display tool options.</p></dd><dt><span class="term">
+						<code class="option">--verbose</code>,
+						<code class="option">-v</code>
+					</span></dt><dd><p>Causes <span class="command"><strong>lteid-tool</strong></span> to be more verbose.
+						Specify this flag several times to enable debug output.</p></dd><dt><span class="term">
+						<code class="option">--reader</code> <em class="replaceable"><code>arg</code></em>,
+						<code class="option">-r</code> <em class="replaceable"><code>arg</code></em>
+					</span></dt><dd><p>
+							Number of the reader to use. By default, the first
+							reader with a present card is used. If
+							<em class="replaceable"><code>arg</code></em> is an ATR, the
+							reader with a matching card will be chosen.
+						</p></dd><dt><span class="term">
+						<code class="option">--wait</code>,
+						<code class="option">-w</code>
+					</span></dt><dd><p>Causes <span class="command"><strong>lteid-tool</strong></span> to wait for the token
+						to be inserted into reader.</p></dd><dt><span class="term">
+						<code class="option">--can</code> <em class="replaceable"><code>can</code></em>
+						<code class="option">-c</code> <em class="replaceable"><code>can</code></em>
+					</span></dt><dd><p>
+							This option can be used to specify the CAN value
+							on the command line. If the value is set to
+							<code class="literal">env:</code><em class="replaceable"><code>VARIABLE</code></em>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</p></dd><dt><span class="term">
+						<code class="option">--pin</code> <em class="replaceable"><code>pin</code></em>
+						<code class="option">-p</code> <em class="replaceable"><code>pin</code></em>
+					</span></dt><dd><p>
+							This option can be used to specify the PIN value
+							on the command line. If the value is set to
+							<code class="literal">env:</code><em class="replaceable"><code>VARIABLE</code></em>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</p></dd><dt><span class="term">
+						<code class="option">--puk</code> <em class="replaceable"><code>puk</code></em>
+						<code class="option">-u</code> <em class="replaceable"><code>puk</code></em>
+					</span></dt><dd><p>
+							This option can be used to specify the PUK value
+							on the command line. If the value is set to
+							<code class="literal">env:</code><em class="replaceable"><code>VARIABLE</code></em>, the value
+							of the specified environment variable is used. By default,
+							the code is prompted on the command line if needed.
+						</p></dd><dt><span class="term">
+						<code class="option">--change-pin</code>
+						<code class="option">-C</code>
+					</span></dt><dd><p>
+							Change PIN.
+						</p></dd><dt><span class="term">
+						<code class="option">--resume</code>
+						<code class="option">-R</code>
+					</span></dt><dd><p>
+							Resume eID PIN use after 2 incorrect attempts using current PIN.
+						</p></dd><dt><span class="term">
+						<code class="option">--unblock</code>
+						<code class="option">-U</code>
+					</span></dt><dd><p>
+							Unblock eID PIN use after 3 incorrect attempts using PUK.
+						</p></dd><dt><span class="term">
+						<code class="option">--verify-can</code>
+						<code class="option">-V</code>
+					</span></dt><dd><p>
+							Verify Card Access Number (CAN). Use with
+							<code class="literal">--can=XXXXXX</code> option to
+							non-interactively verify and store CAN.
+						</p></dd></dl></div><p>
+		</p></div><div class="refsect1"><a name="id-1.9.6"></a><h2>See also</h2><p>
+			<span class="citerefentry"><span class="refentrytitle">opensc.conf</span>(5)</span>
+		</p></div><div class="refsect1"><a name="id-1.9.7"></a><h2>Authors</h2><p><span class="command"><strong>lteid-tool</strong></span> was written by
+		Tadas Sasnauskas <code class="email">&lt;<a class="email" href="mailto:tadas@yoyo.lt">tadas@yoyo.lt</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="netkey-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>netkey-tool — administrative utility for Netkey E4 cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">netkey-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>COMMAND</code></em>]</p></div></div><div class="refsect1"><a name="id-1.10.4"></a><h2>Description</h2><p>The <span class="command"><strong>netkey-tool</strong></span> utility can be used from the
     command line to perform some smart card operations with NetKey E4 cards
     that cannot be done easily with other OpenSC-tools, such as changing local
     PINs, storing certificates into empty NetKey E4 cert-files or displaying
-    the initial PUK-value.</p></div><div class="refsect1"><a name="id-1.9.5"></a><h2>Options</h2><p>
+    the initial PUK-value.</p></div><div class="refsect1"><a name="id-1.10.5"></a><h2>Options</h2><p>
       </p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
             <code class="option">--help</code>,
             <code class="option">-h</code>
@@ -408,11 +489,11 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
             <code class="option">-v</code>
           </span></dt><dd><p>Causes <span class="command"><strong>netkey-tool</strong></span> to be more verbose. This
           options may be specified multiple times to increase verbosity.</p></dd></dl></div><p>
-    </p></div><div class="refsect1"><a name="id-1.9.6"></a><h2>PIN format</h2><p>With the <code class="option">-p</code>, <code class="option">-u</code>, <code class="option">-0</code> or the <code class="option">-1</code>
+    </p></div><div class="refsect1"><a name="id-1.10.6"></a><h2>PIN format</h2><p>With the <code class="option">-p</code>, <code class="option">-u</code>, <code class="option">-0</code> or the <code class="option">-1</code>
     one of the cards pins may be specified. You may use plain ascii-strings (i.e. 123456) or a hex-string
     (i.e. 31:32:33:34:35:36). A hex-string must consist of exactly n 2-digit hexnumbers separated by n-1 colons.
     Otherwise it will be interpreted as an ascii string. For example :12:34: and 1:2:3:4 are both pins of
-    length 7, while 12:34 and 01:02:03:04 are pins of length 2 and 4.</p></div><div class="refsect1"><a name="id-1.9.7"></a><h2>Commands</h2><p>When used without any options or commands, <span class="command"><strong>netkey-tool</strong></span> will
+    length 7, while 12:34 and 01:02:03:04 are pins of length 2 and 4.</p></div><div class="refsect1"><a name="id-1.10.7"></a><h2>Commands</h2><p>When used without any options or commands, <span class="command"><strong>netkey-tool</strong></span> will
     display information about the smart cards pins and certificates. This will not change
     your card in any aspect (assumed there are no bugs in <span class="command"><strong>netkey-tool</strong></span>).
     In particular the tries-left counters of the pins are investigated without doing
@@ -456,11 +537,11 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
           </span></dt><dd><p>This unblocks the specified pin. You must specify another pin
           to be able to do this and if you don't specify a correct one,
           <span class="command"><strong>netkey-tool</strong></span> will tell you which one is needed.</p></dd></dl></div><p>
-    </p></div><div class="refsect1"><a name="id-1.9.8"></a><h2>See also</h2><p>
+    </p></div><div class="refsect1"><a name="id-1.10.8"></a><h2>See also</h2><p>
       <span class="citerefentry"><span class="refentrytitle">opensc-explorer</span>(1)</span>
-    </p></div><div class="refsect1"><a name="id-1.9.9"></a><h2>Authors</h2><p><span class="command"><strong>netkey-tool</strong></span> was written by
+    </p></div><div class="refsect1"><a name="id-1.10.9"></a><h2>Authors</h2><p><span class="command"><strong>netkey-tool</strong></span> was written by
     Peter Koch <code class="email">&lt;<a class="email" href="mailto:pk_opensc@web.de">pk_opensc@web.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="npa-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>npa-tool — displays information of an ID card or ePassport.
-		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">npa-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.10.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">npa-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.11.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>npa-tool</strong></span> utility is used to display information
             stored on an ID card or on a passport and to perform some write and
             verification operations.
@@ -470,7 +551,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 			travel document (<abbr class="abbrev">MRTD</abbr>) as well as EAC compliant ID
 			cards, for example the German ID card (neuer Personalausweis,
 			<abbr class="abbrev">nPA</abbr>), may be read.
-		</p></div><div class="refsect1"><a name="id-1.10.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.11.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--help</code>,
 						<code class="option">-h</code></span></dt><dd><p>Print help and exit.</p></dd><dt><span class="term">
@@ -490,7 +571,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						Causes <span class="command"><strong>npa-tool</strong></span> to be more verbose.
 						Specify this flag several times to be more verbose.
 					</p></dd></dl></div><p>
-		</p><div class="refsect2"><a name="id-1.10.5.3"></a><h3>Password Authenticated Connection Establishment (<abbr class="abbrev">PACE</abbr>)</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+		</p><div class="refsect2"><a name="id-1.11.5.3"></a><h3>Password Authenticated Connection Establishment (<abbr class="abbrev">PACE</abbr>)</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--pin</code>  [<em class="replaceable"><code>STRING</code></em>],
 						<code class="option">-p</code>  [<em class="replaceable"><code>STRING</code></em>]
 					</span></dt><dd><p>
@@ -517,7 +598,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						and <code class="envar">NEWPIN</code>.
 						You may want to clean your environment before enabling this.
 						(default=off)
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.4"></a><h3>PIN management</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.4"></a><h3>PIN management</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--new-pin</code>  [<em class="replaceable"><code>STRING</code></em>],
 						<code class="option">-N</code>  [<em class="replaceable"><code>STRING</code></em>]
 					</span></dt><dd><p>
@@ -534,7 +615,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>
 						Unblock PIN (uses PUK to activate three more retries).
 						(default=off)
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.5"></a><h3>Terminal Authentication (<abbr class="abbrev">TA</abbr>) and Chip Authentication (<abbr class="abbrev">CA</abbr>)</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.5"></a><h3>Terminal Authentication (<abbr class="abbrev">TA</abbr>) and Chip Authentication (<abbr class="abbrev">CA</abbr>)</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--cv-certificate</code> <em class="replaceable"><code>FILENAME</code></em>,
 						<code class="option">-C</code> <em class="replaceable"><code>FILENAME</code></em>
 					</span></dt><dd><p>
@@ -578,21 +659,21 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						(default=off)
 					</p></dd><dt><span class="term"><code class="option">--disable-ca-checks</code></span></dt><dd><p>
 						Disable passive authentication. (default=off)
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.6"></a><h3>Card application</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--application</code> <em class="replaceable"><code>app</code></em></span></dt><dd><p>
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.6"></a><h3>Card application</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--application</code> <em class="replaceable"><code>app</code></em></span></dt><dd><p>
 						What application to select on the card, use <code class="literal">eID</code> for the
 						electronic identification application and <code class="literal">eMRTD</code> for the
 						ePassport application. (default=<code class="literal">eID</code>)
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.7"></a><h3>Read and write data groups</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--read-all-dgs</code></span></dt><dd><p>Read all available data groups.</p></dd><dt><span class="term"><code class="option">--read-dg1</code></span></dt><dd><p>Read data group 1.</p></dd><dt><span class="term"><code class="option">--read-dg2</code></span></dt><dd><p>Read data group 2.</p></dd><dt><span class="term"><code class="option">--read-dg3</code></span></dt><dd><p>Read data group 3.</p></dd><dt><span class="term"><code class="option">--read-dg4</code></span></dt><dd><p>Read data group 4.</p></dd><dt><span class="term"><code class="option">--read-dg5</code></span></dt><dd><p>Read data group 5.</p></dd><dt><span class="term"><code class="option">--read-dg6</code></span></dt><dd><p>Read data group 6.</p></dd><dt><span class="term"><code class="option">--read-dg7</code></span></dt><dd><p>Read data group 7.</p></dd><dt><span class="term"><code class="option">--read-dg8</code></span></dt><dd><p>Read data group 8.</p></dd><dt><span class="term"><code class="option">--read-dg9</code></span></dt><dd><p>Read data group 9.</p></dd><dt><span class="term"><code class="option">--read-dg10</code></span></dt><dd><p>Read data group 10.</p></dd><dt><span class="term"><code class="option">--read-dg11</code></span></dt><dd><p>Read data group 11.</p></dd><dt><span class="term"><code class="option">--read-dg12</code></span></dt><dd><p>Read data group 12.</p></dd><dt><span class="term"><code class="option">--read-dg13</code></span></dt><dd><p>Read data group 13.</p></dd><dt><span class="term"><code class="option">--read-dg14</code></span></dt><dd><p>Read data group 14.</p></dd><dt><span class="term"><code class="option">--read-dg15</code></span></dt><dd><p>Read data group 15.</p></dd><dt><span class="term"><code class="option">--read-dg16</code></span></dt><dd><p>Read data group 16.</p></dd><dt><span class="term"><code class="option">--read-dg17</code></span></dt><dd><p>Read data group 17.</p></dd><dt><span class="term"><code class="option">--read-dg18</code></span></dt><dd><p>Read data group 18.</p></dd><dt><span class="term"><code class="option">--read-dg19</code></span></dt><dd><p>Read data group 19.</p></dd><dt><span class="term"><code class="option">--read-dg20</code></span></dt><dd><p>Read data group 20.</p></dd><dt><span class="term"><code class="option">--read-dg21</code></span></dt><dd><p>Read data group 21.</p></dd><dt><span class="term">
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.7"></a><h3>Read and write data groups</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--read-all-dgs</code></span></dt><dd><p>Read all available data groups.</p></dd><dt><span class="term"><code class="option">--read-dg1</code></span></dt><dd><p>Read data group 1.</p></dd><dt><span class="term"><code class="option">--read-dg2</code></span></dt><dd><p>Read data group 2.</p></dd><dt><span class="term"><code class="option">--read-dg3</code></span></dt><dd><p>Read data group 3.</p></dd><dt><span class="term"><code class="option">--read-dg4</code></span></dt><dd><p>Read data group 4.</p></dd><dt><span class="term"><code class="option">--read-dg5</code></span></dt><dd><p>Read data group 5.</p></dd><dt><span class="term"><code class="option">--read-dg6</code></span></dt><dd><p>Read data group 6.</p></dd><dt><span class="term"><code class="option">--read-dg7</code></span></dt><dd><p>Read data group 7.</p></dd><dt><span class="term"><code class="option">--read-dg8</code></span></dt><dd><p>Read data group 8.</p></dd><dt><span class="term"><code class="option">--read-dg9</code></span></dt><dd><p>Read data group 9.</p></dd><dt><span class="term"><code class="option">--read-dg10</code></span></dt><dd><p>Read data group 10.</p></dd><dt><span class="term"><code class="option">--read-dg11</code></span></dt><dd><p>Read data group 11.</p></dd><dt><span class="term"><code class="option">--read-dg12</code></span></dt><dd><p>Read data group 12.</p></dd><dt><span class="term"><code class="option">--read-dg13</code></span></dt><dd><p>Read data group 13.</p></dd><dt><span class="term"><code class="option">--read-dg14</code></span></dt><dd><p>Read data group 14.</p></dd><dt><span class="term"><code class="option">--read-dg15</code></span></dt><dd><p>Read data group 15.</p></dd><dt><span class="term"><code class="option">--read-dg16</code></span></dt><dd><p>Read data group 16.</p></dd><dt><span class="term"><code class="option">--read-dg17</code></span></dt><dd><p>Read data group 17.</p></dd><dt><span class="term"><code class="option">--read-dg18</code></span></dt><dd><p>Read data group 18.</p></dd><dt><span class="term"><code class="option">--read-dg19</code></span></dt><dd><p>Read data group 19.</p></dd><dt><span class="term"><code class="option">--read-dg20</code></span></dt><dd><p>Read data group 20.</p></dd><dt><span class="term"><code class="option">--read-dg21</code></span></dt><dd><p>Read data group 21.</p></dd><dt><span class="term">
 					<code class="option">--write-dg17</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 17.</p></dd><dt><span class="term">
 					<code class="option">--write-dg18</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 18.</p></dd><dt><span class="term">
 					<code class="option">--write-dg19</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 19.</p></dd><dt><span class="term">
-					<code class="option">--write-dg20</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 20.</p></dd><dt><span class="term"><code class="option">--write-dg21</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 21.</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.8"></a><h3>Verification of validity, age and community ID</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--verify-validity</code> <em class="replaceable"><code>YYYYMMDD</code></em></span></dt><dd><p>
+					<code class="option">--write-dg20</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 20.</p></dd><dt><span class="term"><code class="option">--write-dg21</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>Write data group 21.</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.8"></a><h3>Verification of validity, age and community ID</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--verify-validity</code> <em class="replaceable"><code>YYYYMMDD</code></em></span></dt><dd><p>
 						Verify chip's validity with a reference date.
 					</p></dd><dt><span class="term"><code class="option">--older-than</code> <em class="replaceable"><code>YYYYMMDD</code></em></span></dt><dd><p>
 						Verify age with a reference date.
 					</p></dd><dt><span class="term"><code class="option">--verify-community</code> <em class="replaceable"><code>HEX_STRING</code></em></span></dt><dd><p>
 						Verify community ID with a reference ID.
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.10.5.9"></a><h3>Special options, not always useful</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.11.5.9"></a><h3>Special options, not always useful</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--break</code>,
 						<code class="option">-b</code>
 					</span></dt><dd><p>
@@ -611,9 +692,9 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						Force compliance to BSI TR-03110 version 2.01. (default=off)
 					</p></dd><dt><span class="term"><code class="option">--disable-all-checks</code></span></dt><dd><p>
 						 Disable all checking of fly-by-data. (default=off)
-					</p></dd></dl></div></div></div><div class="refsect1"><a name="id-1.10.6"></a><h2>Authors</h2><p><span class="command"><strong>npa-tool</strong></span> was written by
+					</p></dd></dl></div></div></div><div class="refsect1"><a name="id-1.11.6"></a><h2>Authors</h2><p><span class="command"><strong>npa-tool</strong></span> was written by
 		Frank Morgner <code class="email">&lt;<a class="email" href="mailto:frankmorgner@gmail.com">frankmorgner@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="openpgp-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>openpgp-tool — utility for accessing visible data OpenPGP smart cards
-		and compatible tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">openpgp-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.11.4"></a><h2>Description</h2><p>
+		and compatible tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">openpgp-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.12.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>openpgp-tool</strong></span> utility is used for
 			accessing data from the OpenPGP v1.1 and v2.0 smart cards
 			and compatible tokens like e.g. GPF CryptoStick v1.x,
@@ -621,7 +702,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 			PKCS#15 objects but available in custom files on the
 			card. The data can be printed on screen or used by
 			other programs via environment variables.
-		</p></div><div class="refsect1"><a name="id-1.11.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.12.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--card-info</code>,
 						<code class="option">-C</code>
@@ -742,21 +823,21 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>
 						Wait for a card to be inserted.
 					</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.11.6"></a><h2>Authors</h2><p><span class="command"><strong>openpgp-tool</strong></span> utility was written by
+		</p></div><div class="refsect1"><a name="id-1.12.6"></a><h2>Authors</h2><p><span class="command"><strong>openpgp-tool</strong></span> utility was written by
 		Peter Marschall <code class="email">&lt;<a class="email" href="mailto:peter@adpm.de">peter@adpm.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="opensc-asn1"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>opensc-asn1 — parse ASN.1 data
-		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-asn1</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>FILES</code></em>]</p></div></div><div class="refsect1"><a name="id-1.12.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-asn1</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>FILES</code></em>]</p></div></div><div class="refsect1"><a name="id-1.13.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>opensc-asn1</strong></span> utility is used to parse ASN.1 data.
-		</p></div><div class="refsect1"><a name="id-1.12.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.13.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--help</code>,
 						<code class="option">-h</code></span></dt><dd><p>Print help and exit.</p></dd><dt><span class="term">
 						<code class="option">--version</code>,
 						<code class="option">-V</code></span></dt><dd><p>Print version and exit.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.12.6"></a><h2>Authors</h2><p><span class="command"><strong>opensc-asn1</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.13.6"></a><h2>Authors</h2><p><span class="command"><strong>opensc-asn1</strong></span> was written by
 		Frank Morgner <code class="email">&lt;<a class="email" href="mailto:frankmorgner@gmail.com">frankmorgner@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="opensc-explorer"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>opensc-explorer — 
 			generic interactive utility for accessing smart card
 			and similar security token functions
-		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-explorer</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>SCRIPT</code></em>]</p></div></div><div class="refsect1"><a name="id-1.13.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-explorer</code>  [<em class="replaceable"><code>OPTIONS</code></em>] [<em class="replaceable"><code>SCRIPT</code></em>]</p></div></div><div class="refsect1"><a name="id-1.14.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>opensc-explorer</strong></span> utility can be
 			used to perform miscellaneous operations
 			such as exploring the contents of or sending arbitrary
@@ -768,7 +849,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 			one command per line.
 			If no script is given, <span class="command"><strong>opensc-explorer</strong></span>
 			runs in interactive mode, reading commands from standard input.
-		</p></div><div class="refsect1"><a name="id-1.13.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.14.5"></a><h2>Options</h2><p>
 			The following are the command-line options for
 			<span class="command"><strong>opensc-explorer</strong></span>.  There are additional
 			interactive commands available once it is running.
@@ -809,7 +890,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>
 							Wait for a card to be inserted.
 						</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.13.6"></a><h2>Commands</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.14.6"></a><h2>Commands</h2><p>
 			<span class="command"><strong>opensc-explorer</strong></span> supports commands with arguments
 			at its interactive prompt or in script files passed via the command line
 			parameter <em class="replaceable"><code>SCRIPT</code></em>.
@@ -1214,20 +1295,20 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 							Call the card's <code class="literal">open</code> or
 							<code class="literal">close</code> Secure Messaging handler.
 						</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.13.7"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.14.7"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">opensc-tool</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.13.8"></a><h2>Authors</h2><p><span class="command"><strong>opensc-explorer</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.14.8"></a><h2>Authors</h2><p><span class="command"><strong>opensc-explorer</strong></span> was written by
 		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="opensc-notify"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>opensc-notify —  monitor smart card events and send notifications
-		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-notify</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.14.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-notify</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.15.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>opensc-notify</strong></span> utility is used to
 			monitor smart card events and send the appropriate notification.
-		</p></div><div class="refsect1"><a name="id-1.14.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.15.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--help</code>,
 						<code class="option">-h</code></span></dt><dd><p>Print help and exit.</p></dd><dt><span class="term">
 						<code class="option">--version</code>,
 						<code class="option">-V</code></span></dt><dd><p>Print version and exit.</p></dd></dl></div><p>
-		</p><div class="refsect2"><a name="id-1.14.5.3"></a><h3>Mode: customized</h3><p>
+		</p><div class="refsect2"><a name="id-1.15.5.3"></a><h3>Mode: customized</h3><p>
 				Send customized notifications.
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--title</code>  [<em class="replaceable"><code>STRING</code></em>],
@@ -1239,7 +1320,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						<code class="option">-m</code>  [<em class="replaceable"><code>STRING</code></em>]
 					</span></dt><dd><p>
 						Specify the main text of the notification.
-					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.14.5.4"></a><h3>Mode: standard</h3><p>
+					</p></dd></dl></div></div><div class="refsect2"><a name="id-1.15.5.4"></a><h3>Mode: standard</h3><p>
 				Manually send standard notifications.
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--notify-card-inserted</code>,
@@ -1261,12 +1342,12 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						<code class="option">-B</code></span></dt><dd><p>
 						See <em class="parameter"><code>notify_pin_bad</code></em>
 						in <code class="filename">opensc.conf</code> (default=off).
-					</p></dd></dl></div></div></div><div class="refsect1"><a name="id-1.14.6"></a><h2>Authors</h2><p><span class="command"><strong>opensc-notify</strong></span> was written by
-		Frank Morgner <code class="email">&lt;<a class="email" href="mailto:frankmorgner@gmail.com">frankmorgner@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="opensc-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>opensc-tool — generic smart card utility</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.15.4"></a><h2>Description</h2><p>
+					</p></dd></dl></div></div></div><div class="refsect1"><a name="id-1.15.6"></a><h2>Authors</h2><p><span class="command"><strong>opensc-notify</strong></span> was written by
+		Frank Morgner <code class="email">&lt;<a class="email" href="mailto:frankmorgner@gmail.com">frankmorgner@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="opensc-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>opensc-tool — generic smart card utility</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">opensc-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.16.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>opensc-tool</strong></span> utility can be used from the command line to perform
 			miscellaneous smart card operations such as getting the card ATR or
 			sending arbitrary APDU commands to a card.
-		</p></div><div class="refsect1"><a name="id-1.15.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.16.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--version</code>
 					</span></dt><dd><p>Print the OpenSC package release version.</p></dd><dt><span class="term">
@@ -1339,10 +1420,10 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 						<code class="option">--wait</code>,
 						<code class="option">-w</code>
 					</span></dt><dd><p>Wait for a card to be inserted.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.15.6"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.16.6"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">opensc-explorer</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.15.7"></a><h2>Authors</h2><p><span class="command"><strong>opensc-tool</strong></span> was written by
-		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="piv-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>piv-tool — smart card utility for HSPD-12 PIV cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">piv-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.16.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.16.7"></a><h2>Authors</h2><p><span class="command"><strong>opensc-tool</strong></span> was written by
+		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="piv-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>piv-tool — smart card utility for HSPD-12 PIV cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">piv-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.17.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>piv-tool</strong></span> utility can be used from the command line to perform
 			miscellaneous smart card operations on a HSPD-12 PIV smart card as defined in
 			<a class="ulink" href="https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final" target="_top">
@@ -1351,7 +1432,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 			It is intended for use with test cards only. It can load objects and generate
 			key pairs, as well as send arbitrary APDU commands to a card after having authenticated
 			to the card using the card key provided by the card vendor.
-		</p></div><div class="refsect1"><a name="id-1.16.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.17.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><p class="title"><b>Description</b></p><dl class="variablelist"><dt><span class="term">
 						<code class="option">--serial</code>
 					</span></dt><dd><p>Print the card serial number derived from the CHUID object,
@@ -1440,16 +1521,16 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>Causes <span class="command"><strong>piv-tool</strong></span> to be more verbose.
 					Specify this flag several times to enable debug output in the opensc
 					library.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.16.6"></a><h2>Examples</h2><p>Authenticate to the card and create History Object to use the 20 retired keys</p><p><span class="command"><strong>piv-tool <code class="option">-A</code> <em class="replaceable"><code>argument</code></em> -s "00:DB:3F:FF:0F:5C:03:5F:C1:0C:53:08:C1:01:14:C2:01:00:FE:00"</strong></span></p></div><div class="refsect1"><a name="id-1.16.7"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.17.6"></a><h2>Examples</h2><p>Authenticate to the card and create History Object to use the 20 retired keys</p><p><span class="command"><strong>piv-tool <code class="option">-A</code> <em class="replaceable"><code>argument</code></em> -s "00:DB:3F:FF:0F:5C:03:5F:C1:0C:53:08:C1:01:14:C2:01:00:FE:00"</strong></span></p></div><div class="refsect1"><a name="id-1.17.7"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">opensc-tool</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.16.8"></a><h2>Authors</h2><p><span class="command"><strong>piv-tool</strong></span> was written by
-		Douglas E. Engert <code class="email">&lt;<a class="email" href="mailto:deengert@gmail.com">deengert@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs11-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs11-tool — utility for managing and using PKCS #11 security tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs11-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.17.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.17.8"></a><h2>Authors</h2><p><span class="command"><strong>piv-tool</strong></span> was written by
+		Douglas E. Engert <code class="email">&lt;<a class="email" href="mailto:deengert@gmail.com">deengert@gmail.com</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs11-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs11-tool — utility for managing and using PKCS #11 security tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs11-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.18.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>pkcs11-tool</strong></span> utility is used to manage the
 			data objects on smart cards and similar PKCS #11 security tokens.
 			Users can list and read PINs, keys and certificates stored on the
 			token. User PIN authentication is performed for those operations
 			that require it.
-		</p></div><div class="refsect1"><a name="id-1.17.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.18.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--attr-from</code> <em class="replaceable"><code>filename</code></em>
 					</span></dt><dd><p>Extract information from <em class="replaceable"><code>filename</code></em>
@@ -1755,7 +1836,7 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>Specify the PKCS#11 URI for module, slot, token or object</p></dd><dt><span class="term">
 						<code class="option">--uri-with-slot-id</code>
 					</span></dt><dd><p>Include SlotId in PKCS#11 URI</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.17.6"></a><h2>Examples</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.18.6"></a><h2>Examples</h2><p>
 			Perform a basic functionality test of the card:
 				</p><pre class="programlisting">pkcs11-tool --test --login</pre><p>
 
@@ -1850,13 +1931,13 @@ pkcs11-tool --login --unwrap --mechanism RSA-PKCS --id 22 \
 				</p><pre class="programlisting">
 pkcs11-tool --login --login-type so --init-pin
 				</pre><p>
-		</p></div><div class="refsect1"><a name="id-1.17.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs11-tool</strong></span> was written by
-		Olaf Kirch <code class="email">&lt;<a class="email" href="mailto:okir@suse.de">okir@suse.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-crypt"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-crypt — perform crypto operations using PKCS#15 smart cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-crypt</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.18.4"></a><h2>Description</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.18.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs11-tool</strong></span> was written by
+		Olaf Kirch <code class="email">&lt;<a class="email" href="mailto:okir@suse.de">okir@suse.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-crypt"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-crypt — perform crypto operations using PKCS#15 smart cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-crypt</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.19.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>pkcs15-crypt</strong></span> utility can be used from the
 			command line to perform cryptographic operations such as computing
 			digital signatures or decrypting data, using keys stored on a PKCS#15
 			compliant smart card.
-		</p></div><div class="refsect1"><a name="id-1.18.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.19.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
                                                 <code class="option">--version</code>,
                                         </span></dt><dd><p>Print the OpenSC package release version.</p></dd><dt><span class="term">
@@ -1953,18 +2034,18 @@ pkcs11-tool --login --login-type so --init-pin
 					</span></dt><dd><p>Causes <span class="command"><strong>pkcs15-crypt</strong></span> to be more
 					verbose. Specify this flag several times to enable debug output
 					in the OpenSC library.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.18.6"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.19.6"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">pkcs15-init</span>(1)</span>,
 			<span class="citerefentry"><span class="refentrytitle">pkcs15-tool</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.18.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-crypt</strong></span> was written by
-		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-init"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-init — smart card personalization utility</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-init</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.19.5"></a><h2>Description</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.19.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-crypt</strong></span> was written by
+		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-init"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-init — smart card personalization utility</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-init</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.20.5"></a><h2>Description</h2><p>
 			The <span class="command"><strong>pkcs15-init</strong></span> utility can be used to create a PKCS #15
 			structure on a smart card, and add key or certificate objects. Details of the
 			structure that will be created are controlled via profiles.
 		</p><p>
 			The profile used by default is <span class="command"><strong>pkcs15</strong></span>. Alternative
 			profiles can be specified via the <code class="option">-p</code> switch.
-		</p></div><div class="refsect1"><a name="id-1.19.6"></a><h2>PIN Usage</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.20.6"></a><h2>PIN Usage</h2><p>
 			<span class="command"><strong>pkcs15-init</strong></span> can be used to create a PKCS #15 structure on
 			your smart card, create PINs, and install keys and certificates on the card.
 			This process is also called <em class="replaceable"><code>personalization</code></em>.
@@ -1996,7 +2077,7 @@ pkcs11-tool --login --login-type so --init-pin
 			are protected and cannot be parsed without authentication (usually with User PIN).
 			This authentication need to be done immediately after the card binding.
 			In such cases <code class="option">--verify-pin</code> has to be used.
-		</p></div><div class="refsect1"><a name="id-1.19.7"></a><h2>Modes of operation</h2><div class="refsect2"><a name="id-1.19.7.2"></a><h3>Initialization</h3><p>This is the first step during card personalization, and will create the
+		</p></div><div class="refsect1"><a name="id-1.20.7"></a><h2>Modes of operation</h2><div class="refsect2"><a name="id-1.20.7.2"></a><h3>Initialization</h3><p>This is the first step during card personalization, and will create the
 				basic files on the card. To create the initial PKCS #15 structure, invoke the
 				utility as
 			</p><p>
@@ -2006,7 +2087,7 @@ pkcs11-tool --login --login-type so --init-pin
 			</p><p>
 				If the card supports it, you should erase the contents of the card with
 				<span class="command"><strong>pkcs15-init --erase-card</strong></span> before creating the PKCS#15 structure.
-			</p></div><div class="refsect2"><a name="id-1.19.7.3"></a><h3>User PIN Installation</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.3"></a><h3>User PIN Installation</h3><p>
 				Before installing any user objects such as private keys, you need at least one
 				PIN to protect these objects. you can do this using
 			</p><p>
@@ -2020,7 +2101,7 @@ pkcs11-tool --login --login-type so --init-pin
 			</p><p>
 				To set a label for this PIN object (which can be used by applications to display
 				a meaningful prompt to the user), use the <code class="option">--label</code> command line option.
-			</p></div><div class="refsect2"><a name="id-1.19.7.4"></a><h3>Key generation</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.4"></a><h3>Key generation</h3><p>
 				<span class="command"><strong>pkcs15-init</strong></span> lets you generate a new key and store it on the card.
 				You can do this using:
 			</p><p>
@@ -2045,7 +2126,7 @@ pkcs11-tool --login --login-type so --init-pin
 				In addition to storing the private portion of the key on the card,
 				<span class="command"><strong>pkcs15-init</strong></span> will also store the public portion of the
 				key as a PKCS #15 public key object.
-			</p></div><div class="refsect2"><a name="id-1.19.7.5"></a><h3>Private Key Upload</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.5"></a><h3>Private Key Upload</h3><p>
 				You can use a private key generated by other means and upload it to the card.
 				For instance, to upload a private key contained in a file named
 				<code class="filename">okir.pem</code>, which is in PEM format, you would use
@@ -2069,7 +2150,7 @@ pkcs11-tool --login --login-type so --init-pin
 				a file. A PKCS #12 file usually contains the X.509 certificate corresponding
 				to the private key. If that is the case, <span class="command"><strong>pkcs15-init</strong></span> will
 				store the certificate instead of the public key portion.
-			</p></div><div class="refsect2"><a name="id-1.19.7.6"></a><h3>Public Key Upload</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.6"></a><h3>Public Key Upload</h3><p>
 				You can also upload individual public keys to the card using the
 				<code class="option">--store-public-key</code> option, which takes a filename as an
 				argument. This file is supposed to contain the public key. If you don't
@@ -2080,12 +2161,12 @@ pkcs11-tool --login --login-type so --init-pin
 				Since the corresponding public keys are always uploaded automatically
 				when generating a new key, or when uploading a private key, you will
 				probably use this option only very rarely.
-			</p></div><div class="refsect2"><a name="id-1.19.7.7"></a><h3>Certificate Upload</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.7"></a><h3>Certificate Upload</h3><p>
 				You can upload certificates to the card using the
 				<code class="option">--store-certificate</code> option, which takes a filename as
 				an argument. This file is supposed to contain the PEM encoded X.509
 				certificate.
-			</p></div><div class="refsect2"><a name="id-1.19.7.8"></a><h3>Uploading PKCS #12 bags</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.8"></a><h3>Uploading PKCS #12 bags</h3><p>
 				Most browsers nowadays use PKCS #12 format files when you ask them to
 				export your key and certificate to a file. <span class="command"><strong>pkcs15-init</strong></span>
 				is capable of parsing these files, and storing their contents on the
@@ -2099,7 +2180,7 @@ pkcs11-tool --login --login-type so --init-pin
 				and protect it with the PIN referenced by authentication ID <code class="literal">01</code>.
 				It will also store any X.509 certificates contained in the file, which is
 				usually the user certificate that goes with the key, as well as the CA certificate.
-			</p></div><div class="refsect2"><a name="id-1.19.7.9"></a><h3>Secret Key Upload</h3><p>
+			</p></div><div class="refsect2"><a name="id-1.20.7.9"></a><h3>Secret Key Upload</h3><p>
 				You can use a secret key generated by other means and upload it to the card.
 				For instance, to upload an AES-secret key generated by the system random generator
 				you would use
@@ -2108,7 +2189,7 @@ pkcs11-tool --login --login-type so --init-pin
 			</p><p>
 				By default a random ID is generated for the secret key. You may specify an ID
 				with the <code class="option">--id</code> if needed.
-			</p></div></div><div class="refsect1"><a name="id-1.19.8"></a><h2>Options</h2><p>
+			</p></div></div><div class="refsect1"><a name="id-1.20.8"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--version</code>,
 					</span></dt><dd><p>Print the OpenSC package release version.</p></dd><dt><span class="term">
@@ -2447,17 +2528,17 @@ pkcs11-tool --login --login-type so --init-pin
 					</span></dt><dd><p>
 							Display help message
 						</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.19.9"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.20.9"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">pkcs15-profile</span>(5)</span>
-		</p></div><div class="refsect1"><a name="id-1.19.10"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-init</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.20.10"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-init</strong></span> was written by
 		Olaf Kirch <code class="email">&lt;<a class="email" href="mailto:okir@suse.de">okir@suse.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-tool — utility for manipulating PKCS #15 data structures
-		on smart cards and similar security tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.20.4"></a><h2>Description</h2><p>
+		on smart cards and similar security tokens</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.21.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>pkcs15-tool</strong></span> utility is used to manipulate
 			the PKCS #15 data structures on smart cards and similar security
 			tokens. Users can list and read PINs, keys and certificates stored
 			on the token. User PIN authentication is performed for those
 			operations that require it.
-		</p></div><div class="refsect1"><a name="id-1.20.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.21.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
                                                 <code class="option">--version</code>
                                         </span></dt><dd><p>Print the OpenSC package release version.</p></dd><dt><span class="term">
@@ -2605,16 +2686,16 @@ pkcs11-tool --login --login-type so --init-pin
 					wait for a card insertion.</p></dd><dt><span class="term">
 						<code class="option">--use-pinpad</code>
 					</span></dt><dd><p>Do not prompt the user; if no PINs supplied, pinpad will be used.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.20.6"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.21.6"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">pkcs15-init</span>(1)</span>,
 			<span class="citerefentry"><span class="refentrytitle">pkcs15-crypt</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.20.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-tool</strong></span> was written by
-		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="sc-hsm-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>sc-hsm-tool — smart card utility for SmartCard-HSM</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">sc-hsm-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.21.4"></a><p>
+		</p></div><div class="refsect1"><a name="id-1.21.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs15-tool</strong></span> was written by
+		Juha Yrjölä <code class="email">&lt;<a class="email" href="mailto:juha.yrjola@iki.fi">juha.yrjola@iki.fi</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="sc-hsm-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>sc-hsm-tool — smart card utility for SmartCard-HSM</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">sc-hsm-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.22.4"></a><p>
 			The <span class="command"><strong>sc-hsm-tool</strong></span> utility can be used from the command line to perform
 			extended maintenance tasks not available via PKCS#11 or other tools in the OpenSC package.
 			It can be used to query the status of a SmartCard-HSM, initialize a device, generate and import
 			Device Key Encryption Key (DKEK) shares and to wrap and unwrap keys.
-		</p></div><div class="refsect1"><a name="id-1.21.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.22.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--initialize</code>,
 						<code class="option">-X</code>
@@ -2727,16 +2808,16 @@ pkcs11-tool --login --login-type so --init-pin
 					</span></dt><dd><p>Causes <span class="command"><strong>sc-hsm-tool</strong></span> to be more verbose.
 					Specify this flag several times to enable debug output in the opensc
 					library.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.21.6"></a><h2>Examples</h2><p>Create a DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --create-dkek-share dkek-share-1.pbe</strong></span></p><p>Create a DKEK share with random password split up using a (3, 5) threshold scheme:</p><p><span class="command"><strong>sc-hsm-tool --create-dkek-share dkek-share-1.pbe --pwd-shares-threshold 3 --pwd-shares-total 5</strong></span></p><p>Initialize SmartCard-HSM to use a single DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --initialize --so-pin 3537363231383830 --pin 648219 --dkek-shares 1 --label mytoken</strong></span></p><p>Import DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --import-dkek-share dkek-share-1.pbe</strong></span></p><p>Import DKEK share using a password split up using a (3, 5) threshold scheme for encryption:</p><p><span class="command"><strong>sc-hsm-tool --import-dkek-share dkek-share-1.pbe  --pwd-shares-total 3</strong></span></p><p>Wrap referenced key, description and certificate:</p><p><span class="command"><strong>sc-hsm-tool --wrap-key wrap-key.bin --key-reference 1 --pin 648219</strong></span></p><p>Unwrap key into same or in different SmartCard-HSM with the same DKEK:</p><p><span class="command"><strong>sc-hsm-tool --unwrap-key wrap-key.bin --key-reference 10 --pin 648219 --force</strong></span></p><p>Initialize SmartCard-HSM to use M-of-N public key authentication with M=2 and N=5</p><p><span class="command"><strong>sc-hsm-tool --initialize --required-pub-keys 2 --public-key-auth 5</strong></span></p><p>Export a public key for M-of-N public key authentication to a file</p><p><span class="command"><strong>sc-hsm-tool --key-reference 1 --export-for-pub-key-auth ./public_key1.asn1</strong></span></p><p>Register a public key for M-of-N public key authentication from a file</p><p><span class="command"><strong>sc-hsm-tool --register-public-key ./public_key1.asn1</strong></span></p></div><div class="refsect1"><a name="id-1.21.7"></a><h2>See also</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.22.6"></a><h2>Examples</h2><p>Create a DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --create-dkek-share dkek-share-1.pbe</strong></span></p><p>Create a DKEK share with random password split up using a (3, 5) threshold scheme:</p><p><span class="command"><strong>sc-hsm-tool --create-dkek-share dkek-share-1.pbe --pwd-shares-threshold 3 --pwd-shares-total 5</strong></span></p><p>Initialize SmartCard-HSM to use a single DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --initialize --so-pin 3537363231383830 --pin 648219 --dkek-shares 1 --label mytoken</strong></span></p><p>Import DKEK share:</p><p><span class="command"><strong>sc-hsm-tool --import-dkek-share dkek-share-1.pbe</strong></span></p><p>Import DKEK share using a password split up using a (3, 5) threshold scheme for encryption:</p><p><span class="command"><strong>sc-hsm-tool --import-dkek-share dkek-share-1.pbe  --pwd-shares-total 3</strong></span></p><p>Wrap referenced key, description and certificate:</p><p><span class="command"><strong>sc-hsm-tool --wrap-key wrap-key.bin --key-reference 1 --pin 648219</strong></span></p><p>Unwrap key into same or in different SmartCard-HSM with the same DKEK:</p><p><span class="command"><strong>sc-hsm-tool --unwrap-key wrap-key.bin --key-reference 10 --pin 648219 --force</strong></span></p><p>Initialize SmartCard-HSM to use M-of-N public key authentication with M=2 and N=5</p><p><span class="command"><strong>sc-hsm-tool --initialize --required-pub-keys 2 --public-key-auth 5</strong></span></p><p>Export a public key for M-of-N public key authentication to a file</p><p><span class="command"><strong>sc-hsm-tool --key-reference 1 --export-for-pub-key-auth ./public_key1.asn1</strong></span></p><p>Register a public key for M-of-N public key authentication from a file</p><p><span class="command"><strong>sc-hsm-tool --register-public-key ./public_key1.asn1</strong></span></p></div><div class="refsect1"><a name="id-1.22.7"></a><h2>See also</h2><p>
 			<span class="citerefentry"><span class="refentrytitle">opensc-tool</span>(1)</span>
-		</p></div><div class="refsect1"><a name="id-1.21.8"></a><h2>Authors</h2><p><span class="command"><strong>sc-hsm-tool</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.22.8"></a><h2>Authors</h2><p><span class="command"><strong>sc-hsm-tool</strong></span> was written by
 		Andreas Schwier <code class="email">&lt;<a class="email" href="mailto:andreas.schwier@cardcontact.de">andreas.schwier@cardcontact.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="westcos-tool"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>westcos-tool — utility for manipulating data structures
-			on westcos smart cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">westcos-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.22.4"></a><h2>Description</h2><p>
+			on westcos smart cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">westcos-tool</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.23.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>westcos-tool</strong></span> utility is used to manipulate
 			the westcos data structures on 2 Ko smart cards / tokens. Users can create PINs,
 			keys and certificates stored on the card / token. User PIN authentication is
 			performed for those operations that require it.
-		</p></div><div class="refsect1"><a name="id-1.22.5"></a><h2>Options</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.23.5"></a><h2>Options</h2><p>
 			</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 						<code class="option">--change-pin</code>,
 						<code class="option">-n</code>
@@ -2824,5 +2905,5 @@ pkcs11-tool --login --login-type so --init-pin
 					from disk to card.
 					On the card the file is written in <em class="replaceable"><code>filename</code></em>.
 					User authentication is required for this operation.</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.22.6"></a><h2>Authors</h2><p><span class="command"><strong>westcos-tool</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.23.6"></a><h2>Authors</h2><p><span class="command"><strong>westcos-tool</strong></span> was written by
 		Francois Leblanc <code class="email">&lt;<a class="email" href="mailto:francois.leblanc@cev-sa.com">francois.leblanc@cev-sa.com</a>&gt;</code>.</p></div></div></div></body></html>

--- a/doc/tools/tools.xml
+++ b/doc/tools/tools.xml
@@ -12,6 +12,7 @@
 	<xi:include href="eidenv.1.xml"/>
 	<xi:include href="gids-tool.1.xml"/>
 	<xi:include href="iasecc-tool.1.xml"/>
+	<xi:include href="lteid-tool.1.xml"/>
 	<xi:include href="netkey-tool.1.xml"/>
 	<xi:include href="npa-tool.1.xml"/>
 	<xi:include href="openpgp-tool.1.xml"/>

--- a/packaging/opensc.spec
+++ b/packaging/opensc.spec
@@ -174,6 +174,7 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 %{_bindir}/egk-tool
 %{_bindir}/goid-tool
 %{_bindir}/dtrust-tool
+%{_bindir}/lteid-tool
 %{_datadir}/opensc/
 %{_mandir}/man1/cardos-tool.1*
 %{_mandir}/man1/cryptoflex-tool.1*
@@ -199,6 +200,7 @@ rm %{buildroot}%{_mandir}/man1/opensc-notify.1*
 %{_mandir}/man1/dnie-tool.1*
 %{_mandir}/man1/egk-tool.1*
 %{_mandir}/man1/dtrust-tool.1*
+%{_mandir}/man1/lteid-tool.1*
 %{_mandir}/man5/pkcs15-profile.5*
 
 %files libs

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -51,6 +51,7 @@ libopensc_la_SOURCES_BASE = \
 	card-isoApplet.c card-masktech.c card-gids.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-esteid2025.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
+	card-lteid.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
@@ -58,8 +59,8 @@ libopensc_la_SOURCES_BASE = \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
-	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c pkcs15-dtrust.c compression.c sm.c \
-	aux-data.c
+	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c pkcs15-dtrust.c pkcs15-lteid.c \
+	compression.c sm.c aux-data.c
 
 if ENABLE_CRYPTOTOKENKIT
 # most platforms don't support objective C the way we needed.
@@ -132,6 +133,7 @@ TIDY_FILES = \
 	card-isoApplet.c card-masktech.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
+	card-lteid.c \
 	\
 	pkcs15-openpgp.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \
@@ -139,8 +141,8 @@ TIDY_FILES = \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
-	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-dtrust.c compression.c sm.c \
-	aux-data.c \
+	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-dtrust.c pkcs15-lteid.c \
+	compression.c sm.c aux-data.c \
 	#$(SOURCES)
 
 check-local:

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -29,6 +29,7 @@ OBJECTS			= \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-esteid2025.obj card-idprime.obj \
 	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj card-dtrust.obj \
+	card-lteid.obj \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj pkcs15-tcos.obj \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \
@@ -37,7 +38,7 @@ OBJECTS			= \
 	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-jpki.obj \
 	pkcs15-esteid2018.obj pkcs15-esteid2025.obj pkcs15-idprime.obj pkcs15-nqApplet.obj \
 	pkcs15-starcos-esign.obj pkcs15-skeid.obj pkcs15-eoi.obj pkcs15-dtrust.obj \
-	compression.obj sm.obj aux-data.obj \
+	pkcs15-lteid.obj compression.obj sm.obj aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res
 LIBS = $(TOPDIR)\src\scconf\scconf.lib \
 	   $(TOPDIR)\src\common\common.lib \

--- a/src/libopensc/card-lteid.c
+++ b/src/libopensc/card-lteid.c
@@ -1,0 +1,591 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "asn1.h"
+#include "common/compat_strlcat.h"
+#include "internal.h"
+#include "opensc.h"
+#include "sm/sm-eac.h"
+
+static const struct sc_card_operations *iso_ops = NULL;
+static struct sc_card_operations lteid_ops;
+
+static struct sc_card_driver lteid_drv = {
+		"Lithuanian eID card (asmens tapatybės kortelė)", "lteid",
+		&lteid_ops, NULL, 0, NULL};
+
+#define DRVDATA(card)	 ((struct lteid_drv_data *)((card)->drv_data))
+#define LTEID_CAN_LENGTH 6
+
+struct lteid_drv_data {
+	unsigned char pace;
+	unsigned char pace_pin_ref;
+	unsigned char can[LTEID_CAN_LENGTH];
+	unsigned char can_from_cache;
+};
+
+void
+lteid_get_can_cache_path(sc_card_t *card, char *buf, size_t buf_len)
+{
+	sc_get_cache_dir(card->ctx, buf, buf_len);
+
+#ifdef _WIN32
+	strlcat(buf, "\\", buf_len);
+#else
+	strlcat(buf, "/", buf_len);
+#endif
+
+	strlcat(buf, "lteid_can", buf_len);
+}
+
+static int
+lteid_get_cached_can(sc_card_t *card, unsigned char *can)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	char path[PATH_MAX];
+
+	lteid_get_can_cache_path(card, path, sizeof(path));
+
+	FILE *fd = fopen(path, "r");
+
+	if (!fd) {
+		LOG_FUNC_RETURN(card->ctx, 0);
+	}
+
+	if (LTEID_CAN_LENGTH != fread(can, 1, LTEID_CAN_LENGTH, fd)) {
+		LOG_FUNC_RETURN(card->ctx, 0);
+	}
+
+	fclose(fd);
+
+	LOG_FUNC_RETURN(card->ctx, 1);
+}
+
+static int
+lteid_cache_can(sc_card_t *card, const char *can)
+{
+	int rv;
+	char path[PATH_MAX];
+
+	lteid_get_can_cache_path(card, path, sizeof(path));
+
+	FILE *fd = fopen(path, "w");
+
+	if (!fd && errno == ENOENT) {
+		if ((rv = sc_make_cache_dir(card->ctx)) < 0)
+			return rv;
+
+		fd = fopen(path, "w");
+	}
+
+	if (!fd) {
+		return SC_ERROR_INTERNAL;
+	}
+
+	fwrite(can, 1, 6, fd);
+	fclose(fd);
+
+	return SC_SUCCESS;
+}
+
+static int
+lteid_clear_cached_can(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	char path[PATH_MAX];
+
+	lteid_get_can_cache_path(card, path, sizeof(path));
+
+	if (!unlink(path)) {
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_get_can(sc_card_t *card, struct establish_pace_channel_input *pace_input)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	struct lteid_drv_data *drv_data = DRVDATA(card);
+	int got_can = 0;
+
+	drv_data->can_from_cache = 0;
+
+	// Try env variables first
+	const char *can_from_env = getenv("LTEID_CAN");
+	if (can_from_env && strlen(can_from_env) == LTEID_CAN_LENGTH) {
+		got_can = 1;
+		memcpy(drv_data->can, can_from_env, LTEID_CAN_LENGTH);
+	}
+
+	// Try getting one from the cache
+	if (!got_can && lteid_get_cached_can(card, drv_data->can)) {
+		got_can = 1;
+		drv_data->can_from_cache = 1;
+	}
+
+	// Finally see if there is a default in configuration
+	if (!got_can) {
+		const char *can_from_config = NULL;
+
+		for (size_t i = 0; card->ctx->conf_blocks[i]; ++i) {
+			scconf_block **blocks = scconf_find_blocks(card->ctx->conf, card->ctx->conf_blocks[i], "card_driver", "lteid");
+			if (!blocks)
+				continue;
+			for (size_t j = 0; blocks[j]; ++j)
+				if ((can_from_config = scconf_get_str(blocks[j], "can", NULL)))
+					break;
+			free(blocks);
+		}
+
+		if (can_from_config && strlen(can_from_config) == LTEID_CAN_LENGTH) {
+			got_can = 1;
+			memcpy(drv_data->can, can_from_config, LTEID_CAN_LENGTH);
+		}
+	}
+
+	if (!got_can) {
+		sc_log(card->ctx, "Missing or invalid CAN. 6 digits required.");
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN);
+	}
+
+	pace_input->pin_id = PACE_PIN_ID_CAN;
+	pace_input->pin = drv_data->can;
+	pace_input->pin_length = LTEID_CAN_LENGTH;
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_perform_pace(struct sc_card *card, const int ref, const unsigned char *pin, size_t pinlen, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	struct lteid_drv_data *drv_data = DRVDATA(card);
+	struct establish_pace_channel_input pace_input = {0};
+	struct establish_pace_channel_output pace_output = {0};
+
+	if (drv_data->pace) {
+		sc_sm_stop(card);
+		drv_data->pace = 0;
+		drv_data->pace_pin_ref = 0;
+	}
+
+	if (ref == PACE_PIN_ID_CAN && !pin) {
+		if (SC_SUCCESS != lteid_get_can(card, &pace_input)) {
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN);
+		}
+	} else {
+		pace_input.pin_id = ref;
+		pace_input.pin = pin;
+		pace_input.pin_length = pinlen;
+	}
+
+	int rv = perform_pace(card, pace_input, &pace_output, EAC_TR_VERSION_2_02);
+	if (rv != SC_SUCCESS) {
+		sc_log(card->ctx, "Error performing PACE for pin ref 0x%02x.", ref);
+
+		drv_data->pace = 0;
+		drv_data->pace_pin_ref = 0;
+
+		// Special case after entering incorrect PACE PIN twice. Card locks with 1 PIN attempt remaining.
+		if (ref == PACE_PIN_ID_PIN && rv == SC_ERROR_NO_CARD_SUPPORT) {
+			rv = SC_ERROR_AUTH_METHOD_BLOCKED;
+		}
+
+		// When CAN code authentication fails and CAN code comes from cache - clear it.
+		// We don't want to make multiple attempts if code is wrong. User should run lteid-tool
+		// again to set up the card.
+		if (ref == PACE_PIN_ID_CAN && drv_data->can_from_cache && rv != SC_ERROR_INTERNAL) {
+			if (lteid_clear_cached_can(card)) {
+				drv_data->can_from_cache = 0;
+			}
+		}
+
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	// If caller provided CAN is valid - cache it.
+	if (ref == PACE_PIN_ID_CAN && pin) {
+		lteid_cache_can(card, (const char *)pin);
+	}
+
+	// Track PACE status
+	drv_data->pace = 1;
+	drv_data->pace_pin_ref = ref;
+
+	free(pace_output.ef_cardaccess);
+	free(pace_output.recent_car);
+	free(pace_output.previous_car);
+	free(pace_output.id_icc);
+	free(pace_output.id_pcd);
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_unlock(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	if (SC_SUCCESS != lteid_perform_pace(card, PACE_PIN_ID_CAN, NULL, 0, NULL)) {
+		sc_log(card->ctx, "Unlock with CAN code failed. No CAN found in environment, opensc.conf nor cache.");
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_init(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+	int rv;
+
+	struct lteid_drv_data *drv_data = calloc(1, sizeof(struct lteid_drv_data));
+
+	if (drv_data == NULL)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+
+	drv_data->pace = 0;
+	drv_data->pace_pin_ref = 0;
+	card->drv_data = drv_data;
+
+	memset(&card->sm_ctx, 0, sizeof card->sm_ctx);
+
+	card->max_send_size = 65535;
+	card->max_recv_size = 65535;
+	card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO | SC_CARD_CAP_APDU_EXT;
+
+	_sc_card_add_ec_alg(card, 384, SC_ALGORITHM_ECDSA_HASH_NONE | SC_ALGORITHM_ECDSA_RAW, 0, NULL);
+
+	rv = sc_enum_apps(card);
+	LOG_TEST_RET(card->ctx, rv, "Enumerate apps failed");
+
+	rv = lteid_unlock(card);
+	LOG_TEST_RET(card->ctx, rv, "Unlock card failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_finish(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	sc_sm_stop(card);
+
+	free(card->drv_data);
+	card->drv_data = NULL;
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_logout(sc_card_t *card)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	sc_sm_stop(card);
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	int rv;
+
+	// Authentication key refers to PACE PIN -> 0x03
+	// Meanwhile, signing key refers to PIN.QES -> 0x81. This pin is verifiable via regular iso7816 cmd verify call.
+	switch (data->pin_reference) {
+	case PACE_PIN_ID_CAN:
+	case PACE_PIN_ID_PIN:
+	case PACE_PIN_ID_PUK:
+		rv = lteid_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len, tries_left);
+		break;
+	default:
+		rv = iso_ops->pin_cmd(card, data, tries_left);
+		break;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int
+lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	struct lteid_drv_data *drv_data = DRVDATA(card);
+	int rv;
+
+	// PACE CAN code info: as far as we know there's no limit to CAN verification attempts
+	if (data->pin_reference == PACE_PIN_ID_CAN) {
+		data->pin1.max_tries = -1;
+		data->pin1.tries_left = -1;
+
+		if (tries_left) {
+			*tries_left = -1;
+		}
+
+		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	}
+
+	// PACE PIN and PUK codes: max and remaining attempts are stored in ACE3 and ACE4 files.
+	if (data->pin_reference == PACE_PIN_ID_PIN || data->pin_reference == PACE_PIN_ID_PUK) {
+		struct sc_apdu apdu;
+		unsigned char buf[0xbe] = {0};
+		u8 id[] = {0xac, 0x00};
+		size_t taglen = 0;
+
+		switch (data->pin_reference) {
+		case PACE_PIN_ID_PIN:
+			id[1] = 0xe3;
+			break;
+		case PACE_PIN_ID_PUK:
+			id[1] = 0xe4;
+			break;
+		default:
+			break;
+		}
+
+		sc_format_apdu_ex(&apdu, 0x00, 0xa4, 0x00, 0x04, id, sizeof(id), buf, sizeof(buf));
+
+		rv = sc_transmit_apdu(card, &apdu);
+		LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+
+		const u8 *tag = sc_asn1_find_tag(card->ctx, buf, apdu.resplen, 0x62, &taglen);
+		tag = sc_asn1_find_tag(card->ctx, tag, taglen, 0xa5, &taglen);
+		tag = sc_asn1_find_tag(card->ctx, tag, taglen, 0xa2, &taglen);
+		tag = sc_asn1_find_tag(card->ctx, tag, taglen, 0xa3, &taglen);
+		tag = sc_asn1_find_tag(card->ctx, tag, taglen, 0x82, &taglen);
+
+		if (tag && taglen == 2) {
+			data->pin1.tries_left = tag[0];
+			data->pin1.max_tries = tag[1];
+
+			if (tries_left) {
+				*tries_left = data->pin1.tries_left;
+			}
+		} else {
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_FOUND);
+		}
+
+		if (drv_data->pace_pin_ref == data->pin_reference) {
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_IN;
+		} else {
+			data->pin1.logged_in = SC_PIN_STATE_LOGGED_OUT;
+		}
+
+		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	}
+
+	// PIN.QES is a regular iso7816 pin
+	if (data->pin_reference == 0x81) {
+		rv = iso_ops->pin_cmd(card, data, tries_left);
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_FOUND);
+}
+
+static int
+lteid_pin_cmd_unblock(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	int rv;
+
+	// PACE PIN for unblocking command is known as pin ref 0x07
+	if (data->pin_reference == PACE_PIN_ID_PIN) {
+		struct sc_pin_cmd_data with_changed_pin_ref = *data;
+
+		with_changed_pin_ref.pin_reference = 0x07;
+		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref, tries_left);
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	// PIN.QES is a regular iso7816 pin
+	if (data->pin_reference == 0x81) {
+		rv = iso_ops->pin_cmd(card, data, tries_left);
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_FOUND);
+}
+
+static int
+lteid_pin_cmd_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	int rv;
+
+	// PACE PIN for unblocking command is known as pin ref 0x07
+	if (data->pin_reference == PACE_PIN_ID_PIN) {
+		struct sc_pin_cmd_data with_changed_pin_ref = *data;
+
+		with_changed_pin_ref.pin_reference = 0x07;
+		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref, tries_left);
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	// PIN.QES is a regular iso7816 pin
+	if (data->pin_reference == 0x81) {
+		rv = iso_ops->pin_cmd(card, data, tries_left);
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_FOUND);
+}
+
+static int
+lteid_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	int rv;
+
+	switch (data->cmd) {
+	case SC_PIN_CMD_VERIFY:
+		rv = lteid_pin_cmd_verify(card, data, tries_left);
+		break;
+	case SC_PIN_CMD_GET_INFO:
+		rv = lteid_pin_cmd_get_info(card, data, tries_left);
+		break;
+	case SC_PIN_CMD_UNBLOCK:
+		rv = lteid_pin_cmd_unblock(card, data, tries_left);
+		break;
+	case SC_PIN_CMD_CHANGE:
+		rv = lteid_pin_cmd_change(card, data, tries_left);
+		break;
+	default:
+		rv = SC_ERROR_NOT_SUPPORTED;
+		break;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int
+lteid_set_security_env(struct sc_card *card, const struct sc_security_env *env, int se_num)
+{
+	LOG_FUNC_CALLED(card->ctx);
+
+	struct sc_apdu apdu;
+	int rv;
+
+	if (env == NULL || env->key_ref_len != 1)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
+
+	sc_log(card->ctx, "algo: %lu operation: %d keyref: %d", env->algorithm, env->operation, env->key_ref[0]);
+
+	if (env->algorithm != SC_ALGORITHM_EC || env->operation != SC_SEC_OPERATION_SIGN)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
+	const u8 data[] = {0x84, 0x01, env->key_ref[0]};
+	sc_format_apdu_ex(&apdu, 0x00, 0x22, 0x41, 0xB6, data, sizeof(data), NULL, 0);
+
+	rv = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed");
+
+	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, rv, "SET SECURITY ENV failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+lteid_compute_signature(struct sc_card *card, const u8 *data, size_t data_len, u8 *out, size_t outlen)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	// Usually this is called with 104 bytes buffer. But we expect card to return 96 byte hash.
+	if (outlen < 96)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_BUFFER_TOO_SMALL);
+
+	memset(out, 0, outlen);
+
+	const int rv = iso_ops->compute_signature(card, data, data_len, out, 96);
+
+	LOG_FUNC_RETURN(card->ctx, rv);
+}
+
+static int
+lteid_process_fci(struct sc_card *card, struct sc_file *file, const u8 *buf, size_t buflen)
+{
+	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
+
+	int rv = iso_ops->process_fci(card, file, buf, buflen);
+
+	if (rv != SC_SUCCESS) {
+		LOG_FUNC_RETURN(card->ctx, rv);
+	}
+
+	// Card reports most of the file size as 0, even if they're not empty.
+	// This confuses PKCS#15 loader, and it fails to load/init keys/certs/pins/etc.
+	// As a quick workaround - lets report size to be something large enough to fit any object.
+	if (file->size == 0) {
+		file->size = 2048;
+	}
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+struct sc_card_driver *
+sc_get_lteid_driver(void)
+{
+	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
+
+	if (iso_ops == NULL)
+		iso_ops = iso_drv->ops;
+
+	lteid_ops = *iso_ops;
+	lteid_ops.init = lteid_init;
+	lteid_ops.finish = lteid_finish;
+	lteid_ops.set_security_env = lteid_set_security_env;
+	lteid_ops.compute_signature = lteid_compute_signature;
+	lteid_ops.pin_cmd = lteid_pin_cmd;
+	lteid_ops.logout = lteid_logout;
+	lteid_ops.process_fci = lteid_process_fci;
+
+	return &lteid_drv;
+}
+
+#else
+
+#include "opensc.h"
+
+struct sc_card_driver *
+sc_get_lteid_driver(void)
+{
+	return NULL;
+}
+
+#endif

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -278,6 +278,9 @@ enum {
 	SC_CARD_TYPE_DTRUST_V5_1_M100,
 	SC_CARD_TYPE_DTRUST_V5_4_STD,
 	SC_CARD_TYPE_DTRUST_V5_4_MULTI,
+
+	/* Lithuanian eID cards */
+	SC_CARD_TYPE_LTEID = 43000,
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);
@@ -322,6 +325,7 @@ extern sc_card_driver_t *sc_get_nqApplet_driver(void);
 extern sc_card_driver_t *sc_get_skeid_driver(void);
 extern sc_card_driver_t *sc_get_eoi_driver(void);
 extern sc_card_driver_t *sc_get_dtrust_driver(void);
+extern sc_card_driver_t *sc_get_lteid_driver(void);
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -137,6 +137,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "idprime",	(void *(*)(void)) sc_get_idprime_driver },
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
 	{ "edo",        (void *(*)(void)) sc_get_edo_driver },
+	{ "lteid", (void *(*)(void)) sc_get_lteid_driver },
 #endif
 
 /* Here should be placed drivers that need some APDU transactions in the

--- a/src/libopensc/pkcs15-lteid.c
+++ b/src/libopensc/pkcs15-lteid.c
@@ -1,0 +1,76 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "internal.h"
+#include "pkcs15.h"
+
+static int
+lteid_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_object *pkobjs[32];
+	int rv, count;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!df)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (df->enumerated)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	rv = sc_pkcs15_parse_df(p15card, df);
+	LOG_TEST_RET(ctx, rv, "DF parse error");
+
+	if (df->type != SC_PKCS15_PRKDF)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY, pkobjs, sizeof(pkobjs) / sizeof(pkobjs[0]));
+	LOG_TEST_RET(ctx, rv, "Cannot get PRKEY objects list");
+
+	count = rv;
+	for (int i = 0; i < count; i++) {
+		struct sc_pkcs15_prkey_info *prkey_info = (struct sc_pkcs15_prkey_info *)pkobjs[i]->data;
+		prkey_info->field_length = 384;
+	}
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+static int
+sc_pkcs15emu_lteid_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	LOG_FUNC_CALLED(p15card->card->ctx);
+
+	int rv = sc_pkcs15_bind_internal(p15card, aid);
+	p15card->ops.parse_df = lteid_parse_df;
+
+	LOG_FUNC_RETURN(p15card->card->ctx, rv);
+}
+
+int
+sc_pkcs15emu_lteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
+{
+	if (p15card->card->type == SC_CARD_TYPE_LTEID) {
+		return sc_pkcs15emu_lteid_init(p15card, aid);
+	}
+
+	return SC_ERROR_WRONG_CARD;
+}

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -63,6 +63,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "esign",      sc_pkcs15emu_starcos_esign_init_ex },
 	{ "eOI",        sc_pkcs15emu_eoi_init_ex },
 	{ "dtrust",     sc_pkcs15emu_dtrust_init_ex },
+	{ "lteid",      sc_pkcs15emu_lteid_init_ex },
 	{ NULL, NULL }
 };
 
@@ -126,6 +127,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DTRUST_V5_1_MULTI:
 		case SC_CARD_TYPE_DTRUST_V5_1_M100:
 		case SC_CARD_TYPE_DTRUST_V5_4_MULTI:
+		case SC_CARD_TYPE_LTEID:
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -58,6 +58,7 @@ int sc_pkcs15emu_starcos_esign_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid 
 int sc_pkcs15emu_skeid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_eoi_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_dtrust_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
+int sc_pkcs15emu_lteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1250,6 +1250,7 @@ const char *pkcs15_get_default_use_file_cache(struct sc_card *card)
 			"nqapplet",
 			"tcos",
 			"dtrust",
+			"lteid",
 	};
 
 	if (NULL == card || NULL == card->driver || NULL == card->driver->short_name)

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -25,7 +25,7 @@ noinst_HEADERS = util.h fread_to_eof.h \
 bin_PROGRAMS = opensc-tool opensc-explorer opensc-asn1 \
 	pkcs15-tool pkcs15-crypt pkcs11-tool pkcs11-register \
 	cardos-tool eidenv openpgp-tool iasecc-tool egk-tool goid-tool \
-	dtrust-tool
+	dtrust-tool lteid-tool
 if ENABLE_OPENSSL
 bin_PROGRAMS += cryptoflex-tool pkcs15-init netkey-tool piv-tool \
 	westcos-tool sc-hsm-tool dnie-tool gids-tool
@@ -104,6 +104,10 @@ endif
 if HAVE_SHORTEN_WARNING_OPTION
 npa_tool_CFLAGS += -Wno-shorten-64-to-32
 endif
+
+lteid_tool_SOURCES = lteid-tool.c util.c
+lteid_tool_LDADD = $(OPTIONAL_OPENSSL_LIBS) $(OPENPACE_LIBS)
+lteid_tool_CFLAGS = $(OPTIONAL_OPENSSL_CFLAGS) $(OPENPACE_CFLAGS)
 
 opensc_notify_SOURCES = opensc-notify.c opensc-notify-cmdline.c
 opensc_notify_CFLAGS = $(PTHREAD_CFLAGS)

--- a/src/tools/lteid-tool.c
+++ b/src/tools/lteid-tool.c
@@ -1,0 +1,562 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "common/compat_strlcat.h"
+#include "libopensc/opensc.h"
+#include "libopensc/pkcs15.h"
+#include "sm/sm-eac.h"
+#include "util.h"
+
+/* win32 needs this in open(2) */
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+static const char *app_name = "lteid-tool";
+
+#define OP_NONE	      0 /* no operation requested */
+#define OP_RESUME     1 /* resume pin entry using CAN code */
+#define OP_UNBLOCK    2 /* unblock using PUK code */
+#define OP_CHANGE_PIN 3
+
+static const struct option options[] = {
+		{"help",	 0, NULL, 'h'},
+		{"verbose",    0, NULL, 'v'},
+		{"reader",	   1, NULL, 'r'},
+		{"wait",	 0, NULL, 'w'},
+		{"can",	1, NULL, 'c'},
+		{"pin",	1, NULL, 'p'},
+		{"puk",	1, NULL, 'u'},
+		{"change-pin", 0, NULL, 'C'},
+		{"resume",	   0, NULL, 'R'},
+		{"unblock",    0, NULL, 'U'},
+		{"verify-can", 0, NULL, 'V'},
+		{NULL,	       0, NULL, 0	 }
+};
+
+static const char *option_help[] = {
+		"Display tool options",
+		"Display all the information available",
+		"Uses reader number <arg> [0]",
+		"Wait for a card to be inserted",
+		"Specify CAN",
+		"Specify PIN",
+		"Specify PUK",
+		"Change PIN",
+		"Resume authentication key PIN after 2 incorrect attempts",
+		"Unblock PIN using PUK",
+		"Verify Card Access Number (CAN)",
+};
+
+static int
+get_tries_left(sc_pkcs15_card_t *p15card, u8 pin_reference, int *pin_tries_left)
+{
+	int rv, i;
+	struct sc_pkcs15_object *objs[32];
+
+	*pin_tries_left = -1;
+
+	rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH, objs, 32);
+	if (rv < 0) {
+		fprintf(stderr, "AUTH objects enumeration failed: %s\n", sc_strerror(rv));
+		return 1;
+	}
+
+	for (i = 0; i < rv; i++) {
+		sc_pkcs15_get_pin_info(p15card, objs[i]);
+
+		const struct sc_pkcs15_auth_info *auth_info = (const struct sc_pkcs15_auth_info *)objs[i]->data;
+
+		if (auth_info->auth_id.len == 1 && auth_info->auth_id.value[0] == pin_reference) {
+			*pin_tries_left = auth_info->tries_left;
+			return SC_SUCCESS;
+		}
+	}
+
+	return SC_ERROR_OBJECT_NOT_FOUND;
+}
+
+static int
+display_pin_tries_left(sc_pkcs15_card_t *p15card)
+{
+	int pace_pin_tries_left, qes_pin_tries_left, puk_tries_left;
+
+	get_tries_left(p15card, PACE_PIN_ID_PUK, &puk_tries_left);
+	get_tries_left(p15card, PACE_PIN_ID_PIN, &pace_pin_tries_left);
+	get_tries_left(p15card, 0x81, &qes_pin_tries_left);
+
+	printf("\n");
+	printf("PUK tries left: %i\n", puk_tries_left);
+	printf("PIN (for authentication) tries left: %i\n", pace_pin_tries_left);
+	printf("PIN (for electronic signatures) tries left: %i\n", qes_pin_tries_left);
+	printf("\n");
+
+	return SC_SUCCESS;
+}
+
+static int
+display_basic_details(sc_pkcs15_card_t *p15card)
+{
+	printf("\nCard label: %s\n", p15card->tokeninfo->label);
+	printf("Serial number: %s\n", p15card->tokeninfo->serial_number);
+
+	display_pin_tries_left(p15card);
+
+	return SC_SUCCESS;
+}
+
+int
+input_number(const char *description, size_t min_len, size_t max_len, const char *provided_via_cli, char **number)
+{
+	size_t number_len = 0;
+
+	if (provided_via_cli && strlen(provided_via_cli) >= min_len && strlen(provided_via_cli) <= max_len) {
+		*number = strdup(provided_via_cli);
+
+		printf("Using %s provided via command line arguments.\n", description);
+
+		return SC_SUCCESS;
+	}
+
+	printf("Enter %s ", description);
+
+	if (min_len == max_len) {
+		printf("(%zu digits): ", min_len);
+	} else {
+		printf("(%zu..%zu digits): ", min_len, max_len);
+	}
+
+	number_len = util_getpass(number, NULL, stdin);
+
+	if (number_len < min_len || number_len > max_len) {
+		return SC_ERROR_INTERNAL;
+	}
+
+	for (size_t i = 0; i < number_len; i++) {
+		if ((*number)[i] < '0' || (*number)[i] > '9') {
+			return SC_ERROR_INTERNAL;
+		}
+	}
+
+	return SC_SUCCESS;
+}
+
+int
+verify_and_cache_pace_can(sc_card_t *card, const char *opt_can)
+{
+	int rv;
+	struct sc_path path;
+	char *can = NULL;
+
+	rv = input_number("number from the bottom right corner of the card", 6, 6, opt_can, &can);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "CAN number blank, too short or too long.\n");
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	sc_format_path("3F00", &path);
+	sc_select_file(card, &path, NULL);
+
+	struct sc_pin_cmd_data can_verify_cmd = {0};
+	can_verify_cmd.cmd = SC_PIN_CMD_VERIFY;
+	can_verify_cmd.pin_type = SC_AC_CHV;
+	can_verify_cmd.pin_reference = PACE_PIN_ID_CAN;
+	can_verify_cmd.pin1.data = (unsigned char *)can;
+	can_verify_cmd.pin1.len = strlen(can);
+
+	rv = card->ops->pin_cmd(card, &can_verify_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "CAN number verification failed: %s\nCheck the number and try again.\n", sc_strerror(rv));
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	printf("\nThe new CAN code is now persisted.\n");
+	printf("\nIf you are about to use the card in your web browser - you may have to remove and re-insert it.\n");
+
+	return SC_SUCCESS;
+}
+
+/*
+ * Officially card has a single PIN. But under the hood it's really two separate PINs:
+ *
+ *   - PACE-PIN with ID 0x03, tied to the key intended for authentication.
+ *   - PIN.QES with ID 0x81, tied to the key intended for signature
+ *
+ * The procedure below follows this and applies change to both PINs.
+ */
+int
+change_pin(sc_card_t *card, const char *opt_pin)
+{
+	int rv;
+	struct sc_path path;
+	char *pin = NULL;
+	char *new_pin = NULL;
+	char *new_pin_repeated = NULL;
+	unsigned char pace_pin_changed = 0, qes_pin_changed = 0;
+
+	rv = input_number("Current PIN", 6, 12, opt_pin, &pin);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN number blank, too short or too long.\n");
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	sc_format_path("3F00", &path);
+	sc_select_file(card, &path, NULL);
+
+	struct sc_pin_cmd_data pin_verify_cmd = {0};
+	pin_verify_cmd.cmd = SC_PIN_CMD_VERIFY;
+	pin_verify_cmd.pin_type = SC_AC_CHV;
+	pin_verify_cmd.pin_reference = PACE_PIN_ID_PIN;
+	pin_verify_cmd.pin1.data = (unsigned char *)pin;
+	pin_verify_cmd.pin1.len = strlen(pin);
+
+	rv = card->ops->pin_cmd(card, &pin_verify_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN code verification failed: %s\n", sc_strerror(rv));
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	rv = input_number("New PIN", 6, 12, NULL, &new_pin);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN number blank, too short or too long.\n");
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	input_number("New PIN (repeat)", 6, 12, NULL, &new_pin_repeated);
+
+	if (new_pin_repeated == NULL || strcmp(new_pin, new_pin_repeated) != 0) {
+		fprintf(stderr, "New PIN and repeated entry do not match. PIN was not changed.\n");
+		return SC_ERROR_INTERNAL;
+	}
+
+	printf("\n");
+
+	struct sc_pin_cmd_data pace_pin_cmd = {0};
+	pace_pin_cmd.cmd = SC_PIN_CMD_CHANGE;
+	pace_pin_cmd.pin_type = SC_AC_CHV;
+	pace_pin_cmd.pin_reference = PACE_PIN_ID_PIN;
+	pace_pin_cmd.pin2.data = (unsigned char *)new_pin;
+	pace_pin_cmd.pin2.len = strlen(new_pin);
+
+	rv = card->ops->pin_cmd(card, &pace_pin_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN for authentication change failed: %s\n", sc_strerror(rv));
+	} else {
+		printf("PIN for authentication changed.\n");
+		pace_pin_changed = 1;
+	}
+
+	sc_format_path("3F00DF02", &path);
+	sc_select_file(card, &path, NULL);
+
+	struct sc_pin_cmd_data qes_pin_cmd = {0};
+	qes_pin_cmd.cmd = SC_PIN_CMD_CHANGE;
+	qes_pin_cmd.pin_type = SC_AC_CHV;
+	qes_pin_cmd.pin_reference = 0x81;
+	qes_pin_cmd.pin1.data = (unsigned char *)pin;
+	qes_pin_cmd.pin1.len = strlen(pin);
+	qes_pin_cmd.pin2.data = (unsigned char *)new_pin;
+	qes_pin_cmd.pin2.len = strlen(new_pin);
+
+	rv = card->ops->pin_cmd(card, &qes_pin_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN for signature change failed: %s\n", sc_strerror(rv));
+	} else {
+		printf("PIN for signature changed.\n");
+		qes_pin_changed = 1;
+	}
+
+	return (pace_pin_changed && qes_pin_changed) ? SC_SUCCESS : SC_ERROR_INTERNAL;
+}
+
+int
+resume(sc_pkcs15_card_t *p15card, const char *opt_can, const char *opt_pin)
+{
+	int rv;
+	struct sc_card *card = p15card->card;
+	struct establish_pace_channel_input pace_input = {0};
+	struct establish_pace_channel_output pace_output = {0};
+	struct sc_path path;
+	char *pin = NULL;
+	int tries_left;
+
+	rv = get_tries_left(p15card, PACE_PIN_ID_PIN, &tries_left);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "Cannot get remaining tries left: %s\n", sc_strerror(rv));
+		return rv;
+	}
+
+	if (tries_left > 1) {
+		fprintf(stderr, "PIN for authentication is not blocked, there's %i tries remaining.\n", tries_left);
+		return SC_ERROR_NOT_ALLOWED;
+	}
+
+	if (tries_left == 0) {
+		fprintf(stderr, "PIN for authentication is fully blocked with 0 attempts remaining. Use 'lteid-tool --unblock' instead.\n");
+		return SC_ERROR_NOT_ALLOWED;
+	}
+
+	rv = input_number("PIN number", 6, 12, opt_pin, &pin);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN number blank, too short or too long.\n");
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	sc_format_path("3F00", &path);
+	sc_select_file(card, &path, NULL);
+
+	struct sc_pin_cmd_data can_verify_cmd = {0};
+	can_verify_cmd.cmd = SC_PIN_CMD_VERIFY;
+	can_verify_cmd.pin_type = SC_AC_CHV;
+	can_verify_cmd.pin_reference = PACE_PIN_ID_CAN;
+	can_verify_cmd.pin1.data = (unsigned char *)opt_can;
+	if (opt_can)
+		can_verify_cmd.pin1.len = strlen(opt_can);
+
+	rv = card->ops->pin_cmd(card, &can_verify_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "CAN code verification failed: %s\n", sc_strerror(rv));
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	pace_input.pin_id = PACE_PIN_ID_PIN;
+	pace_input.pin = (unsigned char *)pin;
+	pace_input.pin_length = strlen(pin);
+
+	rv = perform_pace(card, pace_input, &pace_output, EAC_TR_VERSION_2_02);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN code verification failed: %s\n", sc_strerror(rv));
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	printf("PIN for authentication unblocked.\n");
+
+	return SC_SUCCESS;
+}
+
+int
+unblock_using_puk(sc_pkcs15_card_t *p15card, const char *opt_puk)
+{
+	int rv;
+	struct sc_card *card = p15card->card;
+	struct sc_path path;
+	char *puk = NULL;
+	int pace_pin_tries_left, qes_pin_tries_left;
+
+	get_tries_left(p15card, PACE_PIN_ID_PIN, &pace_pin_tries_left);
+	get_tries_left(p15card, 0x81, &qes_pin_tries_left);
+
+	if (pace_pin_tries_left > 0 && qes_pin_tries_left > 0) {
+		fprintf(stderr, "None of the PINs require unblocking.\n");
+		return SC_ERROR_INTERNAL;
+	}
+
+	rv = input_number("PUK number", 8, 12, opt_puk, &puk);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PIN number blank, too short or too long.\n");
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	sc_format_path("3F00", &path);
+	sc_select_file(card, &path, NULL);
+
+	struct sc_pin_cmd_data puk_verify_cmd = {0};
+	puk_verify_cmd.cmd = SC_PIN_CMD_VERIFY;
+	puk_verify_cmd.pin_type = SC_AC_CHV;
+	puk_verify_cmd.pin_reference = PACE_PIN_ID_PUK;
+	puk_verify_cmd.pin1.data = (unsigned char *)puk;
+	puk_verify_cmd.pin1.len = strlen(puk);
+
+	rv = card->ops->pin_cmd(card, &puk_verify_cmd, NULL);
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PUK code verification failed: %s\n", sc_strerror(rv));
+		return SC_ERROR_PIN_CODE_INCORRECT;
+	}
+
+	if (pace_pin_tries_left == 0) {
+		struct sc_pin_cmd_data pace_pin_cmd = {0};
+		pace_pin_cmd.cmd = SC_PIN_CMD_UNBLOCK;
+		pace_pin_cmd.pin_type = SC_AC_CHV;
+		pace_pin_cmd.pin_reference = PACE_PIN_ID_PIN;
+
+		rv = card->ops->pin_cmd(card, &pace_pin_cmd, NULL);
+
+		if (rv != SC_SUCCESS) {
+			fprintf(stderr, "PIN for authentication reset failed: %s\n", sc_strerror(rv));
+			return rv;
+		}
+	}
+
+	if (qes_pin_tries_left == 0) {
+		struct sc_pin_cmd_data qes_pin_cmd = {0};
+		qes_pin_cmd.cmd = SC_PIN_CMD_UNBLOCK;
+		qes_pin_cmd.pin_type = SC_AC_CHV;
+		qes_pin_cmd.pin_reference = 0x81;
+
+		sc_format_path("3F00DF02", &path);
+		sc_select_file(card, &path, NULL);
+
+		rv = card->ops->pin_cmd(card, &qes_pin_cmd, NULL);
+
+		if (rv != SC_SUCCESS) {
+			fprintf(stderr, "PIN for signature reset failed: %s\n", sc_strerror(rv));
+			return rv;
+		}
+	}
+
+	printf("PIN unblocked.\n");
+
+	return SC_SUCCESS;
+}
+
+int
+main(int argc, char *argv[])
+{
+	int opt_wait = 0;
+	const char *opt_can = NULL;
+	const char *opt_pin = NULL;
+	const char *opt_puk = NULL;
+	const char *opt_reader = NULL;
+	int verbose = 0;
+	int opt_change_pin = 0;
+	int opt_resume = 0;
+	int opt_unblock = 0;
+	int opt_verify_can = 0;
+
+	int err = 0;
+	sc_context_t *ctx = NULL;
+	sc_context_param_t ctx_param = {0};
+	sc_card_t *card = NULL;
+	struct sc_pkcs15_card *p15card = NULL;
+	int c, rv;
+
+	while ((c = getopt_long(argc, argv, "hr:wc:p:u:vCRUV", options, (int *)0)) != -1) {
+		switch (c) {
+		case 'r':
+			opt_reader = optarg;
+			break;
+		case 'w':
+			opt_wait = 1;
+			break;
+		case 'c':
+			util_get_pin(optarg, &opt_can);
+			break;
+		case 'p':
+			util_get_pin(optarg, &opt_pin);
+			break;
+		case 'u':
+			util_get_pin(optarg, &opt_puk);
+			break;
+		case 'v':
+			verbose++;
+			break;
+		case 'C':
+			opt_change_pin = 1;
+			break;
+		case 'R':
+			opt_resume = 1;
+			break;
+		case 'U':
+			opt_unblock = 1;
+			break;
+		case 'V':
+			opt_verify_can = 1;
+			break;
+		case 'h':
+		default:
+			util_print_usage_and_die(app_name, options, option_help, NULL);
+		}
+	}
+
+	ctx_param.app_name = app_name;
+	ctx_param.debug = verbose;
+	if (verbose)
+		ctx_param.debug_file = stderr;
+	rv = sc_context_create(&ctx, &ctx_param);
+	if (rv) {
+		fprintf(stderr, "Error: Failed to establish context: %s\n", sc_strerror(rv));
+		err = -1;
+		goto cleanup;
+	}
+
+	if (util_connect_card(ctx, &card, opt_reader, opt_wait)) {
+		fprintf(stderr, "Error: Cannot connect with card\n");
+		err = -1;
+		goto cleanup;
+	}
+
+	if (strcmp("lteid", card->driver->short_name) != 0) {
+		fprintf(stderr, "Error: Card in the reader does not appear to be Lithuanian identity card.\n");
+		err = -1;
+		goto cleanup;
+	}
+
+	rv = sc_pkcs15_bind(card, NULL, &p15card);
+
+	if (rv == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED || opt_verify_can) {
+		printf("\nCAN number is not set/stored.\n\n");
+		err = verify_and_cache_pace_can(card, opt_can);
+		goto cleanup;
+	}
+
+	if (rv != SC_SUCCESS) {
+		fprintf(stderr, "PKCS#15 binding failed: %s\n", sc_strerror(rv));
+		err = -1;
+		goto cleanup;
+	}
+
+	display_basic_details(p15card);
+
+	if (opt_change_pin) {
+		err = change_pin(card, opt_pin);
+	} else if (opt_resume) {
+		err = resume(p15card, opt_can, opt_pin);
+	} else if (opt_unblock) {
+		err = unblock_using_puk(p15card, opt_puk);
+	}
+
+cleanup:
+	if (card) {
+		sc_unlock(card);
+		sc_disconnect_card(card);
+	}
+	sc_release_context(ctx);
+	return err;
+}

--- a/win32/Make.rules.mak
+++ b/win32/Make.rules.mak
@@ -77,7 +77,7 @@ OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\$(PLATFORM)\$(BUILD_TYPE)\libcrypto_static.l
 OPENSSL_LIB = $(OPENSSL_LIB) user32.lib advapi32.lib crypt32.lib ws2_32.lib
 
 PROGRAMS_OPENSSL = cryptoflex-tool.exe pkcs15-init.exe netkey-tool.exe piv-tool.exe \
-	westcos-tool.exe sc-hsm-tool.exe dnie-tool.exe gids-tool.exe
+	westcos-tool.exe sc-hsm-tool.exe dnie-tool.exe gids-tool.exe lteid-tool.exe
 OPENSC_FEATURES = $(OPENSC_FEATURES) openssl
 WIXFLAGS = -d OpenSSL="$(OPENSSL_DIR)" $(WIXFLAGS)
 !ENDIF


### PR DESCRIPTION
Hello all,

So here's the result of the discussion I started about Lithuanian electronic ID cards: https://github.com/OpenSC/OpenSC/discussions/3563

I hope I could get some early feedback if possible.

As far as I know there's no official/public documentation available for the card. So this is based on all kinds of guesswork, looking at other drivers, looking at Finnish, Estonian eIDs documentation.

Card uses PACE authentication, so to get even the most basic details we need 6 digit card access number. 

Officially it is documented to have a single PIN code, but under the hood it's two PINs that are kept in sync. One pin is for authentication key, other - for signatures. PIN change and unblock is implemented in the 'lteid-tool'.

Card also includes cardholder details like full name, date of birth, national identification number, black and white photo. But for now that's not implemented. My goal here is authentication with public gov services.

Confirmed working with:
 - TLS client certificates - was able to sign in to a gov website.
 - SSH, both key for signatures and for auth. SSH working is not really a goal of this, but it's a reasonable test.

## Demo / test

First run of `lteid-tool`:

<img width="1828" height="926" alt="Screenshot From 2026-02-19 13-27-32" src="https://github.com/user-attachments/assets/0c3e8f3f-b13f-4763-bd4b-b375dcad1fc4" />

After re-inserting the card, Firefox security devices dialog shows:

<img width="1622" height="884" alt="Screenshot From 2026-02-19 13-28-18" src="https://github.com/user-attachments/assets/08aa0e2f-2735-414a-85f2-4421d21d0e36" />

I'm now able to sign in to some* gov websites:

<img width="1570" height="1460" alt="Screenshot From 2026-02-19 13-30-47" src="https://github.com/user-attachments/assets/23014082-f2ce-4b91-9301-775ef691fec1" />

<img width="1570" height="1460" alt="Screenshot From 2026-02-19 13-30-58" src="https://github.com/user-attachments/assets/1bdec586-d627-415e-99a0-2d876046f0fd" />

`pkcs15-tool -D` output:

```
Using reader with a card: Gemalto PC Twin Reader (AD010CEC) 00 00
Connecting to card in reader Gemalto PC Twin Reader (AD010CEC) 00 00...
Using card driver Lithuanian eID card (asmens tapatybės kortelė).
PKCS#15 Card [TADAS SASNAUSKAS]:
        Version        : 1
        Serial number  : d461ee13bdb8d752
        Manufacturer ID: MaskTech International GmbH
        Flags          : Read-only, Login required, PRN generation
                 sc_supported_algo_info[0]:
                         reference  : 1 (0x01)
                         mechanism  : [0x03] CKM_RSA_X_509
                         operations : [0x02], compute_signature
                         algo_id    : 1.2.840.113549.1.1.1
                         algo_ref   : [0x0f]
                 sc_supported_algo_info[1]:
                         reference  : 2 (0x02)
                         mechanism  : [0x03] CKM_RSA_X_509
                         operations : [0x20], decipher
                         algo_id    : 1.2.840.113549.1.1.1
                         algo_ref   : [0x0f]
                 sc_supported_algo_info[2]:
                         reference  : 3 (0x03)
                         mechanism  : [0x40] CKM_SHA256_RSA_PKCS
                         operations : [0x02], compute_signature
                         algo_id    : 1.2.840.113549.1.1.11
                         algo_ref   : [0x11]
                 sc_supported_algo_info[3]:
                         reference  : 4 (0x04)
                         mechanism  : [0x43] CKM_SHA256_RSA_PKCS_PSS
                         operations : [0x02], compute_signature
                         algo_id    : 1.2.840.113549.1.1.10
                         algo_ref   : [0x21]
                 sc_supported_algo_info[4]:
                         reference  : 5 (0x05)
                         mechanism  : [0x1041] CKM_ECDSA
                         operations : [0x02], compute_signature
                         algo_id    : 1.2.840.10045.2.1
                         algo_ref   : [0x0f]


PIN [PACE-PUK]
        Object Flags   : [0x00]
        ID             : 04
        Flags          : [0x805D], case-sensitive, change-disabled, unblock-disabled, initialized, unblockingPin
        Length         : min_len:8, max_len:12, stored_len:0
        Pad char       : 0x00
        Reference      : 4 (0x04)
        Type           : ascii-numeric
        Path           : 3f00
        Tries left     : 3

PIN [PACE-PIN]
        Object Flags   : [0x02], modifiable
        Auth ID        : 04
        ID             : 03
        Flags          : [0x8111], case-sensitive, initialized, disable_allowed
        Length         : min_len:6, max_len:12, stored_len:0
        Pad char       : 0x00
        Reference      : 3 (0x03)
        Type           : ascii-numeric
        Path           : 3f00
        Tries left     : 3

PIN [PACE-CAN]
        Object Flags   : [0x00]
        ID             : 02
        Flags          : [0x801D], case-sensitive, change-disabled, unblock-disabled, initialized
        Length         : min_len:6, max_len:12, stored_len:0
        Pad char       : 0x00
        Reference      : 2 (0x02)
        Type           : ascii-numeric
        Path           : 3f00

PIN [PIN.QES]
        Object Flags   : [0x00]
        Auth ID        : 04
        ID             : 81
        Flags          : [0x213], case-sensitive, local, initialized, integrity-protected
        Length         : min_len:6, max_len:12, stored_len:0
        Pad char       : 0x00
        Reference      : 129 (0x81)
        Type           : ascii-numeric
        Path           : 3f00df02
        Tries left     : 0

Private EC Key [Signature Key 1 QES]
        Object Flags   : [0x01], private
        Usage          : [0x204], sign, nonRepudiation
        Access Flags   : [0x09], sensitive, neverExtract
        Algo_refs      : 5
        FieldLength    : 384
        Key ref        : 136 (0x88)
        Native         : yes
        Path           : 3f00df02
        Auth ID        : 81
        ID             : 01
        MD:guid        : 6e4e5217-43fe-c208-d516-7d77be6f4ce4

Private EC Key [Signature Key 2]
        Object Flags   : [0x01], private
        Usage          : [0x04], sign
        Access Flags   : [0x09], sensitive, neverExtract
        Algo_refs      : 5
        FieldLength    : 384
        Key ref        : 140 (0x8C)
        Native         : yes
        Path           : 3f00df02
        Auth ID        : 03
        ID             : 02
        MD:guid        : 9ddbf5df-d102-10ed-4b86-31496bbb653e

Public EC Key [Signature Key 1 QES]
        Object Flags   : [0x02], modifiable
        Usage          : [0x40], verify
        Access Flags   : [0x00]
        FieldLength    : 384
        Key ref        : 136 (0x88)
        Native         : no
        Path           : 3f00df021f07
        ID             : 01

Public EC Key [Signature Key 2]
        Object Flags   : [0x02], modifiable
        Usage          : [0x40], verify
        Access Flags   : [0x00]
        FieldLength    : 384
        Key ref        : 140 (0x8C)
        Native         : no
        Path           : 3f00df021f0b
        ID             : 02

X.509 Certificate [Signature Key 1 QES]
        Object Flags   : [0x00]
        Authority      : no
        Path           : 3f00df021f06
        ID             : 01
        Encoded serial : 02 0E 699B525DEC76E52E0000000061B5

X.509 Certificate [Signature Key 2]
        Object Flags   : [0x00]
        Authority      : no
        Path           : 3f00df021f0a
        ID             : 02
        Encoded serial : 02 0E 699B525DEC76E52E0000000061B6
```

`pkcs11-tool -M` output:

```
Using slot 0 with a present token (0x0)
Supported mechanisms:
  SHA-1, digest
  SHA224, digest
  SHA256, digest
  SHA384, digest
  SHA512, digest
  MD5, digest
  RIPEMD160, digest
  GOSTR3411, digest
  ECDSA, keySize={384,384}, hw, sign, verify
  ECDSA-SHA1, keySize={384,384}, sign, verify
  ECDSA-SHA224, keySize={384,384}, sign, verify
  ECDSA-SHA256, keySize={384,384}, sign, verify
  ECDSA-SHA384, keySize={384,384}, sign, verify
  ECDSA-SHA512, keySize={384,384}, sign, verify
```

`lteid-tool` allows resuming, unblocking and changing PINs:

<img width="1514" height="658" alt="image" src="https://github.com/user-attachments/assets/45debc63-e599-42ca-a3f2-77ff2872eaa3" />

That part needs more testing as soon as I get a replacement card, managed to completely lock electronic signature PIN.

It works for me, but I'm kinda newbie in this + not exactly experienced with C.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is added or updated
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS token is tested
