### PR TITLE
pkcs11: enable C_WaitForSlotEvent for all platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -884,13 +884,6 @@ fi
 
 if test "${enable_pcsc}" = "yes"; then
 	if test "${WIN32}" != "yes"; then
-		PKG_CHECK_EXISTS(
-			[libpcsclite],
-			[PKG_CHECK_MODULES([PCSC], [libpcsclite >= 1.8.22],
-				[AC_DEFINE([PCSCLITE_GOOD], [1], [Sufficient version of PCSC-Lite with all the required features])],
-				[:]
-			)]
-		)
 		if test -z "${PCSC_CFLAGS}"; then
 			case "${host}" in
 				*-*-darwin*)

--- a/src/pkcs11/pkcs11-global.c
+++ b/src/pkcs11/pkcs11-global.c
@@ -805,11 +805,6 @@ CK_RV C_WaitForSlotEvent(CK_FLAGS flags,   /* blocking/nonblocking flag */
 		return  CKR_ARGUMENTS_BAD;
 
 	sc_log(context, "C_WaitForSlotEvent(block=%d)", !(flags & CKF_DONT_BLOCK));
-#ifndef PCSCLITE_GOOD
-	/* Not all pcsc-lite versions implement consistently used functions as they are */
-	if (!(flags & CKF_DONT_BLOCK))
-		return CKR_FUNCTION_NOT_SUPPORTED;
-#endif /* PCSCLITE_GOOD */
 	rv = sc_pkcs11_lock();
 	if (rv != CKR_OK)
 		return rv;


### PR DESCRIPTION
raises requirement of libpcsclite to >= 1.8.22 (17 June 2017). macOS and Windows are also supporting the required APIs

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested