### PR TITLE
ci: Fixup artifact names

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
               SUFFIX="-${{ github.base_ref }}-pr${{ github.event.number }}"
             fi
           fi
-          PACKAGE_SUFFIX="${{ matrix.configuration == 'Light' && '-Light' || '' }}${SUFFIX}"
+          PACKAGE_SUFFIX="${SUFFIX}${{ matrix.configuration == 'Light' && '-Light' || '' }}"
           sed -i.bak "s/^PACKAGE_SUFFIX=\([-~]*[0-9a-zA-Z]*\)$/PACKAGE_SUFFIX=$PACKAGE_SUFFIX/g" VERSION.mk
           cat VERSION.mk
           while IFS='=' read -r key value; do
@@ -130,7 +130,7 @@ jobs:
         id: upload-unsigned-artifact
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ env.ARTIFACT_NAME }}.zip
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./win32/*.msi
       - name: Push to Signpath.io
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'OpenSC/OpenSC' }}
@@ -145,7 +145,7 @@ jobs:
       - name: Archive debug artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ env.ARTIFACT_NAME }}-dbg.zip
+          name: ${{ env.ARTIFACT_NAME }}-dbg
           path: |
             ./src/**/*.pdb
             ./win32/*.pdb


### PR DESCRIPTION
Hopefully last fixup of the Windows artifact names.

* Do not include the zip extension (included automatically)
* Put the Light suffix only after the original suffix (-rcX)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
