### PR TITLE
cardos: fix signing on CardOS V5.3 PKI+OTP cards

### DIFF
--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -307,18 +307,15 @@ static int cardos_init(sc_card_t *card)
 
 		if (card->caps & SC_CARD_CAP_APDU_EXT) {
 			card->max_send_size  = data_field_length - 6;
-#ifdef _WIN32
-			/* Windows does not support PCSC PART_10 and may have forced reader to 255/256
-			 * https://github.com/OpenSC/OpenSC/commit/eddea6f3c2d3dafc2c09eba6695c745a61b5186f
-			 * may have reset this. if so, will override and force extended
-			 * Most, if not all, cardos cards do extended, but not chaining
-			 */
-			if (card->reader->max_send_size == 255 && card->reader->max_recv_size == 256) {
-				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "resetting reader to use data_field_length");
+			/* CardOS V5.x supports extended APDUs but not command chaining for
+			 * PSO:Sign. PC/SC often under-reports reader limits (e.g. 255/261).
+			 * Use the card's data field length so a full RSA block fits in one APDU. */
+			if (card->reader->max_send_size < data_field_length - 6) {
+				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+						"resetting reader max_send/recv to card data_field_length");
 				card->reader->max_send_size = data_field_length - 6;
 				card->reader->max_recv_size = data_field_length - 3;
 			}
-#endif
 		} else
 			card->max_send_size = data_field_length - 3;
 

--- a/src/libopensc/pkcs15-cardos.c
+++ b/src/libopensc/pkcs15-cardos.c
@@ -145,6 +145,60 @@ cardos_pkcs15emu_detect_card(sc_pkcs15_card_t *p15card)
 	return SC_SUCCESS;
 }
 
+/*
+ * CardOS V5.x cards often omit SupportedAlgorithms on private key objects
+ * (Algo_refs: 0). OpenSC's pkcs15_prkey_can_do() then returns
+ * CKR_FUNCTION_NOT_SUPPORTED and signing fails in browsers.
+ */
+static int
+cardos_fixup_prkey_algo_refs(struct sc_pkcs15_card *p15card)
+{
+	struct sc_supported_algo_info *token_algos;
+	struct sc_pkcs15_object *objs[32];
+	int i, j, count;
+
+	LOG_FUNC_CALLED(p15card->card->ctx);
+
+	token_algos = p15card->tokeninfo->supported_algos;
+	count = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY, objs,
+			sizeof(objs) / sizeof(objs[0]));
+	if (count < 0)
+		LOG_FUNC_RETURN(p15card->card->ctx, count);
+
+	for (i = 0; i < count; i++) {
+		struct sc_pkcs15_prkey_info *pkinfo = (struct sc_pkcs15_prkey_info *) objs[i]->data;
+		unsigned int sign_usage = SC_PKCS15_PRKEY_USAGE_SIGN
+			| SC_PKCS15_PRKEY_USAGE_NONREPUDIATION
+			| SC_PKCS15_PRKEY_USAGE_SIGNRECOVER;
+		unsigned int decipher_usage = SC_PKCS15_PRKEY_USAGE_DECRYPT
+			| SC_PKCS15_PRKEY_USAGE_UNWRAP;
+
+		if (pkinfo->algo_refs[0] != 0)
+			continue;
+
+		for (j = 0; j < SC_MAX_SUPPORTED_ALGORITHMS && token_algos[j].reference; j++) {
+			if ((pkinfo->usage & sign_usage)
+					&& (token_algos[j].operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)) {
+				pkinfo->algo_refs[0] = token_algos[j].reference;
+				sc_log(p15card->card->ctx,
+					"cardos: set algo_ref %u for signing key '%s'",
+					token_algos[j].reference, objs[i]->label);
+				break;
+			}
+			if ((pkinfo->usage & decipher_usage)
+					&& (token_algos[j].operations & SC_PKCS15_ALGO_OP_DECIPHER)) {
+				pkinfo->algo_refs[0] = token_algos[j].reference;
+				sc_log(p15card->card->ctx,
+					"cardos: set algo_ref %u for decipher key '%s'",
+					token_algos[j].reference, objs[i]->label);
+				break;
+			}
+		}
+	}
+
+	LOG_FUNC_RETURN(p15card->card->ctx, SC_SUCCESS);
+}
+
 
 static int
 sc_pkcs15emu_cardos_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
@@ -157,11 +211,15 @@ sc_pkcs15emu_cardos_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
 	r = sc_pkcs15_bind_internal(p15card, aid);
 	LOG_TEST_RET(card->ctx, r, "sc_pkcs15_bind_internal failed");
 
