### PR TITLE
pkcs11-tool: fixed possible buffer overflow

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9797,7 +9797,7 @@ static void test_ec(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 		printf("ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return;
 	}
-	opt_object_id_len = (size_t) i;
+	opt_object_id_len = (size_t)i;
 	if (opt_object_id_len > sizeof(opt_object_id)) {
 		fprintf(stderr, "ERR: object ID too long\n");
 		return;

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9797,7 +9797,11 @@ static void test_ec(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 		printf("ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return;
 	}
-	i = (size_t) opt_object_id_len;
+	opt_object_id_len = (size_t) i;
+	if (opt_object_id_len > sizeof(opt_object_id)) {
+		fprintf(stderr, "ERR: object ID too long\n");
+		return session;
+	}
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */

--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9800,7 +9800,7 @@ static void test_ec(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 	opt_object_id_len = (size_t) i;
 	if (opt_object_id_len > sizeof(opt_object_id)) {
 		fprintf(stderr, "ERR: object ID too long\n");
-		return session;
+		return;
 	}
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 


### PR DESCRIPTION
identical to CVE-2026-10275, but for ECC rather than for RSA keys:
- https://github.com/OpenSC/OpenSC/pull/3684
- https://github.com/advisories/GHSA-c758-vvqj-x96q

fixes https://github.com/OpenSC/OpenSC/issues/3705