### PR TITLE
CI: build on Ubuntu with Pro+fips-updates enabled.

### DIFF
--- a/.github/workflows/ubuntu-fips.yml
+++ b/.github/workflows/ubuntu-fips.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           working-directory: /shared
           commands: |
-            ./.github/setup-linux.sh gcc force-install
+            ./.github/setup-linux.sh force-install
 
       - name: Build
         uses: canonical/setup-ubuntu-fips/run@v1
         with:
           working-directory: /shared
           commands: |
-            ./.github/build.sh fips dist
+            ./.github/build.sh dist
 
       - name: Upload test logs
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ubuntu-fips.yml
+++ b/.github/workflows/ubuntu-fips.yml
@@ -1,0 +1,58 @@
+name: Ubuntu w/FIPS
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.PRO_TOKEN != '' }}" >> $GITHUB_OUTPUT
+
+  ubuntu-fips:
+    needs: check-secret
+    if: needs.check-secret.outputs.has-token == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup FIPS environment
+        uses: canonical/setup-ubuntu-fips@v1
+        with:
+          pro-token: ${{ secrets.PRO_TOKEN }}
+          shared-path: ${{ github.workspace }}
+
+      - name: Install build dependencies
+        uses: canonical/setup-ubuntu-fips/run@v1
+        with:
+          working-directory: /shared
+          commands: |
+            ./.github/setup-linux.sh gcc force-install
+
+      - name: Build
+        uses: canonical/setup-ubuntu-fips/run@v1
+        with:
+          working-directory: /shared
+          commands: |
+            ./.github/build.sh fips dist
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ubuntu-fips-test-logs
+          path: |
+            tests/*.log
+            src/tests/unittests/*.log
+
+      - name: Cleanup
+        if: always()
+        uses: canonical/setup-ubuntu-fips/cleanup@v1
+        with:
+          vm-name: fips-vm


### PR DESCRIPTION
## Add CI workflow for Ubuntu with FIPS mode

### Summary

This PR adds a new GitHub Actions workflow to build and test OpenSC on Ubuntu with FIPS mode enabled using Ubuntu Pro.

### Changes

- Add `.github/workflows/ubuntu-fips.yml` workflow that:
  - Uses Canonical's `setup-ubuntu-fips` action to provision a FIPS-enabled Ubuntu environment (developed with this particualr use case in mind)
  - Builds OpenSC with the `fips` configuration
  - Uploads test logs as artifacts on failure
  - Only runs when the `PRO_TOKEN` secret is configured (gracefully skips otherwise)

### Details

The workflow uses a two-job pattern to conditionally execute based on secret availability:
1. `check-secret` - Determines if `PRO_TOKEN` is set and exposes the result as an output
2. `ubuntu-fips` - Runs the actual build only when the token is available

This approach ensures the workflow doesn't fail on forks or environments without the Ubuntu Pro token configured.

**Technical implementation:** To overcome limitations of GitHub runners (which cannot be rebooted or have kernel-level FIPS mode enabled), the actions spin up an LXD VM. This allows enabling `fips-updates` and rebooting the VM to activate FIPS mode at the kernel level. A shared directory between the GitHub runner and the VM is used to exchange the source code and build artifacts.

### Testing

- Workflow triggers on pushes to `master`, pull requests, and manual dispatch
- Requires `PRO_TOKEN` repository secret with a valid Ubuntu Pro token

### Note

I've been in touch with the Ubuntu Pro project lead. We have a pool of Ubuntu Pro licenses available to grant for testing and CI purposes. If you'd like to enable this workflow, please reach out to me via the email in my GitHub profile or commits.