### PR TITLE
Bugs with oseid encrypt/decrypt

### DIFF
--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -2023,7 +2023,7 @@ myeid_enc_dec_sym(struct sc_card *card, const u8 *data, size_t datalen,
 		else
 			apdu_datalen = len;
 
-		if (cbc)
+		if (cbc && len > apdu_datalen)
 			apdu.cla = 0x10;
 
 		len -= apdu_datalen;

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -5818,7 +5818,12 @@ pkcs15_skey_encrypt(struct sc_pkcs11_session *session, void *obj,
 		return sc_to_cryptoki_error(rv, "C_Encrypt...");
 
 	/* pointer CK_ULONG_PTR to size_t conversion */
-	lpEncryptedDataLen = pulEncryptedDataLen ? &lEncryptedDataLen : NULL;
+	if (pulEncryptedDataLen) {
+		lEncryptedDataLen = *pulEncryptedDataLen;
+		lpEncryptedDataLen = &lEncryptedDataLen;
+	} else {
+		lpEncryptedDataLen = NULL;
+	}
 
 	rv = sc_pkcs15_encrypt_sym(fw_data->p15_card, skey->prv_p15obj, flags,
 			pData, ulDataLen, pEncryptedData, lpEncryptedDataLen,


### PR DESCRIPTION
I stumbled upon the two bugs while looking at https://github.com/OpenSC/OpenSC/pull/3620. I think this correctly fixes the bug with chaining encryption/decryption APDUs with oseid.

From 4 non-working CI tests this fixes two testcases. However, I'm not sure why the comparison with OpenSSL's encryption/decryption shows a mismatch. @popovec , could you please have a look?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
