### PR TITLE
ci: Update to latest libressl 4.2.1

### DIFF
--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -3,7 +3,7 @@
 set -ex -o xtrace
 
 # WARNING: Change this also in .github/workflows/linux.yml
-V=libressl-4.0.0
+V=libressl-4.2.1
 
 sudo apt-get remove -y libssl-dev
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ env:
   JAVA_DEPS: |
     ant openjdk-8-jdk maven cmake
   JCARDSIM: https://github.com/Jakuje/jcardsim.git
-  LIBRESSL_VERSION: 4.0.0
+  LIBRESSL_VERSION: 4.2.1
 
 jobs:
   build:


### PR DESCRIPTION
The latest libressl version is 4.2.1 so lets update our CI to that

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
