### PR TITLE
Fix for null pointer dereference

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -203,6 +203,8 @@ sc_pkcs11_find_mechanism(struct sc_pkcs11_card *p11card, CK_MECHANISM_TYPE mech,
 	sc_pkcs11_mechanism_type_t *mt;
 	unsigned int n;
 
+	if (p11card == NULL)
+		return NULL;
 	for (n = 0; n < p11card->nmechanisms; n++) {
 		mt = p11card->mechanisms[n];
 		if (mt && mt->mech == mech && ((mt->mech_info.flags & flags) == flags))


### PR DESCRIPTION
Add a NULL check at the entry of `sc_pkcs11_find_mechanism`. This ensures that callers who pass `slot->p11card` (which may be NULL if no card is present in the slot) do not trigger a crash.

## Details
- **Component:** OpenSC PKCS#11 Module
- **Version:** `19868984d` (latest upstream `master` as of Apr 22 2026)
- **File:** `src/pkcs11/mechanism.c`
- **Vulnerability Type:** NULL Pointer Dereference

## Reproduction
The crash occurs when `C_GetMechanismInfo` is called with a valid `slotID` but the internal `p11card` pointer is NULL. This was triggered during fuzzing with a mock PC/SC driver that simulates multiple card types.

### Stack Trace (UBSan)
```text
/home/bughunting/pkcs11-fuzzer/src/opensc/src/pkcs11/mechanism.c:206:27: runtime error: member access within null pointer of type 'struct sc_pkcs11_card'
    #0 0x7b5f2d8cbb7f in sc_pkcs11_find_mechanism /home/bughunting/pkcs11-fuzzer/src/opensc/src/pkcs11/mechanism.c:206:27
    #1 0x7b5f2d8cc217 in sc_pkcs11_get_mechanism_info /home/bughunting/pkcs11-fuzzer/src/opensc/src/pkcs11/mechanism.c:254:13
    #2 0x7b5f2d8af87e in C_GetMechanismInfo /home/bughunting/pkcs11-fuzzer/src/opensc/src/pkcs11/pkcs11-global.c:718:8
    #3 0x6513f9d0084d in LLVMFuzzerTestOneInput /home/bughunting/pkcs11-fuzzer/harnesses/opensc_pkcs11_fuzz.c:325:17
```

### Reproducer (Base64 encoded input)
`AAAA8b09AEBQZ2Vtc2FmAAAAAA37AgME`

## Root Cause Analysis
In `src/pkcs11/mechanism.c`, the function `sc_pkcs11_find_mechanism` iterates over `p11card->mechanisms` without verifying if `p11card` is valid:

```c
sc_pkcs11_mechanism_type_t *
sc_pkcs11_find_mechanism(struct sc_pkcs11_card *p11card, CK_MECHANISM_TYPE mech, CK_FLAGS flags)
{
    sc_pkcs11_mechanism_type_t *mt;
    unsigned int n;

    // MISSING: if (p11card == NULL) return NULL;

    for (n = 0; n < p11card->nmechanisms; n++) { // <--- NULL Deref here
        mt = p11card->mechanisms[n];
        if (mt && mt->mech == mech && ((mt->mech_info.flags & flags) == flags))
            return mt;
    }
    return NULL;
}
```
