### PR TITLE
PKCS#11: return CKR_TOKEN_NOT_RECOGNIZED if card detection fails

### DIFF
--- a/src/pkcs11/slot.c
+++ b/src/pkcs11/slot.c
@@ -269,7 +269,7 @@ again:
 		rc = sc_connect_card(reader, &p11card->card);
 		if (rc != SC_SUCCESS) {
 			sc_log(context, "%s: SC connect card error %i", reader->name, rc);
-			rv = sc_to_cryptoki_error(rc, NULL);
+			rv = CKR_TOKEN_NOT_RECOGNIZED;
 			goto fail;
 		}
 
@@ -300,7 +300,7 @@ again:
 				break;
 		/*TODO: only first framework is used: pkcs15init framework is not reachable here */
 		if (frameworks[i] == NULL) {
-			rv = CKR_GENERAL_ERROR;
+			rv = CKR_TOKEN_NOT_RECOGNIZED;
 			goto fail;
 		}
 
@@ -332,6 +332,7 @@ again:
 				sc_log(context,
 				       "%s: cannot bind 'generic' token: rv 0x%lX",
 				       reader->name, rv);
+				rv = CKR_TOKEN_NOT_RECOGNIZED;
 				goto fail;
 			}
 
@@ -341,6 +342,7 @@ again:
 				sc_log(context,
 				       "%s: create 'generic' token error 0x%lX",
 				       reader->name, rv);
+				rv = CKR_TOKEN_NOT_RECOGNIZED;
 				goto fail;
 			}
 			/* p11card is now bound to some slot */
@@ -369,6 +371,7 @@ again:
 				sc_log(context,
 				       "%s: create %s token error 0x%lX",
 				       reader->name, app_name, rv);
+				rv = CKR_TOKEN_NOT_RECOGNIZED;
 				goto fail;
 			}
 			/* p11card is now bound to some slot */


### PR DESCRIPTION
... no matter what kind of lower layer error was encountered

fixes https://github.com/OpenSC/OpenSC/issues/3393

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
