### PR TITLE
Build with no-modules to include legacy provider in static build

### DIFF
--- a/MacOSX/build-openssl-macos.sh
+++ b/MacOSX/build-openssl-macos.sh
@@ -29,13 +29,13 @@ if ! test -e openssl; then
 fi
 
 pushd openssl
-./Configure darwin64-x86_64 no-shared no-apps --prefix=$PREFIX enable-ec_nistp_64_gcc_128
+./Configure darwin64-x86_64 no-shared no-module no-apps --prefix=$PREFIX enable-ec_nistp_64_gcc_128
 make clean
 make -j 4
 make DESTDIR=$BUILDPATH/openssl_bin install_sw
 make clean
 
-./Configure darwin64-arm64 no-shared no-apps --prefix=$PREFIX enable-ec_nistp_64_gcc_128
+./Configure darwin64-arm64 no-shared no-module no-apps --prefix=$PREFIX enable-ec_nistp_64_gcc_128
 make -j 4
 make DESTDIR=$BUILDPATH/openssl_arm64 install_sw
 


### PR DESCRIPTION
Fixes #3612

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested

Signed-off-by: Raul Metsma <raul@metsma.ee>