### PR TITLE
pkcs11: Fix SHA1 mechanisms registration in FIPS mode

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -1786,7 +1786,7 @@ sc_pkcs11_register_sign_and_hash_mechanism(struct sc_pkcs11_card *p11card,
 	CK_RV rv;
 
 	LOG_FUNC_CALLED(p11card->card->ctx);
-	sc_log(p11card->card->ctx, "mech = %lx, hash_mech = %lx", mech, hash_mech);
+	sc_log(p11card->card->ctx, "mech = 0x%lx, hash_mech = 0x%lx", mech, hash_mech);
 
 	if (!sign_type)
 		LOG_FUNC_RETURN(p11card->card->ctx, CKR_MECHANISM_INVALID);

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -305,14 +305,12 @@ sc_pkcs11_register_openssl_mechanisms(struct sc_pkcs11_card *p11card)
 #endif
 #endif /* !defined(OPENSSL_NO_ENGINE) */
 
-	if (!FIPS_mode()) {
-		openssl_sha1_mech.mech_data = sc_evp_md(context, "sha1");
-		openssl_sha1_mech.free_mech_data = ossl_md_free;
-		openssl_sha1_mech.copy_mech_data = ossl_md_copy;
-		mt = dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech);
-		sc_pkcs11_register_mechanism(p11card, mt, NULL);
-		sc_pkcs11_free_mechanism(&mt);
-	}
+	openssl_sha1_mech.mech_data = sc_evp_md(context, "sha1");
+	openssl_sha1_mech.free_mech_data = ossl_md_free;
+	openssl_sha1_mech.copy_mech_data = ossl_md_copy;
+	mt = dup_mem(&openssl_sha1_mech, sizeof openssl_sha1_mech);
+	sc_pkcs11_register_mechanism(p11card, mt, NULL);
+	sc_pkcs11_free_mechanism(&mt);
 
 	openssl_sha224_mech.mech_data = sc_evp_md(context, "sha224");
 	openssl_sha224_mech.free_mech_data = ossl_md_free;


### PR DESCRIPTION
With the FIPS mode detection done right, the FIPS provider does not have SHA1 mechanism, which causes registration fail. This skips all SHA1 based mechanisms in FIPS mode.

Unfortunately, I did not catch this before trying the OpenSC internals in fips mode over last couple of weeks.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [-] Documentation is added or updated
- [-] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
