### PR TITLE
Fix epass2003 regression with SM

### DIFF
--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -1462,6 +1462,8 @@ decrypt_response(struct sc_card *card, unsigned char *in, size_t inlen, unsigned
 	if (cipher_len < 2 || cipher_len > sizeof plaintext)
 		return -1;
 
+	/* Skip the 0x01 separator between tag and ciphertext */
+	p++;
 	/* decrypt */
 	if (KEY_TYPE_AES == exdata->smtype)
 		aes128_decrypt_cbc(card, exdata->sk_enc, 16, iv, p, cipher_len - 1, plaintext);


### PR DESCRIPTION
There is 0x01 separator between the tag and value, which was breaking the encryption for last couple of weeks.

Fixup of 5ebb04ded3e8a54a9544a3745b3b5bd566d1e0b2

Fixes: #3693

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
