### PR TITLE
common: Add a way to exclude the RTLD_DEEPBIND from dlopen flags

### DIFF
--- a/doc/files/files.html
+++ b/doc/files/files.html
@@ -1218,6 +1218,29 @@ app <em class="replaceable"><code>application</code></em> {
 					<code class="option">card_drivers =  <em class="replaceable"><code>name</code></em>... ;</code>
 				</a>
 				</p></dd><dt><span class="term">
+					<code class="envar">OPENSC_DEEPBIND</code>
+				</span></dt><dd><p>
+						The OpenSC and its tools are dynamically loading various
+						libraries (pcsclite, dynamic drivers and other pkcs11
+						modules) using
+						<span class="citerefentry"><span class="refentrytitle">dlopen</span>(3)</span>.
+					</p><p>
+						When this environment variable is set to
+						<code class="literal">1</code>
+						for the process running OpenSC, the calls will include
+						<code class="literal">RTLD_DEEPBIND</code> flag, which should
+						cause better symbol isolation between OpenSC and
+						loaded libraries. On the other hand, this is incompatible
+						with various static analysis tools as well as some
+						browser builds.
+					</p><p>
+						This option may be useful, if OpenSC needs to load a library
+						that pollutes the processes' global namespace and thereby
+						causes the unintended use of a different function with the
+						same name. In particular, this may happen when
+						<code class="literal">pkcs11-spy</code>
+						is used for logging between application and PKCS#11 library.
+				</p></dd><dt><span class="term">
 					<code class="envar">CARDMOD_LOW_LEVEL_DEBUG</code>
 				</span></dt><dd><p>
 						Write minidriver debug information to

--- a/doc/files/opensc.conf.5.xml.in
+++ b/doc/files/opensc.conf.5.xml.in
@@ -1886,6 +1886,38 @@ app <replaceable>application</replaceable> {
 			</varlistentry>
 			<varlistentry>
 				<term>
+					<envar>OPENSC_DEEPBIND</envar>
+				</term>
+				<listitem><para>
+						The OpenSC and its tools are dynamically loading various
+						libraries (pcsclite, dynamic drivers and other pkcs11
+						modules) using
+						<citerefentry>
+							<refentrytitle>dlopen</refentrytitle>
+							<manvolnum>3</manvolnum>
+						</citerefentry>.
+					</para>
+					<para>
+						When this environment variable is set to
+						<literal>1</literal>
+						for the process running OpenSC, the calls will include
+						<literal>RTLD_DEEPBIND</literal> flag, which should
+						cause better symbol isolation between OpenSC and
+						loaded libraries. On the other hand, this is incompatible
+						with various static analysis tools as well as some
+						browser builds.
+					</para>
+					<para>
+						This option may be useful, if OpenSC needs to load a library
+						that pollutes the processes' global namespace and thereby
+						causes the unintended use of a different function with the
+						same name. In particular, this may happen when
+						<literal>pkcs11-spy</literal>
+						is used for logging between application and PKCS#11 library.
+				</para></listitem>
+			</varlistentry>
+			<varlistentry>
+				<term>
 					<envar>CARDMOD_LOW_LEVEL_DEBUG</envar>
 				</term>
 				<listitem><para>

--- a/doc/tools/pkcs11-tool.1.xml
+++ b/doc/tools/pkcs11-tool.1.xml
@@ -777,6 +777,44 @@
 	</refsect1>
 
 	<refsect1>
+		<title>Environment</title>
+		<variablelist>
+			<varlistentry>
+				<term>
+					<envar>OPENSC_DEEPBIND</envar>
+				</term>
+				<listitem><para>
+						The OpenSC and its tools are dynamically loading various
+						libraries (pcsclite, dynamic drivers and other pkcs11
+						modules) using
+						<citerefentry>
+							<refentrytitle>dlopen</refentrytitle>
+							<manvolnum>3</manvolnum>
+						</citerefentry>.
+					</para>
+					<para>
+						When this environment variable is set to
+						<literal>1</literal>
+						for the process running OpenSC, the calls will include
+						<literal>RTLD_DEEPBIND</literal> flag, which should
+						cause better symbol isolation between OpenSC and
+						loaded libraries. On the other hand, this is incompatible
+						with various static analysis tools as well as some
+						browser builds.
+					</para>
+					<para>
+						This option may be useful, if OpenSC needs to load a library
+						that pollutes the processes' global namespace and thereby
+						causes the unintended use of a different function with the
+						same name. In particular, this may happen when
+						<literal>pkcs11-spy</literal>
+						is used for logging between application and PKCS#11 library.
+				</para></listitem>
+			</varlistentry>
+		</variablelist>
+	</refsect1>
+
+	<refsect1>
 		<title>Examples</title>
 		<para>
 			Perform a basic functionality test of the card:

--- a/doc/tools/tools.html
+++ b/doc/tools/tools.html
@@ -1836,7 +1836,30 @@ to enable debug output in the opensc library.</p></dd></dl></div><p>
 					</span></dt><dd><p>Specify the PKCS#11 URI for module, slot, token or object</p></dd><dt><span class="term">
 						<code class="option">--uri-with-slot-id</code>
 					</span></dt><dd><p>Include SlotId in PKCS#11 URI</p></dd></dl></div><p>
-		</p></div><div class="refsect1"><a name="id-1.18.6"></a><h2>Examples</h2><p>
+		</p></div><div class="refsect1"><a name="id-1.18.6"></a><h2>Environment</h2><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+					<code class="envar">OPENSC_DEEPBIND</code>
+				</span></dt><dd><p>
+						The OpenSC and its tools are dynamically loading various
+						libraries (pcsclite, dynamic drivers and other pkcs11
+						modules) using
+						<span class="citerefentry"><span class="refentrytitle">dlopen</span>(3)</span>.
+					</p><p>
+						When this environment variable is set to
+						<code class="literal">1</code>
+						for the process running OpenSC, the calls will include
+						<code class="literal">RTLD_DEEPBIND</code> flag, which should
+						cause better symbol isolation between OpenSC and
+						loaded libraries. On the other hand, this is incompatible
+						with various static analysis tools as well as some
+						browser builds.
+					</p><p>
+						This option may be useful, if OpenSC needs to load a library
+						that pollutes the processes' global namespace and thereby
+						causes the unintended use of a different function with the
+						same name. In particular, this may happen when
+						<code class="literal">pkcs11-spy</code>
+						is used for logging between application and PKCS#11 library.
+				</p></dd></dl></div></div><div class="refsect1"><a name="id-1.18.7"></a><h2>Examples</h2><p>
 			Perform a basic functionality test of the card:
 				</p><pre class="programlisting">pkcs11-tool --test --login</pre><p>
 
@@ -1931,7 +1954,7 @@ pkcs11-tool --login --unwrap --mechanism RSA-PKCS --id 22 \
 				</p><pre class="programlisting">
 pkcs11-tool --login --login-type so --init-pin
 				</pre><p>
-		</p></div><div class="refsect1"><a name="id-1.18.7"></a><h2>Authors</h2><p><span class="command"><strong>pkcs11-tool</strong></span> was written by
+		</p></div><div class="refsect1"><a name="id-1.18.8"></a><h2>Authors</h2><p><span class="command"><strong>pkcs11-tool</strong></span> was written by
 		Olaf Kirch <code class="email">&lt;<a class="email" href="mailto:okir@suse.de">okir@suse.de</a>&gt;</code>.</p></div></div><div class="refentry"><div class="refentry.separator"><hr></div><a name="pkcs15-crypt"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>pkcs15-crypt — perform crypto operations using PKCS#15 smart cards</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">pkcs15-crypt</code>  [<em class="replaceable"><code>OPTIONS</code></em>]</p></div></div><div class="refsect1"><a name="id-1.19.4"></a><h2>Description</h2><p>
 			The <span class="command"><strong>pkcs15-crypt</strong></span> utility can be used from the
 			command line to perform cryptographic operations such as computing

--- a/src/common/libpkcs11.c
+++ b/src/common/libpkcs11.c
@@ -60,9 +60,9 @@ C_LoadModule(const char *mspec, CK_FUNCTION_LIST_PTR_PTR funcs)
 		free(mod);
 		return NULL;
 	}
-	mod->handle = sc_dlopen_deep(mspec);
+	mod->handle = sc_dlopen(mspec);
 	if (mod->handle == NULL) {
-		fprintf(stderr, "sc_dlopen_deep failed: %s\n", sc_dlerror());
+		fprintf(stderr, "sc_dlopen failed: %s\n", sc_dlerror());
 		goto failed;
 	}
 

--- a/src/common/libscdl.c
+++ b/src/common/libscdl.c
@@ -34,11 +34,6 @@ void *sc_dlopen(const char *filename)
 	DWORD flags = PathIsRelativeA(filename) ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH;
 	return (void *)LoadLibraryExA(filename, NULL, flags);
 }
