### PR TITLE
 refactored pin commands to avoid tries_left as additional parameter 

### DIFF
--- a/src/libopensc/card-asepcos.c
+++ b/src/libopensc/card-asepcos.c
@@ -929,15 +929,11 @@ static int asepcos_build_pin_apdu(sc_card_t *card, sc_apdu_t *apdu,
 /* generic function to handle the different PIN operations, i.e verify
  * change and unblock.
  */
-static int asepcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *pdata,
-	int *tries_left)
+static int asepcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *pdata)
 {
 	sc_apdu_t apdu;
 	int r = SC_SUCCESS;
 	u8  sbuf[SC_MAX_APDU_BUFFER_SIZE];
-
-	if (tries_left)
-		*tries_left = -1;
 
 	/* only PIN verification is supported at the moment  */
 
@@ -1025,8 +1021,8 @@ static int asepcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *pdata,
 	/* check for remaining tries if verification failed */
 	if (r == SC_SUCCESS) {
 		if (apdu.sw1 == 0x63) {
-			if ((apdu.sw2 & 0xF0) == 0xC0 && tries_left != NULL)
-				*tries_left = apdu.sw2 & 0x0F;
+			if ((apdu.sw2 & 0xF0) == 0xC0)
+				pdata->pin1.tries_left = apdu.sw2 & 0x0F;
 			r = SC_ERROR_PIN_CODE_INCORRECT;
 			return r;
 		}

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -86,7 +86,7 @@ static int authentic_select_file(struct sc_card *card, const struct sc_path *pat
 static int authentic_process_fci(struct sc_card *card, struct sc_file *file, const unsigned char *buf, size_t buflen);
 static int authentic_get_serialnr(struct sc_card *card, struct sc_serial_number *serial);
 static int authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struct sc_acl_entry *acls);
-static int authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, int *tries_left);
+static int authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd);
 static int authentic_select_mf(struct sc_card *card, struct sc_file **file_out);
 static int authentic_card_ctl(struct sc_card *card, unsigned long cmd, void *ptr);
 
@@ -980,7 +980,7 @@ authentic_delete_file(struct sc_card *card, const struct sc_path *path)
 
 
 static int
-authentic_chv_verify_pinpad(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, int *tries_left)
+authentic_chv_verify_pinpad(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 {
 	struct sc_context *ctx = card->ctx;
 	unsigned char buffer[0x100];
@@ -990,7 +990,7 @@ authentic_chv_verify_pinpad(struct sc_card *card, struct sc_pin_cmd_data *pin_cm
 	LOG_FUNC_CALLED(ctx);
 	sc_log(ctx, "Verify PIN(ref:%i) with pin-pad", pin_cmd->pin_reference);
 
-	rv = authentic_pin_is_verified(card, pin_cmd, tries_left);
+	rv = authentic_pin_is_verified(card, pin_cmd);
 	if (!rv)
 		LOG_FUNC_RETURN(ctx, rv);
 
@@ -1008,15 +1008,14 @@ authentic_chv_verify_pinpad(struct sc_card *card, struct sc_pin_cmd_data *pin_cm
 	pin_cmd->cmd = SC_PIN_CMD_VERIFY;
 	pin_cmd->flags |= SC_PIN_CMD_USE_PINPAD;
 
-	rv = iso_ops->pin_cmd(card, pin_cmd, tries_left);
+	rv = iso_ops->pin_cmd(card, pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
 static int
-authentic_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd,
-		int *tries_left)
+authentic_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_apdu apdu;
@@ -1047,7 +1046,7 @@ authentic_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd,
 		apdu.lc = pin_len;
 	}
 	else if ((card->reader->capabilities & SC_READER_CAP_PIN_PAD) && !pin1->data && !pin1->len)   {
-		rv = authentic_chv_verify_pinpad(card, pin_cmd, tries_left);
+		rv = authentic_chv_verify_pinpad(card, pin_cmd);
 		sc_log(ctx, "authentic_chv_verify() authentic_chv_verify_pinpad returned %i", rv);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
@@ -1060,8 +1059,6 @@ authentic_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd,
 
 	if (apdu.sw1 == 0x63 && (apdu.sw2 & 0xF0) == 0xC0)   {
 		pin1->tries_left = apdu.sw2 & 0x0F;
-		if (tries_left)
-			*tries_left = apdu.sw2 & 0x0F;
 	}
 
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
@@ -1071,8 +1068,7 @@ authentic_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd,
 
 
 static int
-authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd_data,
-		int *tries_left)
+authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd_data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_pin_cmd_data pin_cmd;
@@ -1087,7 +1083,7 @@ authentic_pin_is_verified(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd_
 	pin_cmd.pin1.data = (unsigned char *)"";
 	pin_cmd.pin1.len = 0;
 
-	rv = authentic_chv_verify(card, &pin_cmd, tries_left);
+	rv = authentic_chv_verify(card, &pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
@@ -1107,7 +1103,7 @@ authentic_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 
 	if (pin_cmd->pin1.data && !pin_cmd->pin1.len)   {
 		pin_cmd->pin1.tries_left = -1;
-		rv = authentic_pin_is_verified(card, pin_cmd, &pin_cmd->pin1.tries_left);
+		rv = authentic_pin_is_verified(card, pin_cmd);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
 
@@ -1130,7 +1126,7 @@ authentic_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_PIN_LENGTH, "PIN policy check failed");
 
 	pin_cmd->pin1.tries_left = -1;
-	rv = authentic_chv_verify(card, pin_cmd, &pin_cmd->pin1.tries_left);
+	rv = authentic_chv_verify(card, pin_cmd);
 	LOG_TEST_RET(ctx, rv, "PIN CHV verification error");
 
 	memcpy(prv_data->pins_sha1[pin_cmd->pin_reference], pin_sha1, SHA_DIGEST_LENGTH);
@@ -1182,14 +1178,14 @@ authentic_pin_change_pinpad(struct sc_card *card, unsigned reference, int *tries
 	       pin_cmd.pin2.max_length, pin_cmd.pin2.min_length,
 	       pin_cmd.pin2.pad_length);
 
-	rv = iso_ops->pin_cmd(card, &pin_cmd, tries_left);
+	rv = iso_ops->pin_cmd(card, &pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
 static int
-authentic_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+authentic_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct authentic_private_data *prv_data = (struct authentic_private_data *) card->drv_data;
@@ -1206,7 +1202,7 @@ authentic_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 	if (!data->pin1.data && !data->pin1.len && !data->pin2.data && !data->pin2.len)   {
 		if (!(card->reader->capabilities & SC_READER_CAP_PIN_PAD))
 			LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "PIN pad not supported");
-		rv = authentic_pin_change_pinpad(card, data->pin_reference, tries_left);
+		rv = authentic_pin_change_pinpad(card, data->pin_reference, &data->pin1.tries_left);
 		sc_log(ctx, "authentic_pin_cmd(SC_PIN_CMD_CHANGE) chv_change_pinpad returned %i", rv);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
@@ -1274,7 +1270,7 @@ authentic_chv_set_pinpad(struct sc_card *card, unsigned char reference)
 	       "PIN2 max/min/pad %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
 	       pin_cmd.pin2.max_length, pin_cmd.pin2.min_length,
 	       pin_cmd.pin2.pad_length);
-	rv = iso_ops->pin_cmd(card, &pin_cmd, NULL);
+	rv = iso_ops->pin_cmd(card, &pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
@@ -1332,7 +1328,7 @@ authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, st
 
 
 static int
-authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct authentic_private_data *prv_data = (struct authentic_private_data *) card->drv_data;
@@ -1376,9 +1372,6 @@ authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 
 			rv = authentic_pin_verify(card, &puk_cmd);
 
-			if (tries_left && rv == SC_ERROR_PIN_CODE_INCORRECT)
-				*tries_left = puk_cmd.pin1.tries_left;
-
 			LOG_TEST_RET(ctx, rv, "Cannot verify PUK");
 		}
 	}
@@ -1418,7 +1411,7 @@ authentic_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 
 
 static int
-authentic_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+authentic_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	int rv = SC_ERROR_INTERNAL;
@@ -1433,10 +1426,10 @@ authentic_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 		rv = authentic_pin_verify(card, data);
 		break;
 	case SC_PIN_CMD_CHANGE:
-		rv = authentic_pin_change(card, data, tries_left);
+		rv = authentic_pin_change(card, data);
 		break;
 	case SC_PIN_CMD_UNBLOCK:
-		rv = authentic_pin_reset(card, data, tries_left);
+		rv = authentic_pin_reset(card, data);
 		break;
 	case SC_PIN_CMD_GET_INFO:
 		rv = authentic_pin_get_policy(card, data, NULL);
@@ -1444,9 +1437,6 @@ authentic_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	default:
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Unsupported PIN command");
 	}
-
-	if (rv == SC_ERROR_PIN_CODE_INCORRECT && tries_left)
-		*tries_left = data->pin1.tries_left;
 
 	LOG_FUNC_RETURN(ctx, rv);
 }

--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -332,7 +332,7 @@ static int belpic_read_binary(sc_card_t *card,
 	return r;
 }
 
-static int belpic_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+static int belpic_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	data->pin1.encoding = data->pin2.encoding = BELPIC_PIN_ENCODING;
 	data->pin1.pad_char = data->pin2.pad_char = BELPIC_PAD_CHAR;
@@ -340,7 +340,7 @@ static int belpic_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tr
 	data->pin1.max_length = data->pin2.max_length = BELPIC_MAX_USER_PIN_LEN;
 	data->apdu = NULL;
 
-	return iso_ops->pin_cmd(card, data, tries_left);
+	return iso_ops->pin_cmd(card, data);
 }
 
 static int belpic_set_security_env(sc_card_t *card,

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -1860,7 +1860,7 @@ static int cac_logout(sc_card_t *card)
 	return cac_find_first_pki_applet(card, &index);
 }
 
-static int cac_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+static int cac_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	/* CAC, like PIV needs Extra validation of (new) PIN during
 	 * a PIN change request, to ensure it's not outside the
@@ -1896,7 +1896,7 @@ static int cac_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries
 		}
 	}
 
-	rv = iso_drv->ops->pin_cmd(card, data, tries_left);
+	rv = iso_drv->ops->pin_cmd(card, data);
 
 	data->apdu = NULL;
 	return rv;

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -1475,8 +1475,7 @@ cardos_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
  * Unfortunately, it doesn't seem to work without this flag :-/
  */
 static int
-cardos_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data,
-		 int *tries_left)
+cardos_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	int rv;
@@ -1501,7 +1500,7 @@ cardos_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data,
 	if (data->pin2.max_length == 0)
 		data->pin2.max_length = 8;
 
-	rv = iso_ops->pin_cmd(card, data, tries_left);
+	rv = iso_ops->pin_cmd(card, data);
 	LOG_FUNC_RETURN(ctx, rv);
 }
 

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -2340,7 +2340,7 @@ static int coolkey_init(sc_card_t *card)
 
 
 static int
-coolkey_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+coolkey_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 	coolkey_private_data_t * priv = COOLKEY_DATA(card);
@@ -2362,9 +2362,6 @@ coolkey_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 			 * instead, coolkey slows down the login command exponentially
 			 */
 			data->pin1.tries_left = 0xf;
-		}
-		if (tries_left) {
-			*tries_left = data->pin1.tries_left;
 		}
 		r = SC_SUCCESS;
 		break;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -2101,8 +2101,7 @@ static int dnie_pin_change(struct sc_card *card, struct sc_pin_cmd_data * data)
  * @param tries_left; on fail stores the number of tries left before car lock
  * @return SC_SUCCESS if ok, else error code; on pin incorrect also sets tries_left
  */
-static int dnie_pin_verify(struct sc_card *card,
-                        struct sc_pin_cmd_data *data, int *tries_left)
+static int dnie_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	int res=SC_SUCCESS;
 	sc_apdu_t apdu;
@@ -2141,11 +2140,9 @@ static int dnie_pin_verify(struct sc_card *card,
 	}
 
 	/* check response and if requested setup tries_left */
-	if (tries_left != NULL) {	/* returning tries_left count is requested */
-		if ((apdu.sw1 == 0x63) && ((apdu.sw2 & 0xF0) == 0xC0)) {
-			*tries_left = apdu.sw2 & 0x0F;
-			LOG_FUNC_RETURN(card->ctx, SC_ERROR_PIN_CODE_INCORRECT);
-		}
+	if ((apdu.sw1 == 0x63) && ((apdu.sw2 & 0xF0) == 0xC0)) {
+		data->pin1.tries_left = apdu.sw2 & 0x0F;
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_PIN_CODE_INCORRECT);
 	}
 	res = dnie_check_sw(card, apdu.sw1, apdu.sw2);	/* not a pinerr: parse result */
 