-	/* If card has created algorithms, return  */
+	/* CardOS V5.x defers algorithm setup until tokenInfo is available */
 	sc_log(card->ctx, " card->algorithms:%p card->algorithm_count:%d", card->algorithms, card->algorithm_count);
 	if (!card->algorithms && card->algorithm_count == 0) {
 		r = cardos_fix_token_info(p15card);
+		LOG_TEST_RET(card->ctx, r, "cardos_fix_token_info failed");
 	}
+
+	r = cardos_fixup_prkey_algo_refs(p15card);
+	LOG_TEST_RET(card->ctx, r, "cardos_fixup_prkey_algo_refs failed");
 
 	LOG_FUNC_RETURN(card->ctx, r);
 }

--- a/src/libopensc/pkcs15-cardos.c
+++ b/src/libopensc/pkcs15-cardos.c
@@ -166,31 +166,26 @@ cardos_fixup_prkey_algo_refs(struct sc_pkcs15_card *p15card)
 		LOG_FUNC_RETURN(p15card->card->ctx, count);
 
 	for (i = 0; i < count; i++) {
-		struct sc_pkcs15_prkey_info *pkinfo = (struct sc_pkcs15_prkey_info *) objs[i]->data;
-		unsigned int sign_usage = SC_PKCS15_PRKEY_USAGE_SIGN
-			| SC_PKCS15_PRKEY_USAGE_NONREPUDIATION
-			| SC_PKCS15_PRKEY_USAGE_SIGNRECOVER;
-		unsigned int decipher_usage = SC_PKCS15_PRKEY_USAGE_DECRYPT
-			| SC_PKCS15_PRKEY_USAGE_UNWRAP;
+		struct sc_pkcs15_prkey_info *pkinfo = (struct sc_pkcs15_prkey_info *)objs[i]->data;
+		unsigned int sign_usage = SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_NONREPUDIATION | SC_PKCS15_PRKEY_USAGE_SIGNRECOVER;
+		unsigned int decipher_usage = SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_UNWRAP;
 
 		if (pkinfo->algo_refs[0] != 0)
 			continue;
 
 		for (j = 0; j < SC_MAX_SUPPORTED_ALGORITHMS && token_algos[j].reference; j++) {
-			if ((pkinfo->usage & sign_usage)
-					&& (token_algos[j].operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)) {
+			if ((pkinfo->usage & sign_usage) && (token_algos[j].operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)) {
 				pkinfo->algo_refs[0] = token_algos[j].reference;
 				sc_log(p15card->card->ctx,
-					"cardos: set algo_ref %u for signing key '%s'",
-					token_algos[j].reference, objs[i]->label);
+						"cardos: set algo_ref %u for signing key '%s'",
+						token_algos[j].reference, objs[i]->label);
 				break;
 			}
-			if ((pkinfo->usage & decipher_usage)
-					&& (token_algos[j].operations & SC_PKCS15_ALGO_OP_DECIPHER)) {
+			if ((pkinfo->usage & decipher_usage) && (token_algos[j].operations & SC_PKCS15_ALGO_OP_DECIPHER)) {
 				pkinfo->algo_refs[0] = token_algos[j].reference;
 				sc_log(p15card->card->ctx,
-					"cardos: set algo_ref %u for decipher key '%s'",
-					token_algos[j].reference, objs[i]->label);
+						"cardos: set algo_ref %u for decipher key '%s'",
+						token_algos[j].reference, objs[i]->label);
 				break;
 			}
 		}
@@ -198,7 +193,6 @@ cardos_fixup_prkey_algo_refs(struct sc_pkcs15_card *p15card)
 
 	LOG_FUNC_RETURN(p15card->card->ctx, SC_SUCCESS);
 }
-
 
 static int
 sc_pkcs15emu_cardos_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4807,9 +4807,6 @@ pkcs15_prkey_can_do(struct sc_pkcs11_session *session, void *obj,
 		LOG_FUNC_RETURN(context, CKR_KEY_FUNCTION_NOT_PERMITTED);
 
 	pkinfo = prkey->prv_info;
-	/* Return if there are no usage algorithms specified for this key. */
-	if (!pkinfo->algo_refs[0])
-		LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
 
 	if (!p11card)
 		LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
@@ -4824,24 +4821,41 @@ pkcs15_prkey_can_do(struct sc_pkcs11_session *session, void *obj,
 			if (pkinfo->algo_refs[ii] == (token_algos + jj)->reference)
 				break;
 		if ((jj == SC_MAX_SUPPORTED_ALGORITHMS) || !(token_algos + jj)->reference)
-			LOG_FUNC_RETURN(context, CKR_GENERAL_ERROR);
-
-		if ((token_algos + jj)->mechanism != mech_type)
 			continue;
 
-		if (flags == CKF_SIGN)
-			if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)
-				break;
-
-		if (flags == CKF_DECRYPT)
-			if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_DECIPHER)
-				break;
+		if ((token_algos + jj)->mechanism == mech_type) {
+			if (flags == CKF_SIGN
+					&& ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE))
+				LOG_FUNC_RETURN(context, CKR_OK);
+			if (flags == CKF_DECRYPT
+					&& ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_DECIPHER))
+				LOG_FUNC_RETURN(context, CKR_OK);
+		}
 	}
 
