### PR TITLE
pkcs11-tool: fix CKA_VERIFY_RECOVER queried on secret key objects

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -6834,7 +6834,7 @@ show_key(CK_SESSION_HANDLE sess, CK_OBJECT_HANDLE obj)
 		printf("%sverify", sepa);
 		sepa = ", ";
 	}
-	if (pub && getVERIFY_RECOVER(sess, obj)) {
+	if (pub && !sec && getVERIFY_RECOVER(sess, obj)) {
 		printf("%sverifyRecover", sepa);
 		sepa = ", ";
 	}


### PR DESCRIPTION
## Summary

- In `show_key()`, the `pub` flag is initialized to `1` and is never
  reset to `0` for `CKO_SECRET_KEY` objects — only `sec` is set to `1`.
- This causes `getVERIFY_RECOVER()` (i.e. `C_GetAttributeValue(CKA_VERIFY_RECOVER)`)
  to be called on secret key objects such as AES keys.
- Per PKCS#11, `CKA_VERIFY_RECOVER` is a public-key-only attribute; tokens
  correctly return `CKR_ATTRIBUTE_TYPE_INVALID`, surfacing as a spurious warning.

Fix: add `!sec` to the `getVERIFY_RECOVER` guard in `show_key()`.