@@ -2173,8 +2170,7 @@ static int dnie_pin_verify(struct sc_card *card,
  * @param tries_left; if pin_verify() operation, on incorrect pin stores the number of tries left before car lock
  * @return SC_SUCCESS if ok, else error code; on pin incorrect also sets tries_left
  */
-static int dnie_pin_cmd(struct sc_card *card,
-			struct sc_pin_cmd_data *data, int *tries_left)
+static int dnie_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	int res = SC_SUCCESS;
 	int lc = SC_CARDCTRL_LIFECYCLE_USER;
@@ -2211,7 +2207,7 @@ static int dnie_pin_cmd(struct sc_card *card,
 	/* This DNIe driver only supports VERIFY operation */
 	switch (data->cmd) {
 	case SC_PIN_CMD_VERIFY:
-		res =  dnie_pin_verify(card,data,tries_left);
+		res =  dnie_pin_verify(card,data);
 		break;
 	case SC_PIN_CMD_CHANGE:
 		res =  dnie_pin_change(card,data);

--- a/src/libopensc/card-dtrust.c
+++ b/src/libopensc/card-dtrust.c
@@ -596,8 +596,7 @@ dtrust_perform_pace(struct sc_card *card,
 
 static int
 dtrust_pin_cmd_get_info(struct sc_card *card,
-		struct sc_pin_cmd_data *data,
-		int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct dtrust_drv_data_t *drv_data;
 	int r;
@@ -609,9 +608,6 @@ dtrust_pin_cmd_get_info(struct sc_card *card,
 	switch (data->pin_reference) {
 	case PACE_PIN_ID_CAN:
 		/* unlimited number of retries */
-		if (tries_left != NULL) {
-			*tries_left = -1;
-		}
 		data->pin1.max_tries = -1;
 		data->pin1.tries_left = -1;
 		r = SC_SUCCESS;
@@ -627,9 +623,6 @@ dtrust_pin_cmd_get_info(struct sc_card *card,
 		/* FIXME: Doesn't work. Returns SW1=69 SW2=85 (Conditions of use not satisfied) instead. */
 		data->pin1.max_tries = 3;
 		r = eac_pace_get_tries_left(card, data->pin_reference, &data->pin1.tries_left);
-		if (tries_left != NULL) {
-			*tries_left = data->pin1.tries_left;
-		}
 		break;
 
 	default:
@@ -645,7 +638,7 @@ dtrust_pin_cmd_get_info(struct sc_card *card,
 		}
 
 		/* Now query PIN information */
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 		break;
 	}
 
@@ -654,8 +647,7 @@ dtrust_pin_cmd_get_info(struct sc_card *card,
 
 static int
 dtrust_pin_cmd_verify(struct sc_card *card,
-		struct sc_pin_cmd_data *data,
-		int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct dtrust_drv_data_t *drv_data;
 	int r;
@@ -676,7 +668,7 @@ dtrust_pin_cmd_verify(struct sc_card *card,
 	case DTRUST5_PIN_ID_PIN_T:
 	case DTRUST5_PIN_ID_PIN_T_AUT:
 		/* Establish secure channel via PACE */
-		r = dtrust_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len, tries_left);
+		r = dtrust_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len, &data->pin1.tries_left);
 		break;
 
 	default:
@@ -692,7 +684,7 @@ dtrust_pin_cmd_verify(struct sc_card *card,
 		}
 
 		/* Now verify the PIN */
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 
 		break;
 	}
@@ -702,8 +694,7 @@ dtrust_pin_cmd_verify(struct sc_card *card,
 
 static int
 dtrust_pin_cmd(struct sc_card *card,
-		struct sc_pin_cmd_data *data,
-		int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct dtrust_drv_data_t *drv_data;
 	int r;
@@ -734,7 +725,7 @@ dtrust_pin_cmd(struct sc_card *card,
 		/* Check verification state */
 		data2.cmd = SC_PIN_CMD_GET_INFO;
 		data2.pin_type = data->pin_type;
-		r = dtrust_pin_cmd(card, &data2, tries_left);
+		r = dtrust_pin_cmd(card, &data2);
 
 		if (data2.pin1.logged_in & SC_PIN_STATE_LOGGED_IN) {
 			/* Return if we are already authenticated */
@@ -749,17 +740,17 @@ dtrust_pin_cmd(struct sc_card *card,
 
 	/* No special handling for D-Trust Card 4.1/4.4 */
 	if (card->type >= SC_CARD_TYPE_DTRUST_V4_1_STD && card->type <= SC_CARD_TYPE_DTRUST_V4_4_MULTI) {
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 		LOG_FUNC_RETURN(card->ctx, r);
 	}
 
 	switch (data->cmd) {
 	case SC_PIN_CMD_GET_INFO:
-		r = dtrust_pin_cmd_get_info(card, data, tries_left);
+		r = dtrust_pin_cmd_get_info(card, data);
 		break;
 
 	case SC_PIN_CMD_VERIFY:
-		r = dtrust_pin_cmd_verify(card, data, tries_left);
+		r = dtrust_pin_cmd_verify(card, data);
 		break;
 
 	case SC_PIN_CMD_CHANGE:
@@ -784,7 +775,7 @@ dtrust_pin_cmd(struct sc_card *card,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 		}
 
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 		break;
 
 	case SC_PIN_CMD_UNBLOCK:
@@ -796,7 +787,7 @@ dtrust_pin_cmd(struct sc_card *card,
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 		}
 
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 		break;
 
 	default:

--- a/src/libopensc/card-entersafe.c
+++ b/src/libopensc/card-entersafe.c
@@ -870,8 +870,7 @@ static void entersafe_init_pin_info(struct sc_pin_cmd_pin *pin, unsigned int num
 	pin->pad_char   = 0x00;
 }
 
-static int entersafe_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-							 int *tries_left)
+static int entersafe_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
@@ -880,7 +879,7 @@ static int entersafe_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 	data->flags |= SC_PIN_CMD_NEED_PADDING;
 
 	if (data->cmd != SC_PIN_CMD_UNBLOCK) {
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 		sc_log(card->ctx, "Verify rv:%i", r);
 	} else {
 		{ /*verify*/

--- a/src/libopensc/card-eoi.c
+++ b/src/libopensc/card-eoi.c
@@ -377,7 +377,7 @@ static int eoi_logout(struct sc_card *card)
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 
-static int eoi_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+static int eoi_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 
@@ -396,7 +396,7 @@ static int eoi_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 		/* Verify PUK, establish SM if necessary */
 		data->cmd = SC_PIN_CMD_VERIFY;
 		data->pin_reference = data->puk_reference;
-		r = eoi_pin_cmd(card, data, tries_left);
+		r = eoi_pin_cmd(card, data);
 		if (r != SC_SUCCESS)
 			LOG_FUNC_RETURN(card->ctx, r);
 		/* RESET RETRY COUNTER */
@@ -404,7 +404,7 @@ static int eoi_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 		data->pin_reference = 0x80|pin_reference;
 		data->pin1.len = 0;
 		data->pin2.len = 0;
-		r = sc_get_iso7816_driver()->ops->pin_cmd(card, data, tries_left);
+		r = sc_get_iso7816_driver()->ops->pin_cmd(card, data);
 		if (r != SC_SUCCESS)
 			LOG_FUNC_RETURN(card->ctx, r);
 		/* Continue as CHANGE PIN */
@@ -416,7 +416,7 @@ static int eoi_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 	if (data->cmd == SC_PIN_CMD_CHANGE)
 		data->pin1.len = 0;
 
-	LOG_FUNC_RETURN(card->ctx, sc_get_iso7816_driver()->ops->pin_cmd(card, data, tries_left));
+	LOG_FUNC_RETURN(card->ctx, sc_get_iso7816_driver()->ops->pin_cmd(card, data));
 }
 
 static int

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -3186,7 +3186,7 @@ update_secret_key(struct sc_card *card, unsigned char ktype, unsigned char kid,
 
 /* use external auth secret as pin */
 static int
-epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 	u8 kid;
@@ -3210,8 +3210,6 @@ epass2003_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 		r = get_external_key_retries(card, 0x80 | kid, &retries);
 		if (r == SC_SUCCESS) {
 			data->pin1.tries_left = retries;
-			if (tries_left)
-				*tries_left = retries;
 
 			r = get_external_key_maxtries(card, &maxtries);
 			LOG_TEST_RET(card->ctx, r, "get max counter failed");

--- a/src/libopensc/card-esteid2018.c
+++ b/src/libopensc/card-esteid2018.c
@@ -229,7 +229,7 @@ static int esteid_get_pin_remaining_tries(sc_card_t *card, int pin_reference) {
 	return (int)apdu_resp[13];
 }
 
-static int esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left) {
+static int esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data) {
 	int r;
 	struct sc_pin_cmd_data tmp;
 	LOG_FUNC_CALLED(card->ctx);
@@ -250,7 +250,7 @@ static int esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tr
 		tmp.cmd = SC_PIN_CMD_VERIFY;
 		tmp.pin_reference = PUK_REF;
 		tmp.pin2.len = 0;
-		r = iso_ops->pin_cmd(card, &tmp, tries_left);
+		r = iso_ops->pin_cmd(card, &tmp);
 		LOG_TEST_RET(card->ctx, r, "VERIFY during unblock failed");
 
 		if (data->pin_reference == PIN2_REF) {
@@ -260,12 +260,12 @@ static int esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tr
 		tmp = *data;
 		tmp.cmd = SC_PIN_CMD_UNBLOCK;
 		tmp.pin1.len = 0;
-		r = iso_ops->pin_cmd(card, &tmp, tries_left);
+		r = iso_ops->pin_cmd(card, &tmp);
 		sc_mem_clear(&tmp, sizeof(tmp));
 		LOG_FUNC_RETURN(card->ctx, r);
 	}
 
-	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data, tries_left));
+	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data));
 }
 
 static int esteid_init(sc_card_t *card) {

--- a/src/libopensc/card-esteid2025.c
+++ b/src/libopensc/card-esteid2025.c
@@ -185,7 +185,7 @@ esteid_get_pin_info(sc_card_t *card, struct sc_pin_cmd_data *data)
 }
 
 static int
-esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	LOG_FUNC_CALLED(card->ctx);
 	sc_log(card->ctx, "PIN CMD is %d", data->cmd);
@@ -193,7 +193,7 @@ esteid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 		sc_log(card->ctx, "SC_PIN_CMD_GET_INFO for %d", data->pin_reference);
 		LOG_FUNC_RETURN(card->ctx, esteid_get_pin_info(card, data));
 	}
-	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data, tries_left));
+	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data));
 }
 
 static int

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -1160,8 +1160,7 @@ static void flex_init_pin_info(struct sc_pin_cmd_pin *pin, unsigned int num)
 	pin->offset     = 5 + num * 8;
 }
 
-static int flex_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-			int *tries_left)
+static int flex_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	sc_apdu_t apdu;
 	int r;
@@ -1187,9 +1186,8 @@ static int flex_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 
 	/* According to the Cryptoflex documentation, the card
 	 * does not return the number of attempts left using
-	 * the 63C0xx convention, hence we don't pass the
-	 * tries_left pointer. */
-	r = iso_ops->pin_cmd(card, data, NULL);
+	 * the 63C0xx convention */
+	r = iso_ops->pin_cmd(card, data);
 	if (old_cla != -1)
 		card->cla = old_cla;
 	data->apdu = NULL;

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -1021,11 +1021,11 @@ static int gids_get_pin_policy(struct sc_card *card, struct sc_pin_cmd_data *dat
 }
 
 static int
-gids_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left) {
+gids_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data) {
 	if (data->cmd == SC_PIN_CMD_GET_INFO) {
 		return gids_get_pin_policy(card, data);
 	} else {
-		return iso_ops->pin_cmd(card, data, tries_left);
+		return iso_ops->pin_cmd(card, data);
 	}
 }
 
@@ -1845,7 +1845,7 @@ static int gids_initialize(sc_card_t *card, sc_cardctl_gids_init_param_t* param)
 	pindata.pin2.data = param->user_pin;
 	pindata.pin_reference = 0x80;
 
-	r = sc_pin_cmd(card, &pindata, NULL);
+	r = sc_pin_cmd(card, &pindata);
 	LOG_TEST_RET(card->ctx, r, "gids set pin");
 
 	// create file

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -144,8 +144,8 @@ static int iasecc_process_fci(struct sc_card *card, struct sc_file *file, const 
 static int iasecc_get_serialnr(struct sc_card *card, struct sc_serial_number *serial);
 static int iasecc_sdo_get_data(struct sc_card *card, struct iasecc_sdo *sdo);
 static int iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struct iasecc_pin_policy *pin);
-static int iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left);
-static int iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left);
+static int iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data);
+static int iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data);
 static int iasecc_check_update_pin(struct sc_pin_cmd_data *data, struct sc_pin_cmd_pin *pin);
 static void iasecc_set_pin_padding(struct sc_pin_cmd_data *data, struct sc_pin_cmd_pin *pin,
 				   size_t pad_len);
