### PR TITLE
ci: Simplify kryoptic tests by using packaged version

### DIFF
--- a/.github/setup-fedora.sh
+++ b/.github/setup-fedora.sh
@@ -19,7 +19,7 @@ else
 fi
 
 if [ "$1" == "kryoptic" ]; then
-	DEPS="$DEPS clang meson cargo expect pkgconf-pkg-config openssl-devel p11-kit-devel gnutls-utils g++ sqlite-devel python3-six git"
+	DEPS="$DEPS kryoptic"
 fi
 
 sudo dnf install -y $DEPS

--- a/.github/setup-kryoptic.sh
+++ b/.github/setup-kryoptic.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# build kryoptic
-if [ ! -d "kryoptic" ]; then
-	git clone https://github.com/latchset/kryoptic.git
-fi
-pushd kryoptic
-cargo build --features dynamic,standard,nssdb,pqc
-popd

--- a/.github/workflows/external-pkcs11.yaml
+++ b/.github/workflows/external-pkcs11.yaml
@@ -23,7 +23,6 @@ env:
     libglib2.0-dev libnss3-dev gnutls-bin libusb-dev libudev-dev flex
     libnss3-tools
     libpcsclite-dev libcmocka-dev libssl-dev zlib1g-dev libreadline-dev softhsm2
-  KRYOPTIC: https://github.com/latchset/kryoptic.git
 
 jobs:
   #######################
@@ -44,8 +43,6 @@ jobs:
         run: .github/setup-fedora.sh kryoptic
       - name: Install OpenSC
         run: .github/build.sh
-      - name: Setup Kryoptic
-        run: .github/setup-kryoptic.sh
       - name: Test with Kryoptic
         run: tests/test-kryoptic.sh
 
@@ -105,7 +102,5 @@ jobs:
         run: .github/setup-fedora.sh kryoptic
       - name: Install OpenSC
         run: .github/build.sh
-      - name: Setup Kryoptic
-        run: .github/setup-kryoptic.sh
       - name: Interoperability tests
         run: tests/test-pkcs11-tool-unwrap-wrap-interoperability-test.sh


### PR DESCRIPTION
Building kryoptic is slow, but we have recent version in Fedora now so we can use that one to get the CI 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
