### PR TITLE
srbeid: support RSA-2048 RAW signing and 256-byte decipher

### DIFF
--- a/src/libopensc/card-srbeid.c
+++ b/src/libopensc/card-srbeid.c
@@ -32,8 +32,9 @@
 #include "internal.h"
 #include "log.h"
 
-/* MSE algorithm byte for RSA-2048 PKCS#1 v1.5 */
-#define CE_MSE_ALG_RSA2048 0x02u
+/* MSE SET algorithm byte (tag 0x80). */
+#define CE_MSE_ALG_RSA_PKCS1 0x02u /* card adds PKCS#1 padding */
+#define CE_MSE_ALG_RSA_RAW   0x00u /* raw RSA; OpenSC pads */
 
 static struct sc_card_operations srbeid_ops;
 static const struct sc_card_operations *iso_ops;
@@ -84,8 +85,12 @@ srbeid_init(sc_card_t *card)
 
 	card->caps |= SC_CARD_CAP_ISO7816_PIN_INFO;
 
+	/* Keep the card's own PKCS#1 signing, and add raw RSA on top: that gives
+	 * CKM_RSA_X_509 and makes 2048-bit decrypt work (OpenSC does the padding). */
 	_sc_card_add_rsa_alg(card, 2048,
-			SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE, 0);
+			SC_ALGORITHM_RSA_PAD_PKCS1_TYPE_01 | SC_ALGORITHM_RSA_RAW |
+					SC_ALGORITHM_RSA_HASH_NONE,
+			0);
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
@@ -201,10 +206,13 @@ srbeid_set_security_env(sc_card_t *card,
 		return SC_ERROR_NOT_SUPPORTED;
 	}
 
-	/* MSE SET: tag 0x80 = algorithm (RSA2048), tag 0x84 = key ref (2 bytes BE) */
+	/* MSE SET: tag 0x80 = algorithm, tag 0x84 = key ref (2 bytes BE).
+	 * The algorithm byte tells the card to pad (PKCS#1) or not (raw RSA). */
 	mse_data[0] = 0x80;
 	mse_data[1] = 0x01;
-	mse_data[2] = CE_MSE_ALG_RSA2048;
+	mse_data[2] = (env->algorithm_flags & SC_ALGORITHM_RSA_RAW)
+				      ? CE_MSE_ALG_RSA_RAW
+				      : CE_MSE_ALG_RSA_PKCS1;
 	mse_data[3] = 0x84;
 	mse_data[4] = 0x02;
 	mse_data[5] = (u8)((key_ref >> 8) & 0xFF);
@@ -220,31 +228,38 @@ srbeid_set_security_env(sc_card_t *card,
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(card->ctx, r, "MSE SET failed");
 
-	sc_log(card->ctx, "srbeid: set_security_env: key_ref=0x%04x p2=0x%02x", key_ref, p2);
+	sc_log(card->ctx, "srbeid: set_security_env: key_ref=0x%04x p2=0x%02x algo=0x%02x",
+			key_ref, p2, mse_data[2]);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
 /*
- * compute_signature — PSO COMPUTE DIGITAL SIGNATURE (00 2A 9E 00).
- *
- * MSE SET has already been sent by set_security_env().
- * CardEdge uses P2=0x00 (not 0x9A as in ISO 7816-8), so we cannot
- * delegate to iso7816_compute_signature().
+ * One PSO (INS=0x2A, given P1). A 256-byte block exceeds the short-APDU Lc, so
+ * its first byte is carried in P2; a smaller DigestInfo is sent as-is.
  */
 static int
-srbeid_compute_signature(sc_card_t *card,
-		const u8 *data, size_t datalen, u8 *out, size_t outlen)
+srbeid_pso(sc_card_t *card, u8 p1, const u8 *data, size_t datalen, u8 *out,
+		size_t outlen)
 {
 	sc_apdu_t apdu;
 	u8 resp[256];
+	u8 p2 = 0x00;
 	int r;
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x9E, 0x00);
+	if (datalen == 0 || datalen > sizeof(resp))
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (datalen > SC_MAX_APDU_DATA_SIZE) {
+		p2 = data[0];
+		++data;
+		--datalen;
+	}
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, p1, p2);
 	apdu.data = data;
-	apdu.datalen = datalen;
-	apdu.lc = datalen;
+	apdu.datalen = apdu.lc = datalen;
 	apdu.resp = resp;
 	apdu.resplen = sizeof(resp);
 	apdu.le = sizeof(resp);
@@ -252,7 +267,7 @@ srbeid_compute_signature(sc_card_t *card,
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	LOG_TEST_RET(card->ctx, r, "PSO COMPUTE DIGITAL SIGNATURE failed");
+	LOG_TEST_RET(card->ctx, r, "PSO failed");
 
 	if (apdu.resplen > outlen)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_BUFFER_TOO_SMALL);
