### PR TITLE
pkcs15-sc-hsm.c Comparing Brainpool EC parameters

### DIFF
--- a/src/libopensc/pkcs15-sc-hsm.c
+++ b/src/libopensc/pkcs15-sc-hsm.c
@@ -838,7 +838,11 @@ int sc_pkcs15emu_sc_hsm_get_curve_oid(sc_cvc_t *cvc, const struct sc_lv_data **o
 	int i;
 
 	for (i = 0; curves[i].oid.value; i++) {
-		if ((curves[i].prime.len == cvc->primeOrModuluslen) && !memcmp(curves[i].prime.value, cvc->primeOrModulus, cvc->primeOrModuluslen)) {
+		if ((curves[i].prime.len == cvc->primeOrModuluslen) &&
+				!memcmp(curves[i].prime.value, cvc->primeOrModulus, cvc->primeOrModuluslen) &&
+				(curves[i].coefficientA.len == cvc->coefficientAorExponentlen) &&
+				!memcmp(curves[i].coefficientA.value,
+						cvc->coefficientAorExponent, cvc->coefficientAorExponentlen)) {
 			*oid = &curves[i].oid;
 			return SC_SUCCESS;
 		}


### PR DESCRIPTION
Brainpool regular and twisted curves use the same prime number P. `sc_pkcs15emu_sc_hsm_get_curve_oid` was only comparing P to determine the OID. It now compares P and A because the twisted versions use a different A sometimes called A'. The table of EC parameters used in the compare is in libopensc/pkcs15-sc-hsm.c where #3601 adds the twisted curves.

 Tested on branch PR-3601
 Changes to be committed:
	modified:   libopensc/pkcs15-sc-hsm.c

Fixes: #3601 when SC-HSM tries to use a twisted curve.

It can then be merged:

-  now as existing EC curves all have different P and A and will work  as before. 

- immediately after #3601 which adds the twisted curves and the problem. 

Tested against "SmartCard-HSM version 4.1', type:26000", card with atr:3b:de:96:ff:81:91:fe:1f:c3:80:31:81:54:48:53:4d:31:73:80:21:40:81:07:92
using:
```
sc-hsm-tool --initialize --so-pin 3132333435363738 --pin 123456
./pkcs11-tool -l --pin 123456 --keypairgen --key-type EC:brainpoolP256t1 --label bp256t1 --id 12
./pkcs11-tool --sign -m ECDSA-SHA256 --id 12 --signature-format openssl --input-file /tmp/ecdsa.sign.text --output-file /tmp/ecdsa.sign.text.sig
openssl dgst -verify /tmp/ecdsa.sign.pubkey.12.pem -sha256 -signature /tmp/ecdsa.sign.text.sig /tmp/ecdsa.sign.text
Verified OK
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X ] PKCS#11 module is tested for key generation and ECDSA signature verified by OpenSSL
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
