### PR TITLE
reader-ctk: added guards against missing card object

### DIFF
--- a/src/libopensc/reader-cryptotokenkit.m
+++ b/src/libopensc/reader-cryptotokenkit.m
@@ -180,7 +180,7 @@ static int cryptotokenkit_connect(sc_reader_t *reader)
 	}
 
 	if (!priv->tksmartcard || !priv->tksmartcard.valid)
-		return SC_ERROR_CARD_NOT_PRESENT;
+		return SC_ERROR_CARD_REMOVED;
 
 	/* if tksmartcard.context is set to nil, we know that the card has been
 	 * reset or acquired by a different session */
@@ -212,6 +212,8 @@ static int cryptotokenkit_lock(sc_reader_t *reader)
 
 	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		goto err;
+	if (!priv->tksmartcard)
+		return SC_ERROR_CARD_REMOVED;
 
 	if (priv->tksmartcard.context == nil) {
 		r = SC_ERROR_CARD_RESET;
@@ -239,8 +241,11 @@ static int cryptotokenkit_unlock(sc_reader_t *reader)
 
 	LOG_FUNC_CALLED(reader->ctx);
 
+
 	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
+	if (!priv->tksmartcard)
+		return SC_ERROR_CARD_REMOVED;
 
 	[priv->tksmartcard endSession];
 
@@ -258,6 +263,9 @@ static int cryptotokenkit_transmit(sc_reader_t *reader, sc_apdu_t *apdu)
 	dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
 	LOG_FUNC_CALLED(reader->ctx);
+
+	if (!priv->tksmartcard)
+		return SC_ERROR_CARD_REMOVED;
 
 	r = sc_apdu_get_octets(reader->ctx, apdu, &sbuf, &ssize, reader->active_protocol);
 	if (r != SC_SUCCESS)
@@ -343,6 +351,8 @@ int cryptotokenkit_perform_verify(struct sc_reader *reader, struct sc_pin_cmd_da
 
 	if (reader->ctx->flags & SC_CTX_FLAG_TERMINATE)
 		return SC_ERROR_NOT_ALLOWED;
+	if (!priv->tksmartcard)
+		return SC_ERROR_CARD_REMOVED;
 
 	/* The APDU must be provided by the card driver */
 	if (!data->apdu) {


### PR DESCRIPTION
fixes https://github.com/OpenSC/OpenSC/issues/2519

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
