### PR TITLE
card-dnie: Tear down SM channel before PIN re-verification on DNIe 3.0

### DIFF
--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -2116,6 +2116,9 @@ static int dnie_pin_verify(struct sc_card *card,
 	if (card->atr.value[15] >= DNIE_30_VERSION) {
 		/* the provider should be prepared for using PIN information */
 		sc_log(card->ctx, "DNIe 3.0 detected doing PIN initialization");
+		/* Tear down any active SM channel first to avoid desynchronization
+		 * when re-establishing SM (e.g. during PIN cache revalidation) */
+		cwa_create_secure_channel(card, GET_DNIE_PRIV_DATA(card)->cwa_provider, CWA_SM_OFF);
 		dnie_change_cwa_provider_to_pin(card);
 	}
 	res = cwa_create_secure_channel(card, GET_DNIE_PRIV_DATA(card)->cwa_provider, CWA_SM_ON);


### PR DESCRIPTION
- Fixes https://github.com/OpenSC/OpenSC/issues/3613

> [!NOTE]
> This issue was found and fixed through Claude. I understand the code at a generic level but I lack the SmartCard-specific knowledge to get the nuances. I tried the fix locally with my ID, and it solves the issue I was seeing.

Card tested: DNIe 4.0 (Spanish national ID card), identified by `opensc-tool -n` as `dnie`.

## Problem

DNIe 3.0 keys require re-authentication before each private key operation (effectively `CKA_ALWAYS_AUTHENTICATE`), but are not tagged with this attribute in the card's PKCS#15 data. OpenSC handles this via PIN cache revalidation: when a signing operation gets SW 6982, `sc_pkcs15_pincache_revalidate()` re-verifies the cached PIN by calling `dnie_pin_verify()`.

During the initial login, `dnie_pin_verify()` works correctly because the SM channel is already OFF (from `dnie_init()`). However, during revalidation the DATA SM channel is still active. `dnie_pin_verify()` switches the CWA provider to PIN mode and calls `cwa_create_secure_channel(CWA_SM_ON)` without first tearing down the active DATA SM channel. The PIN SM establishment and PIN verification both succeed, but the subsequent DATA SM re-establishment fails — the card returns corrupted responses during certificate reading via GET RESPONSE, causing the entire revalidation to fail with `CKR_USER_NOT_LOGGED_IN`.

## Fix

Add `cwa_create_secure_channel(card, provider, CWA_SM_OFF)` at the start of `dnie_pin_verify()` for DNIe 3.0, before switching to the PIN provider. This mirrors what `dnie_init()` already does during card initialization: set `SM_MODE_NONE` on the host and send a plain SELECT MF to close the card-side SM channel. When SM is already OFF (e.g., during the initial login), the teardown is a harmless no-op.

##### Checklist
- [x] PKCS#11 module is tested
