### PR TITLE
card-piv.c - circumvent problem with G&D card response to select aid

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -484,8 +484,10 @@ static const struct sc_atr_table piv_atrs[] = {
 	{ "3B:7A:18:00:00:73:66:74:65:20:63:64:31:34:34", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE_DUAL_CAC, 0, NULL },
 	/* Giesecke & Devrient (CAC PIV Endpoint) 2019 */
 	{ "3B:F9:18:00:00:00:53:43:45:37:20:03:00:20:46", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE_DUAL_CAC, 0, NULL },
+	/* Giesecke & Devrient SCE7 (PIV-only) (DoD Alternate Token G+D Sm@rtCafe Expert v7.0 144K DI 2025) */
+	{ "3B:F9:96:00:00:80:31:FE:45:53:43:45:37:20:0F:00:20:46:4E", NULL, NULL, SC_CARD_TYPE_PIV_II_GI_DE, 0, NULL },
 
-	/* IDEMIA (new name for Oberthur) (DoD Alternate Token IDEMIA Cosmo V8.0 2019*/
+	/* IDEMIA (new name for Oberthur) (DoD Alternate Token IDEMIA Cosmo V8.0 2025 */
 	{ "3B:D8:18:00:80:B1:FE:45:1F:07:80:31:C1:64:08:06:92:0F:D5", NULL, NULL, SC_CARD_TYPE_PIV_II_OBERTHUR, 0, NULL },
 	{ "3b:86:80:01:80:31:c1:52:41:1a:7e", NULL, NULL, SC_CARD_TYPE_PIV_II_OBERTHUR, 0, NULL }, /* contactless */
 
@@ -561,10 +563,12 @@ static struct piv_supported_ec_curves {
 		{{{-1}},			    0,   0		     }  /* This entry must not be touched. */
 };
 
-/* all have same AID */
+/* all cards must respond to entry 0, some may return different PIX which will accept */
 static struct piv_aid piv_aids[] = {
 	{SC_CARD_TYPE_PIV_II_GENERIC, /* Not really card type but what PIV AID is supported */
 		 9, 9, (u8 *) "\xA0\x00\x00\x03\x08\x00\x00\x10\x00" },
+	{SC_CARD_TYPE_PIV_II_GI_DE, /* bug in some G&D cards in response to select aid */
+		 9, 9, (u8 *) "\xA0\x00\x00\x03\x08\x00\x10\x00\x01" },
 	{0,  9, 0, NULL }
 };
 
@@ -2982,7 +2986,8 @@ piv_find_aid(sc_card_t *card)
 
 				/* early cards returned full AID, rather then just the pix */
 				for (i = 0; piv_aids[i].len_long != 0; i++) {
-					if ((pixlen >= 6 && memcmp(pix, piv_aids[i].value + 5, piv_aids[i].len_long - 5) == 0) ||
+					if ((pixlen >= piv_aids[i].len_long - 5 &&
+							    memcmp(pix, piv_aids[i].value + 5, piv_aids[i].len_long - 5) == 0) ||
 							((pixlen >= piv_aids[i].len_short && memcmp(pix, piv_aids[i].value,
 													     piv_aids[i].len_short) == 0))) {
 						free(priv->aid_der.value); /* free previous value if any */


### PR DESCRIPTION
As documented in #3702 the G&D card response to SELECT AID was: 
`61 0F 4F 06 00 10 00 01 00 00 79 05 A0 00 00 03 08`
The  `00 10 00 01 00 00` should have been `01 00 10 00 01 00` (dropping leading 00)
```
The new code will test the first 4 bytes accept either 01 00 10 00 or 00 10 00 01.
The last two bytes are a version number and can be anything.  

this is a replacement PR for #3702  

Thanks to @hirashix0  for reporting the problem and testing the fix.

 On branch GD-pix
 Changes to be committed:
	modified:   src/libopensc/card-piv.c

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] PKCS#11 module is tested