@@ -1858,8 +1858,7 @@ iasecc_set_security_env(struct sc_card *card,
 
 
 static int
-iasecc_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, unsigned char *scbs,
-		  int *tries_left)
+iasecc_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, unsigned char *scbs)
 {
 	struct sc_context *ctx = card->ctx;
 	unsigned char scb = scbs[IASECC_ACLS_CHV_VERIFY];
@@ -1870,11 +1869,11 @@ iasecc_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, unsigne
 	       scb);
 
 	if (scb & IASECC_SCB_METHOD_SM) {
-		rv = iasecc_sm_pin_verify(card, scb & IASECC_SCB_METHOD_MASK_REF, pin_cmd, tries_left);
+		rv = iasecc_sm_pin_verify(card, scb & IASECC_SCB_METHOD_MASK_REF, pin_cmd);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
 
-	rv = iso_ops->pin_cmd(card, pin_cmd, tries_left);
+	rv = iso_ops->pin_cmd(card, pin_cmd);
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
@@ -1917,7 +1916,7 @@ iasecc_se_at_to_chv_reference(struct sc_card *card, unsigned reference,
 
 
 static int
-iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_pin_cmd_data info;
@@ -1933,7 +1932,7 @@ iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data, int *t
 	info.pin_type = data->pin_type;
 	info.pin_reference = data->pin_reference;
 
-	rv = iso_ops->pin_cmd(card, &info, tries_left);
+	rv = iso_ops->pin_cmd(card, &info);
 	LOG_TEST_RET(ctx, rv, "Failed to get PIN info");
 
 	data->pin1.max_tries = info.pin1.max_tries;
@@ -1945,7 +1944,7 @@ iasecc_pin_get_status(struct sc_card *card, struct sc_pin_cmd_data *data, int *t
 
 
 static int
-iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	unsigned type = data->pin_type;
@@ -1961,7 +1960,7 @@ iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	       type, reference, data->pin1.len, data->pin1.data);
 
 	if (type == SC_AC_AUT)   {
-		rv =  iasecc_sm_external_authentication(card, reference, tries_left);
+		rv =  iasecc_sm_external_authentication(card, reference, &data->pin1.tries_left);
 		LOG_FUNC_RETURN(ctx, rv);
 	}
 
@@ -1988,7 +1987,7 @@ iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	pin_cmd.pin_reference = reference;
 	pin_cmd.cmd = SC_PIN_CMD_VERIFY;
 
-	rv = iasecc_pin_get_status(card, &pin_cmd, tries_left);
+	rv = iasecc_pin_get_status(card, &pin_cmd);
 	if (data->pin1.data && !data->pin1.len)
 		LOG_FUNC_RETURN(ctx, rv);
 
@@ -2013,7 +2012,7 @@ iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 			iasecc_set_pin_padding(&pin_cmd, &pin_cmd.pin1, policy.stored_length);
 	}
 
-	rv = iasecc_chv_verify(card, &pin_cmd, policy.scbs, tries_left);
+	rv = iasecc_chv_verify(card, &pin_cmd, policy.scbs);
 
 	/*
 	 * Detect and log PIN-pads which don't handle variable-length PIN - special case where they
@@ -2140,7 +2139,7 @@ err:
 
 
 static int
-iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct iasecc_pin_policy policy;
@@ -2155,7 +2154,7 @@ iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 	 * tries, and the second one for the maximum tries. If a field is present in both, the
 	 * policy takes precedence.
 	 */
-	rv = iasecc_pin_get_status(card, data, tries_left);
+	rv = iasecc_pin_get_status(card, data);
 	LOG_TEST_RET(ctx, rv, "Failed to get PIN status");
 
 	rv = iasecc_pin_get_policy(card, data, &policy);
@@ -2170,9 +2169,6 @@ iasecc_pin_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tri
 	data->pin1.max_tries = policy.tries_maximum;
 	if (policy.tries_remaining >= 0)
 		data->pin1.tries_left = policy.tries_remaining;
-
-	if (tries_left)
-		*tries_left = data->pin1.tries_left;
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
@@ -2256,7 +2252,7 @@ iasecc_pin_merge_policy(struct sc_card *card, struct sc_pin_cmd_data *data,
 
 
 static int
-iasecc_keyset_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_keyset_change(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct iasecc_sdo_update update;
@@ -2318,7 +2314,7 @@ iasecc_keyset_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
  *   Absent     Absent       Both PINs are input.
  */
 static int
-iasecc_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	struct sc_pin_cmd_data pin_cmd;
@@ -2348,7 +2344,7 @@ iasecc_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	LOG_TEST_RET(ctx, rv, "Failed to update PIN1 info");
 
 	if (!(pin_cmd.flags & SC_PIN_CMD_USE_PINPAD)) {
-		rv = iasecc_chv_verify(card, &pin_cmd, policy.scbs, tries_left);
+		rv = iasecc_chv_verify(card, &pin_cmd, policy.scbs);
 		LOG_TEST_RET(ctx, rv, "PIN CHV verification error");
 	}
 
@@ -2374,7 +2370,7 @@ iasecc_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
 	rv = iasecc_check_update_pin(&pin_cmd, &pin_cmd.pin2);
 	LOG_TEST_RET(ctx, rv, "Invalid PIN2");
 
-	rv = iso_ops->pin_cmd(card, &pin_cmd, tries_left);
+	rv = iso_ops->pin_cmd(card, &pin_cmd);
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
@@ -2389,7 +2385,7 @@ iasecc_pin_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries
  *   Absent     Absent       Both PUK and new PIN are input.
  */
 static int
-iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	unsigned char scb;
@@ -2422,7 +2418,7 @@ iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_
 				pin_cmd.pin_type = SC_AC_SEN;
 				pin_cmd.pin_reference = se_num;
 			}
-			rv = iasecc_pin_verify(card, &pin_cmd, tries_left);
+			rv = iasecc_pin_verify(card, &pin_cmd);
 			LOG_TEST_RET(ctx, rv, "iasecc_pin_reset() verify PUK error");
 
 			if (!need_all)
@@ -2435,7 +2431,7 @@ iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_
 		}
 
 		if (scb & IASECC_SCB_METHOD_EXT_AUTH)   {
-			rv =  iasecc_sm_external_authentication(card, data->pin_reference, tries_left);
+			rv =  iasecc_sm_external_authentication(card, data->pin_reference, &data->pin1.tries_left);
 			LOG_TEST_RET(ctx, rv, "iasecc_pin_reset() external authentication error");
 		}
 	} while(0);
@@ -2449,14 +2445,14 @@ iasecc_pin_reset(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_
 	rv = iasecc_pin_merge_policy(card, &pin_cmd, &pin_cmd.pin2, &policy);
 	LOG_TEST_RET(ctx, rv, "Failed to update PIN2 info");
 
-	rv = iso_ops->pin_cmd(card, &pin_cmd, tries_left);
+	rv = iso_ops->pin_cmd(card, &pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
 
 
 static int
-iasecc_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 	int rv;
@@ -2468,19 +2464,19 @@ iasecc_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_le
 
 	switch (data->cmd)   {
 	case SC_PIN_CMD_VERIFY:
-		rv = iasecc_pin_verify(card, data, tries_left);
+		rv = iasecc_pin_verify(card, data);
 		break;
 	case SC_PIN_CMD_CHANGE:
 		if (data->pin_type == SC_AC_AUT)
-			rv = iasecc_keyset_change(card, data, tries_left);
+			rv = iasecc_keyset_change(card, data);
 		else
-			rv = iasecc_pin_change(card, data, tries_left);
+			rv = iasecc_pin_change(card, data);
 		break;
 	case SC_PIN_CMD_UNBLOCK:
-		rv = iasecc_pin_reset(card, data, tries_left);
+		rv = iasecc_pin_reset(card, data);
 		break;
 	case SC_PIN_CMD_GET_INFO:
-		rv = iasecc_pin_get_info(card, data, tries_left);
+		rv = iasecc_pin_get_info(card, data);
 		break;
 	default:
 		sc_log(ctx, "Other pin commands not supported yet: 0x%X", data->cmd);

--- a/src/libopensc/card-itacns.c
+++ b/src/libopensc/card-itacns.c
@@ -292,8 +292,7 @@ static int itacns_set_security_env(sc_card_t *card,
  * cards by STIncard.
  */
 static int
-itacns_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-		 int *tries_left)
+itacns_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	data->flags |= SC_PIN_CMD_NEED_PADDING;
 	/* Enable backtracking for STIncard cards. */
@@ -307,7 +306,7 @@ itacns_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		data->pin1.max_length = 8;
 	if (data->pin2.max_length == 0)
 		data->pin2.max_length = 8;
-	return default_ops->pin_cmd(card, data, tries_left);
+	return default_ops->pin_cmd(card, data);
 }
 
 static int itacns_read_binary(sc_card_t *card,

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -209,7 +209,7 @@ jpki_select_file(struct sc_card *card,
 }
 
 static int
-jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int rc;
 	sc_path_t path;
@@ -218,10 +218,6 @@ jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	int max_tries = 0;
 
 	LOG_FUNC_CALLED(card->ctx);
-
-	if (tries_left) {
-		*tries_left = -1;
-	}
 
 	switch (data->pin_reference) {
 	case 1:
@@ -274,9 +270,6 @@ jpki_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 		}
 		data->pin1.logged_in = priv->logged_in;
 		data->pin1.tries_left = apdu.sw2 & 0xF;
-		if (tries_left) {
-			*tries_left = data->pin1.tries_left;
-		}
 		break;
 	default:
 		sc_log(card->ctx, "Card does not support PIN command: %d", data->cmd);

--- a/src/libopensc/card-lteid.c
+++ b/src/libopensc/card-lteid.c
@@ -181,7 +181,7 @@ lteid_get_can(sc_card_t *card, struct establish_pace_channel_input *pace_input)
 }
 
 static int
-lteid_perform_pace(struct sc_card *card, const int ref, const unsigned char *pin, size_t pinlen, int *tries_left)
+lteid_perform_pace(struct sc_card *card, const int ref, const unsigned char *pin, size_t pinlen)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -315,7 +315,7 @@ lteid_logout(sc_card_t *card)
 }
 
 static int
-lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -327,10 +327,10 @@ lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 	case PACE_PIN_ID_CAN:
 	case PACE_PIN_ID_PIN:
 	case PACE_PIN_ID_PUK:
-		rv = lteid_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len, tries_left);
+		rv = lteid_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len);
 		break;
 	default:
-		rv = iso_ops->pin_cmd(card, data, tries_left);
+		rv = iso_ops->pin_cmd(card, data);
 		break;
 	}
 
@@ -338,7 +338,7 @@ lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 }
 
 static int
-lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -349,10 +349,6 @@ lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 	if (data->pin_reference == PACE_PIN_ID_CAN) {
 		data->pin1.max_tries = -1;
 		data->pin1.tries_left = -1;
-
-		if (tries_left) {
-			*tries_left = -1;
-		}
 
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 	}
@@ -389,10 +385,6 @@ lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 		if (tag && taglen == 2) {
 			data->pin1.tries_left = tag[0];
 			data->pin1.max_tries = tag[1];
-
-			if (tries_left) {
-				*tries_left = data->pin1.tries_left;
-			}
 		} else {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OBJECT_NOT_FOUND);
 		}
