### PR TITLE
CI: Windows artifact contain release (candidate) tags or short hash o…

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -8,27 +8,14 @@ if [ -x "/bin/sudo" ]; then
 	SUDO="sudo"
 fi
 
-if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-	PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-	if [ "$GITHUB_BASE_REF" == "master" ]; then
-		SUFFIX="-pr$PR_NUMBER"
-	else
-		SUFFIX="$GITHUB_BASE_REF-pr$PR_NUMBER"
-	fi
-else
-	TAG_OR_BRANCH=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-	if [ "$GITHUB_REF_TYPE" == "tag" ]; then
-		if [[ "$TAG_OR_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-			# Tag matches the version scheme without suffix -- no suffix needed
-			SUFFIX=""
-		elif [[ "$TAG_OR_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.+)$ ]]; then
-			# rc suffix after version. Use the suffix part only
-			SUFFIX="${BASH_REMATCH[1]}"
-		else
-			SUFFIX="-$TAG_OR_BRANCH"
-		fi
-	elif [ "$TAG_OR_BRANCH" != "master" ]; then
-		SUFFIX="-$TAG_OR_BRANCH"
+SUFFIX="-${GITHUB_SHA:0:7}"
+if [ "$GITHUB_REF_TYPE" == "tag" ]; then
+	if [[ "$GITHUB_REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		# Tag matches the version scheme without suffix -- no suffix needed
+		SUFFIX=""
+	elif [[ "$GITHUB_REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.+)$ ]]; then
+		# rc suffix after version. Use the suffix part only
+		SUFFIX="${BASH_REMATCH[1]}"
 	fi
 fi
 if [ -n "$SUFFIX" ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,23 +41,12 @@ jobs:
       - name: Package suffix
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if [[ "${{ github.base_ref }}" == "master" ]]; then
-              SUFFIX="-pr${{ github.event.number }}"
-            else
-              SUFFIX="-${{ github.base_ref }}-pr${{ github.event.number }}"
-            fi
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.ref_type }}" == "tag" ]]; then
-              if [[ "${{ github.ref_name }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                SUFFIX="" # regular release tag
-              elif [[ "${{ github.ref_name }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.+)$ ]]; then
-                SUFFIX="${BASH_REMATCH[1]}" # rc release tag
-              else
-                SUFFIX="-${{ github.ref_name }}"
-              fi
-            elif [[ "${{ github.ref_name }}" != "master" ]]; then
-              SUFFIX="-${{ github.ref_name }}"
+          SUFFIX="-${GITHUB_SHA:0:7}"
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            if [[ "${{ github.ref_name }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              SUFFIX="" # regular release tag
+            elif [[ "${{ github.ref_name }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.+)$ ]]; then
+              SUFFIX="${BASH_REMATCH[1]}" # rc release tag
             fi
           fi
           PACKAGE_SUFFIX="${SUFFIX}${{ matrix.configuration == 'Light' && '-Light' || '' }}"


### PR DESCRIPTION
…therwise

fixes problem with artifact upload when ref_name contains invalid characters such as "/"

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