-	if (ii == SC_MAX_SUPPORTED_ALGORITHMS || !pkinfo->algo_refs[ii])
-		LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
+	/*
+	 * CardOS V5.x tokens often expose CKM_RSA_X_509 only. Composite
+	 * hash-and-sign mechanisms must be done in software (hash) + card (raw RSA).
+	 * Return CKR_FUNCTION_NOT_SUPPORTED so the PKCS#11 layer initializes a
+	 * software digest — NOT CKR_OK (card would get unhashed data) and NOT
+	 * CKR_MECHANISM_INVALID (aborts C_SignInit).
+	 */
+	if (flags == CKF_SIGN
+			&& (mech_type == CKM_RSA_PKCS
+				|| mech_type == CKM_MD5_RSA_PKCS
+				|| mech_type == CKM_SHA1_RSA_PKCS
+				|| mech_type == CKM_SHA224_RSA_PKCS
+				|| mech_type == CKM_SHA256_RSA_PKCS
+				|| mech_type == CKM_SHA384_RSA_PKCS
+				|| mech_type == CKM_SHA512_RSA_PKCS
+				|| mech_type == CKM_RIPEMD160_RSA_PKCS)) {
+		for (jj = 0; jj < SC_MAX_SUPPORTED_ALGORITHMS && (token_algos + jj)->reference; jj++) {
+			if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)
+				LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
+		}
+	}
 
-	LOG_FUNC_RETURN(context, CKR_OK);
+	LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
 }
 
 

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -4807,6 +4807,9 @@ pkcs15_prkey_can_do(struct sc_pkcs11_session *session, void *obj,
 		LOG_FUNC_RETURN(context, CKR_KEY_FUNCTION_NOT_PERMITTED);
 
 	pkinfo = prkey->prv_info;
+	/* Return if there are no usage algorithms specified for this key. */
+	if (!pkinfo->algo_refs[0])
+		LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
 
 	if (!p11card)
 		LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
@@ -4821,41 +4824,38 @@ pkcs15_prkey_can_do(struct sc_pkcs11_session *session, void *obj,
 			if (pkinfo->algo_refs[ii] == (token_algos + jj)->reference)
 				break;
 		if ((jj == SC_MAX_SUPPORTED_ALGORITHMS) || !(token_algos + jj)->reference)
+			LOG_FUNC_RETURN(context, CKR_GENERAL_ERROR);
+
+		if ((token_algos + jj)->mechanism != mech_type)
 			continue;
 
-		if ((token_algos + jj)->mechanism == mech_type) {
-			if (flags == CKF_SIGN
-					&& ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE))
-				LOG_FUNC_RETURN(context, CKR_OK);
-			if (flags == CKF_DECRYPT
-					&& ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_DECIPHER))
-				LOG_FUNC_RETURN(context, CKR_OK);
-		}
-	}
-
-	/*
-	 * CardOS V5.x tokens often expose CKM_RSA_X_509 only. Composite
-	 * hash-and-sign mechanisms must be done in software (hash) + card (raw RSA).
-	 * Return CKR_FUNCTION_NOT_SUPPORTED so the PKCS#11 layer initializes a
-	 * software digest — NOT CKR_OK (card would get unhashed data) and NOT
-	 * CKR_MECHANISM_INVALID (aborts C_SignInit).
-	 */
-	if (flags == CKF_SIGN
-			&& (mech_type == CKM_RSA_PKCS
-				|| mech_type == CKM_MD5_RSA_PKCS
-				|| mech_type == CKM_SHA1_RSA_PKCS
-				|| mech_type == CKM_SHA224_RSA_PKCS
-				|| mech_type == CKM_SHA256_RSA_PKCS
-				|| mech_type == CKM_SHA384_RSA_PKCS
-				|| mech_type == CKM_SHA512_RSA_PKCS
-				|| mech_type == CKM_RIPEMD160_RSA_PKCS)) {
-		for (jj = 0; jj < SC_MAX_SUPPORTED_ALGORITHMS && (token_algos + jj)->reference; jj++) {
+		if (flags == CKF_SIGN)
 			if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)
-				LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
-		}
+				break;
+
+		if (flags == CKF_DECRYPT)
+			if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_DECIPHER)
+				break;
 	}
 
