### PR TITLE
MacOSX/build-openssl: Fix infinite loop on missing CLI arg

### DIFF
--- a/MacOSX/build-openssl-macos.sh
+++ b/MacOSX/build-openssl-macos.sh
@@ -9,11 +9,17 @@ while [ $# -gt 0 ]; do
     case "$1" in
         -b|--buildpath)
             BUILDPATH="$2"
-            shift 2
+            if ! shift 2; then
+	    	echo "Error: Missing argument for $1" >&2
+	    	exit 1
+	    fi
             ;;
         -p|--prefix)
             PREFIX="$2"
-            shift 2
+            if ! shift 2; then
+	    	echo "Error: Missing argument for $1" >&2
+	    	exit 1
+	    fi
             ;;
         *)
             echo "Unknown option: $1" >&2


### PR DESCRIPTION
This PR fixes a minor bug where the arg-checking loop in `MacOSX/build-openssl-macos.sh` could loop infinitely if insufficient arguments are given, because `shift 2` fails and thus does not reduce the value of `$#`.

Example that causes infinite loop: `./MacOSX/build-openssl-macos.sh -b`
