### PR TITLE
Add a hint about "openssl error during verification"

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -8435,6 +8435,7 @@ static int sign_verify_openssl(CK_SESSION_HANDLE session,
 		errors++;
 	} else if (err != 1) {
 		printf("openssl error during verification: 0x%0x (%d)\n", err, err);
+		ERR_print_errors_fp(stdout);
 	} else
 		printf("OK\n");
 


### PR DESCRIPTION

--test gives an openssl error.

```
$ pkcs11-tool -t -l
[....]
testing key 1 (Authentication Certificate) with 1 mechanism
    RSA-PKCS: openssl error during verification: 0xffffffff (-1)
[...]

```

I had this "openssl error during verification" and my question on opensc couldn't be answered.

[Posting to opensc-devel](https://sourceforge.net/p/opensc/mailman/message/59322232/)

It took me some time until I found it out (by experimenting and printf in OpenSSL).
After I found the solution I made this patch which may help someone in the future.


<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