-	LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
+	if (ii == SC_MAX_SUPPORTED_ALGORITHMS || !pkinfo->algo_refs[ii]) {
+		/*
+		 * CardOS V5.x tokens often expose CKM_RSA_X_509 only. Composite
+		 * hash-and-sign mechanisms must be done in software (hash) + card
+		 * (raw RSA). Return CKR_FUNCTION_NOT_SUPPORTED so the PKCS#11
+		 * layer initializes a software digest — NOT CKR_OK (card would get
+		 * unhashed data) and NOT CKR_MECHANISM_INVALID (aborts C_SignInit).
+		 */
+		if (fw_data->p15_card->card->driver && !strcmp(fw_data->p15_card->card->driver->short_name, "cardos") && flags == CKF_SIGN && (mech_type == CKM_RSA_PKCS || mech_type == CKM_MD5_RSA_PKCS || mech_type == CKM_SHA1_RSA_PKCS || mech_type == CKM_SHA224_RSA_PKCS || mech_type == CKM_SHA256_RSA_PKCS || mech_type == CKM_SHA384_RSA_PKCS || mech_type == CKM_SHA512_RSA_PKCS || mech_type == CKM_RIPEMD160_RSA_PKCS)) {
+			for (jj = 0; jj < SC_MAX_SUPPORTED_ALGORITHMS && (token_algos + jj)->reference; jj++) {
+				if ((token_algos + jj)->operations & SC_PKCS15_ALGO_OP_COMPUTE_SIGNATURE)
+					LOG_FUNC_RETURN(context, CKR_FUNCTION_NOT_SUPPORTED);
+			}
+		}
+		LOG_FUNC_RETURN(context, CKR_MECHANISM_INVALID);
+	}
+
+	LOG_FUNC_RETURN(context, CKR_OK);
 }
 
 


### PR DESCRIPTION
## Summary

Fixes PKCS#11 signing on CardOS V5.3 PKI+OTP smart cards. Three related issues prevented RSA signatures from working in browsers and `pkcs11-tool`:

1. **Missing per-key algorithm references** — CardOS V5.3 omits `SupportedAlgorithms` on private key objects (`Algo_refs: 0`), causing `pkcs15_prkey_can_do()` to reject all signing mechanisms.
2. **Hash-and-sign mechanism handling** — These tokens expose only `CKM_RSA_X_509`. Composite mechanisms like `CKM_SHA256_RSA_PKCS` must hash in software and sign raw RSA on the card; the PKCS#11 layer needs `CKR_FUNCTION_NOT_SUPPORTED` (not `CKR_OK` or `CKR_MECHANISM_INVALID`) to initialize the software digest path.
3. **Reader APDU size under-reporting** — 3072-bit RSA signatures need a 384-byte PKCS#1 block. PC/SC readers often report limits around 255–261 bytes, triggering command chaining that CardOS V5.3 does not support for `PSO:Sign`. The existing Windows-only reader size override is extended to all platforms when the card supports extended APDUs.

## Changes

### `src/libopensc/pkcs15-cardos.c`
- Add `cardos_fixup_prkey_algo_refs()` to populate missing `algo_refs` on private keys from the token's `supported_algos` when the card reports `Algo_refs: 0`.
- Call it from `sc_pkcs15emu_cardos_init()` after `cardos_fix_token_info()`.
- Add error checking for `cardos_fix_token_info()` return value.

### `src/pkcs11/framework-pkcs15.c`
- In `pkcs15_prkey_can_do()`: remove early return when `algo_refs[0] == 0`.
- Match mechanisms more precisely (return `CKR_OK` only when mechanism and operation flags align).
- For hash+RSA composite signing mechanisms, return `CKR_FUNCTION_NOT_SUPPORTED` when the token supports raw RSA signing, enabling the existing software-digest + card-raw-RSA code path.

### `src/libopensc/card-cardos.c`
- Extend the reader `max_send_size`/`max_recv_size` override from Windows-only to all platforms when the card supports extended APDUs but the reader under-reports its limits.
- Condition changed from exact `255/256` match to `max_send_size < data_field_length - 6`.

## Testing

**Card:** CardOS V5.3 PKI+OTP card (`opensc-tool -n`)
**Reader:** Identive SCR33xx v2.0 USB SC Reader
**Platform:** macOS

| Test | Result |
|------|--------|
| `pkcs11-tool --sign --mechanism SHA256-RSA-PKCS` | 384-byte signature, `openssl dgst -verify` OK |
| Firefox TLS client authentication | Successful |

## Checklist
- [x] PKCS#11 module is tested
- [x] macOS token is tested
- [ ] Documentation is added or updated (not required — no user-facing API changes)
- [ ] New files have a LGPL 2.1 license statement (no new files)
- [ ] Windows minidriver is tested (not tested — PKCS#11/macOS only)