### PR TITLE
srbeid: match by ATR whitelist, drop AID fallback

### DIFF
--- a/src/libopensc/card-srbeid.c
+++ b/src/libopensc/card-srbeid.c
@@ -2,8 +2,8 @@
  * card-srbeid.c: Driver for Serbian cards using the CardEdge PKI applet.
  *
  * Serbian eID, health insurance, and Chamber of Commerce cards use the
- * same CardEdge PKCS#15 applet.  Cards are matched either by ATR
- * (Gemalto 2014+ eID) or by AID selection.
+ * same CardEdge PKCS#15 applet.  Cards are matched by ATR whitelist,
+ * with a PKCS#15 AID select as a confirmation step.
  *
  * Copyright (C) 2026 LibreSCRS contributors
  *
@@ -44,37 +44,36 @@ static struct sc_card_driver srbeid_drv = {
 		&srbeid_ops,
 		NULL, 0, NULL};
 
-/*
- * ATR table.
- *
- * Gemalto (2014+) Serbian eID:  3B:FF:94 ...
- * Mask FF:FF:FF matches the first 3 bytes; remaining bytes vary between
- * individual cards and are don't-cares.
- *
- * Other CardEdge cards have no distinct ATR and are identified via AID
- * selection in match_card().
- *
- * Apollo 2008 ATR 3B:B9:18 ... is intentionally absent — no CardEdge applet.
- */
+/* Full ATR list provided by NetSeT (the CardEdge PKI applet vendor). Covers
+ * citizen eID, foreigner eID, PKS Chamber of Commerce, and RFZO health
+ * insurance cards across their various underlying card platforms. */
 static const struct sc_atr_table srbeid_atrs[] = {
-		{"3B:FF:94", "FF:FF:FF", "Serbian eID (Gemalto 2014+)", SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
-		{NULL,       NULL,	     NULL,			   0,			      0, NULL}
+		{"3B:FF:94:00:00:81:31:80:43:80:31:80:65:B0:85:02:01:F3:12:0F:FF:82:90:00:79", NULL, "Serbian eID (Gemalto Multiapp 80K)",		   SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:F8:13:00:00:81:31:FE:45:4A:43:4F:50:76:32:34:31:B7",			  NULL, "Serbian eID (NXP JCOP v2.4.1 80K)",		     SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:FA:13:00:00:81:31:FE:45:4A:43:4F:50:32:31:56:32:33:31:91",		NULL, "Serbian eID (NXP JCOP21 v2.3.1)",			 SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:F4:13:00:00:81:31:FE:45:52:46:5A:4F:ED",				      NULL, "Serbian health card (NXP JCOP21 v2.4.1)",	       SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:7A:96:00:00:80:65:A2:01:01:02:3D:72:D6:43",				 NULL, "Serbian eID (Gemalto Multiapp 80K IDCore10)",	      SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:F9:96:00:00:80:31:FE:45:53:43:45:37:20:47:43:4E:33:5E",		     NULL, "Serbian eID (SmartCafe Expert v7.0)",		  SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:FD:94:00:00:81:31:80:43:80:31:80:65:B1:F3:01:07:0F:83:01:90:00:17",	 NULL, "Serbian eID (Gemalto Dual-Interface 144K Contact)", SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:89:80:01:53:43:45:2E:37:20:20:20:20:44",				      NULL, "Serbian eID (SmartCafe Expert v7.0 Contactless)",   SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:F9:96:00:00:80:31:FE:45:53:43:45:37:20:20:00:20:20:07",		     NULL, "Serbian eID (SmartCafe Expert v7.1)",		  SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:DE:97:00:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:31:56:30:0D:0A:2E",	 NULL, "Serbian PKS card (SmartCafe Expert v8.0 B)",	     SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:9E:96:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:31:56:30:0D:0A:6F",	      NULL, "Serbian eID (SmartCafe Expert v8.0)",		   SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:9E:96:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:32:56:30:0D:0A:6C",	      NULL, "Serbian eID (SmartCafe Expert v8.0 C2)",	      SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:D5:18:FF:81:91:FE:1F:C3:80:73:C8:21:10:0A",				 NULL, "Serbian eID (NXP JCOP4 P71)",			      SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:DE:97:00:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:32:56:30:0D:0A:2D",	 NULL, "Serbian PKS card (SmartCafe Expert v8.0 C2 B)",	SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{"3B:9E:97:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:31:56:30:0D:0A:6E",	      NULL, "Serbian health card (SmartCafe Expert v8.0 S)",     SC_CARD_TYPE_SRBEID_BASE, 0, NULL},
+		{NULL,									 NULL, NULL,						0,			      0, NULL}
 };
 
 static int
 srbeid_match_card(sc_card_t *card)
 {
-	/* ATR hit: Gemalto 2014+ Serbian eID (3B:FF:94 ...) */
-	if (_sc_match_atr(card, srbeid_atrs, &card->type) >= 0)
-		return 1;
-
-	/* AID-based match for cards without a distinct ATR. */
-	if (iso7816_select_aid(card, AID_PKCS15, AID_PKCS15_LEN, NULL, NULL) == SC_SUCCESS) {
-		sc_log(card->ctx, "srbeid: CardEdge applet found via AID");
-		card->type = SC_CARD_TYPE_SRBEID_BASE;
+	int i = _sc_match_atr(card, srbeid_atrs, &card->type);
+	if (i >= 0 && iso7816_select_aid(card, AID_PKCS15, AID_PKCS15_LEN, NULL, NULL) == SC_SUCCESS) {
+		card->name = srbeid_atrs[i].name;
 		return 1;
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #3663. 

The old `srbeid_match_card` fell back to selecting the PKCS#15 AID (`A0 00 00 00 63 50 4B 43 53 2D 31 35`) whenever ATR didn't match. That is the standard PKCS#15 AID defined in ISO/IEC 7816-15, hosted by every compliant applet — which caused the false match on the Lithuanian eID reported in #3663. 

Replaced the fallback with a 15-entry ATR whitelist covering all Serbian CardEdge deployments across citizen eID, foreigner eID, PKS Chamber of Commerce, and RFZO health insurance cards. The list comes from the NetSeT (vendor of the CardEdge PKI applet). 

After ATR match, the driver selects the PKCS#15 AID as a confirmation step — same pattern as `card-esteid2018`. The AID call only runs when ATR is already a hit, so the previous false-match bug is not reintroduced.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
## Tests

Hardware-tested on Linux (Manjaro 6.12) with a Gemalto PC Twin Reader.                                                                                                                                                                    
Four physical Serbian card categories available:                                                                                                                                                                                      
                                                                                                                                                                                                                                            
 | Card | ATR | `opensc-tool --name` |                                            
  |---|---|---|                                                                                                                                                                                                                             
  | Foreigner eID | `3B:FF:94:00:00:81:31:80:43:80:31:80:65:B0:85:02:01:F3:12:0F:FF:82:90:00:79` | Serbian eID (Gemalto Multiapp 80K) |
  | Citizen eID | `3B:9E:96:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:32:56:30:0D:0A:6C` | Serbian eID (SmartCafe Expert v8.0 C2) |                                                                                                            
  | PKS Chamber of Commerce | `3B:DE:97:00:80:31:FE:45:53:43:45:20:38:2E:30:2D:43:31:56:30:0D:0A:2E` | Serbian PKS card (SmartCafe Expert v8.0 B) |
  | RFZO health card | `3B:F4:13:00:00:81:31:FE:45:52:46:5A:4F:ED` | Serbian health card (NXP JCOP21 v2.4.1) |    

Signing was exercised on of the cards (both key slots, both tool interfaces). Commands executed:                                                                                                                                                                                                           
                                                                                                                                                                                                                                            
  ```                                                                                                                                                                                                                                       
  $ echo -n "srbeid sign test — PKS card" > /tmp/msg.txt                                                                                                                                                                                    
  $ sha256sum /tmp/msg.txt | cut -d' ' -f1 | xxd -r -p > /tmp/hash.bin                                                                                                                                                                      
                                                                                                                                                                                                                                            
  $ pkcs15-tool --read-certificate 01 | openssl x509 -pubkey -noout > /tmp/pub-ke.pem                                                                                                                                                       
  $ pkcs15-tool --read-certificate 02 | openssl x509 -pubkey -noout > /tmp/pub-ds.pem                                                                                                                                                       
                                                                                                                                                                                                                                            
  $ pkcs15-crypt --sign --pkcs1 --sha-256 --key 01 --input /tmp/hash.bin --output /tmp/sig.bin                                                                                                                                              
  $ openssl dgst -sha256 -verify /tmp/pub-ke.pem -signature /tmp/sig.bin /tmp/msg.txt                                                                                                                                                       
  Verified OK                                                                                                                                                                                                                               
                                                                                                                                                                                                                                            
  $ pkcs15-crypt --sign --pkcs1 --sha-256 --key 02 --input /tmp/hash.bin --output /tmp/sig.bin
  $ openssl dgst -sha256 -verify /tmp/pub-ds.pem -signature /tmp/sig.bin /tmp/msg.txt                                                                                                                                                       
  Verified OK                                                                                                                                                                                                                               
                                             
  $ pkcs11-tool --module opensc-pkcs11.so --sign --mechanism SHA256-RSA-PKCS --id 01 --login \                                                                                                                                              
      --input-file /tmp/msg.txt --output-file /tmp/sig.bin                                                                                                                                                                                  
  $ openssl dgst -sha256 -verify /tmp/pub-ke.pem -signature /tmp/sig.bin /tmp/msg.txt
  Verified OK                                                                                                                                                                                                                               
                                                                                                                                                                                                                                            
  $ pkcs11-tool --module opensc-pkcs11.so --sign --mechanism SHA256-RSA-PKCS --id 02 --login \                                                                                                                                              
      --input-file /tmp/msg.txt --output-file /tmp/sig.bin                                                                                                                                                                                  
  $ openssl dgst -sha256 -verify /tmp/pub-ds.pem -signature /tmp/sig.bin /tmp/msg.txt                                                                                                                                                       
  Verified OK                                                                                                                                                                                                                               
  ```                                                              
  
Negative test — the Lithuanian ATR from the report (`3B:9D:18:81:31:FC:35:80:31:C0:69:4D:54:43:4F:53:73:02:06:05:D0`) is not in the table and there's no longer an AID path that could pick it up. Fall-through to other drivers works as before. 

Build:                                                                                                                                                                                                                                    
  - `clang-format --dry-run -Werror src/libopensc/card-srbeid.c` clean.                                                                                                                                                                     
  - No new warnings under `-Wall -Wextra -Werror -Wstrict-aliasing=2`.