### PR TITLE
piv: add ATR for Giesecke+Devrient SCE7

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -484,6 +484,8 @@ static const struct sc_atr_table piv_atrs[] = {
 	{ "3B:7A:18:00:00:73:66:74:65:20:63:64:31:34:34", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE_DUAL_CAC, 0, NULL },
 	/* Giesecke & Devrient (CAC PIV Endpoint) 2019 */
 	{ "3B:F9:18:00:00:00:53:43:45:37:20:03:00:20:46", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE_DUAL_CAC, 0, NULL },
+	/* Giesecke & Devrient SCE7 (PIV-only) */
+	{ "3B:F9:96:00:00:80:31:FE:45:53:43:45:37:20:0F:00:20:46:4E", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE, 0, NULL },
 
 	/* IDEMIA (new name for Oberthur) (DoD Alternate Token IDEMIA Cosmo V8.0 2019*/
 	{ "3B:D8:18:00:80:B1:FE:45:1F:07:80:31:C1:64:08:06:92:0F:D5", NULL, NULL, SC_CARD_TYPE_PIV_II_OBERTHUR, 0, NULL },


### PR DESCRIPTION
# piv: add ATR for Giesecke+Devrient SCE7

## What

Adds the ATR of the Giesecke+Devrient SCE7 (a PIV-only card) to the PIV
driver's ATR table. One row.

## Why

The SCE7 uses a vendor-specific PIX, so its tag 0x4F PIX does not match the
NIST PIX in `piv_aids[]`; without an ATR entry it falls back to
`SC_CARD_TYPE_PIV_II_BASE` and is rejected. But the card returns a valid
**Discovery object** whose tag 0x4F carries the full NIST PIV AID, so once
its ATR maps it to `SC_CARD_TYPE_PIV_II_GI_DE` the card is recognized via
the discovery-first path (`piv_find_aid` is not used). The single ATR row
is therefore sufficient.

Reuses the existing `SC_CARD_TYPE_PIV_II_GI_DE` type (no new enum), as #2995
did for an Idemia card.

## Testing

On a real G+D SCE7 (ATR `3B:F9:96:...:46:4E`):

- card binds as PIV; both certificates read (PIV Authentication, Digital
  Signature);
- `SHA256-RSA-PKCS` sign with the PIV Authentication (id 01) and Digital
  Signature (id 02) keys — both `openssl dgst -verify` → **Verified OK**.

## Build

- `git-clang-format --diff upstream/master`: no changes.
- Builds clean under `-Wall -Wextra -Werror -Wstrict-aliasing=2`.
- One file (`src/libopensc/card-piv.c`), +2 lines.

Tested on a single card variant (G+D SCE7).