@@ -408,7 +400,7 @@ lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 
 	// PIN.QES is a regular iso7816 pin
 	if (data->pin_reference == 0x81) {
-		rv = iso_ops->pin_cmd(card, data, tries_left);
+		rv = iso_ops->pin_cmd(card, data);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
@@ -416,7 +408,7 @@ lteid_pin_cmd_get_info(struct sc_card *card, struct sc_pin_cmd_data *data, int *
 }
 
 static int
-lteid_pin_cmd_unblock(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+lteid_pin_cmd_unblock(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -427,13 +419,13 @@ lteid_pin_cmd_unblock(struct sc_card *card, struct sc_pin_cmd_data *data, int *t
 		struct sc_pin_cmd_data with_changed_pin_ref = *data;
 
 		with_changed_pin_ref.pin_reference = 0x07;
-		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref, tries_left);
+		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
 	// PIN.QES is a regular iso7816 pin
 	if (data->pin_reference == 0x81) {
-		rv = iso_ops->pin_cmd(card, data, tries_left);
+		rv = iso_ops->pin_cmd(card, data);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
@@ -441,7 +433,7 @@ lteid_pin_cmd_unblock(struct sc_card *card, struct sc_pin_cmd_data *data, int *t
 }
 
 static int
-lteid_pin_cmd_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+lteid_pin_cmd_change(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -452,13 +444,13 @@ lteid_pin_cmd_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 		struct sc_pin_cmd_data with_changed_pin_ref = *data;
 
 		with_changed_pin_ref.pin_reference = 0x07;
-		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref, tries_left);
+		rv = iso_ops->pin_cmd(card, &with_changed_pin_ref);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
 	// PIN.QES is a regular iso7816 pin
 	if (data->pin_reference == 0x81) {
-		rv = iso_ops->pin_cmd(card, data, tries_left);
+		rv = iso_ops->pin_cmd(card, data);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
@@ -466,7 +458,7 @@ lteid_pin_cmd_change(struct sc_card *card, struct sc_pin_cmd_data *data, int *tr
 }
 
 static int
-lteid_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+lteid_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -474,16 +466,16 @@ lteid_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_lef
 
 	switch (data->cmd) {
 	case SC_PIN_CMD_VERIFY:
-		rv = lteid_pin_cmd_verify(card, data, tries_left);
+		rv = lteid_pin_cmd_verify(card, data);
 		break;
 	case SC_PIN_CMD_GET_INFO:
-		rv = lteid_pin_cmd_get_info(card, data, tries_left);
+		rv = lteid_pin_cmd_get_info(card, data);
 		break;
 	case SC_PIN_CMD_UNBLOCK:
-		rv = lteid_pin_cmd_unblock(card, data, tries_left);
+		rv = lteid_pin_cmd_unblock(card, data);
 		break;
 	case SC_PIN_CMD_CHANGE:
-		rv = lteid_pin_cmd_change(card, data, tries_left);
+		rv = lteid_pin_cmd_change(card, data);
 		break;
 	default:
 		rv = SC_ERROR_NOT_SUPPORTED;

--- a/src/libopensc/card-lteid.c
+++ b/src/libopensc/card-lteid.c
@@ -181,7 +181,7 @@ lteid_get_can(sc_card_t *card, struct establish_pace_channel_input *pace_input)
 }
 
 static int
-lteid_perform_pace(struct sc_card *card, const int ref, const unsigned char *pin, size_t pinlen)
+lteid_perform_pace(struct sc_card *card, const int ref, const unsigned char *pin, size_t pinlen, int *tries_left)
 {
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -327,7 +327,7 @@ lteid_pin_cmd_verify(struct sc_card *card, struct sc_pin_cmd_data *data)
 	case PACE_PIN_ID_CAN:
 	case PACE_PIN_ID_PIN:
 	case PACE_PIN_ID_PUK:
-		rv = lteid_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len);
+		rv = lteid_perform_pace(card, data->pin_reference, data->pin1.data, data->pin1.len, &data->pin1.tries_left);
 		break;
 	default:
 		rv = iso_ops->pin_cmd(card, data);

--- a/src/libopensc/card-masktech.c
+++ b/src/libopensc/card-masktech.c
@@ -205,8 +205,7 @@ static int masktech_decipher(sc_card_t *card,
 
 /* unblock pin cmd */
 static int masktech_pin_unblock(sc_card_t *card,
-                            struct sc_pin_cmd_data *data,
-                            int *tries_left)
+                            struct sc_pin_cmd_data *data)
 {
 	int rv = 0;
 	struct sc_pin_cmd_data verify_data;
@@ -221,7 +220,7 @@ static int masktech_pin_unblock(sc_card_t *card,
 	verify_data.flags = data->flags;
 	verify_data.pin1.prompt = data->pin1.prompt;
 
-	rv = iso_ops->pin_cmd(card, &verify_data, tries_left);
+	rv = iso_ops->pin_cmd(card, &verify_data);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed - verify unblock PIN");
 
 	/* Build a SC_PIN_CMD_UNBLOCK APDU */
@@ -235,15 +234,14 @@ static int masktech_pin_unblock(sc_card_t *card,
 	reset_data.flags = data->flags | SC_PIN_CMD_IMPLICIT_CHANGE;
 	reset_data.pin2.prompt = data->pin2.prompt;
 
-	rv = iso_ops->pin_cmd(card, &reset_data, tries_left);
+	rv = iso_ops->pin_cmd(card, &reset_data);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed - reset unblock PIN");
 
 	return 0;
 }
 
 static int masktech_pin_change(sc_card_t *card,
-                            struct sc_pin_cmd_data *data,
-                            int *tries_left)
+                            struct sc_pin_cmd_data *data)
 {
 	int rv = 0;
 	struct sc_pin_cmd_data verify_data;
@@ -258,7 +256,7 @@ static int masktech_pin_change(sc_card_t *card,
 	verify_data.flags = data->flags;
 	verify_data.pin1.prompt = data->pin1.prompt;
 
-	rv = iso_ops->pin_cmd(card, &verify_data, tries_left);
+	rv = iso_ops->pin_cmd(card, &verify_data);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed - verify change PIN");
 
 	/* Build a SC_PIN_CMD_CHANGE APDU */
@@ -272,15 +270,14 @@ static int masktech_pin_change(sc_card_t *card,
 	change_data.flags = data->flags | SC_PIN_CMD_IMPLICIT_CHANGE;
 	change_data.pin2.prompt = data->pin2.prompt;
 
-	rv = iso_ops->pin_cmd(card, &change_data, tries_left);
+	rv = iso_ops->pin_cmd(card, &change_data);
 	LOG_TEST_RET(card->ctx, rv, "APDU transmit failed - change PIN");
 
 	return 0;
 }
 
 static int masktech_pin_cmd(sc_card_t *card,
-                            struct sc_pin_cmd_data *data,
-                            int *tries_left)
+                            struct sc_pin_cmd_data *data)
 {
 	int       rv;
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
@@ -288,13 +285,13 @@ static int masktech_pin_cmd(sc_card_t *card,
 	switch(data->cmd)
 	{
 	case SC_PIN_CMD_UNBLOCK:
-		rv = masktech_pin_unblock(card, data, tries_left);
+		rv = masktech_pin_unblock(card, data);
 		break;
 	case SC_PIN_CMD_CHANGE:
-		rv = masktech_pin_change(card, data, tries_left);
+		rv = masktech_pin_change(card, data);
 		break;
 	default:
-		rv = iso_ops->pin_cmd(card, data, tries_left);
+		rv = iso_ops->pin_cmd(card, data);
 		break;
 	}
 	return rv;

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1025,8 +1025,7 @@ static int mcrd_compute_signature(sc_card_t * card,
 }
 
 /* added by -mp, to give pin information in the card driver (pkcs15emu->driver needed) */
-static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
-			int *tries_left)
+static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data)
 {
 	LOG_FUNC_CALLED(card->ctx);
 	data->pin1.offset = 5;
@@ -1037,7 +1036,7 @@ static int mcrd_pin_cmd(sc_card_t * card, struct sc_pin_cmd_data *data,
 		if (data->pin_reference == 0x02)
 			data->pin_reference = data->pin_reference | 0x80;
 	}
-	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, iso_ops->pin_cmd(card, data, tries_left));
+	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, iso_ops->pin_cmd(card, data));
 }
 
 static int mcrd_logout(sc_card_t * card)

--- a/src/libopensc/card-muscle.c
+++ b/src/libopensc/card-muscle.c
@@ -547,8 +547,7 @@ static int muscle_list_files(sc_card_t *card, u8 *buf, size_t bufLen)
 	return count;
 }
 
-static int muscle_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *cmd,
-				int *tries_left)
+static int muscle_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *cmd)
 {
 	muscle_private_t* priv = MUSCLE_DATA(card);
 	const int bufferLength = MSC_MAX_PIN_COMMAND_LENGTH;
@@ -564,7 +563,7 @@ static int muscle_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *cmd,
 				return r;
 			cmd->apdu = &apdu;
 			cmd->pin1.offset = 5;
-			r = iso_ops->pin_cmd(card, cmd, tries_left);
+			r = iso_ops->pin_cmd(card, cmd);
 			if(r >= 0)
 				priv->verifiedPins |= (1 << cmd->pin_reference);
 			return r;
@@ -586,7 +585,7 @@ static int muscle_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *cmd,
 			if (r < 0)
 				return r;
 			cmd->apdu = &apdu;
-			return iso_ops->pin_cmd(card, cmd, tries_left);
+			return iso_ops->pin_cmd(card, cmd);
 		}
 		case SC_AC_TERM:
 		case SC_AC_PRO:
@@ -605,7 +604,7 @@ static int muscle_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *cmd,
 			if (r < 0)
 				return r;
 			cmd->apdu = &apdu;
-			return iso_ops->pin_cmd(card, cmd, tries_left);
+			return iso_ops->pin_cmd(card, cmd);
 		}
 		case SC_AC_TERM:
 		case SC_AC_PRO:

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -663,8 +663,7 @@ static int myeid_delete_file(struct sc_card *card, const struct sc_path *path)
 	LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
 }
 
-static int myeid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-			 int *tries_left)
+static int myeid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	myeid_private_data_t *priv = (myeid_private_data_t *) card->drv_data;
 
@@ -684,7 +683,7 @@ static int myeid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		return SC_SUCCESS;
 	}
 
-	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data, tries_left));
+	LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data));
 }
 
 #define IS_SYMETRIC_CRYPT(x) ((x) == SC_SEC_OPERATION_ENCRYPT_SYM || (x) == SC_SEC_OPERATION_DECRYPT_SYM)

--- a/src/libopensc/card-npa.c
+++ b/src/libopensc/card-npa.c
@@ -472,12 +472,12 @@ static int npa_set_security_env(struct sc_card *card,
 }
 
 static int npa_pin_cmd_get_info(struct sc_card *card,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	int r;
 	u8 pin_reference;
 
-	if (!data || data->pin_type != SC_AC_CHV || !tries_left) {
+	if (!data || data->pin_type != SC_AC_CHV) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
 		goto err;
 	}
@@ -487,28 +487,25 @@ static int npa_pin_cmd_get_info(struct sc_card *card,
 		case PACE_PIN_ID_CAN:
 		case PACE_PIN_ID_MRZ:
 			/* usually unlimited number of retries */
-			*tries_left = -1;
-			data->pin1.max_tries = -1;
 			data->pin1.tries_left = -1;
+			data->pin1.max_tries = -1;
 			r = SC_SUCCESS;
 			break;
 
 		case PACE_PIN_ID_PUK:
 			/* usually 10 tries */
-			*tries_left = 10;
+			data->pin1.tries_left = 10;
 			data->pin1.max_tries = 10;
 			r = eac_pace_get_tries_left(card,
-					pin_reference, tries_left);
-			data->pin1.tries_left = *tries_left;
+					pin_reference, &data->pin1.tries_left);
 			break;
 
 		case PACE_PIN_ID_PIN:
 			/* usually 3 tries */
-			*tries_left = 3;
+			data->pin1.tries_left = 3;
 			data->pin1.max_tries = 3;
 			r = eac_pace_get_tries_left(card,
-					pin_reference, tries_left);
-			data->pin1.tries_left = *tries_left;
+					pin_reference, &data->pin1.tries_left);
 			break;
 
 		default:
