### PR TITLE
pkcs11-tool: prevent buffer overflow

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -1342,6 +1342,8 @@ int main(int argc, char * argv[])
 		}
 		if (opt_uri->id) {
 			opt_object_id_len = opt_uri->id_len;
+			if (opt_object_id_len > sizeof(opt_object_id))
+				util_fatal("URI's object ID too long");
 			memcpy(opt_object_id, opt_uri->id, opt_object_id_len);
 		}
 	}
@@ -9608,6 +9610,10 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 		return session;
 	}
 	opt_object_id_len = (size_t) i;
+	if (opt_object_id_len > sizeof(opt_object_id)) {
+		fprintf(stderr, "ERR: object ID too long\n");
+		return session;
+	}
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */


### PR DESCRIPTION
Reported by @HMF2021 hippofu999

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
