### PR TITLE
srbeid: bound CardEdge dir entry count before allocation

### DIFF
--- a/src/libopensc/pkcs15-srbeid.c
+++ b/src/libopensc/pkcs15-srbeid.c
@@ -147,6 +147,10 @@ ce_parse_dir(const u8 *data, size_t len, ce_dir_entry_t **entries_out)
 	if (count == 0)
 		return 0;
 
+	/* Bound count against buffer size before allocation. */
+	if (count > (len - CE_DIR_HEADER_SIZE) / CE_DIR_ENTRY_SIZE)
+		return -1;
+
 	entries = calloc(count, sizeof(ce_dir_entry_t));
 	if (!entries)
 		return -1;
@@ -155,10 +159,6 @@ ce_parse_dir(const u8 *data, size_t len, ce_dir_entry_t **entries_out)
 		size_t off = CE_DIR_HEADER_SIZE + i * CE_DIR_ENTRY_SIZE;
 		int k;
 
-		if (off + CE_DIR_ENTRY_SIZE > len) {
-			free(entries);
-			return -1;
-		}
 		/* Name: up to 8 ASCII chars, may not be NUL-terminated on card. */
 		memcpy(entries[i].name, data + off, 8);
 		entries[i].name[8] = '\0';


### PR DESCRIPTION
Fixes Coverity CID 503167 (TAINTED_SCALAR), reported after #3595 was merged.                                                                                                                                                              
                                                                                                                                                                                                                                            
  The CardEdge directory entry count comes from the card and is passed                                                                                                                                                                      
  straight to `calloc()` as an allocation size, with no upper bound.                                                                                                                                                                        
                                                                                                                                                                                                                                            
  Check `count` against the buffer length before allocating:                                                                                                                                                                                
                                                                                                                                                                                                                                            
      if (count > (len - CE_DIR_HEADER_SIZE) / CE_DIR_ENTRY_SIZE)
          return -1;                                                                                                                                                                                                                        
   
  I used the division form to avoid `count * CE_DIR_ENTRY_SIZE` overflowing.                                                                                                                                                                
  With this check in place, the `off + CE_DIR_ENTRY_SIZE > len` check inside                                                                                                                                                                
  the loop is no longer needed, so I removed it.                                                                                                                                                                                            
                                                                                                                                                                                                                                            
  Context: https://github.com/OpenSC/OpenSC/pull/3595#issuecomment-4237086269                                                                                                                                                               
                                                            
  ## Test plan                                                                                                                                                                                                                              
                                                            
  Tested on Linux (Manjaro 6.12) with a Serbian CardEdge PKS (Chamber of                                                                                                                                                                    
  Commerce) card in a Gemalto PC Twin Reader.
                                                                                                                                                                                                                                            
  Enumeration (goes through `ce_parse_dir()`):                                                                                                                                                                                              
   
  | Command | Result |                                                                                                                                                                                                                      
  |---|---|                                                 
  | `pkcs15-tool -D` | 1 PIN, 2 keys, 2 certs |
  | `pkcs15-tool --list-pins` | `Tries left: 3` |                                                                                                                                                                                           
  | `pkcs15-tool --list-certificates` | Key Exchange + Digital Signature |
  | `pkcs15-tool --list-keys` | Both RSA-2048 keys |                                                                                                                                                                                        
  | `pkcs15-tool --read-certificate 01` / `02` | X.509 OK |                                                                                                                                                                                 
                                                                                                                                                                                                                                            
  Signing:                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  | Command | Verified with | Result |                      
  |---|---|---|
  | `pkcs15-crypt --sign --pkcs1 --sha-256 --key 02` | `openssl dgst -sha256 -verify` | Verified OK |
  | `pkcs11-tool --sign --mechanism SHA256-RSA-PKCS --id 02` | `openssl dgst -sha256 -verify` | Verified OK |                                                                                                                               
                                                                                                                                                                                                                                            
  Build:                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  - `clang-format --dry-run -Werror` is clean               
  - No new warnings with `-Wall -Wextra -Werror -Wstrict-aliasing=2`
  - PIN retry counter was 3 the whole time                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  ##### Checklist                                                                                                                                                                                                                           
                                                                                                                                                                                                                                            
  - [x] Documentation is added or updated (N/A — internal check)
  - [x] Unit tests are added or updated (N/A — hardware-only; enumeration covers the fix)
  - [x] Works on my test card                                                                                                                                                                                                               
  - [x] Follows the project's coding style
