### PR TITLE
Fix PKCS#15 binding failure for cards with AES-only `AlgorithmInfo`

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1758,7 +1758,12 @@ static int asn1_decode(sc_context_t *ctx, struct sc_asn1_entry *asn1,
 			r = asn1_decode(ctx,
 				(struct sc_asn1_entry *) entry->parm,
 				p, left, &p, &left, 1, depth + 1);
-			if (r >= 0)
+			/* When the inner call fails it returns before writing
+			 * back to *newp and *len_left, so the caller's p/left are
+			 * unchanged.  Swallowing the error for an optional
+			 * CHOICE is therefore safe: the next field will be
+			 * attempted at the same position. */
+			if (r >= 0 || (entry->flags & SC_ASN1_OPTIONAL))
 				r = 0;
 			goto decode_ok;
 		}

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -53,15 +53,17 @@ static const struct sc_asn1_entry c_asn1_twlabel[] = {
 	{ NULL, 0, 0, 0, NULL, NULL }
 };
 
+// clang-format off
 static const struct sc_asn1_entry c_asn1_algorithm_info[7] = {
-	{ "reference",		SC_ASN1_INTEGER,	SC_ASN1_TAG_INTEGER,	0, NULL, NULL },
-	{ "algorithmPKCS#11",	SC_ASN1_INTEGER,	SC_ASN1_TAG_INTEGER,	0, NULL, NULL },
-	{ "parameters",		SC_ASN1_CHOICE,		0,			0, NULL, NULL },
-	{ "supportedOperations",SC_ASN1_BIT_FIELD,	SC_ASN1_TAG_BIT_STRING,	0, NULL, NULL },
+	{ "reference",		SC_ASN1_INTEGER,	SC_ASN1_TAG_INTEGER,	0,                NULL, NULL },
+	{ "algorithmPKCS#11",	SC_ASN1_INTEGER,	SC_ASN1_TAG_INTEGER,	0,                NULL, NULL },
+	{ "parameters",		SC_ASN1_CHOICE,		0,			SC_ASN1_OPTIONAL, NULL, NULL },
+	{ "supportedOperations",SC_ASN1_BIT_FIELD,	SC_ASN1_TAG_BIT_STRING,	0,                NULL, NULL },
 	{ "objId",		SC_ASN1_OBJECT,		SC_ASN1_TAG_OBJECT,	SC_ASN1_OPTIONAL, NULL, NULL },
 	{ "algRef",		SC_ASN1_INTEGER,	SC_ASN1_TAG_INTEGER,	SC_ASN1_OPTIONAL, NULL, NULL },
 	{ NULL, 0, 0, 0, NULL, NULL }
 };
+// clang-format on
 
 static const struct sc_asn1_entry c_asn1_algorithm_info_parameters[3] = {
 	{ "PKCS15RSAParameters",SC_ASN1_NULL,		SC_ASN1_TAG_NULL,	0, NULL, NULL },

--- a/src/tests/unittests/asn1.c
+++ b/src/tests/unittests/asn1.c
@@ -599,9 +599,199 @@ static void torture_asn1_encode_simple(void **state)
 	free(outptr);
 }
 
