### PR TITLE
make sure sc_pin_cmd is always called tries_left

### DIFF
--- a/src/libopensc/sec.c
+++ b/src/libopensc/sec.c
@@ -208,6 +208,11 @@ int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		card->ctx->debug = 0;
 	}
 
+	if (tries_left == NULL) {
+		/* FIXME refactor code to remove the obsolete tries_left */
+		tries_left = &data->pin1.tries_left;
+	}
+
 	if (card->ops->pin_cmd) {
 		r = card->ops->pin_cmd(card, data, tries_left);
 	} else if (!(data->flags & SC_PIN_CMD_USE_PINPAD)) {


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/3586 closes https://github.com/OpenSC/OpenSC/pull/3587

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
