### PR TITLE
pkcs15-tool: prevent buffer overflow on RSA key parsing

### DIFF
--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -1132,7 +1132,7 @@ static int read_ssh_key(void)
 		len = sprintf((char *) buf+4,"ssh-rsa");
 		len+=4;
 
-		if (sizeof(buf)-len < 4+pubkey->u.rsa.exponent.len)
+		if (sizeof(buf)-len < 5+pubkey->u.rsa.exponent.len)
 			goto fail;
 
 		n = pubkey->u.rsa.exponent.len;


### PR DESCRIPTION
Attribution

This vulnerability was discovered by Claude, Anthropic's AI assistant, with OSS-Fuzz fuzzing and triaged by Ada Logics manually in collaboration with Anthropic Research. reborted by @arthurscchan Arthur Chan

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