+/*
+ * Tests for SC_ASN1_OPTIONAL on SC_ASN1_CHOICE entries.
+ *
+ * Schema used in the first four tests (outer has three entries):
+ *   before  INTEGER          mandatory
+ *   choice  CHOICE(NULL|OID) optional in tests 1,2,4; mandatory in test 3
+ *   after   INTEGER          mandatory
+ *
+ * The end-of-stream test (test 5) omits the "after" field.
+ */
+static void
+torture_asn1_decode_optional_choice_absent(void **state)
+{
+	sc_context_t *ctx = *state;
+	// clang-format off
+	struct sc_asn1_entry choice_alts[3] = {
+		{ "null_alt",   SC_ASN1_NULL,   SC_ASN1_TAG_NULL,   0, NULL, NULL },
+		{ "object_alt", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry outer[4] = {
+		{ "before", SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ "choice", SC_ASN1_CHOICE,  0,                   SC_ASN1_OPTIONAL, NULL, NULL },
+		{ "after",  SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	// clang-format on
+	/* INTEGER(1), no CHOICE tag, INTEGER(2) */
+	const u8 data[] = {0x02, 0x01, 0x01, 0x02, 0x01, 0x02};
+	int before = 0, after = 0;
+	int rv;
+
+	sc_format_asn1_entry(&outer[0], &before, NULL, 0);
+	sc_format_asn1_entry(&outer[1], choice_alts, NULL, 0);
+	sc_format_asn1_entry(&outer[2], &after, NULL, 0);
+
+	rv = sc_asn1_decode(ctx, outer, data, sizeof(data), NULL, NULL);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_int_equal(before, 1);
+	assert_int_equal(after, 2);
+	assert_false(choice_alts[0].flags & SC_ASN1_PRESENT);
+	assert_false(choice_alts[1].flags & SC_ASN1_PRESENT);
+}
+
+static void
+torture_asn1_decode_optional_choice_present(void **state)
+{
+	sc_context_t *ctx = *state;
+	struct sc_object_id oid_val;
+	// clang-format off
+	struct sc_asn1_entry choice_alts[3] = {
+		{ "null_alt",   SC_ASN1_NULL,   SC_ASN1_TAG_NULL,   0, NULL, NULL },
+		{ "object_alt", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry outer[4] = {
+		{ "before", SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ "choice", SC_ASN1_CHOICE,  0,                   SC_ASN1_OPTIONAL, NULL, NULL },
+		{ "after",  SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	// clang-format on
+	/* INTEGER(1), OID {1.2} (0x06 0x01 0x2a — matches second CHOICE alternative), INTEGER(2) */
+	const u8 data[] = {0x02, 0x01, 0x01, 0x06, 0x01, 0x2a, 0x02, 0x01, 0x02};
+	int before = 0, after = 0;
+	int rv;
+
+	sc_format_asn1_entry(&choice_alts[1], &oid_val, NULL, 0);
+	sc_format_asn1_entry(&outer[0], &before, NULL, 0);
+	sc_format_asn1_entry(&outer[1], choice_alts, NULL, 0);
+	sc_format_asn1_entry(&outer[2], &after, NULL, 0);
+
+	rv = sc_asn1_decode(ctx, outer, data, sizeof(data), NULL, NULL);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_int_equal(before, 1);
+	assert_int_equal(after, 2);
+	assert_false(choice_alts[0].flags & SC_ASN1_PRESENT);
+	assert_true(choice_alts[1].flags & SC_ASN1_PRESENT);
+	assert_int_equal(oid_val.value[0], 1);
+	assert_int_equal(oid_val.value[1], 2);
+}
+
+static void
+torture_asn1_decode_mandatory_choice_absent(void **state)
+{
+	sc_context_t *ctx = *state;
+	// clang-format off
+	struct sc_asn1_entry choice_alts[3] = {
+		{ "null_alt",   SC_ASN1_NULL,   SC_ASN1_TAG_NULL,   0, NULL, NULL },
+		{ "object_alt", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry outer[4] = {
+		{ "before", SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0, NULL, NULL },
+		{ "choice", SC_ASN1_CHOICE,  0,                   0, NULL, NULL }, /* NOT optional */
+		{ "after",  SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	// clang-format on
+	/* INTEGER(1), no CHOICE tag, INTEGER(2) — CHOICE is mandatory so this must fail */
+	const u8 data[] = {0x02, 0x01, 0x01, 0x02, 0x01, 0x02};
+	int before = 0, after = 0;
+	int rv;
+
+	sc_format_asn1_entry(&outer[0], &before, NULL, 0);
+	sc_format_asn1_entry(&outer[1], choice_alts, NULL, 0);
+	sc_format_asn1_entry(&outer[2], &after, NULL, 0);
+
+	rv = sc_asn1_decode(ctx, outer, data, sizeof(data), NULL, NULL);
+	assert_int_equal(rv, SC_ERROR_ASN1_OBJECT_NOT_FOUND);
+	assert_int_equal(before, 1);
+	assert_int_equal(after, 0);
+	assert_false(choice_alts[0].flags & SC_ASN1_PRESENT);
+	assert_false(choice_alts[1].flags & SC_ASN1_PRESENT);
+}
+
+static void
+torture_asn1_decode_optional_choice_malformed(void **state)
+{
+	sc_context_t *ctx = *state;
+	struct sc_object_id oid_val;
+	// clang-format off
+	struct sc_asn1_entry choice_alts[3] = {
+		{ "null_alt",   SC_ASN1_NULL,   SC_ASN1_TAG_NULL,   0, NULL, NULL },
+		{ "object_alt", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry outer[4] = {
+		{ "before", SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ "choice", SC_ASN1_CHOICE,  0,                   SC_ASN1_OPTIONAL, NULL, NULL },
+		{ "after",  SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	// clang-format on
+	/* INTEGER(1), OID tag with malformed content (0x81 has the multi-byte continuation
+	 * bit set but no following byte), INTEGER(2).  A real storage pointer is required on
+	 * the OID alternative: with parm=NULL asn1_decode_entry skips content validation and
+	 * the TLV is silently consumed.  With parm set, sc_asn1_decode_object_id returns an
+	 * error; the inner decoder exits before writing back p/left, so the optional CHOICE
+	 * swallows the error and the position is unchanged.  "after" then sees 0x06 (OID tag)
+	 * where INTEGER (0x02) was expected → SC_ERROR_ASN1_OBJECT_NOT_FOUND. */
+	const u8 data[] = {0x02, 0x01, 0x01, 0x06, 0x01, 0x81, 0x02, 0x01, 0x02};
+	int before = 0, after = 0;
+	int rv;
+
+	sc_format_asn1_entry(&choice_alts[1], &oid_val, NULL, 0);
+	sc_format_asn1_entry(&outer[0], &before, NULL, 0);
+	sc_format_asn1_entry(&outer[1], choice_alts, NULL, 0);
+	sc_format_asn1_entry(&outer[2], &after, NULL, 0);
+
+	rv = sc_asn1_decode(ctx, outer, data, sizeof(data), NULL, NULL);
+	assert_int_equal(rv, SC_ERROR_ASN1_OBJECT_NOT_FOUND);
+	assert_int_equal(before, 1);
+	assert_int_equal(after, 0);
+	assert_false(choice_alts[0].flags & SC_ASN1_PRESENT);
+	assert_false(choice_alts[1].flags & SC_ASN1_PRESENT);
+}
+
+static void
+torture_asn1_decode_optional_choice_end_of_stream(void **state)
+{
+	sc_context_t *ctx = *state;
+	// clang-format off
+	struct sc_asn1_entry choice_alts[3] = {
+		{ "null_alt",   SC_ASN1_NULL,   SC_ASN1_TAG_NULL,   0, NULL, NULL },
+		{ "object_alt", SC_ASN1_OBJECT, SC_ASN1_TAG_OBJECT, 0, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	struct sc_asn1_entry outer[3] = {
+		{ "before", SC_ASN1_INTEGER, SC_ASN1_TAG_INTEGER, 0,                NULL, NULL },
+		{ "choice", SC_ASN1_CHOICE,  0,                   SC_ASN1_OPTIONAL, NULL, NULL },
+		{ NULL, 0, 0, 0, NULL, NULL }
+	};
+	// clang-format on
+	/* INTEGER(1) only — stream ends before the optional CHOICE */
+	const u8 data[] = {0x02, 0x01, 0x01};
+	int before = 0;
+	int rv;
+
+	sc_format_asn1_entry(&outer[0], &before, NULL, 0);
+	sc_format_asn1_entry(&outer[1], choice_alts, NULL, 0);
+
+	rv = sc_asn1_decode(ctx, outer, data, sizeof(data), NULL, NULL);
+	assert_int_equal(rv, SC_SUCCESS);
+	assert_int_equal(before, 1);
+	assert_false(choice_alts[0].flags & SC_ASN1_PRESENT);
+	assert_false(choice_alts[1].flags & SC_ASN1_PRESENT);
+}
+
 int main(void)
 {
 	int rc;
+	// clang-format off
 	struct CMUnitTest tests[] = {
 		/* INTEGER */
 		cmocka_unit_test(torture_asn1_integer_zero),
@@ -669,7 +859,19 @@ int main(void)
 		/* encode() */
 		cmocka_unit_test_setup_teardown(torture_asn1_encode_simple,
 			setup_sc_context, teardown_sc_context),
+		/* decode(): optional CHOICE */
+		cmocka_unit_test_setup_teardown(torture_asn1_decode_optional_choice_absent,
+			setup_sc_context, teardown_sc_context),
+		cmocka_unit_test_setup_teardown(torture_asn1_decode_optional_choice_present,
+			setup_sc_context, teardown_sc_context),
+		cmocka_unit_test_setup_teardown(torture_asn1_decode_mandatory_choice_absent,
+			setup_sc_context, teardown_sc_context),
+		cmocka_unit_test_setup_teardown(torture_asn1_decode_optional_choice_malformed,
+			setup_sc_context, teardown_sc_context),
+		cmocka_unit_test_setup_teardown(torture_asn1_decode_optional_choice_end_of_stream,
+			setup_sc_context, teardown_sc_context),
 	};
+	// clang-format on
 
 	rc = cmocka_run_group_tests(tests, NULL, NULL);
 	return rc;


### PR DESCRIPTION
### Problem

Cards that list only AES algorithms in their `EF(TokenInfo)` `AlgorithmInfo` sequence
fail with `PKCS#15 binding failed` when OpenSC attempts to parse the token information.
The `AlgorithmInfo.parameters` field is an ASN.1 Information Object Class (IOC) field
whose presence depends on whether the referenced algorithm's class object defines
`&Parameters`.  AES algorithms are not defined in PKCS#15 v1.1 itself; cards use the
standard NIST OIDs (`2.16.840.1.101.3.4.1.*`) as a de-facto extension, and no
`&Parameters` type is defined for those OIDs, so the field is correctly absent.  OpenSC
was treating its absence as a hard error.

**Reproduction:**

```
$ pkcs15-tool -D
Using reader with a card: VMware Virtual USB CCID 00 00
PKCS#15 binding failed: Unsupported card
```

Despite the card having a fully valid native PKCS#15 structure, OpenSC cannot bind it at
all and falls through to synthetic emulators, all of which also fail.  The root cause is
visible with debug output enabled:

```
sc_pkcs15_parse_tokeninfo: ASN.1 parsing of EF(TokenInfo) failed: -1402 (Required ASN.1 object not found)
sc_pkcs15_bind_internal:   cannot parse TokenInfo content: Required ASN.1 object not found
sc_pkcs15_bind_internal:   returning with: -1402 (Required ASN.1 object not found)
```

### Root cause

Two bugs cooperate to produce the failure:

**1. `pkcs15.c`: wrong flags on `AlgorithmInfo.parameters`**

The PKCS#15 v1.1 ASN.1 module defines `AlgorithmInfo` as:

```asn1
AlgorithmInfo ::= SEQUENCE {
    reference           Reference,
    algorithm           PKCS15-ALGORITHM.&id({AlgorithmSet}),
    parameters          PKCS15-ALGORITHM.&Parameters({AlgorithmSet}{@algorithm}),
    supportedOperations PKCS15-ALGORITHM.&Operations({AlgorithmSet}{@algorithm}),
    algId               PKCS15-ALGORITHM.&objectIdentifier({AlgorithmSet}{@algorithm})
                        OPTIONAL,
    algRef              Reference OPTIONAL
}
```

`parameters` has no explicit `OPTIONAL` keyword.  Its presence is governed by the IOC
mechanism: the field is absent when the specific algorithm's class object does not define
`&Parameters`.  AES is not part of the PKCS#15 v1.1 algorithm set; cards encode it using
NIST OIDs as a de-facto extension, and no `&Parameters` is defined for those OIDs.
OpenSC itself reflects this in `pkcs15-myeid.c`, where `_add_supported_algo()` never sets
`algo->parameters` for AES entries, leaving it zero-initialised and absent from the
encoded EF(TokenInfo).  The OpenSC-Java implementation handles decoding the same way —
it only encodes `parameters` when `getKeyInfo().getParameters() != null`, with AES
falling into a `NullAlgorithmInfo` / `NullKeyInfo` path that returns `null`.  The OpenSC
schema entry was missing `SC_ASN1_OPTIONAL`:

```c
/* before */
{ "parameters",  SC_ASN1_CHOICE,  0,  0,                NULL, NULL },
/* after  */
{ "parameters",  SC_ASN1_CHOICE,  0,  SC_ASN1_OPTIONAL, NULL, NULL },
```

**2. `asn1.c`: `SC_ASN1_CHOICE` never checked `SC_ASN1_OPTIONAL`**

`asn1_decode()` has a fast path for `SC_ASN1_CHOICE` entries (which carry no tag of their
own) that returns the inner decoder's error directly, without ever inspecting the entry's
`SC_ASN1_OPTIONAL` flag.  The general optional-skip logic that follows is therefore never
reached.

```c
/* before */
if (r >= 0)
    r = 0;
goto decode_ok;

/* after */
if (r >= 0 || (entry->flags & SC_ASN1_OPTIONAL))
    r = 0;
goto decode_ok;
```

### After the fix

With both fixes applied, `pkcs15-tool -D` successfully binds the card and enumerates all
objects, including the four AES `AlgorithmInfo` entries that previously caused the failure:

```
$ pkcs15-tool -D
Using reader with a card: VMware Virtual USB CCID 00 00
PKCS#15 Card [Example PKI card]:
    Version        : 0
    Serial number  : 00000000000000000000
    Manufacturer ID: Aventra
    Last update    : 20250217071654Z
    Flags          : EID compliant
         sc_supported_algo_info[0]:
             reference  : 1 (0x01)
             mechanism  : [0x1081] CKM_AES_ECB
             operations : [0x30], encipher, decipher
             algo_id    : 2.16.840.1.101.3.4.1.1
             algo_ref   : [0x00]
         sc_supported_algo_info[1]:
             reference  : 2 (0x02)
             mechanism  : [0x1082] CKM_AES_CBC
             operations : [0x30], encipher, decipher
             algo_id    : 2.16.840.1.101.3.4.1.2
             algo_ref   : [0x00]
         sc_supported_algo_info[2]:
             reference  : 3 (0x03)
             mechanism  : [0x1081] CKM_AES_ECB
             operations : [0x30], encipher, decipher
             algo_id    : 2.16.840.1.101.3.4.1.41
             algo_ref   : [0x00]
         sc_supported_algo_info[3]:
             reference  : 4 (0x04)
             mechanism  : [0x1082] CKM_AES_CBC
             operations : [0x30], encipher, decipher
             algo_id    : 2.16.840.1.101.3.4.1.42
             algo_ref   : [0x00]

... removed objects ...
```

The four AES-128-ECB, AES-128-CBC, AES-256-ECB, and AES-256-CBC entries (NIST OIDs
`2.16.840.1.101.3.4.1.{1,2,41,42}`) are now decoded successfully even though the
`parameters` field is absent in every entry — consistent with how OpenSC itself encodes
them and how OpenSC-Java decodes them.

### Tests

A set of cmocka unit tests is added to `src/tests/unittests/asn1.c` covering five cases:

| Test | Description |
|------|-------------|
| `torture_asn1_decode_optional_choice_absent`          | Optional CHOICE absent → `SC_SUCCESS`, surrounding fields decoded |
| `torture_asn1_decode_optional_choice_present`         | Optional CHOICE present → `SC_SUCCESS`, CHOICE alternative decoded |
| `torture_asn1_decode_mandatory_choice_absent`         | Mandatory CHOICE absent → `SC_ERROR_ASN1_OBJECT_NOT_FOUND` |
| `torture_asn1_decode_optional_choice_malformed`       | Optional CHOICE tag matches but content is malformed → `SC_ERROR_ASN1_OBJECT_NOT_FOUND` |
| `torture_asn1_decode_optional_choice_end_of_stream`   | Optional CHOICE at end of stream → `SC_SUCCESS` |

All 55 unit tests pass with `--enable-cmocka --disable-openssl`.

The fix was verified on hardware with an Aventra MyEID 4.5.5 card
(`opensc-tool -n` → `MyEID cards with PKCS#15 applet`) whose EF(TokenInfo)
contains only AES AlgorithmInfo entries.  Before the fix `pkcs15-tool -D`
fails with "PKCS#15 binding failed"; after the fix it enumerates all card
objects correctly, including the four AES algorithm entries shown above.
`pkcs11-tool -T` succeeds, and a PKCS#11-backed mTLS client application
completes a full TLS handshake against a remote server using the card's
RSA private key.

##### Checklist
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested

---

Disclaimer:
- I did use my assistant to debug the new smart card problem and tried to add as much as information possible for easier review experience.
- I do not have access to latest standards to do cross check with them (i.e. if `AlgorithmInfo` has been changed).
- I tired to cross check with information I had an access to make sure that stuff here is as correct as I could make it
- There seems to be failing GitHub workflows but they seem to be same as in earlier runs

That being said -- I am happy to provide additional information if required -- if you want it less verbose or want something to be changed feel free to ask.