@@ -522,7 +519,7 @@ err:
 
 static int npa_pace_verify(struct sc_card *card,
 		unsigned char pin_reference, struct sc_pin_cmd_pin *pin,
-		const unsigned char *chat, size_t chat_length, int *tries_left)
+		const unsigned char *chat, size_t chat_length)
 {
 	int r;
 	struct establish_pace_channel_input pace_input;
@@ -543,13 +540,11 @@ static int npa_pace_verify(struct sc_card *card,
 
 	r = perform_pace(card, pace_input, &pace_output, EAC_TR_VERSION_2_02);
 
-	if (tries_left) {
-		if (pace_output.mse_set_at_sw1 == 0x63
-				&& (pace_output.mse_set_at_sw2 & 0xc0) == 0xc0) {
-			*tries_left = pace_output.mse_set_at_sw2 & 0x0f;
-		} else {
-			*tries_left = -1;
-		}
+	if (pace_output.mse_set_at_sw1 == 0x63
+			&& (pace_output.mse_set_at_sw2 & 0xc0) == 0xc0) {
+		pin->tries_left = pace_output.mse_set_at_sw2 & 0x0f;
+	} else {
+		pin->tries_left = -1;
 	}
 
 	/* resume the PIN if needed */
@@ -579,27 +574,23 @@ static int npa_pace_verify(struct sc_card *card,
 
 			if (r == SC_SUCCESS) {
 				sc_log(card->ctx, "%s resumed.\n", eac_secret_name(pin_reference));
-				if (tries_left) {
-					*tries_left = EAC_MAX_PIN_TRIES;
-				}
+				pin->tries_left = EAC_MAX_PIN_TRIES;
 			} else {
-				if (tries_left) {
-					if (pace_output.mse_set_at_sw1 == 0x63
-							&& (pace_output.mse_set_at_sw2 & 0xc0) == 0xc0) {
-						*tries_left = pace_output.mse_set_at_sw2 & 0x0f;
-					} else {
-						*tries_left = -1;
-					}
+				if (pace_output.mse_set_at_sw1 == 0x63
+						&& (pace_output.mse_set_at_sw2 & 0xc0) == 0xc0) {
+					pin->tries_left = pace_output.mse_set_at_sw2 & 0x0f;
+				} else {
+					pin->tries_left = -1;
 				}
 			}
 		}
 	}
 
-	if (pin_reference == PACE_PIN_ID_PIN && tries_left) {
-	   if (*tries_left == 0) {
+	if (pin_reference == PACE_PIN_ID_PIN) {
+	   if (pin->tries_left == 0) {
 		   sc_log(card->ctx, "%s is suspended and must be resumed.\n",
 				   eac_secret_name(pin_reference));
-	   } else if (*tries_left == 1) {
+	   } else if (pin->tries_left == 1) {
 		   sc_log(card->ctx, "%s is blocked and must be unblocked.\n",
 				   eac_secret_name(pin_reference));
 	   }
@@ -616,7 +607,7 @@ static int npa_pace_verify(struct sc_card *card,
 }
 
 static int npa_standard_pin_cmd(struct sc_card *card,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	int r;
 	struct sc_card_driver *iso_drv;
@@ -626,7 +617,7 @@ static int npa_standard_pin_cmd(struct sc_card *card,
 	if (!iso_drv || !iso_drv->ops || !iso_drv->ops->pin_cmd) {
 		r = SC_ERROR_INTERNAL;
 	} else {
-		r = iso_drv->ops->pin_cmd(card, data, tries_left);
+		r = iso_drv->ops->pin_cmd(card, data);
 	}
 
 	return r;
@@ -704,7 +695,7 @@ npa_reset_retry_counter(sc_card_t *card, enum s_type pin_id,
 }
 
 static int npa_pin_cmd(struct sc_card *card,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	int r;
 
@@ -720,7 +711,7 @@ static int npa_pin_cmd(struct sc_card *card,
 
 	switch (data->cmd) {
 		case SC_PIN_CMD_GET_INFO:
-			r = npa_pin_cmd_get_info(card, data, tries_left);
+			r = npa_pin_cmd_get_info(card, data);
 			if (r != SC_SUCCESS)
 				goto err;
 			break;
@@ -737,7 +728,7 @@ static int npa_pin_cmd(struct sc_card *card,
 			if (card->sm_ctx.sm_mode != SM_MODE_TRANSMIT) {
 				/* PUK has not yet been verified */
 				r = npa_pace_verify(card, PACE_PIN_ID_PUK, &(data->pin1), NULL,
-						0, NULL);
+						0);
 				if (r != SC_SUCCESS)
 					goto err;
 			}
@@ -756,7 +747,7 @@ static int npa_pin_cmd(struct sc_card *card,
 				case PACE_PIN_ID_MRZ:
 				case PACE_PIN_ID_PIN:
 					r = npa_pace_verify(card, data->pin_reference,
-							&(data->pin1), NULL, 0, tries_left);
+							&(data->pin1), NULL, 0);
 					if (r != SC_SUCCESS)
 						goto err;
 					break;
@@ -768,7 +759,7 @@ static int npa_pin_cmd(struct sc_card *card,
 					 * unlocked, see npa_init().
 					 *
 					 * Now, verify the QES PIN. */
-					r = npa_standard_pin_cmd(card, data, tries_left);
+					r = npa_standard_pin_cmd(card, data);
 					if (r != SC_SUCCESS)
 						goto err;
 					break;

--- a/src/libopensc/card-nqApplet.c
+++ b/src/libopensc/card-nqApplet.c
@@ -451,17 +451,17 @@ static int nqapplet_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 }
 
 static int
-nqapplet_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+nqapplet_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
-	r = iso_operations->pin_cmd(card, data, tries_left);
+	r = iso_operations->pin_cmd(card, data);
 	if (r == SC_ERROR_OBJECT_NOT_FOUND) {
 		/* it is possible that the NQ-Applet is not active, try to activate it */
 		r = select_nqapplet(card, NULL, NULL, NULL, 0, NULL);
 		if (r == SC_SUCCESS) {
-			r = iso_operations->pin_cmd(card, data, tries_left);
+			r = iso_operations->pin_cmd(card, data);
 		}
 	}
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -122,9 +122,9 @@ static int auth_read_component(struct sc_card *card,
 static int auth_pin_is_verified(struct sc_card *card, int pin_reference,
 		int *tries_left);
 static int auth_pin_verify(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left);
+		struct sc_pin_cmd_data *data);
 static int auth_pin_reset(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left);
+		struct sc_pin_cmd_data *data);
 static int auth_create_reference_data (struct sc_card *card,
 		struct sc_cardctl_oberthur_createpin_info *args);
 static int auth_get_serialnr(struct sc_card *card, struct sc_serial_number *serial);
@@ -1564,8 +1564,8 @@ auth_pin_verify_pinpad(struct sc_card *card, int pin_reference, int *tries_left)
 	memset(ffs1, 0xFF, sizeof(ffs1));
 	memset(&pin_cmd, 0, sizeof(pin_cmd));
 
-        rv = auth_pin_is_verified(card, pin_reference, tries_left);
-    	sc_log(card->ctx, "auth_pin_is_verified returned rv %i", rv);
+	rv = auth_pin_is_verified(card, pin_reference, tries_left);
+	sc_log(card->ctx, "auth_pin_is_verified returned rv %i", rv);
 
 	/* Return SUCCESS without verifying if
 	 * PIN has been already verified and PIN pad has to be used. */
@@ -1599,7 +1599,7 @@ auth_pin_verify_pinpad(struct sc_card *card, int pin_reference, int *tries_left)
 	pin_cmd.pin1.len = OBERTHUR_AUTH_MAX_LENGTH_PIN;
 	pin_cmd.pin1.pad_length = OBERTHUR_AUTH_MAX_LENGTH_PIN;
 
-	rv = iso_drv->ops->pin_cmd(card, &pin_cmd, tries_left);
+	rv = iso_drv->ops->pin_cmd(card, &pin_cmd);
 	LOG_TEST_RET(card->ctx, rv, "PIN CMD 'VERIFY' with pinpad failed");
 
 	LOG_FUNC_RETURN(card->ctx, rv);
@@ -1608,7 +1608,7 @@ auth_pin_verify_pinpad(struct sc_card *card, int pin_reference, int *tries_left)
 
 static int
 auth_pin_verify(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	int rv;
@@ -1627,7 +1627,7 @@ auth_pin_verify(struct sc_card *card, unsigned int type,
 			|| data->pin_reference == OBERTHUR_PIN_REFERENCE_ONETIME)
 		data->pin_reference  |= OBERTHUR_PIN_LOCAL;
 
-        rv = auth_pin_is_verified(card, data->pin_reference, tries_left);
+        rv = auth_pin_is_verified(card, data->pin_reference, &data->pin1.tries_left);
     	sc_log(card->ctx, "auth_pin_is_verified returned rv %i", rv);
 
 	/* Return if only PIN status has been asked. */
@@ -1640,9 +1640,9 @@ auth_pin_verify(struct sc_card *card, unsigned int type,
 		LOG_FUNC_RETURN(card->ctx, rv);
 
 	if (!data->pin1.data && !data->pin1.len)
-		rv = auth_pin_verify_pinpad(card, data->pin_reference, tries_left);
+		rv = auth_pin_verify_pinpad(card, data->pin_reference, &data->pin1.tries_left);
 	else
-		rv = iso_drv->ops->pin_cmd(card, data, tries_left);
+		rv = iso_drv->ops->pin_cmd(card, data);
 
 	LOG_FUNC_RETURN(card->ctx, rv);
 }
@@ -1675,8 +1675,7 @@ auth_pin_is_verified(struct sc_card *card, int pin_reference, int *tries_left)
 
 
 static int
-auth_pin_change_pinpad(struct sc_card *card, struct sc_pin_cmd_data *data,
-		int *tries_left)
+auth_pin_change_pinpad(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	struct sc_pin_cmd_data pin_cmd;
@@ -1724,7 +1723,7 @@ auth_pin_change_pinpad(struct sc_card *card, struct sc_pin_cmd_data *data,
 	pin_cmd.pin1.offset = 5;
 	pin_cmd.pin2.data = ffs2;
 
-	rv = iso_drv->ops->pin_cmd(card, &pin_cmd, tries_left);
+	rv = iso_drv->ops->pin_cmd(card, &pin_cmd);
 	LOG_TEST_RET(card->ctx, rv, "PIN CMD 'VERIFY' with pinpad failed");
 
 	LOG_FUNC_RETURN(card->ctx, rv);
@@ -1733,7 +1732,7 @@ auth_pin_change_pinpad(struct sc_card *card, struct sc_pin_cmd_data *data,
 
 static int
 auth_pin_change(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	int rv = SC_ERROR_INTERNAL;
@@ -1751,11 +1750,11 @@ auth_pin_change(struct sc_card *card, unsigned int type,
 		auth_init_pin_info(card, &data->pin1, OBERTHUR_AUTH_TYPE_PIN);
 		auth_init_pin_info(card, &data->pin2, OBERTHUR_AUTH_TYPE_PIN);
 
-		rv = iso_drv->ops->pin_cmd(card, data, tries_left);
+		rv = iso_drv->ops->pin_cmd(card, data);
 		LOG_TEST_RET(card->ctx, rv, "CMD 'PIN CHANGE' failed");
 	} else if (!data->pin1.len && !data->pin2.len) {
 		/* Oberthur unblock style with PIN pad. */
-		rv = auth_pin_change_pinpad(card, data, tries_left);
+		rv = auth_pin_change_pinpad(card, data);
 		LOG_TEST_RET(card->ctx, rv, "'PIN CHANGE' failed: SOPIN verify with pinpad failed");
 	} else {
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "'PIN CHANGE' failed");
@@ -1767,7 +1766,7 @@ auth_pin_change(struct sc_card *card, unsigned int type,
 
 static int
 auth_pin_reset_oberthur_style(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	struct sc_pin_cmd_data pin_cmd;
@@ -1793,7 +1792,7 @@ auth_pin_reset_oberthur_style(struct sc_card *card, unsigned int type,
 	pin_cmd.pin_reference = OBERTHUR_PIN_REFERENCE_PUK;
 	memcpy(&pin_cmd.pin1, &data->pin1, sizeof(pin_cmd.pin1));
 
-	rv = auth_pin_verify(card, SC_AC_CHV, &pin_cmd, tries_left);
+	rv = auth_pin_verify(card, SC_AC_CHV, &pin_cmd);
 	LOG_TEST_RET(card->ctx, rv, "Oberthur style 'PIN RESET' failed: SOPIN verify error");
 
 	sc_format_path("2000", &tmp_path);
@@ -1825,7 +1824,7 @@ auth_pin_reset_oberthur_style(struct sc_card *card, unsigned int type,
 
 	if (data->pin2.data) {
 		memcpy(&pin_cmd.pin2, &data->pin2, sizeof(pin_cmd.pin2));
-		rv = auth_pin_reset(card, SC_AC_CHV, &pin_cmd, tries_left);
+		rv = auth_pin_reset(card, SC_AC_CHV, &pin_cmd);
 		LOG_FUNC_RETURN(card->ctx, rv);
 	}
 
@@ -1849,7 +1848,7 @@ auth_pin_reset_oberthur_style(struct sc_card *card, unsigned int type,
 	pin_cmd.pin2.max_length = 8;
 	pin_cmd.pin2.encoding = SC_PIN_ENCODING_ASCII;
 
-	rvv = iso_drv->ops->pin_cmd(card, &pin_cmd, tries_left);
+	rvv = iso_drv->ops->pin_cmd(card, &pin_cmd);
 	if (rvv)
 		sc_log(card->ctx,
 				"%s: PIN CMD 'VERIFY' with pinpad failed",
@@ -1874,14 +1873,14 @@ auth_pin_reset_oberthur_style(struct sc_card *card, unsigned int type,
 
 static int
 auth_pin_reset(struct sc_card *card, unsigned int type,
-		struct sc_pin_cmd_data *data, int *tries_left)
+		struct sc_pin_cmd_data *data)
 {
 	int rv;
 
 	LOG_FUNC_CALLED(card->ctx);
 
 	/* Oberthur unblock style: PUK value is a SOPIN */
-	rv = auth_pin_reset_oberthur_style(card, SC_AC_CHV, data, tries_left);
+	rv = auth_pin_reset_oberthur_style(card, SC_AC_CHV, data);
 	LOG_TEST_RET(card->ctx, rv, "Oberthur style 'PIN RESET' failed");
 
 	LOG_FUNC_RETURN(card->ctx, rv);
@@ -1889,7 +1888,7 @@ auth_pin_reset(struct sc_card *card, unsigned int type,
 
 
 static int
-auth_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+auth_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	int rv = SC_ERROR_INTERNAL;
 
@@ -1902,15 +1901,15 @@ auth_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left
 			data->pin2.data, data->pin2.len);
 	switch (data->cmd) {
 	case SC_PIN_CMD_VERIFY:
-		rv = auth_pin_verify(card, SC_AC_CHV, data, tries_left);
+		rv = auth_pin_verify(card, SC_AC_CHV, data);
 		LOG_TEST_RET(card->ctx, rv, "CMD 'PIN VERIFY' failed");
 		break;
 	case SC_PIN_CMD_CHANGE:
-		rv = auth_pin_change(card, SC_AC_CHV, data, tries_left);
+		rv = auth_pin_change(card, SC_AC_CHV, data);
 		LOG_TEST_RET(card->ctx, rv, "CMD 'PIN VERIFY' failed");
 		break;
 	case SC_PIN_CMD_UNBLOCK:
-		rv = auth_pin_reset(card, SC_AC_CHV, data, tries_left);
+		rv = auth_pin_reset(card, SC_AC_CHV, data);
 		LOG_TEST_RET(card->ctx, rv, "CMD 'PIN VERIFY' failed");
 		break;
 	default:

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -2300,7 +2300,7 @@ out:
 }
 
 static int
-pgp_kdf_do_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+pgp_kdf_do_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r = SC_ERROR_INVALID_ARGUMENTS;
 	struct pgp_priv_data *priv = DRVDATA(card);
@@ -2322,7 +2322,7 @@ pgp_kdf_do_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_lef
 	case SC_PIN_CMD_UNBLOCK:
 		break;
 	default:
-		LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data, tries_left));
+		LOG_FUNC_RETURN(card->ctx, iso_ops->pin_cmd(card, data));
 	}
 	if (!info) {
 		return r;
@@ -2365,7 +2365,7 @@ pgp_kdf_do_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_lef
 	}
 
 	if (r == SC_SUCCESS) {
-		r = iso_ops->pin_cmd(card, data, tries_left);
+		r = iso_ops->pin_cmd(card, data);
 	}
 	if (pin1_derived) {
 		data->pin1.data = pin1;
@@ -2385,7 +2385,7 @@ pgp_kdf_do_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_lef
  * ABI: ISO 7816-9 PIN CMD - verify/change/unblock a PIN.
  */
 static int
-pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	struct pgp_priv_data *priv = DRVDATA(card);
 	struct sc_card_operations ops = {.pin_cmd = iso_ops->pin_cmd};
@@ -2482,10 +2482,8 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 		data->pin1.tries_left = c4data[3 + (data->pin_reference & 0x0F)];
 		data->pin1.max_tries = 3;
 		data->pin1.logged_in = SC_PIN_STATE_UNKNOWN;
-		if (tries_left != NULL)
-			*tries_left = data->pin1.tries_left;
 
-                LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 	}
 
 #ifdef ENABLE_OPENSSL
@@ -2494,7 +2492,7 @@ pgp_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	}
 #endif /* ENABLE_OPENSSL */
 
-	LOG_FUNC_RETURN(card->ctx, ops.pin_cmd(card, data, tries_left));
+	LOG_FUNC_RETURN(card->ctx, ops.pin_cmd(card, data));
 }
 
 

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -6040,7 +6040,7 @@ piv_check_protected_objects(sc_card_t *card)
 
 
 static int
-piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
+piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r = 0;
 	piv_private_data_t * priv = PIV_DATA(card);
@@ -6070,8 +6070,6 @@ piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	if (data->cmd == SC_PIN_CMD_GET_INFO) { /* fill in what we think it should be */
 		data->pin1.logged_in = priv->logged_in;
 		data->pin1.tries_left = priv->tries_left;
-		if (tries_left)
-			*tries_left = priv->tries_left;
 
 		/*
 		 * If called to check on the login state for a context specific login
@@ -6113,7 +6111,7 @@ piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 	}
 
 	priv->pin_cmd_verify = 1; /* tell piv_check_sw its a verify to save sw1, sw2 */
-	r = iso_drv->ops->pin_cmd(card, data, tries_left);
+	r = iso_drv->ops->pin_cmd(card, data);
 	priv->pin_cmd_verify = 0;
 
 	/* tell user verify not supported on contactless without VCI */
@@ -6139,7 +6137,7 @@ piv_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data, int *tries_left)
 		piv_find_aid(card);
 
 		priv->pin_cmd_verify = 1; /* tell piv_check_sw its a verify to save sw1, sw2 */
-		r = iso_drv->ops->pin_cmd(card, data, tries_left);
+		r = iso_drv->ops->pin_cmd(card, data);
 		priv->pin_cmd_verify = 0;
 	}
 

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -343,8 +343,7 @@ static int sc_hsm_soc_select_minbioclient(sc_card_t *card)
 	return iso7816_select_aid(card, minBioClient_aid.value, minBioClient_aid.len, NULL, NULL);
 }
 
-static int sc_hsm_soc_change(sc_card_t *card, struct sc_pin_cmd_data *data,
-			   int *tries_left)
+static int sc_hsm_soc_change(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	sc_apdu_t apdu;
 	sc_path_t path;
@@ -410,8 +409,7 @@ err:
 	return r;
 }
 
-static int sc_hsm_soc_unblock(sc_card_t *card, struct sc_pin_cmd_data *data,
-			   int *tries_left)
+static int sc_hsm_soc_unblock(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	sc_apdu_t apdu;
 	sc_path_t path;
@@ -449,8 +447,7 @@ err:
 	return r;
 }
 
-static int sc_hsm_soc_biomatch(sc_card_t *card, struct sc_pin_cmd_data *data,
-			   int *tries_left)
+static int sc_hsm_soc_biomatch(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	sc_apdu_t apdu;
 	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
@@ -615,8 +612,7 @@ static int sc_hsm_perform_chip_authentication(sc_card_t *card)
 
 
 
-static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-			   int *tries_left)
+static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	sc_hsm_private_data_t *priv = (sc_hsm_private_data_t *) card->drv_data;
 	sc_apdu_t apdu;
@@ -640,12 +636,12 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		   	&& (data->cmd == SC_PIN_CMD_CHANGE)
 		   	&& (data->pin_reference == 0x81)
 			&& (!data->pin1.data || data->pin1.len <= 0)) {
-		return sc_hsm_soc_change(card, data, tries_left);
+		return sc_hsm_soc_change(card, data);
 	} else if ((card->caps & SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH)
 		   	&& (data->cmd == SC_PIN_CMD_UNBLOCK)
 		   	&& (data->pin_reference == 0x81)
 			&& (!data->pin1.data || data->pin1.len <= 0)) {
-		return sc_hsm_soc_unblock(card, data, tries_left);
+		return sc_hsm_soc_unblock(card, data);
 	}
 
 #ifdef ENABLE_SM
@@ -664,7 +660,7 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		r = SC_ERROR_NOT_ALLOWED;
 		if (card->sm_ctx.sm_mode == SM_MODE_TRANSMIT) {
 			/* check if the existing SM channel is still valid */
-			r = sc_pin_cmd(card, &check_sm_pin_data, NULL);
+			r = sc_pin_cmd(card, &check_sm_pin_data);
 		}
 		if (r == SC_ERROR_ASN1_OBJECT_NOT_FOUND || r == SC_ERROR_NOT_ALLOWED) {
 			/* need to establish a new SM channel */
@@ -679,7 +675,7 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 			&& (data->cmd == SC_PIN_CMD_VERIFY)
 			&& (data->pin_reference == 0x81)
 			&& (!data->pin1.data || data->pin1.len <= 0)) {
-		r = sc_hsm_soc_biomatch(card, data, tries_left);
+		r = sc_hsm_soc_biomatch(card, data);
 	} else {
 		if ((data->cmd == SC_PIN_CMD_VERIFY) && (data->pin_reference == 0x88)) {
 			if (data->pin1.len != 16)
@@ -724,7 +720,7 @@ static int sc_hsm_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		data->pin1.offset = 5;
 		data->pin2.offset = 5;
 
-		r = (*iso_ops->pin_cmd)(card, data, tries_left);
+		r = (*iso_ops->pin_cmd)(card, data);
 		data->apdu = NULL;
 	}
 	LOG_TEST_RET(card->ctx, r, "Verification failed");
@@ -1316,7 +1312,7 @@ static int sc_hsm_initialize(sc_card_t *card, sc_cardctl_sc_hsm_init_param_t *pa
 		pincmd.pin1.data = params->user_pin;
 		pincmd.pin1.len = params->user_pin_len;
 
-		r = (*iso_ops->pin_cmd)(card, &pincmd, NULL);
+		r = (*iso_ops->pin_cmd)(card, &pincmd);
 		LOG_TEST_RET(ctx, r, "Could not verify PIN");
 
 		r = sc_hsm_write_ef(card, 0x2F03, 0, p, tilen);

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -2075,8 +2075,7 @@ static int starcos_logout(sc_card_t *card)
 	return sc_check_sw(card, apdu.sw1, apdu.sw2);
 }
 
-static int starcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-			    int *tries_left)
+static int starcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r;
 
@@ -2086,7 +2085,7 @@ static int starcos_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 		data->flags |= SC_PIN_CMD_NEED_PADDING;
 		data->pin1.encoding = ex_data->pin_encoding;
 	}
-	r = iso_ops->pin_cmd(card, data, tries_left);
+	r = iso_ops->pin_cmd(card, data);
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, r);
 }
 

--- a/src/libopensc/iasecc-sdo.h
+++ b/src/libopensc/iasecc-sdo.h
@@ -322,7 +322,7 @@ int iasecc_docp_copy(struct sc_context *, struct iasecc_sdo_docp *, struct iasec
 int iasecc_se_get_info(struct sc_card *card, struct iasecc_se_info *se);
 
 int iasecc_sm_external_authentication(struct sc_card *card, unsigned skey_ref, int *tries_left);
-int iasecc_sm_pin_verify(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_data *data, int *tries_left);
+int iasecc_sm_pin_verify(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_data *data);
 int iasecc_sm_pin_reset(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_data *data);
 int iasecc_sm_update_binary(struct sc_card *card, unsigned se_num, size_t offs, const unsigned char *buff, size_t count);
 int iasecc_sm_read_binary(struct sc_card *card, unsigned se_num, size_t offs, unsigned char *buff, size_t count);

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -447,7 +447,7 @@ iasecc_sm_rsa_update(struct sc_card *card, unsigned se_num, struct iasecc_sdo_rs
 
 
 int
-iasecc_sm_pin_verify(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_data *data, int *tries_left)
+iasecc_sm_pin_verify(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_data *data)
 {
 	struct sc_context *ctx = card->ctx;
 #ifdef ENABLE_SM
@@ -465,9 +465,9 @@ iasecc_sm_pin_verify(struct sc_card *card, unsigned se_num, struct sc_pin_cmd_da
 
 	sc_remote_data_init(&rdata);
 	rv = iasecc_sm_cmd(card, &rdata);
-	if (rv && rdata.length && tries_left)
+	if (rv && rdata.length)
 		if (rdata.data->apdu.sw1 == 0x63 && (rdata.data->apdu.sw2 & 0xF0) == 0xC0)
-			*tries_left = rdata.data->apdu.sw2 & 0x0F;
+			data->pin1.tries_left = rdata.data->apdu.sw2 & 0x0F;
 
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_pin_verify() SM 'PIN VERIFY' failed");
 

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1281,16 +1281,13 @@ iso7816_build_pin_apdu(struct sc_card *card, struct sc_apdu *apdu,
 
 
 static int
-iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_left)
+iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 {
 	struct sc_apdu local_apdu, *apdu;
 	int r;
 	u8  sbuf[SC_MAX_APDU_BUFFER_SIZE];
 
 	data->pin1.tries_left = -1;
-	if (tries_left != NULL) {
-		*tries_left = data->pin1.tries_left;
-	}
 
 	/* Many cards do support PIN status queries, but some cards don't and
 	 * mistakenly count the command as a failed PIN attempt, so for now we
@@ -1359,9 +1356,6 @@ iso7816_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data, int *tries_l
 		data->pin1.logged_in = SC_PIN_STATE_LOGGED_OUT;
 		if (data->cmd == SC_PIN_CMD_GET_INFO)
 			r = SC_SUCCESS;
-	}
-	if (tries_left != NULL) {
-		*tries_left = data->pin1.tries_left;
 	}
 
 	return r;

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -800,8 +800,7 @@ struct sc_card_operations {
 	/* pin_cmd: verify/change/unblock command; optionally using the
 	 * card's pin pad if supported.
 	 */
-	int (*pin_cmd)(struct sc_card *, struct sc_pin_cmd_data *,
-				int *tries_left);
+	int (*pin_cmd)(struct sc_card *, struct sc_pin_cmd_data *);
 
 	int (*get_data)(struct sc_card *, unsigned int, u8 *, size_t);
 	int (*put_data)(struct sc_card *, unsigned int, const u8 *, size_t);
@@ -1389,7 +1388,7 @@ int sc_verify(struct sc_card *card, unsigned int type, int ref, const u8 *pin,
  *         doesn't support a logout command and an error code otherwise
  */
 int sc_logout(struct sc_card *card);
-int sc_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *, int *tries_left);
+int sc_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *);
 int sc_change_reference_data(struct sc_card *card, unsigned int type,
 			     int ref, const u8 *old, size_t oldlen,
 			     const u8 *newref, size_t newlen,

--- a/src/libopensc/pkcs15-din-66291.c
+++ b/src/libopensc/pkcs15-din-66291.c
@@ -68,7 +68,7 @@ sc_pkcs15emu_din_66291_init(sc_pkcs15_card_t *p15card)
     data.pin_type = SC_AC_CHV;
     data.pin_reference = user_pin_ref;
 
-    if (SC_SUCCESS == sc_pin_cmd(p15card->card, &data, NULL)) {
+    if (SC_SUCCESS == sc_pin_cmd(p15card->card, &data)) {
         const unsigned char user_pin_id = 1;
 
         for (i = 0; i < 2; i++) {

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -182,7 +182,7 @@ static int sc_pkcs15emu_gids_init (sc_pkcs15_card_t * p15card)
 	pin_cmd_data.pin_type = SC_AC_CHV;
 	pin_cmd_data.pin_reference = pin_info.attrs.pin.reference;
 
-	r = sc_pin_cmd(card, &pin_cmd_data, NULL);
+	r = sc_pin_cmd(card, &pin_cmd_data);
 	if (r == SC_SUCCESS) {
 		pin_info.max_tries = pin_cmd_data.pin1.max_tries;
 		pin_info.tries_left = pin_cmd_data.pin1.tries_left;
@@ -196,7 +196,7 @@ static int sc_pkcs15emu_gids_init (sc_pkcs15_card_t * p15card)
 	 * link PIN with PUK.
 	 */
 	pin_cmd_data.pin_reference = 0x81;
-	has_puk = sc_pin_cmd(card, &pin_cmd_data, NULL) == SC_SUCCESS;
+	has_puk = sc_pin_cmd(card, &pin_cmd_data) == SC_SUCCESS;
 	if (has_puk) {
 		pin_obj.auth_id.len = 1;
 		pin_obj.auth_id.value[0] = 0x81;

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -142,7 +142,8 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		pin_cmd_data.cmd = SC_PIN_CMD_GET_INFO;
 		pin_cmd_data.pin_type = SC_AC_CHV;
 		pin_cmd_data.pin_reference = jpki_pin_ref[i];
-		rc = sc_pin_cmd(card, &pin_cmd_data, &pin_info.tries_left);
+		rc = sc_pin_cmd(card, &pin_cmd_data);
+		pin_info.tries_left = pin_cmd_data.pin1.tries_left;
 		LOG_TEST_RET(card->ctx, rc, "sc_pin_cmd failed");
 		strlcpy(pin_obj.label, jpki_pin_names[i], sizeof(pin_obj.label));
 		pin_obj.flags = jpki_pin_flags[i];

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -439,7 +439,8 @@ int sc_pkcs15_verify_pin_with_session_pin(struct sc_pkcs15_card *p15card,
 			goto out;
 	}
 
-	r = sc_pin_cmd(card, &data, &auth_info->tries_left);
+	r = sc_pin_cmd(card, &data);
+	auth_info->tries_left = data.pin1.tries_left;
 	sc_log(ctx, "PIN cmd result %i", r);
 	if (r == SC_SUCCESS) {
 		sc_pkcs15_pincache_add(p15card, pin_obj, pincode, pinlen);
@@ -548,7 +549,8 @@ int sc_pkcs15_change_pin(struct sc_pkcs15_card *p15card,
 		}
 	}
 
-	r = sc_pin_cmd(card, &data, &auth_info->tries_left);
+	r = sc_pin_cmd(card, &data);
+	auth_info->tries_left = data.pin1.tries_left;
 	if (r == SC_SUCCESS)
 		sc_pkcs15_pincache_add(p15card, pin_obj, newpin, newpinlen);
 
@@ -674,7 +676,8 @@ int sc_pkcs15_unblock_pin(struct sc_pkcs15_card *p15card,
 		}
 	}
 
-	r = sc_pin_cmd(card, &data, &auth_info->tries_left);
+	r = sc_pin_cmd(card, &data);
+	auth_info->tries_left = data.pin1.tries_left;
 	if (r == SC_SUCCESS)
 		sc_pkcs15_pincache_add(p15card, pin_obj, newpin, newpinlen);
 
@@ -716,11 +719,10 @@ int sc_pkcs15_get_pin_info(struct sc_pkcs15_card *p15card,
 	data.pin_type = pin_info->auth_method;
 	data.pin_reference = pin_info->attrs.pin.reference;
 
-	r = sc_pin_cmd(card, &data, NULL);
+	r = sc_pin_cmd(card, &data);
 	if (r == SC_SUCCESS) {
 		if (data.pin1.max_tries > 0)
 			pin_info->max_tries = data.pin1.max_tries;
-		/* tries_left must be supported or sc_pin_cmd should not return SC_SUCCESS */
 		pin_info->tries_left = data.pin1.tries_left;
 		pin_info->logged_in = data.pin1.logged_in;
 	}

--- a/src/libopensc/pkcs15-pteid.c
+++ b/src/libopensc/pkcs15-pteid.c
@@ -274,7 +274,7 @@ static int sc_pkcs15emu_pteid_init(sc_pkcs15_card_t * p15card)
 			pin_cmd_data.cmd = SC_PIN_CMD_GET_INFO;
 			pin_cmd_data.pin_type = pin_info->attrs.pin.type;
 			pin_cmd_data.pin_reference = pin_info->attrs.pin.reference;
-			rv = sc_pin_cmd(p15card->card, &pin_cmd_data, NULL);
+			rv = sc_pin_cmd(p15card->card, &pin_cmd_data);
 			if (rv == SC_SUCCESS) {
 				pin_info->tries_left = pin_cmd_data.pin1.tries_left;
 				pin_info->logged_in = pin_cmd_data.pin1.logged_in;

--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -1554,7 +1554,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 		pindata.pin_type = SC_AC_CHV;
 		pindata.pin_reference = 0x85;
 
-		r = sc_pin_cmd(card, &pindata, NULL);
+		r = sc_pin_cmd(card, &pindata);
 	}
 	if (r == SC_ERROR_DATA_OBJECT_NOT_FOUND) {
 		memset(&pindata, 0, sizeof(pindata));
@@ -1562,7 +1562,7 @@ static int sc_pkcs15emu_sc_hsm_init (sc_pkcs15_card_t * p15card)
 		pindata.pin_type = SC_AC_CHV;
 		pindata.pin_reference = 0x86;
 
-		r = sc_pin_cmd(card, &pindata, NULL);
+		r = sc_pin_cmd(card, &pindata);
 	}
 
 	if ((r != SC_ERROR_DATA_OBJECT_NOT_FOUND) && (r != SC_ERROR_INCORRECT_PARAMETERS) && (r != SC_ERROR_REF_DATA_NOT_USABLE))

--- a/src/libopensc/pkcs15-srbeid.c
+++ b/src/libopensc/pkcs15-srbeid.c
@@ -436,16 +436,15 @@ sc_pkcs15emu_srbeid_init(sc_pkcs15_card_t *p15card)
 	/* Query PIN tries_left via card driver's pin_cmd. */
 	{
 		struct sc_pin_cmd_data pin_data = {0};
-		int pin_tries_left = -1;
 
 		pin_data.cmd = SC_PIN_CMD_GET_INFO;
 		pin_data.pin_type = SC_AC_CHV;
 		pin_data.pin_reference = CE_PIN_REFERENCE;
+		pin_data.pin1.tries_left = -1;
 
 		/* Best-effort: failure to query PIN status is not fatal. */
-		if (sc_pin_cmd(card, &pin_data, &pin_tries_left) >= 0 && pin_tries_left < 0)
-			pin_tries_left = pin_data.pin1.tries_left;
-		sc_log(card->ctx, "srbeid: PIN tries_left=%d", pin_tries_left);
+		sc_pin_cmd(card, &pin_data);
+		sc_log(card->ctx, "srbeid: PIN tries_left=%d", pin_data.pin1.tries_left);
 
 		/* ---- PIN auth object ----
 		 * Must be registered before private keys so auth_id links work. */
@@ -455,7 +454,7 @@ sc_pkcs15emu_srbeid_init(sc_pkcs15_card_t *p15card)
 
 			auth_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
 			auth_info.auth_method = SC_AC_CHV;
-			auth_info.tries_left = pin_tries_left;
+			auth_info.tries_left = pin_data.pin1.tries_left;
 			auth_info.attrs.pin.reference = CE_PIN_REFERENCE;
 			auth_info.attrs.pin.min_length = 4;
 			auth_info.attrs.pin.max_length = CE_PIN_MAX_LENGTH;

--- a/src/libopensc/sec.c
+++ b/src/libopensc/sec.c
@@ -138,7 +138,11 @@ int sc_verify(sc_card_t *card, unsigned int type, int ref,
 	data.pin1.data = pin;
 	data.pin1.len = pinlen;
 
-	return sc_pin_cmd(card, &data, tries_left);
+	int r = sc_pin_cmd(card, &data);
+	if (tries_left)
+		*tries_left = data.pin1.tries_left;
+
+	return r;
 }
 
 int sc_logout(sc_card_t *card)
@@ -164,7 +168,11 @@ int sc_change_reference_data(sc_card_t *card, unsigned int type,
 	data.pin2.data = newref;
 	data.pin2.len = newlen;
 
-	return sc_pin_cmd(card, &data, tries_left);
+	int r = sc_pin_cmd(card, &data);
+	if (tries_left)
+		*tries_left = data.pin1.tries_left;
+
+	return r;
 }
 
 int sc_reset_retry_counter(sc_card_t *card, unsigned int type, int ref,
@@ -182,7 +190,7 @@ int sc_reset_retry_counter(sc_card_t *card, unsigned int type, int ref,
 	data.pin2.data = newref;
 	data.pin2.len = newlen;
 
-	return sc_pin_cmd(card, &data, NULL);
+	return sc_pin_cmd(card, &data);
 }
 
 /*
@@ -192,8 +200,7 @@ int sc_reset_retry_counter(sc_card_t *card, unsigned int type, int ref,
  * send this PIN to the card. If no PIN was given, the driver should
  * ask the reader to obtain the pin(s) via the pin pad
  */
-int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
-		int *tries_left)
+int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	int r, debug;
 
@@ -209,7 +216,7 @@ int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 	}
 
 	if (card->ops->pin_cmd) {
-		r = card->ops->pin_cmd(card, data, tries_left);
+		r = card->ops->pin_cmd(card, data);
 	} else if (!(data->flags & SC_PIN_CMD_USE_PINPAD)) {
 		/* Card driver doesn't support new style pin_cmd, fall
 		 * back to old interface */
@@ -223,7 +230,7 @@ int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 					data->pin_reference,
 					data->pin1.data,
 					(size_t) data->pin1.len,
-					tries_left);
+					&data->pin1.tries_left);
 			break;
 		case SC_PIN_CMD_CHANGE:
 			if (card->ops->change_reference_data != NULL)
@@ -234,7 +241,7 @@ int sc_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data,
 					(size_t) data->pin1.len,
 					data->pin2.data,
 					(size_t) data->pin2.len,
-					tries_left);
+					&data->pin1.tries_left);
 			break;
 		case SC_PIN_CMD_UNBLOCK:
 			if (card->ops->reset_retry_counter != NULL)

--- a/src/pkcs15init/pkcs15-cflex.c
+++ b/src/pkcs15init/pkcs15-cflex.c
@@ -588,7 +588,7 @@ cflex_create_pin_file(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		pin_cmd.pin1.data = dummy_pin_value;
 		pin_cmd.pin1.len = sizeof(dummy_pin_value);
 
-		r = sc_pin_cmd(p15card->card, &pin_cmd, NULL);
+		r = sc_pin_cmd(p15card->card, &pin_cmd);
 		if (r < 0)
 			sc_file_free(file);
 		LOG_TEST_RET(ctx, r, "Cannot verify dummy PIN");

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -4049,7 +4049,7 @@ found:
 		pin_cmd.pin1.data = use_pinpad ? NULL : pinbuf;
 		pin_cmd.pin1.len = use_pinpad ? 0: pinsize;
 
-		r = sc_pin_cmd(p15card->card, &pin_cmd, NULL);
+		r = sc_pin_cmd(p15card->card, &pin_cmd);
 		LOG_TEST_RET(ctx, r, "'VERIFY' pin cmd failed");
 	}
 

--- a/src/tools/dtrust-tool.c
+++ b/src/tools/dtrust-tool.c
@@ -211,20 +211,19 @@ pin_status(sc_card_t *card, int ref, const char *pin_label, unsigned char transp
 {
 	int r;
 	struct sc_pin_cmd_data data;
-	int tries_left = 0;
 
 	memset(&data, 0, sizeof(data));
 	data.cmd = SC_PIN_CMD_GET_INFO;
 	data.pin_type = SC_AC_CHV;
 	data.pin_reference = ref;
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 
 	if (r == SC_SUCCESS) {
-		if (tries_left < 0)
+		if (data.pin1.tries_left < 0)
 			printf("%s: usable\n", pin_label);
 		else
-			printf("%s: usable (%d tries left)\n", pin_label, tries_left);
+			printf("%s: usable (%d tries left)\n", pin_label, data.pin1.tries_left);
 	} else if (r == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED)
 		printf("%s: not usable (transport protection still in force)\n", pin_label);
 	else if (r == SC_ERROR_AUTH_METHOD_BLOCKED)
@@ -292,7 +291,6 @@ unlock_transport_protection4(sc_card_t *card)
 	int r;
 	char *tpin = NULL;
 	char *qespin = NULL;
-	int tries_left;
 
 	memset(&data, 0, sizeof(data));
 	data.cmd = SC_PIN_CMD_CHANGE;
@@ -323,12 +321,12 @@ unlock_transport_protection4(sc_card_t *card)
 		data.pin2.len = strlen(qespin);
 	}
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 
 	if (r == SC_SUCCESS)
 		printf("Transport protection removed. You can now use your Signature PIN.\n");
 	else if (r == SC_ERROR_PIN_CODE_INCORRECT)
-		printf("Wrong pin. %d attempts left.\n", tries_left);
+		printf("Wrong pin. %d attempts left.\n", data.pin1.tries_left);
 	else
 		printf("Can't change pin: %s\n", sc_strerror(r));
 
@@ -352,7 +350,6 @@ unlock_transport_protection5(sc_card_t *card, int ref_pace, int ref_pin, const c
 	struct sc_pin_cmd_data data;
 	char *tpin = NULL;
 	char *newpin = NULL;
-	int tries_left;
 
 	printf("Unlocking %s\n", pin_label);
 
@@ -387,11 +384,11 @@ unlock_transport_protection5(sc_card_t *card, int ref_pace, int ref_pin, const c
 		data.pin1.len = strlen(tpin);
 	}
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 	if (r) {
 		fprintf(stderr, "Error verifying Transport PIN: %s\n", sc_strerror(r));
-		if (tries_left >= 0)
-			fprintf(stderr, "%d attempts left.\n", tries_left);
+		if (data.pin1.tries_left >= 0)
+			fprintf(stderr, "%d attempts left.\n", data.pin1.tries_left);
 		goto fail;
 	}
 
@@ -424,7 +421,7 @@ unlock_transport_protection5(sc_card_t *card, int ref_pace, int ref_pin, const c
 	 * continue as long as the new PIN is set successfully or the user
 	 * aborts the program and renders its card unusable as a consequence. */
 	do {
-		r = sc_pin_cmd(card, &data, NULL);
+		r = sc_pin_cmd(card, &data);
 		if (r == SC_SUCCESS) {
 			printf("Transport protection removed. You can now use your %s.\n", pin_label);
 			break;
@@ -457,7 +454,6 @@ change_pin(sc_card_t *card, int ref_verify, int ref_change)
 	char *newpin = NULL;
 	sc_path_t path;
 	int r;
-	int tries_left;
 
 	memset(&data_verify, 0, sizeof(struct sc_pin_cmd_data));
 	memset(&data_change, 0, sizeof(struct sc_pin_cmd_data));
@@ -573,11 +569,11 @@ change_pin(sc_card_t *card, int ref_verify, int ref_change)
 		goto fail;
 	}
 
-	r = sc_pin_cmd(card, &data_verify, &tries_left);
+	r = sc_pin_cmd(card, &data_verify);
 	if (r) {
 		fprintf(stderr, "Error verifying PIN: %s\n", sc_strerror(r));
-		if (tries_left >= 0)
-			fprintf(stderr, "%d attempts left.\n", tries_left);
+		if (data_verify.pin1.tries_left >= 0)
+			fprintf(stderr, "%d attempts left.\n", data_verify.pin1.tries_left);
 		goto fail;
 	}
 
@@ -589,7 +585,7 @@ change_pin(sc_card_t *card, int ref_verify, int ref_change)
 		}
 	}
 
-	r = sc_pin_cmd(card, &data_change, NULL);
+	r = sc_pin_cmd(card, &data_change);
 	if (r) {
 		fprintf(stderr, "Error changing PIN: %s\n", sc_strerror(r));
 		goto fail;
@@ -658,7 +654,7 @@ resume_pin(sc_card_t *card, int ref_pin)
 		goto fail;
 	}
 
-	r = sc_pin_cmd(card, &data, NULL);
+	r = sc_pin_cmd(card, &data);
 	if (r) {
 		fprintf(stderr, "Error resuming PIN: %s\n", sc_strerror(r));
 		goto fail;
@@ -677,7 +673,6 @@ unblock_pin(sc_card_t *card, int ref_pin)
 	char *puk = NULL;
 	sc_path_t path;
 	int r;
-	int tries_left;
 
 	memset(&data_verify, 0, sizeof(struct sc_pin_cmd_data));
 	memset(&data_unblock, 0, sizeof(struct sc_pin_cmd_data));
@@ -759,11 +754,11 @@ unblock_pin(sc_card_t *card, int ref_pin)
 		goto fail;
 	}
 
-	r = sc_pin_cmd(card, &data_verify, &tries_left);
+	r = sc_pin_cmd(card, &data_verify);
 	if (r) {
 		fprintf(stderr, "Error verifying PUK: %s\n", sc_strerror(r));
-		if (tries_left >= 0)
-			fprintf(stderr, "%d attempts left.\n", tries_left);
+		if (data_verify.pin1.tries_left >= 0)
+			fprintf(stderr, "%d attempts left.\n", data_verify.pin1.tries_left);
 		goto fail;
 	}
 
@@ -775,7 +770,7 @@ unblock_pin(sc_card_t *card, int ref_pin)
 		}
 	}
 
-	r = sc_pin_cmd(card, &data_unblock, NULL);
+	r = sc_pin_cmd(card, &data_unblock);
 	if (r) {
 		fprintf(stderr, "Error unblocking PIN: %s\n", sc_strerror(r));
 		goto fail;
@@ -939,7 +934,7 @@ main(int argc, char *argv[])
 		if (r)
 			goto out;
 
-		r = sc_pin_cmd(card, &data, NULL);
+		r = sc_pin_cmd(card, &data);
 		if (r) {
 			fprintf(stderr, "Error verifying CAN.\n");
 			goto out;

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -228,7 +228,7 @@ static int unblock(sc_card_t* card, const char *so_pin, const char *user_pin) {
 	data.pin2.len = strlen(_user_pin);
 	data.pin2.data = (unsigned char*) _user_pin;
 	data.pin_reference = 0x80;
-	r = sc_pin_cmd(card, &data, NULL);
+	r = sc_pin_cmd(card, &data);
 	if (r < 0) {
 		fprintf(stderr, "reset pin failed with %s\n", sc_strerror(r));
 		return -1;

--- a/src/tools/lteid-tool.c
+++ b/src/tools/lteid-tool.c
@@ -197,7 +197,7 @@ verify_and_cache_pace_can(sc_card_t *card, const char *opt_can)
 	can_verify_cmd.pin1.data = (unsigned char *)can;
 	can_verify_cmd.pin1.len = strlen(can);
 
-	rv = card->ops->pin_cmd(card, &can_verify_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &can_verify_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "CAN number verification failed: %s\nCheck the number and try again.\n", sc_strerror(rv));
@@ -249,7 +249,7 @@ change_pin(sc_card_t *card, const char *opt_pin)
 	pin_verify_cmd.pin1.data = (unsigned char *)pin;
 	pin_verify_cmd.pin1.len = strlen(pin);
 
-	rv = card->ops->pin_cmd(card, &pin_verify_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &pin_verify_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "PIN code verification failed: %s\n", sc_strerror(rv));
@@ -279,7 +279,7 @@ change_pin(sc_card_t *card, const char *opt_pin)
 	pace_pin_cmd.pin2.data = (unsigned char *)new_pin;
 	pace_pin_cmd.pin2.len = strlen(new_pin);
 
-	rv = card->ops->pin_cmd(card, &pace_pin_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &pace_pin_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "PIN for authentication change failed: %s\n", sc_strerror(rv));
@@ -304,7 +304,7 @@ change_pin(sc_card_t *card, const char *opt_pin)
 	qes_pin_cmd.pin2.data = (unsigned char *)new_pin;
 	qes_pin_cmd.pin2.len = strlen(new_pin);
 
-	rv = card->ops->pin_cmd(card, &qes_pin_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &qes_pin_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "PIN for signature change failed: %s\n", sc_strerror(rv));
@@ -366,7 +366,7 @@ resume(sc_pkcs15_card_t *p15card, const char *opt_can, const char *opt_pin)
 	if (opt_can)
 		can_verify_cmd.pin1.len = strlen(opt_can);
 
-	rv = card->ops->pin_cmd(card, &can_verify_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &can_verify_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "CAN code verification failed: %s\n", sc_strerror(rv));
@@ -428,7 +428,7 @@ unblock_using_puk(sc_pkcs15_card_t *p15card, const char *opt_puk)
 	puk_verify_cmd.pin1.data = (unsigned char *)puk;
 	puk_verify_cmd.pin1.len = strlen(puk);
 
-	rv = card->ops->pin_cmd(card, &puk_verify_cmd, NULL);
+	rv = card->ops->pin_cmd(card, &puk_verify_cmd);
 
 	if (rv != SC_SUCCESS) {
 		fprintf(stderr, "PUK code verification failed: %s\n", sc_strerror(rv));
@@ -441,7 +441,7 @@ unblock_using_puk(sc_pkcs15_card_t *p15card, const char *opt_puk)
 		pace_pin_cmd.pin_type = SC_AC_CHV;
 		pace_pin_cmd.pin_reference = PACE_PIN_ID_PIN;
 
-		rv = card->ops->pin_cmd(card, &pace_pin_cmd, NULL);
+		rv = card->ops->pin_cmd(card, &pace_pin_cmd);
 
 		if (rv != SC_SUCCESS) {
 			fprintf(stderr, "PIN for authentication reset failed: %s\n", sc_strerror(rv));
@@ -462,7 +462,7 @@ unblock_using_puk(sc_pkcs15_card_t *p15card, const char *opt_puk)
 			return rv;
 		}
 
-		rv = card->ops->pin_cmd(card, &qes_pin_cmd, NULL);
+		rv = card->ops->pin_cmd(card, &qes_pin_cmd);
 
 		if (rv != SC_SUCCESS) {
 			fprintf(stderr, "PIN for signature reset failed: %s\n", sc_strerror(rv));

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -576,7 +576,6 @@ int do_genkey(sc_card_t *card, u8 in_key_id, const char *keytype)
 int do_verify(sc_card_t *card, char *type, const char *in_pin)
 {
 	struct sc_pin_cmd_data data;
-	int tries_left;
 	int r;
 	if (!type || !in_pin)
 		return SC_ERROR_INVALID_ARGUMENTS;
@@ -597,7 +596,7 @@ int do_verify(sc_card_t *card, char *type, const char *in_pin)
 	data.pin_reference = type[3] - '0';
 	data.pin1.data = (unsigned char *) in_pin;
 	data.pin1.len = (int)strlen(in_pin);
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 	return r;
 }
 

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -1175,7 +1175,7 @@ static int do_pininfo(int argc, char **argv)
 		{ SC_AC_PRO,	"PRO"	},
 		{ SC_AC_NONE,	NULL, 	}
 	};
-	int r, tries_left = -1;
+	int r;
 	size_t i;
 	struct sc_pin_cmd_data data;
 	size_t prefix_len = 0;
@@ -1205,7 +1205,7 @@ static int do_pininfo(int argc, char **argv)
 
 	r = sc_lock(card);
 	if (r == SC_SUCCESS)
-		r = sc_pin_cmd(card, &data, &tries_left);
+		r = sc_pin_cmd(card, &data);
 	sc_unlock(card);
 
 	if (r) {
@@ -1227,8 +1227,8 @@ static int do_pininfo(int argc, char **argv)
 		}
 		printf("\n");
 	}
-	if (tries_left >= 0)
-		printf("%d tries left.\n", tries_left);
+	if (data.pin1.tries_left >= 0)
+		printf("%d tries left.\n", data.pin1.tries_left);
 	return 0;
 }
 
@@ -1241,7 +1241,7 @@ static int do_verify(int argc, char **argv)
 		{ SC_AC_PRO,	"PRO"	},
 		{ SC_AC_NONE,	NULL, 	}
 	};
-	int r, tries_left = -1;
+	int r;
 	u8 buf[SC_MAX_PIN_SIZE];
 	size_t buflen = sizeof(buf), i;
 	struct sc_pin_cmd_data data;
@@ -1307,13 +1307,13 @@ static int do_verify(int argc, char **argv)
 	}
 	r = sc_lock(card);
 	if (r == SC_SUCCESS)
-		r = sc_pin_cmd(card, &data, &tries_left);
+		r = sc_pin_cmd(card, &data);
 	sc_unlock(card);
 
 	if (r) {
 		if (r == SC_ERROR_PIN_CODE_INCORRECT) {
-			if (tries_left >= 0)
-				printf("Incorrect code, %d tries left.\n", tries_left);
+			if (data.pin1.tries_left >= 0)
+				printf("Incorrect code, %d tries left.\n", data.pin1.tries_left);
 			else
 				printf("Incorrect code.\n");
 		} else
@@ -1326,7 +1326,7 @@ static int do_verify(int argc, char **argv)
 
 static int do_change(int argc, char **argv)
 {
-	int ref, r, tries_left = -1;
+	int ref, r;
 	u8 oldpin[SC_MAX_PIN_SIZE];
 	u8 newpin[SC_MAX_PIN_SIZE];
 	size_t oldpinlen = 0;
@@ -1372,12 +1372,12 @@ static int do_change(int argc, char **argv)
 
 	r = sc_lock(card);
 	if (r == SC_SUCCESS)
-		r = sc_pin_cmd(card, &data, &tries_left);
+		r = sc_pin_cmd(card, &data);
 	sc_unlock(card);
 	if (r) {
 		if (r == SC_ERROR_PIN_CODE_INCORRECT) {
-			if (tries_left >= 0)
-				printf("Incorrect code, %d tries left.\n", tries_left);
+			if (data.pin1.tries_left >= 0)
+				printf("Incorrect code, %d tries left.\n", data.pin1.tries_left);
 			else
 				printf("Incorrect code.\n");
 		}
@@ -1437,7 +1437,7 @@ static int do_unblock(int argc, char **argv)
 
 	r = sc_lock(card);
 	if (r == SC_SUCCESS)
-		r = sc_pin_cmd(card, &data, NULL);
+		r = sc_pin_cmd(card, &data);
 	sc_unlock(card);
 	if (r) {
 		if (r == SC_ERROR_PIN_CODE_INCORRECT)

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -480,7 +480,7 @@ static void print_dkek_info(sc_cardctl_sc_hsm_dkek_t *dkekinfo)
 
 static void print_info(sc_card_t *card, sc_file_t *file)
 {
-	int r, tries_left;
+	int r;
 	struct sc_pin_cmd_data data;
 	sc_cardctl_sc_hsm_dkek_t dkekinfo;
 
@@ -508,14 +508,14 @@ static void print_info(sc_card_t *card, sc_file_t *file)
 		data.pin_type = SC_AC_CHV;
 		data.pin_reference = ID_SO_PIN;
 
-		r = sc_pin_cmd(card, &data, &tries_left);
+		r = sc_pin_cmd(card, &data);
 		if (r == SC_ERROR_DATA_OBJECT_NOT_FOUND) {
 			printf("SmartCard-HSM has never been initialized. Please use --initialize to set SO-PIN and user PIN.\n");
 		} else {
-			if (tries_left == 0) {
+			if (data.pin1.tries_left == 0) {
 				printf("SO-PIN locked\n");
 			} else {
-				printf("SO-PIN tries left    : %d\n", tries_left);
+				printf("SO-PIN tries left    : %d\n", data.pin1.tries_left);
 			}
 			/* Try to update PIN info from card */
 			memset(&data, 0, sizeof(data));
@@ -523,16 +523,16 @@ static void print_info(sc_card_t *card, sc_file_t *file)
 			data.pin_type = SC_AC_CHV;
 			data.pin_reference = ID_USER_PIN;
 
-			r = sc_pin_cmd(card, &data, &tries_left);
+			r = sc_pin_cmd(card, &data);
 			if (r == SC_ERROR_CARD_CMD_FAILED) {
 				printf("Public key authentication active.\n");
 			} else if (r == SC_ERROR_REF_DATA_NOT_USABLE) {
 				printf("Transport-PIN active. Please change to user selected PIN first.\n");
 			} else {
-				if (tries_left == 0) {
+				if (data.pin1.tries_left == 0) {
 					printf("User PIN locked\n");
 				} else {
-					printf("User PIN tries left  : %d\n", tries_left);
+					printf("User PIN tries left  : %d\n", data.pin1.tries_left);
 				}
 			}
 		}
@@ -543,15 +543,15 @@ static void print_info(sc_card_t *card, sc_file_t *file)
 		data.pin_type = SC_AC_CHV;
 		data.pin_reference = ID_USER_PIN;
 
-		r = sc_pin_cmd(card, &data, &tries_left);
+		r = sc_pin_cmd(card, &data);
 
 		if (r == SC_ERROR_REF_DATA_NOT_USABLE) {
 			printf("SmartCard-HSM has never been initialized. Please use --initialize to set SO-PIN and user PIN.\n");
 		} else {
-			if (tries_left == 0) {
+			if (data.pin1.tries_left == 0) {
 				printf("User PIN locked\n");
 			} else {
-				printf("User PIN tries left  : %d\n", tries_left);
+				printf("User PIN tries left  : %d\n", data.pin1.tries_left);
 			}
 		}
 	}
@@ -1364,7 +1364,7 @@ static int wrap_key(sc_context_t *ctx, sc_card_t *card, int keyid, const char *o
 	data.pin1.data = (unsigned char *)lpin;
 	data.pin1.len = strlen(lpin);
 
-	r = sc_pin_cmd(card, &data, NULL);
+	r = sc_pin_cmd(card, &data);
 
 	if (r < 0) {
 		fprintf(stderr, "PIN verification failed with %s\n", sc_strerror(r));
@@ -1653,7 +1653,7 @@ static int unwrap_key(sc_card_t *card, int keyid, const char *inf, const char *p
 	data.pin1.data = (u8 *)lpin;
 	data.pin1.len = strlen(lpin);
 
-	r = sc_pin_cmd(card, &data, NULL);
+	r = sc_pin_cmd(card, &data);
 
 	if (r < 0) {
 		fprintf(stderr, "PIN verification failed with %s\n", sc_strerror(r));

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -121,7 +121,7 @@ static void print_openssl_error(void)
 
 static int verify_pin(sc_card_t *card, int pin_reference, const char *pin_value)
 {
-	int r, tries_left = -1;
+	int r;
 	struct sc_pin_cmd_data data;
 
 	memset(&data, 0, sizeof(data));
@@ -150,14 +150,14 @@ static int verify_pin(sc_card_t *card, int pin_reference, const char *pin_value)
 		data.pin1.len = strlen(pin_value);
 	}
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 
 	if (r)
 	{
 		if (r == SC_ERROR_PIN_CODE_INCORRECT)
 		{
-			if (tries_left >= 0)
-				printf("Error %d attempts left.\n", tries_left);
+			if (data.pin1.tries_left >= 0)
+				printf("Error %d attempts left.\n", data.pin1.tries_left);
 			else
 				printf("Wrong pin.\n");
 		}
@@ -174,7 +174,7 @@ static int change_pin(sc_card_t *card,
 		const char *pin_value1,
 		const char *pin_value2)
 {
-	int r, tries_left = -1;
+	int r;
 	struct sc_pin_cmd_data data;
 
 	memset(&data, 0, sizeof(data));
@@ -207,14 +207,14 @@ static int change_pin(sc_card_t *card,
 
 	}
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 
 	if (r)
 	{
 		if (r == SC_ERROR_PIN_CODE_INCORRECT)
 		{
-			if (tries_left >= 0)
-				printf("Error %d attempts left.\n", tries_left);
+			if (data.pin1.tries_left >= 0)
+				printf("Error %d attempts left.\n", data.pin1.tries_left);
 			else
 				printf("Wrong pin.\n");
 		}
@@ -232,7 +232,7 @@ static int unlock_pin(sc_card_t *card,
 			const char *puk_value,
 			const char *pin_value)
 {
-	int r, tries_left = -1;
+	int r;
 	struct sc_pin_cmd_data data;
 
 	memset(&data, 0, sizeof(data));
@@ -265,14 +265,14 @@ static int unlock_pin(sc_card_t *card,
 
 	}
 
-	r = sc_pin_cmd(card, &data, &tries_left);
+	r = sc_pin_cmd(card, &data);
 
 	if (r)
 	{
 		if (r == SC_ERROR_PIN_CODE_INCORRECT)
 		{
-			if (tries_left >= 0)
-				printf("Error %d attempts left.\n", tries_left);
+			if (data.pin1.tries_left >= 0)
+				printf("Error %d attempts left.\n", data.pin1.tries_left);
 			else
 				printf("Wrong pin.\n");
 		}


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
