### PR TITLE
Workaround for RTLD_DEEPBIND crashes Firefox/Chrome

### DIFF
--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -60,9 +60,9 @@ C_LoadModule(const char *mspec, CK_FUNCTION_LIST_PTR_PTR funcs)
 		free(mod);
 		return NULL;
 	}
-	mod->handle = sc_dlopen(mspec);
+	mod->handle = sc_dlopen_deep(mspec);
 	if (mod->handle == NULL) {
-		fprintf(stderr, "sc_dlopen failed: %s\n", sc_dlerror());
+		fprintf(stderr, "sc_dlopen_deep failed: %s\n", sc_dlerror());
 		goto failed;
 	}
 

--- a/src/common/libscdl.c
+++ b/src/common/libscdl.c
@@ -34,6 +34,11 @@ void *sc_dlopen(const char *filename)
 	DWORD flags = PathIsRelativeA(filename) ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH;
 	return (void *)LoadLibraryExA(filename, NULL, flags);
 }
+void *
+sc_dlopen_deep(const char *filename)
+{
+	return sc_dlopen(filename);
+}
 
 void *sc_dlsym(void *handle, const char *symbol)
 {
@@ -69,6 +74,12 @@ int sc_dlclose(void *handle)
 #include <dlfcn.h>
 
 void *sc_dlopen(const char *filename)
+{
+	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL);
+}
+
+void *
+sc_dlopen_deep(const char *filename)
 {
 	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL
 #ifdef RTLD_DEEPBIND

--- a/src/common/libscdl.h
+++ b/src/common/libscdl.h
@@ -21,6 +21,7 @@
 #ifndef __LIBSCDL_H
 #define __LIBSCDL_H
 void *sc_dlopen(const char *filename);
+void *sc_dlopen_deep(const char *filename);
 void *sc_dlsym(void *handle, const char *symbol);
 int sc_dlclose(void *handle);
 const char *sc_dlerror(void);


### PR DESCRIPTION
Fixes #3624

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested

Signed-off-by: Raul Metsma <raul@metsma.ee>