### PR TITLE
Added missing null checks after dynamic memory allocation

### DIFF
--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -493,6 +493,9 @@ sc_pkcs15emu_add_object(sc_pkcs15_card_t *p15card, int type,
 	int		df_type;
 
 	obj = calloc(1, sizeof(*obj));
+	if (!obj) {
+		LOG_FUNC_RETURN(p15card->card->ctx, SC_ERROR_OUT_OF_MEMORY);
+	}
 
 	obj->type  = type;
 	obj->data  = data;

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1426,7 +1426,7 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 			r = SC_ERROR_OUT_OF_MEMORY;
 			LOG_TEST_GOTO_ERR(ctx, r, "failed to malloc() memory");
 		}
-		
+
 		memcpy(pubkey->u.ec.ecpointQ.value, pk.value, pk.len);
 		pubkey->u.ec.ecpointQ.len = pk.len;
 	} else {

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -1422,6 +1422,11 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 		LOG_TEST_GOTO_ERR(ctx, r, "failed to fix EC parameters");
 
 		pubkey->u.ec.ecpointQ.value = malloc(pk.len);
+		if (pubkey->u.ec.ecpointQ.value == NULL) {
+			r = SC_ERROR_OUT_OF_MEMORY;
+			LOG_TEST_GOTO_ERR(ctx, r, "failed to malloc() memory");
+		}
+		
 		memcpy(pubkey->u.ec.ecpointQ.value, pk.value, pk.len);
 		pubkey->u.ec.ecpointQ.len = pk.len;
 	} else {

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3472,7 +3472,7 @@ sc_pkcs15init_new_object(int type, const char *label, struct sc_pkcs15_id *auth_
 		if (!object->data) {
 			return NULL;
 		}
-		
+
 		if (data)
 			memcpy(object->data, data, data_size);
 	}

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3469,6 +3469,10 @@ sc_pkcs15init_new_object(int type, const char *label, struct sc_pkcs15_id *auth_
 
 	if (data_size) {
 		object->data = calloc(1, data_size);
+		if (!object->data) {
+			return NULL;
+		}
+		
 		if (data)
 			memcpy(object->data, data, data_size);
 	}

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -851,8 +851,12 @@ myeid_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 			pubkey->algorithm = SC_ALGORITHM_RSA;
 			pubkey->u.rsa.modulus.len = BYTES4BITS(keybits);
 			pubkey->u.rsa.modulus.data = malloc(pubkey->u.rsa.modulus.len);
+			if (pubkey->u.rsa.modulus.data == NULL)
+				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 			pubkey->u.rsa.exponent.len = MYEID_DEFAULT_PUBKEY_LEN;
 			pubkey->u.rsa.exponent.data = malloc(MYEID_DEFAULT_PUBKEY_LEN);
+			if (pubkey->u.rsa.exponent.data == NULL)
+				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 			memcpy(pubkey->u.rsa.exponent.data, MYEID_DEFAULT_PUBKEY, MYEID_DEFAULT_PUBKEY_LEN);
 
 			/* Get public key modulus */

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -491,8 +491,12 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		pubkey->algorithm		= SC_ALGORITHM_RSA;
 		pubkey->u.rsa.modulus.len	= BYTES4BITS(keybits);
 		pubkey->u.rsa.modulus.data	= malloc(pubkey->u.rsa.modulus.len);
+		if (pubkey->u.rsa.modulus.data == NULL)
+				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 		pubkey->u.rsa.exponent.len	= SETCOS_DEFAULT_PUBKEY_LEN;
 		pubkey->u.rsa.exponent.data	= malloc(SETCOS_DEFAULT_PUBKEY_LEN);
+		if (pubkey->u.rsa.exponent.data == NULL)
+				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 		memcpy(pubkey->u.rsa.exponent.data, SETCOS_DEFAULT_PUBKEY, SETCOS_DEFAULT_PUBKEY_LEN);
 
 		/* Get public key modulus */

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -492,11 +492,11 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		pubkey->u.rsa.modulus.len	= BYTES4BITS(keybits);
 		pubkey->u.rsa.modulus.data	= malloc(pubkey->u.rsa.modulus.len);
 		if (pubkey->u.rsa.modulus.data == NULL)
-				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 		pubkey->u.rsa.exponent.len	= SETCOS_DEFAULT_PUBKEY_LEN;
 		pubkey->u.rsa.exponent.data	= malloc(SETCOS_DEFAULT_PUBKEY_LEN);
 		if (pubkey->u.rsa.exponent.data == NULL)
-				LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 		memcpy(pubkey->u.rsa.exponent.data, SETCOS_DEFAULT_PUBKEY, SETCOS_DEFAULT_PUBKEY_LEN);
 
 		/* Get public key modulus */


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Summary
Fix multiple missing NULL checks after malloc/calloc allocations across PKCS#15 key and object initialization paths.

These issues could lead to NULL pointer dereferences when allocated memory is used without validation.
All changes ensure that allocation failures are handled immediately before memory is accessed.

##### Checklist
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
