### PR TITLE
minidriver: fixed recognition of ECC keys when also RSA is supported

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -2891,17 +2891,17 @@ md_query_key_sizes(PCARD_DATA pCardData, DWORD dwKeySpec, CARD_KEY_SIZES *pKeySi
 					break;
 				}
 			}
-			if (keysize) {
-				pKeySizes->dwMinimumBitlen = keysize;
-				pKeySizes->dwDefaultBitlen = keysize;
-				pKeySizes->dwMaximumBitlen = keysize;
-				pKeySizes->dwIncrementalBitlen = 1;
-			} else {
-				logprintf(pCardData, 0,
-					  "No ECC key found (keyspec=%lu)\n",
-					  (unsigned long)dwKeySpec);
-				return SCARD_E_INVALID_PARAMETER;
-			}
+		}
+		if (keysize) {
+			pKeySizes->dwMinimumBitlen = keysize;
+			pKeySizes->dwDefaultBitlen = keysize;
+			pKeySizes->dwMaximumBitlen = keysize;
+			pKeySizes->dwIncrementalBitlen = 1;
+		} else {
+			logprintf(pCardData, 0,
+					"No ECC key found (keyspec=%lu)\n",
+					(unsigned long)dwKeySpec);
+			return SCARD_E_INVALID_PARAMETER;
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/3228

reported by @MadeNetwork

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