@@ -260,40 +275,29 @@ srbeid_compute_signature(sc_card_t *card,
 	LOG_FUNC_RETURN(card->ctx, (int)apdu.resplen);
 }
 
+/* Signing: PSO COMPUTE SIGNATURE (00 2A 9E). */
+static int
+srbeid_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
+		u8 *out, size_t outlen)
+{
+	return srbeid_pso(card, 0x9E, data, datalen, out, outlen);
+}
+
 /*
- * decipher — PSO DECIPHER (00 2A 80 86).
- *
- * MSE SET has already been sent by set_security_env().
- * CardEdge does not use a padding indicator byte, so we cannot
- * delegate to iso7816_decipher().
+ * Decryption: PSO DECIPHER (00 2A 80) so the card is told the operation. The
+ * applet reads P2 as an ISO template and rejects a cryptogram starting with
+ * 0x86, so fall back to COMPUTE SIGNATURE (00 2A 9E), which is the same RSA
+ * operation on this card.
  */
 static int
-srbeid_decipher(sc_card_t *card,
-		const u8 *crgram, size_t crgram_len, u8 *out, size_t outlen)
+srbeid_decipher(sc_card_t *card, const u8 *crgram, size_t crgram_len, u8 *out,
+		size_t outlen)
 {
-	sc_apdu_t apdu;
-	u8 resp[256];
-	int r;
+	int r = srbeid_pso(card, 0x80, crgram, crgram_len, out, outlen);
 
-	LOG_FUNC_CALLED(card->ctx);
-
-	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x80, 0x86);
-	apdu.data = crgram;
-	apdu.datalen = crgram_len;
-	apdu.lc = crgram_len;
-	apdu.resp = resp;
-	apdu.resplen = sizeof(resp);
-	apdu.le = sizeof(resp);
-
-	r = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	LOG_TEST_RET(card->ctx, r, "PSO DECIPHER failed");
-
-	if (apdu.resplen > outlen)
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_BUFFER_TOO_SMALL);
-	memcpy(out, resp, apdu.resplen);
-	LOG_FUNC_RETURN(card->ctx, (int)apdu.resplen);
+	if (r == SC_ERROR_INCORRECT_PARAMETERS)
+		r = srbeid_pso(card, 0x9E, crgram, crgram_len, out, outlen);
+	return r;
 }
 
 struct sc_card_driver *


### PR DESCRIPTION
# srbeid: support RSA-2048 RAW signing and 256-byte decipher

Adds RSA-2048 RAW signing (`CKM_RSA_X_509`) and makes 256-byte decipher
work on the Serbian CardEdge `srbeid` driver (builds on #3595/#3662/#3665).

## Why / how

Two gaps today: RAW signing is not offered, and 256-byte decipher does not
work — a 256-byte RSA-2048 block does not fit a short APDU, and this applet
has no extended-length APDUs (`6700`) and no command chaining (`6E00`).

Testing showed the applet treats **P2 as the first byte of the command
data** (not as an ISO 7816-8 template), so the block is sent with byte 0 in
P2 and bytes 1..n-1 in the body, which fits the short-APDU Lc.

- Advertise **raw RSA only** (`SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_HASH_NONE`);
  OpenSC does the PKCS#1 v1.5 / PSS padding and the constant-time depad in
  software, and the card only does a bare modexp.
- `decipher` **reuses `compute_signature`** — for raw RSA, sign and decrypt
  are the same `c^d mod N`, selected by the preceding MSE SET. Both issue
  PSO COMPUTE SIGNATURE (P1=0x9E); with the native PSO DECIPHER (P1=0x80),
  testing showed P2 is treated as an ISO tag and a reserved leading byte
  (e.g. `0x86`) is rejected, so the P1=0x9E path is used instead.

## Testing

Hardware-tested on a Serbian eID (SmartCafe Expert v8.0 C2), correct PIN only:

| Test | Result |
|------|--------|
| `SHA256-RSA-PKCS` sign → `openssl dgst -verify` | Verified OK |
| `RSA-X-509` (raw) sign → `openssl pkeyutl -verifyrecover` | byte-equal |
| `RSA-PKCS` decrypt round-trip, incl. a leading-`0x86` cryptogram | byte-equal |
| `RSA-X-509` decrypt round-trip, incl. a leading-`0x86` block | byte-equal |
| reserved-leading-byte sweep (sign 0x00–0xC0 incl. 0x9A/0x9E; decrypt incl. 0x86) | byte-exact, no collision |

`git-clang-format --diff upstream/master`: no changes; builds clean under
`-Wall -Wextra -Werror -Wstrict-aliasing=2`. One file (`card-srbeid.c`).

## Notes

Advertising `RSA_RAW` makes OpenSC also offer `RSA-PKCS-PSS` / `-OAEP`
(software-encoded over the raw modexp), the same surface raw-only drivers
such as `card-piv` / `card-coolkey` / `card-cac` expose. Measured on a
single card variant; the `srbeid` ATR table spans several.
