### PR TITLE
iasecc: fixed possible Stack Buffer Overflow

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -3303,6 +3303,8 @@ iasecc_compute_signature_dst(struct sc_card *card,
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "It's not SC_SEC_OPERATION_SIGN");
 	else if (!(prv->key_size & 0x1E0) || (prv->key_size & ~0x1E0))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid key size for SC_SEC_OPERATION_SIGN");
+	if (sizeof(rbuf) < prv->key_size)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 
 	memset(&qsign_data, 0, sizeof(qsign_data));
 	if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA1)   {


### PR DESCRIPTION
Attribution
Reported by @qp-x-qp

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