-void *
-sc_dlopen_deep(const char *filename)
-{
-	return sc_dlopen(filename);
-}
 
 void *sc_dlsym(void *handle, const char *symbol)
 {
@@ -72,20 +67,23 @@ int sc_dlclose(void *handle)
 #else
 
 #include <dlfcn.h>
+#include <stdlib.h>
 
 void *sc_dlopen(const char *filename)
 {
-	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL);
-}
-
-void *
-sc_dlopen_deep(const char *filename)
-{
-	return dlopen(filename, RTLD_LAZY | RTLD_LOCAL
+	int flags = RTLD_LAZY | RTLD_LOCAL;
 #ifdef RTLD_DEEPBIND
-			| RTLD_DEEPBIND
+	/* By default, the pkcs11 modules and pcsclite are opened without RTLD_DEEPBIND.
+	 * Using RTLD_DEEPBIND causes issues for dynamic analysis tools such as ASAN.
+	 * When the OPENSC_DEEPBIND is set to "1", the flag is included in the calls
+	 * that normally do not use RTLD_DEEPBIND.
+	 */
+	char *deep = getenv("OPENSC_DEEPBIND");
+	if (deep != NULL && deep[0] == '1') {
+		flags |= RTLD_DEEPBIND;
+	}
 #endif
-			);
+	return dlopen(filename, flags);
 }
 
 void *sc_dlsym(void *handle, const char *symbol)

--- a/src/common/libscdl.h
+++ b/src/common/libscdl.h
@@ -21,7 +21,6 @@
 #ifndef __LIBSCDL_H
 #define __LIBSCDL_H
 void *sc_dlopen(const char *filename);
-void *sc_dlopen_deep(const char *filename);
 void *sc_dlsym(void *handle, const char *symbol);
 int sc_dlclose(void *handle);
 const char *sc_dlerror(void);


### PR DESCRIPTION
The address sanitizer does not work with DEEPBIND so we provide (undocumented?) way to exclude this flag from the OpenSC operations based on environment variable.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
