### PR TITLE
pkcs11-tool unwrap_key should read to dynamically allocated buffer instead static one

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4136,7 +4136,8 @@ unwrap_key(CK_SESSION_HANDLE session)
 	int n_attr = 2;
 	CK_RV rv;
 	int fd;
-	unsigned char in_buffer[2048];
+	unsigned char* in_buffer = NULL;
+	CK_ULONG in_buffer_length = 8192;
 	CK_ULONG wrapped_key_length;
 	CK_BYTE_PTR pWrappedKey;
 	params_t params = {0};
@@ -4145,11 +4146,15 @@ unwrap_key(CK_SESSION_HANDLE session)
 	CK_OBJECT_HANDLE hUnwrappingKey;
 	ssize_t sz;
 
+	in_buffer = malloc(in_buffer_length);
+	if(in_buffer == NULL)
+		util_fatal("Cannot allocate enough memory for input buffer\n");
+
 	if (!find_object(session, CKO_PRIVATE_KEY, &hUnwrappingKey,
 			 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
 		if (!find_object(session, CKO_SECRET_KEY, &hUnwrappingKey,
 				 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
-			util_fatal("Private/secret key not found");
+			util_fatal("Private/secret key not found\n");
 
 	if (!opt_mechanism_used)
 		util_fatal("Unable to unwrap, no mechanism specified\n");
@@ -4161,11 +4166,11 @@ unwrap_key(CK_SESSION_HANDLE session)
 	if (opt_input == NULL)
 		fd = 0;
 	else if ((fd = open(opt_input, O_RDONLY | O_BINARY)) < 0)
-		util_fatal("Cannot open %s: %m", opt_input);
+		util_fatal("Cannot open %s: %m\n", opt_input);
 
-	sz = read(fd, in_buffer, sizeof(in_buffer));
+	sz = read(fd, in_buffer, in_buffer_length);
 	if (sz < 0)
-		util_fatal("Cannot read from %s: %m", opt_input);
+		util_fatal("Cannot read from %s: %m\n", opt_input);
 	wrapped_key_length = sz;
 	if (fd != 0)
 		close(fd);

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4136,9 +4136,7 @@ unwrap_key(CK_SESSION_HANDLE session)
 	int n_attr = 2;
 	CK_RV rv;
 	int fd;
-	unsigned char* in_buffer = NULL;
-	size_t in_buffer_size = 512;
-	size_t bytes_read = 0;
+	unsigned char in_buffer[16384];
 	CK_ULONG wrapped_key_length;
 	CK_BYTE_PTR pWrappedKey;
 	params_t params = {0};
@@ -4147,15 +4145,11 @@ unwrap_key(CK_SESSION_HANDLE session)
 	CK_OBJECT_HANDLE hUnwrappingKey;
 	ssize_t sz;
 
-	in_buffer = malloc(in_buffer_size);
-	if (in_buffer == NULL)
-		util_fatal("Cannot allocate enough memory for input buffer\n");
-
 	if (!find_object(session, CKO_PRIVATE_KEY, &hUnwrappingKey,
-			 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
+			    opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
 		if (!find_object(session, CKO_SECRET_KEY, &hUnwrappingKey,
-				 opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
-			util_fatal("Private/secret key not found\n");
+				    opt_object_id_len ? opt_object_id : NULL, opt_object_id_len, NULL, 0))
+			util_fatal("Private/secret key not found");
 
 	if (!opt_mechanism_used)
 		util_fatal("Unable to unwrap, no mechanism specified\n");
@@ -4167,28 +4161,12 @@ unwrap_key(CK_SESSION_HANDLE session)
 	if (opt_input == NULL)
 		fd = 0;
 	else if ((fd = open(opt_input, O_RDONLY | O_BINARY)) < 0)
-		util_fatal("Cannot open %s: %m\n", opt_input);
+		util_fatal("Cannot open %s: %m", opt_input);
 
-	do {
-		size_t space = in_buffer_size - bytes_read;
-		if (space == 0) {
-			unsigned char *tmp;
-			in_buffer_size *= 2;
-			tmp = realloc(in_buffer, in_buffer_size);
-			if (tmp == NULL) {
-				free(in_buffer);
-				util_fatal("Cannot reallocate input buffer\n");
-			}
-			in_buffer = tmp;
-			space = in_buffer_size - bytes_read;
-		}
-		sz = read(fd, in_buffer + bytes_read, space);
-		if (sz < 0)
-			util_fatal("Cannot read from %s: %m\n", opt_input);
-		bytes_read += (size_t)sz;
-	} while (sz > 0);
-
-	wrapped_key_length = (CK_ULONG)bytes_read;
+	sz = read(fd, in_buffer, sizeof(in_buffer));
+	if (sz < 0)
+		util_fatal("Cannot read from %s: %m", opt_input);
+	wrapped_key_length = sz;
 	if (fd != 0)
 		close(fd);
 	pWrappedKey = in_buffer;
@@ -4285,17 +4263,16 @@ unwrap_key(CK_SESSION_HANDLE session)
 
 	if (opt_allowed_mechanisms_len > 0) {
 		FILL_ATTR(keyTemplate[n_attr], CKA_ALLOWED_MECHANISMS, opt_allowed_mechanisms,
-			  sizeof(CK_MECHANISM_TYPE) * opt_allowed_mechanisms_len);
+				sizeof(CK_MECHANISM_TYPE) * opt_allowed_mechanisms_len);
 		n_attr++;
 	}
 	rv = p11->C_UnwrapKey(session, &mechanism, hUnwrappingKey,
-			      pWrappedKey, wrapped_key_length, keyTemplate, n_attr, &hSecretKey);
+			pWrappedKey, wrapped_key_length, keyTemplate, n_attr, &hSecretKey);
 	if (rv != CKR_OK)
 		p11_fatal("C_UnwrapKey", rv);
 
 	free(iv);
 	free(aad);
-	free(in_buffer);
 	printf("Key unwrapped\n");
 	show_object(session, hSecretKey);
 	return 1;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4278,6 +4278,7 @@ unwrap_key(CK_SESSION_HANDLE session)
 
 	free(iv);
 	free(aad);
+	free(in_buffer);
 	printf("Key unwrapped\n");
 	show_object(session, hSecretKey);
 	return 1;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -4137,7 +4137,8 @@ unwrap_key(CK_SESSION_HANDLE session)
 	CK_RV rv;
 	int fd;
 	unsigned char* in_buffer = NULL;
-	CK_ULONG in_buffer_length = 8192;
+	size_t in_buffer_size = 512;
+	size_t bytes_read = 0;
 	CK_ULONG wrapped_key_length;
 	CK_BYTE_PTR pWrappedKey;
 	params_t params = {0};
@@ -4146,8 +4147,8 @@ unwrap_key(CK_SESSION_HANDLE session)
 	CK_OBJECT_HANDLE hUnwrappingKey;
 	ssize_t sz;
 
-	in_buffer = malloc(in_buffer_length);
-	if(in_buffer == NULL)
+	in_buffer = malloc(in_buffer_size);
+	if (in_buffer == NULL)
 		util_fatal("Cannot allocate enough memory for input buffer\n");
 
 	if (!find_object(session, CKO_PRIVATE_KEY, &hUnwrappingKey,
@@ -4168,10 +4169,26 @@ unwrap_key(CK_SESSION_HANDLE session)
 	else if ((fd = open(opt_input, O_RDONLY | O_BINARY)) < 0)
 		util_fatal("Cannot open %s: %m\n", opt_input);
 
-	sz = read(fd, in_buffer, in_buffer_length);
-	if (sz < 0)
-		util_fatal("Cannot read from %s: %m\n", opt_input);
-	wrapped_key_length = sz;
+	do {
+		size_t space = in_buffer_size - bytes_read;
+		if (space == 0) {
+			unsigned char *tmp;
+			in_buffer_size *= 2;
+			tmp = realloc(in_buffer, in_buffer_size);
+			if (tmp == NULL) {
+				free(in_buffer);
+				util_fatal("Cannot reallocate input buffer\n");
+			}
+			in_buffer = tmp;
+			space = in_buffer_size - bytes_read;
+		}
+		sz = read(fd, in_buffer + bytes_read, space);
+		if (sz < 0)
+			util_fatal("Cannot read from %s: %m\n", opt_input);
+		bytes_read += (size_t)sz;
+	} while (sz > 0);
+
+	wrapped_key_length = (CK_ULONG)bytes_read;
 	if (fd != 0)
 		close(fd);
 	pWrappedKey = in_buffer;


### PR DESCRIPTION
Currently pkcs11-tool assumes in unwrap_key function that all input files are smaller or equal to 2048 bytes. 
But currently used algorithms often exceed this limit.
My patch replaces static buffer with dynamically allocated one of length 8192 because additional 8k bytes is big enough to strip down the exe file.
Patch was compiled and tested on ubuntu 24.04.
Exact changes:
1. changed declaration of in_buffer to the pointer;
2. added variable with in_buffer_length = 8192;
3. changed initialization to malloc();
4. changed read() to use in_buffer_length;
5. added free(in_buffer) at the end of function