### PR TITLE
[0.26.1] backport CVE-2026-40510: bound PIV history URL length in piv_process_history

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5057,6 +5057,10 @@ piv_process_history(sc_card_t *card)
 
 			url = sc_asn1_find_tag(card->ctx, body, bodylen, 0xF3, &urllen);
 			if (url) {
+				if (urllen > 118) {
+					r = SC_ERROR_INVALID_ASN1_OBJECT;
+					goto err;
+				}
 				priv->offCardCertURL = calloc(1,urllen+1);
 				if (priv->offCardCertURL == NULL)
 					LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
@@ -5083,8 +5087,9 @@ piv_process_history(sc_card_t *card)
 	 * the card. some of the certs may be on the card as well.
 	 *
 	 * Get file name from url. verify that the filename is valid
-	 * The URL ends in a SHA1 string. We will use this as the filename
+	 * The URL ends in a SHA-256 string. We will use this as the filename
 	 * in the directory used for the  PKCS15 cache
+	 * "http://" <DNS name> "/" <ASCII-HEX encoded SHA-256 hash of OffCardKeyHistoryFile>
 	 */
 
 	r = 0;
@@ -5103,6 +5108,16 @@ piv_process_history(sc_card_t *card)
 			goto err;
 		}
 		fp++;
+		if (strlen(fp) != 64) { /* ASCII-HEX encoded SHA-256 */
+			r = SC_ERROR_INVALID_DATA;
+			goto err;
+		}
+		for (i = 0; i < 64; i++) {
+			if (isxdigit((unsigned char)fp[i]) == 0) {
+				r = SC_ERROR_INVALID_DATA;
+				goto err;
+			}
+		}
 
 		/* Use the same directory as used for other OpenSC cached items */
 		r = sc_get_cache_dir(card->ctx, filename, sizeof(filename) - strlen(fp) - 2);


### PR DESCRIPTION
The 0.26.1 branch doesn't have the piv_process_history() bounds fix that landed on master (PR #3558). On 0.26.1, after building the cache filename, sc_get_cache_dir() is called with sizeof(filename)-strlen(fp)-2 which underflows when the on-card URL filename is long, then strcat(filename, fp) overruns filename[PATH_MAX]. There's no urllen>118 cap and no SHA-256 filename validation.

I checked it actually reaches the overflow on 0.26.1 rather than just diffing: extracted the function plus sc_get_cache_dir's snprintf-bounded home handling into a harness, built with -fsanitize=address on ubuntu:22.04. A PIV history object with an oversized offCardCertURL gives, pre-fix, an ASan stack-buffer-overflow WRITE in strcat; with the fix applied it returns -2 cleanly.

One note: the upstream fix 3f24f0b4 is a merge, so I cherry-picked with -m 1, which yields the intended 16-insertion/1-deletion change; authors (Frank Morgner / Doug Engert) preserved. Clean, no conflicts. Glad to rebase if you'd prefer.

upstream: https://github.com/OpenSC/OpenSC/commit/3f24f0b48a481a8cf2e46059d8238a283ddc1c13
CVE-2026-40510