### PR TITLE
card-piv.c, fuzz_pkcs11.c fix -Wshorten-64-to-32 errors

### DIFF
--- a/.github/workflows/linux-strict.yml
+++ b/.github/workflows/linux-strict.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: .github/setup-linux.sh ${{ matrix.compiler }} force-install
-      - run: .github/build.sh dist
+      - run: .github/build.sh piv-sm dist
         env:
           CC: ${{ matrix.compiler }}
           CFLAGS: ${{ env.CFLAGS }} ${{ matrix.compiler == 'clang' && env.CLANG_CFLAGS || '' }}

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -871,10 +871,10 @@ static void piv_inc(u8 *counter, size_t size)
 	unsigned int c = 1;
 	unsigned int b;
 	int i;
-	for (i = size - 1; c != 0 && i >= 0; i--){
-			b = c + counter[i];
-			counter[i] = b & 0xff;
-			c = b>>8;
+	for (i = (int)size - 1; c != 0 && i >= 0; i--) {
+		b = c + counter[i];
+		counter[i] = b & 0xff;
+		c = b >> 8;
 	}
 }
 
@@ -995,8 +995,8 @@ static int piv_encode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu
 		T87len = 0;
 		padlen = 0;
 	} else {
-		enc_datalen = ((plain->datalen + 15) / 16) * 16; /* may add extra 16 bytes */
-		padlen = enc_datalen - plain->datalen;
+		enc_datalen = (int)(((plain->datalen + 15) / 16) * 16); /* may add extra 16 bytes */
+		padlen = enc_datalen - (int)plain->datalen;
 		r = T87len = sc_asn1_put_tag(0x87, NULL, 1 + enc_datalen, NULL, 0, NULL);
 		if (r < 0)
 			goto err;
@@ -1022,13 +1022,13 @@ static int piv_encode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu
 		*p++ = 0x01; /* padding context indicator */
 
 		/* first round encryptes Enc counter with zero IV, and does not save the output */
-		if (EVP_CIPHER_CTX_reset(ed_ctx) != 1
-				|| EVP_EncryptInit_ex(ed_ctx, (*cs->cipher_cbc)(), NULL, priv->sm_session.SKenc, IV) != 1
-				|| EVP_CIPHER_CTX_set_padding(ed_ctx,0) != 1
-				|| EVP_EncryptUpdate(ed_ctx, p ,&outl, plain->data, plain->datalen) != 1
-				|| EVP_EncryptUpdate(ed_ctx, p + outl, &outll, pad, padlen) != 1
-				|| EVP_EncryptFinal_ex(ed_ctx, discard, &outdl) != 1
-				|| outdl != 0) {  /* should not happen */
+		if (EVP_CIPHER_CTX_reset(ed_ctx) != 1 ||
+				EVP_EncryptInit_ex(ed_ctx, (*cs->cipher_cbc)(), NULL, priv->sm_session.SKenc, IV) != 1 ||
+				EVP_CIPHER_CTX_set_padding(ed_ctx, 0) != 1 ||
+				EVP_EncryptUpdate(ed_ctx, p, &outl, plain->data, (int)plain->datalen) != 1 ||
+				EVP_EncryptUpdate(ed_ctx, p + outl, &outll, pad, padlen) != 1 ||
+				EVP_EncryptFinal_ex(ed_ctx, discard, &outdl) != 1 ||
+				outdl != 0) { /* should not happen */
 			sc_log_openssl(card->ctx);
 			sc_log(card->ctx,"SM _encode failed in OpenSSL");
 			r = SC_ERROR_INTERNAL;
@@ -1042,7 +1042,7 @@ static int piv_encode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu
 		*p++ = 0x01;
 		*p++ = plain->le;
 	}
-	macdatalen = p - sbuf;
+	macdatalen = (int)(p - sbuf);
 
 	memcpy(priv->sm_session.C_MCV_last, priv->sm_session.C_MCV, MCVlen); /* save is case fails */
 
@@ -1272,7 +1272,7 @@ static int piv_decode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu
 #endif
 
 	/*  MCV is first, then BER TLV Encoded Encrypted PIV Data and Status */
-	macdatalen = status.value + status.len - sm_apdu->resp;
+	macdatalen = (int)(status.value + status.len - sm_apdu->resp);
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 	if (CMAC_Init(cmac_ctx, priv->sm_session.SKrmac, priv->sm_session.aes_size, (*cs->cipher_cbc)(), NULL) != 1
@@ -1324,7 +1324,7 @@ static int piv_decode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu
 		plain->resplen = 0;
 	} else {
 		p = ee.value;
-		inlen = ee.len;
+		inlen = (int)ee.len;
 		if (inlen < 17 || *p != 0x01) { /*padding and padding indicator are required */
 			sc_log(card->ctx, "SM padding indicator not 0x01");
 			r = SC_ERROR_SM_AUTHENTICATION_FAILED;
@@ -2594,7 +2594,7 @@ static int piv_sm_open(struct sc_card *card)
 
 		memcpy(p, Qeh_OS, Qeh_OSlen);
 		p += Qeh_OSlen;
-		MacDatalen = p - MacData;
+		MacDatalen = (int)(p - MacData);
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 		if ((cmac_ctx = CMAC_CTX_new()) == NULL

--- a/src/tests/fuzzing/fuzz_pkcs11.c
+++ b/src/tests/fuzzing/fuzz_pkcs11.c
@@ -56,7 +56,8 @@ static int fuzz_card_connect(const uint8_t *data, size_t size, sc_pkcs11_slot_t 
 	struct sc_reader *reader = NULL;
 	struct sc_app_info *app_generic = NULL;
 	sc_pkcs11_slot_t *slot = NULL;
-	int rv = CKR_OK, free_p11card = 0;
+	CK_RV rv = CKR_OK;
+	int free_p11card = 0;
 
 	/* Erase possible virtual slots*/
 	list_clear(&virtual_slots);
@@ -81,7 +82,7 @@ static int fuzz_card_connect(const uint8_t *data, size_t size, sc_pkcs11_slot_t 
 
 	/* Locate a slot related to the reader */
 	for (size_t i = 0; i < list_size(&virtual_slots); i++) {
-		slot = (sc_pkcs11_slot_t *) list_get_at(&virtual_slots, i);
+		slot = (sc_pkcs11_slot_t *)list_get_at(&virtual_slots, (int)i);
 		if (slot->reader == reader) {
 			p11card = slot->p11card;
 			break;
@@ -143,7 +144,7 @@ fail:
 	if (free_p11card) {
 		sc_pkcs11_card_free(p11card);
 	}
-	return rv;
+	return (int)rv;
 }
 #endif
 
@@ -292,7 +293,8 @@ static void test_digest_update(const uint8_t *data, size_t size)
 	CK_MECHANISM      mech = {0, NULL_PTR, 0};
 	unsigned char     buffer[64] = {0};
 	CK_ULONG          hash_len = sizeof(buffer);
-	int               to_process = 0, rv = 0;
+	size_t to_process = 0;
+	CK_RV rv = 0;
 
 	if (set_mechanism(&data, &size, &mech))
 		return;
@@ -387,7 +389,7 @@ static int fuzz_find_object(CK_SESSION_HANDLE sess, CK_OBJECT_CLASS cls,
 	if (count == 0)
 		*ret = CK_INVALID_HANDLE;
 	p11->C_FindObjectsFinal(sess);
-	return count;
+	return (int)count;
 }
 
 static void test_sign(const uint8_t *data, size_t size)


### PR DESCRIPTION
`card-piv.c` has a "Wshorten-64-to-32" error when built using clang and with --enable-piv_sm. 

An actual error in `piv_inc` would only occur if either of the 16 byte  counters `enc_counter` or  `resp_enc_counter`  exceeded 2^128 secure messages in a single session when the counter would overflow.  

A few other places in card-piv SM code where a 64 bit length is converted to a 32 bit integer are type casted to 'int' as none of the numbers are over 32 bits.    

`src/tests/fuzzing/fuzz_pkcs11.c`  had a few "Wshorten-64-to-32" errors.

 On branch Wshorten-64-to-32
 Changes to be committed:
	modified:   src/libopensc/card-piv.c
	modified:   src/tests/fuzzing/fuzz_pkcs11.c

Idemia PIV cards that support NIST Secure Messaging were used in test. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
