### PR TITLE
libopensc: guard NULL tries_left in dtrust PIN info

### DIFF
--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -609,7 +609,9 @@ dtrust_pin_cmd_get_info(struct sc_card *card,
 	switch (data->pin_reference) {
 	case PACE_PIN_ID_CAN:
 		/* unlimited number of retries */
-		*tries_left = -1;
+		if (tries_left != NULL) {
+			*tries_left = -1;
+		}
 		data->pin1.max_tries = -1;
 		data->pin1.tries_left = -1;
 		r = SC_SUCCESS;


### PR DESCRIPTION
sc_pkcs15_get_pin_info() passes tries_left == NULL to sc_pin_cmd(). 

In dtrust_pin_cmd_get_info(), the CAN branch dereferenced tries_left unconditionally, 
which caused a SIGSEGV during pkcs11-tool -L token enumeration. 
Guard the write with a NULL check.

Fixes #3586

Now, I can get all the information:

```console
$ pkcs11-tool -L
Available slots:
Slot 0 (0x0): REINER SCT cyberJack RFID standard (<READER_ID>) 00 00
  token label        : D-TRUST Card 5.1 Std. R... (CAN)
  token manufacturer : D-TRUST GmbH (C)
  token model        : PKCS#15 emulated
  token flags        : login required, PIN pad present, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.0
  serial num         : <REDACTED_SERIAL>
  pin min/max        : 6/6
  uri                : pkcs11:model=PKCS%2315%20emulated;manufacturer=D-TRUST%20GmbH%20%28C%29;serial=<REDACTED_SERIAL>;token=D-TRUST%20Card%205.1%20Std.%20R...%20%28CAN%29

Slot 1 (0x1): REINER SCT cyberJack RFID standard (<READER_ID>) 00 00
  token label        : D-TRUST Card ... (Signature-PIN)
  token manufacturer : D-TRUST GmbH (C)
  token model        : PKCS#15 emulated
  token flags        : login required, PIN pad present, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.0
  serial num         : <REDACTED_SERIAL>
  pin min/max        : 8/8
  uri                : pkcs11:model=PKCS%2315%20emulated;manufacturer=D-TRUST%20GmbH%20%28C%29;serial=<REDACTED_SERIAL>;token=D-TRUST%20Card%20...%20%28Signature-PIN%29

Slot 2 (0x2): REINER SCT cyberJack RFID standard (<READER_ID>) 00 00
  token label        : D-TRUST ... (Authentication-PIN)
  token manufacturer : D-TRUST GmbH (C)
  token model        : PKCS#15 emulated
  token flags        : login required, PIN pad present, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.0
  serial num         : <REDACTED_SERIAL>
  pin min/max        : 8/8
  uri                : pkcs11:model=PKCS%2315%20emulated;manufacturer=D-TRUST%20GmbH%20%28C%29;serial=<REDACTED_SERIAL>;token=D-TRUST%20...%20%28Authentication-PIN%29
```

I was able to run a signature cycle:

```console
$ echo -n "OpenSC issue 3586 test" > data.bin
$ pkcs11-tool --slot 0x1 -r --type cert --id 02 --login > sign-cert.der
$ openssl x509 -inform DER -in sign-cert.der -pubkey -noout > sign-pub.pem
$ pkcs11-tool --slot 0x1 \
  --sign --mechanism SHA256-RSA-PKCS \
  --id 02 --login \
  --input-file data.bin --output-file data.sig
Using signature algorithm SHA256-RSA-PKCS
$ openssl dgst -sha256 -verify sign-pub.pem -signature data.sig data.bin
Verified OK
```
##### Checklist

- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
