### PR TITLE
esteid2018: fixed possible Global-buffer-overflow

### DIFF
--- a/src/libopensc/pkcs15-esteid2018.c
+++ b/src/libopensc/pkcs15-esteid2018.c
@@ -94,6 +94,11 @@ static int sc_pkcs15emu_esteid2018_init(sc_pkcs15_card_t *p15card) {
 		cert_info = (struct sc_pkcs15_cert_info *)obj.data;
 		if (cert_info && cert_info->path.len > 0) {
 			cert_slot = cert_info->path.value[cert_info->path.len - 1] - 1;
+			if (cert_slot != 0 && cert_slot != 1) {
+				/* unknown slot, see `cert_paths` below */
+				r = SC_ERROR_UNKNOWN_DATA_RECEIVED;
+				LOG_TEST_GOTO_ERR(card->ctx, r, "Unknown certificate path");
+			}
 		}
 
 		sc_pkcs15_free_cert_info(cert_info);


### PR DESCRIPTION
Attribution

Reported by @arthurscchan Arthur Chan .  This vulnerability was discovered by Claude, Anthropic's AI assistant, with OSS-Fuzz fuzzing and triaged by Ada Logics manually in collaboration with Anthropic Research.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
