### PR TITLE
asn1: avoid uninitialized read of INTEGER/ENUMERATED debug output

### DIFF
--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1525,12 +1525,9 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_ENUMERATED:
 		if (parm != NULL) {
 			r = sc_asn1_decode_integer(obj, objlen, (int *) entry->parm, 0);
-			if (r == 0) {
+			if (r == SC_SUCCESS) {
 				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' returned %d\n",
 					depth, depth, "", entry->name, *((int *) entry->parm));
-			} else {
-				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' failed: %d\n",
-					depth, depth, "", entry->name, r);
 			}
 		}
 		break;

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1492,7 +1492,7 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	void *parm = entry->parm;
 	int (*callback_func)(sc_context_t *nctx, void *arg, const u8 *nobj,
 			     size_t nobjlen, int ndepth);
-	size_t *len = (size_t *) entry->arg;
+	size_t *len = (size_t *)entry->arg;
 	int r = 0;
 
 	callback_func = parm;
@@ -1524,10 +1524,10 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_INTEGER:
 	case SC_ASN1_ENUMERATED:
 		if (parm != NULL) {
-			r = sc_asn1_decode_integer(obj, objlen, (int *) entry->parm, 0);
+			r = sc_asn1_decode_integer(obj, objlen, (int *)entry->parm, 0);
 			if (r == SC_SUCCESS) {
 				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' returned %d\n",
-					depth, depth, "", entry->name, *((int *) entry->parm));
+					depth, depth, "", entry->name, *((int *)entry->parm));
 			}
 		}
 		break;
@@ -1698,7 +1698,7 @@ static void sc_free_entry(struct sc_asn1_entry *asn1) {
 		switch (entry->type) {
 		case SC_ASN1_CHOICE:
 		case SC_ASN1_STRUCT:
-			sc_free_entry((struct sc_asn1_entry *) entry->parm);
+			sc_free_entry((struct sc_asn1_entry *)entry->parm);
 			break;
 		case SC_ASN1_OCTET_STRING:
 		case SC_ASN1_BIT_STRING_NI:
@@ -1758,7 +1758,7 @@ static int asn1_decode(sc_context_t *ctx, struct sc_asn1_entry *asn1,
 		/* Special case CHOICE has no tag */
 		if (entry->type == SC_ASN1_CHOICE) {
 			r = asn1_decode(ctx,
-				(struct sc_asn1_entry *) entry->parm,
+				(struct sc_asn1_entry *)entry->parm,
 				p, left, &p, &left, 1, depth + 1);
 			/* When the inner call fails it returns before writing
 			 * back to *newp and *len_left, so the caller's p/left are
@@ -1829,7 +1829,7 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 	void *parm = entry->parm;
 	int (*callback_func)(sc_context_t *nctx, void *arg, u8 **nobj,
 			     size_t *nobjlen, int ndepth);
-	const size_t *len = (const size_t *) entry->arg;
+	const size_t *len = (const size_t *)entry->arg;
 	int r = 0;
 	u8 * buf = NULL;
 	size_t buflen = 0;
@@ -1896,7 +1896,7 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 		break;
 	case SC_ASN1_INTEGER:
 	case SC_ASN1_ENUMERATED:
-		r = asn1_encode_integer(*((int *) entry->parm), &buf, &buflen);
+		r = asn1_encode_integer(*((int *)entry->parm), &buf, &buflen);
 		break;
 	case SC_ASN1_BIT_STRING_NI:
 	case SC_ASN1_BIT_STRING:

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1492,7 +1492,7 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	void *parm = entry->parm;
 	int (*callback_func)(sc_context_t *nctx, void *arg, const u8 *nobj,
 			     size_t nobjlen, int ndepth);
-	size_t *len = (size_t *)entry->arg;
+	size_t *len = (size_t *) entry->arg;
 	int r = 0;
 
 	callback_func = parm;
@@ -1524,10 +1524,10 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_INTEGER:
 	case SC_ASN1_ENUMERATED:
 		if (parm != NULL) {
-			r = sc_asn1_decode_integer(obj, objlen, (int *)entry->parm, 0);
+			r = sc_asn1_decode_integer(obj, objlen, (int *) entry->parm, 0);
 			if (r == SC_SUCCESS) {
 				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' returned %d\n",
-					depth, depth, "", entry->name, *((int *)entry->parm));
+						depth, depth, "", entry->name, *((int *)entry->parm));
 			}
 		}
 		break;
@@ -1698,7 +1698,7 @@ static void sc_free_entry(struct sc_asn1_entry *asn1) {
 		switch (entry->type) {
 		case SC_ASN1_CHOICE:
 		case SC_ASN1_STRUCT:
-			sc_free_entry((struct sc_asn1_entry *)entry->parm);
+			sc_free_entry((struct sc_asn1_entry *) entry->parm);
 			break;
 		case SC_ASN1_OCTET_STRING:
 		case SC_ASN1_BIT_STRING_NI:
@@ -1758,7 +1758,7 @@ static int asn1_decode(sc_context_t *ctx, struct sc_asn1_entry *asn1,
 		/* Special case CHOICE has no tag */
 		if (entry->type == SC_ASN1_CHOICE) {
 			r = asn1_decode(ctx,
-				(struct sc_asn1_entry *)entry->parm,
+				(struct sc_asn1_entry *) entry->parm,
 				p, left, &p, &left, 1, depth + 1);
 			/* When the inner call fails it returns before writing
 			 * back to *newp and *len_left, so the caller's p/left are
@@ -1829,7 +1829,7 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 	void *parm = entry->parm;
 	int (*callback_func)(sc_context_t *nctx, void *arg, u8 **nobj,
 			     size_t *nobjlen, int ndepth);
-	const size_t *len = (const size_t *)entry->arg;
+	const size_t *len = (const size_t *) entry->arg;
 	int r = 0;
 	u8 * buf = NULL;
 	size_t buflen = 0;
@@ -1896,7 +1896,7 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 		break;
 	case SC_ASN1_INTEGER:
 	case SC_ASN1_ENUMERATED:
-		r = asn1_encode_integer(*((int *)entry->parm), &buf, &buflen);
+		r = asn1_encode_integer(*((int *) entry->parm), &buf, &buflen);
 		break;
 	case SC_ASN1_BIT_STRING_NI:
 	case SC_ASN1_BIT_STRING:

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -1525,8 +1525,13 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_ENUMERATED:
 		if (parm != NULL) {
 			r = sc_asn1_decode_integer(obj, objlen, (int *) entry->parm, 0);
-			sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' returned %d\n", depth, depth, "",
-					entry->name, *((int *) entry->parm));
+			if (r == 0) {
+				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' returned %d\n",
+					depth, depth, "", entry->name, *((int *) entry->parm));
+			} else {
+				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*sdecoding '%s' failed: %d\n",
+					depth, depth, "", entry->name, r);
+			}
 		}
 		break;
 	case SC_ASN1_BIT_STRING_NI:


### PR DESCRIPTION
Fixes #3685.

Guards the `SC_ASN1_INTEGER` / `SC_ASN1_ENUMERATED` debug log in `asn1_decode_entry()` on the return value of `sc_asn1_decode_integer()`: log the decoded value only on success, otherwise log the error code. The decoder itself is untouched and the success-path log format is unchanged. See the issue for the full root-cause analysis and reproducer.

<!--

Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'

(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,

run this command: opensc-tool -n

-->

##### Checklist

Reproduced and tested with the `fuzz_pkcs15init` native target on Linux x86_64; no physical smart card involved.