### PR TITLE
oberthur-awp: fixed possible out of bounds write on card initialization

### DIFF
--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -724,12 +724,17 @@ awp_update_object_list(struct sc_pkcs15_card *p15card, struct sc_profile *profil
 	if (rv < 0)
 		goto done;
 
+	if (lst_file->size < 5) {
+		rv = SC_ERROR_UNKNOWN_DATA_RECEIVED;
+		goto done;
+	}
+
 	flags = lst_file->ef_structure;
 	rv = sc_read_binary(p15card->card, 0, buff, lst_file->size, &flags);
 	if (rv < 0)
 		goto done;
 
-	for (ii=0; ii < lst_file->size; ii+=5)
+	for (ii=0; ii <= lst_file->size-5; ii+=5)
 		if (*(buff + ii) != COSM_LIST_TAG)
 			break;
 	if (ii>=lst_file->size)   {


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
