### PR TITLE
Add support for the Uruguayan national eID card (cédula de identidad)

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -51,14 +51,14 @@ libopensc_la_SOURCES_BASE = \
 	card-isoApplet.c card-masktech.c card-gids.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-esteid2025.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
-	card-lteid.c card-srbeid.c \
+	card-lteid.c card-srbeid.c card-cedulauy.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-pteid.c pkcs15-esteid2025.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-gemsafeV1.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
-	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
+	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-cedulauy.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c pkcs15-dtrust.c pkcs15-lteid.c \
 	pkcs15-srbeid.c compression.c sm.c aux-data.c
 
@@ -133,14 +133,14 @@ TIDY_FILES = \
 	card-isoApplet.c card-masktech.c card-jpki.c \
 	card-npa.c card-esteid2018.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
-	card-lteid.c card-srbeid.c \
+	card-lteid.c card-srbeid.c card-cedulauy.c \
 	\
 	pkcs15-openpgp.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \
 	pkcs15-cac.c pkcs15-esinit.c pkcs15-pteid.c \
 	pkcs15-oberthur.c pkcs15-itacns.c pkcs15-sc-hsm.c \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
-	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-jpki.c pkcs15-esteid2018.c \
+	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-cedulauy.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-dtrust.c pkcs15-lteid.c \
 	pkcs15-srbeid.c compression.c sm.c aux-data.c \
 	#$(SOURCES)

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -29,13 +29,13 @@ OBJECTS			= \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-esteid2025.obj card-idprime.obj \
 	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj card-dtrust.obj \
-	card-lteid.obj card-srbeid.obj \
+	card-lteid.obj card-srbeid.obj card-cedulauy.obj \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj pkcs15-tcos.obj \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \
 	pkcs15-cac.obj pkcs15-esinit.obj pkcs15-pteid.obj pkcs15-din-66291.obj \
 	pkcs15-oberthur.obj pkcs15-itacns.obj pkcs15-gemsafeV1.obj pkcs15-sc-hsm.obj \
-	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-jpki.obj \
+	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-cedulauy.obj pkcs15-jpki.obj \
 	pkcs15-esteid2018.obj pkcs15-esteid2025.obj pkcs15-idprime.obj pkcs15-nqApplet.obj \
 	pkcs15-starcos-esign.obj pkcs15-skeid.obj pkcs15-eoi.obj pkcs15-dtrust.obj \
 	pkcs15-lteid.obj pkcs15-srbeid.obj compression.obj sm.obj aux-data.obj \

--- a/src/libopensc/card-cedulauy.c
+++ b/src/libopensc/card-cedulauy.c
@@ -1,0 +1,299 @@
+/*
+ * card-cedulauy.c: Support for the Uruguayan eID card (cédula de identidad)
+ *
+ * Copyright (C) 2026 Carlos Andrés Planchón Prestes <carlosandresplanchonprestes@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * The card is a Gemalto/Thales "Classic V4" IAS/ECC platform card, but the
+ * subset it exposes over the contact interface is plain ISO 7816, so the
+ * driver is built on the generic iso7816 operations.  The IAS application
+ * must be selected by AID before anything on the card is accessible.
+ *
+ * The card conventions come from the public documentation and reference code
+ * published by AGESIC, Uruguay's national e-government agency ("Documentación
+ * técnica de la cédula de identidad con chip" and
+ * https://github.com/eIDuy/apdu-services).
+ *
+ * The PKCS#15 view of the card is provided by the synthetic emulator in
+ * pkcs15-cedulauy.c.
+ */
+
+#include "libopensc/errors.h"
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "internal.h"
+
+/* MSE SET algorithm references (AGESIC "AlgoID" table): the hash is encoded
+ * in the high nibble and the padding scheme in the low nibble. */
+#define CEDULAUY_ALGO_HASH_NONE	  0x00 /* DigestInfo built in software */
+#define CEDULAUY_ALGO_HASH_SHA256 0x40 /* card builds the DigestInfo */
+#define CEDULAUY_ALGO_PAD_PKCS1	  0x02 /* PKCS#1 v1.5 */
+
+#define CEDULAUY_ALGO_RSA_PKCS1	       (CEDULAUY_ALGO_HASH_NONE | CEDULAUY_ALGO_PAD_PKCS1)
+#define CEDULAUY_ALGO_RSA_PKCS1_SHA256 (CEDULAUY_ALGO_HASH_SHA256 | CEDULAUY_ALGO_PAD_PKCS1)
+
+// clang-format off
+static const struct sc_atr_table cedulauy_atrs[] = {
+	/* TA1 and the version/batch historical bytes differ between card
+	 * batches and are masked out (mask contributed by Nicolás Gutiérrez,
+	 * @nicolasgutierrezdev). */
+	{ "3B:7F:94:00:00:80:31:80:65:B0:85:03:00:EF:12:0F:FF:82:90:00",
+	  "FF:FF:00:FF:FF:FF:FF:FF:FF:FF:FF:00:00:00:00:00:00:FF:FF:FF",
+	  "Uruguayan eID (cedula de identidad)", SC_CARD_TYPE_CEDULAUY, 0, NULL },
+	{ NULL, NULL, NULL, 0, 0, NULL }
+};
+// clang-format on
+
+/* IAS application AID (AGESIC, documented) */
+static const unsigned char cedulauy_aid[] = {
+		0xA0, 0x00, 0x00, 0x00, 0x18, 0x40, 0x00, 0x00, 0x01, 0x63, 0x42, 0x00};
+
+static const struct sc_card_operations *iso_ops = NULL;
+static struct sc_card_operations cedulauy_ops;
+
+static struct sc_card_driver cedulauy_drv = {
+		"Uruguayan eID (cedula de identidad)",
+		"cedulauy",
+		&cedulauy_ops,
+		NULL, 0, NULL};
+
+#define SC_TRANSMIT_TEST_RET(card, apdu, text) \
+	do { \
+		LOG_TEST_RET(card->ctx, sc_transmit_apdu(card, &apdu), "APDU transmit failed"); \
+		LOG_TEST_RET(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2), text); \
+	} while (0)
+
+static int
+cedulauy_select_app(struct sc_card *card)
+{
+	struct sc_apdu apdu;
+	unsigned char resp[SC_MAX_APDU_RESP_SIZE];
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	sc_format_apdu_ex(&apdu, card->cla, 0xA4, 0x04, 0x00,
+			cedulauy_aid, sizeof cedulauy_aid, resp, sizeof resp);
+	SC_TRANSMIT_TEST_RET(card, apdu, "Cannot select the eID application");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+cedulauy_match_card(struct sc_card *card)
+{
+	int i = _sc_match_atr(card, cedulauy_atrs, &card->type);
+
+	if (i < 0)
+		return 0;
+	card->name = cedulauy_atrs[i].name;
+	return 1;
+}
+
+static int
+cedulauy_init(struct sc_card *card)
+{
+	unsigned long flags;
+	int r;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	card->caps = SC_CARD_CAP_RNG;
+
+	r = cedulauy_select_app(card);
+	LOG_TEST_RET(card->ctx, r, "Cannot select the eID application");
+
+	/* The card builds the DigestInfo on-card only for SHA-256 (algorithm
+	 * reference 0x42).  Everything else is signed as raw PKCS#1 v1.5 over
+	 * a DigestInfo built in software (algorithm reference 0x02). */
+	flags = SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_HASH_SHA256;
+	r = _sc_card_add_rsa_alg(card, 2048, flags, 0);
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
+static int
+cedulauy_card_reader_lock_obtained(struct sc_card *card, int was_reset)
+{
+	if (was_reset)
+		LOG_FUNC_RETURN(card->ctx, cedulauy_select_app(card));
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static const sc_file_t *
+cedulauy_get_mf()
+{
+	static sc_file_t *mf = NULL;
+	if (!mf) {
+		mf = sc_file_new();
+		if (mf) {
+			mf->path = *sc_get_mf_path();
+			mf->id = 0x3F00;
+			mf->type = SC_FILE_TYPE_DF;
+			mf->magic = SC_FILE_MAGIC;
+		}
+	}
+	return mf;
+}
+
+static int
+cedulauy_select_file(struct sc_card *card, const struct sc_path *in_path,
+		struct sc_file **file_out)
+{
+	struct sc_path path = *in_path;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	if (path.aid.len == sizeof cedulauy_aid && 0 == memcmp(path.aid.value, cedulauy_aid, sizeof cedulauy_aid)) {
+		/* swallow cedula AID, it is always selected via init() */
+		path.aid.len = 0;
+	}
+	if (path.type == SC_PATH_TYPE_PATH && path.len >= 2 && path.value[0] == 0x3F && path.value[1] == 0x00) {
+		/* swallow MF, everything resides within the Application DF */
+		memmove(path.value, path.value + 2, path.len - 2);
+		path.len -= 2;
+	}
+	if (path.type == SC_PATH_TYPE_PATH && path.len == 0) {
+		/* Selection of MF was requested */
+		sc_file_dup(file_out, cedulauy_get_mf());
+		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+	}
+
+	LOG_FUNC_RETURN(card->ctx, iso_ops->select_file(card, &path, file_out));
+}
+
+static int
+cedulauy_set_security_env(struct sc_card *card, const struct sc_security_env *env,
+		int se_num)
+{
+	struct sc_apdu apdu;
+	/* MSE SET, Digital Signature Template: key reference and algorithm */
+	unsigned char mse_data[] = {0x84, 0x01, 0xFF, 0x80, 0x01, CEDULAUY_ALGO_RSA_PKCS1};
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	if (env == NULL)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+	if (env->operation != SC_SEC_OPERATION_SIGN)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+	if ((env->flags & SC_SEC_ENV_ALG_PRESENT) && env->algorithm != SC_ALGORITHM_RSA)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+	if (env->key_ref_len != 1)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
+	mse_data[2] = env->key_ref[0];
+	if (env->algorithm_flags & SC_ALGORITHM_RSA_HASH_SHA256)
+		mse_data[5] = CEDULAUY_ALGO_RSA_PKCS1_SHA256;
+
+	sc_format_apdu_ex(&apdu, card->cla, 0x22, 0x41, 0xB6,
+			mse_data, sizeof mse_data, NULL, 0);
+	SC_TRANSMIT_TEST_RET(card, apdu, "MSE SET DST failed");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+}
+
+static int
+cedulauy_compute_signature(struct sc_card *card, const u8 *data, size_t datalen,
+		u8 *out, size_t outlen)
+{
+	struct sc_apdu apdu;
+	unsigned char sbuf[64];
+	unsigned char rbuf[256]; /* RSA 2048 */
+	size_t offs = 0;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	if (data == NULL || out == NULL)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	/* What is loaded here matches the algorithm set in set_security_env:
+	 * for 0x42 'data' is the bare SHA-256 digest and the card builds the
+	 * DigestInfo; for 0x02 'data' is a complete DigestInfo built in
+	 * software, which the card pads (PKCS#1 v1.5) as-is. */
+	if (datalen == 0 || datalen > sizeof(sbuf) - 2)
+		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED,
+				"Unsupported hash/DigestInfo length");
+
+	/* PSO HASH: load the digest */
+	sbuf[offs++] = 0x90;
+	sbuf[offs++] = (unsigned char)datalen;
+	memcpy(sbuf + offs, data, datalen);
+	offs += datalen;
+	sc_format_apdu_ex(&apdu, card->cla, 0x2A, 0x90, 0xA0, sbuf, offs, NULL, 0);
+	SC_TRANSMIT_TEST_RET(card, apdu, "PSO HASH failed");
+
+	/* PSO COMPUTE DIGITAL SIGNATURE */
+	sc_format_apdu_ex(&apdu, card->cla, 0x2A, 0x9E, 0x9A, NULL, 0, rbuf, sizeof rbuf);
+	SC_TRANSMIT_TEST_RET(card, apdu, "PSO COMPUTE DIGITAL SIGNATURE failed");
+
+	if (apdu.resplen > outlen)
+		LOG_TEST_RET(card->ctx, SC_ERROR_BUFFER_TOO_SMALL,
+				"Signature buffer too small");
+	memcpy(out, apdu.resp, apdu.resplen);
+	LOG_FUNC_RETURN(card->ctx, (int)apdu.resplen);
+}
+
+static int
+cedulauy_get_challenge(struct sc_card *card, u8 *rnd, size_t len)
+{
+	/* As on other IAS/ECC cards, GET CHALLENGE only handles a length of 8 */
+	unsigned char rbuf[8];
+	int r;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	r = iso_ops->get_challenge(card, rbuf, sizeof rbuf);
+	LOG_TEST_RET(card->ctx, r, "GET CHALLENGE failed");
+
+	if (len < (size_t)r)
+		r = (int)len;
+	memcpy(rnd, rbuf, (size_t)r);
+
+	LOG_FUNC_RETURN(card->ctx, r);
+}
+
+static int
+cedulauy_logout(struct sc_card *card)
+{
+	/* Re-selecting the application resets its security status. */
+	LOG_FUNC_RETURN(card->ctx, cedulauy_select_app(card));
+}
+
+struct sc_card_driver *
+sc_get_cedulauy_driver(void)
+{
+	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
+
+	if (iso_ops == NULL)
+		iso_ops = iso_drv->ops;
+
+	cedulauy_ops = *iso_ops;
+	cedulauy_ops.match_card = cedulauy_match_card;
+	cedulauy_ops.init = cedulauy_init;
+	cedulauy_ops.select_file = cedulauy_select_file;
+	cedulauy_ops.set_security_env = cedulauy_set_security_env;
+	cedulauy_ops.compute_signature = cedulauy_compute_signature;
+	cedulauy_ops.decipher = NULL; /* the signing key is sign-only */
+	cedulauy_ops.get_challenge = cedulauy_get_challenge;
+	cedulauy_ops.logout = cedulauy_logout;
+	cedulauy_ops.card_reader_lock_obtained = cedulauy_card_reader_lock_obtained;
+
+	return &cedulauy_drv;
+}

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -287,6 +287,9 @@ enum {
 
 	/* Serbian cards (CardEdge PKI applet) */
 	SC_CARD_TYPE_SRBEID_BASE = 44000,
+
+	/* Uruguayan eID card (cedula de identidad) */
+	SC_CARD_TYPE_CEDULAUY = 45000,
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);
@@ -333,6 +336,7 @@ extern sc_card_driver_t *sc_get_eoi_driver(void);
 extern sc_card_driver_t *sc_get_dtrust_driver(void);
 extern sc_card_driver_t *sc_get_lteid_driver(void);
 extern sc_card_driver_t *sc_get_srbeid_driver(void);
+extern sc_card_driver_t *sc_get_cedulauy_driver(void);
 
 #ifdef __cplusplus
 }

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -135,6 +135,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 #endif
 	{ "masktech",	(void *(*)(void)) sc_get_masktech_driver },
 	{ "idprime",	(void *(*)(void)) sc_get_idprime_driver },
+	{ "cedulauy",	(void *(*)(void)) sc_get_cedulauy_driver },
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
 	{ "edo",        (void *(*)(void)) sc_get_edo_driver },
 	{ "lteid", (void *(*)(void)) sc_get_lteid_driver },

--- a/src/libopensc/pkcs15-cedulauy.c
+++ b/src/libopensc/pkcs15-cedulauy.c
@@ -1,0 +1,173 @@
+/*
+ * PKCS#15 emulation for the Uruguayan national eID (cédula de identidad digital),
+ * driven by card-cedulauy.c.
+ *
+ * The card's on-card EF(TokenInfo) encodes one supportedAlgorithms entry with an
+ * empty SEQUENCE (30 00) where PKCS#15 expects NULL/OID, which the generic binder
+ * rejects. Instead of parsing the on-card PKCS#15 structure, this emulator builds
+ * a synthetic view from AGESIC's publicly documented file layout:
+ *   - IAS application AID  A0 00 00 00 18 40 00 00 01 63 42 00
+ *   - signing certificate  EF B001
+ *   - signing key          reference 0x01 (RSA 2048)
+ *   - Global PIN           reference 0x11 (VERIFY 00 20 00 11)
+ * References: AGESIC "Documentación técnica de la cédula de identidad con chip"
+ * and the AGESIC reference code at https://github.com/eIDuy/apdu-services .
+ *
+ * Copyright (C) 2026 Carlos Andrés Planchón Prestes <carlosandresplanchonprestes@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "common/compat_strlcpy.h"
+#include "internal.h"
+#include "log.h"
+#include "pkcs15.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* IAS application AID (AGESIC, documented) */
+static const unsigned char cedulauy_aid[] = {
+		0xA0, 0x00, 0x00, 0x00, 0x18, 0x40, 0x00, 0x00, 0x01, 0x63, 0x42, 0x00};
+
+#define CEDULAUY_CERT_FID "B001" /* signing certificate EF */
+#define CEDULAUY_KEY_REF  0x01	 /* signing private key reference */
+#define CEDULAUY_PIN_REF  0x11	 /* Global PIN reference */
+#define CEDULAUY_OBJ_ID	  0x01	 /* links cert <-> prkey */
+
+static int
+sc_pkcs15emu_cedulauy_init(struct sc_pkcs15_card *p15card)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_aid aid;
+	int r;
+
+	struct sc_pkcs15_auth_info pin_info = {0};
+	struct sc_pkcs15_object pin_obj = {0};
+	struct sc_pkcs15_cert_info cert_info = {0};
+	struct sc_pkcs15_object cert_obj = {0};
+	struct sc_pkcs15_prkey_info prkey_info = {0};
+	struct sc_pkcs15_object prkey_obj = {0};
+	struct sc_pkcs15_cert *cert = NULL;
+	struct sc_app_info *appinfo;
+
+	LOG_FUNC_CALLED(ctx);
+
+	memcpy(aid.value, cedulauy_aid, sizeof cedulauy_aid);
+	aid.len = sizeof cedulauy_aid;
+
+	appinfo = calloc(1, sizeof(struct sc_app_info));
+	if (appinfo == NULL) {
+		LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+	}
+	appinfo->aid = aid;
+	appinfo->ddo.aid = aid;
+	p15card->app = appinfo;
+
+	/* Global PIN (reference 0x11, ASCII numeric, zero-padded to 12 bytes). */
+	pin_info.auth_id.value[0] = CEDULAUY_OBJ_ID;
+	pin_info.auth_id.len = 1;
+	pin_info.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN;
+	pin_info.attrs.pin.reference = CEDULAUY_PIN_REF;
+	pin_info.attrs.pin.flags = SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING;
+	pin_info.attrs.pin.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC;
+	pin_info.attrs.pin.min_length = 4;
+	pin_info.attrs.pin.stored_length = 12;
+	pin_info.attrs.pin.max_length = 12;
+	pin_info.attrs.pin.pad_char = 0x00;
+	pin_info.tries_left = -1;
+	pin_info.max_tries = -1;
+	strlcpy(pin_obj.label, "PIN", sizeof pin_obj.label);
+	r = sc_pkcs15emu_add_pin_obj(p15card, &pin_obj, &pin_info);
+	LOG_TEST_RET(ctx, r, "Cannot add Global PIN object");
+
+	/* Signing certificate (EF B001 under the IAS application). */
+	sc_format_path("i" CEDULAUY_CERT_FID, &cert_info.path); /* 'i' => select by file ID */
+	cert_info.path.aid = aid;
+	cert_info.id.value[0] = CEDULAUY_OBJ_ID;
+	cert_info.id.len = 1;
+	strlcpy(cert_obj.label, "Certificado de Firma", sizeof cert_obj.label);
+	r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+	LOG_TEST_RET(ctx, r, "Cannot add signing certificate object");
+
+	/* Set the token label and serial number from the certificate, when
+	 * readable.  The serial number also keys the file cache. */
+	if (sc_pkcs15_read_certificate(p15card, &cert_info, 0, &cert) == SC_SUCCESS) {
+		static const struct sc_object_id cn_oid = {
+				{2, 5, 4, 3, -1}
+		};
+		u8 *cn = NULL;
+		size_t cn_len = 0;
+		const u8 *serial = cert->serial;
+		size_t serial_len = cert->serial_len;
+
+		sc_pkcs15_get_name_from_dn(ctx, cert->subject, cert->subject_len,
+				&cn_oid, &cn, &cn_len);
+		if (cn_len > 0) {
+			char *label = malloc(cn_len + 1);
+			if (label) {
+				memcpy(label, cn, cn_len);
+				label[cn_len] = '\0';
+				free(p15card->tokeninfo->label);
+				p15card->tokeninfo->label = label;
+			}
+		}
+		free(cn);
+
+		/* strip the ASN.1 INTEGER header, if present */
+		if (serial_len > 2 && serial[0] == 0x02 && serial[1] == serial_len - 2) {
+			serial += 2;
+			serial_len -= 2;
+		}
+		if (serial_len > 0) {
+			char *sn = malloc(serial_len * 2 + 1);
+			if (sn) {
+				sc_bin_to_hex(serial, serial_len, sn, serial_len * 2 + 1, 0);
+				free(p15card->tokeninfo->serial_number);
+				p15card->tokeninfo->serial_number = sn;
+			}
+		}
+
+		sc_pkcs15_free_certificate(cert);
+	}
+
+	/* Signing private key (reference 0x01, RSA 2048, PIN-protected). */
+	prkey_info.id.value[0] = CEDULAUY_OBJ_ID;
+	prkey_info.id.len = 1;
+	prkey_info.usage = SC_PKCS15_PRKEY_USAGE_SIGN | SC_PKCS15_PRKEY_USAGE_NONREPUDIATION;
+	prkey_info.native = 1;
+	prkey_info.key_reference = CEDULAUY_KEY_REF;
+	prkey_info.modulus_length = 2048;
+	prkey_obj.auth_id.value[0] = CEDULAUY_OBJ_ID;
+	prkey_obj.auth_id.len = 1;
+	prkey_obj.flags = SC_PKCS15_CO_FLAG_PRIVATE;
+	strlcpy(prkey_obj.label, "Clave de Firma", sizeof prkey_obj.label);
+	r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+	LOG_TEST_RET(ctx, r, "Cannot add signing private key object");
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+int
+sc_pkcs15emu_cedulauy_init_ex(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	if (p15card->card->type != SC_CARD_TYPE_CEDULAUY)
+		return SC_ERROR_WRONG_CARD;
+
+	return sc_pkcs15emu_cedulauy_init(p15card);
+}

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -51,6 +51,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "sc-hsm",	sc_pkcs15emu_sc_hsm_init_ex	},
 	{ "dnie",       sc_pkcs15emu_dnie_init_ex	},
 	{ "gids",       sc_pkcs15emu_gids_init_ex	},
+	{ "cedulauy",	sc_pkcs15emu_cedulauy_init_ex	},
 	{ "iasecc",	sc_pkcs15emu_iasecc_init_ex	},
 	{ "jpki",	sc_pkcs15emu_jpki_init_ex	},
 	{ "coolkey",    sc_pkcs15emu_coolkey_init_ex	},
@@ -129,6 +130,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DTRUST_V5_1_M100:
 		case SC_CARD_TYPE_DTRUST_V5_4_MULTI:
 		case SC_CARD_TYPE_LTEID:
+		case SC_CARD_TYPE_CEDULAUY:
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -48,6 +48,7 @@ int sc_pkcs15emu_sc_hsm_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
 int sc_pkcs15emu_dnie_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
 int sc_pkcs15emu_gids_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
 int sc_pkcs15emu_iasecc_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
+int sc_pkcs15emu_cedulauy_init_ex(sc_pkcs15_card_t *, struct sc_aid *);
 int sc_pkcs15emu_jpki_init_ex(sc_pkcs15_card_t *,	struct sc_aid *);
 int sc_pkcs15emu_coolkey_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);
 int sc_pkcs15emu_din_66291_init_ex(sc_pkcs15_card_t *p15card,	struct sc_aid *);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -1235,6 +1235,7 @@ const char *pkcs15_get_default_use_file_cache(struct sc_card *card)
 			"belpic",
 			"cac1",
 			"cac",
+			"cedulauy",
 			"coolkey",
 			"edo",
 			"esteid2018",

--- a/src/libopensc/sc.c
+++ b/src/libopensc/sc.c
@@ -648,6 +648,8 @@ void sc_file_dup(sc_file_t **dest, const sc_file_t *src)
 	const sc_acl_entry_t *e;
 	unsigned int op;
 
+	if (!dest)
+		return;
 	*dest = NULL;
 	if (!sc_file_valid(src))
 		return;


### PR DESCRIPTION
*(Description updated to reflect the final implementation after review. The first iteration patched `card-iasecc.c` with a card subtype; see the review below for how the implementation evolved.)*

## Summary 🇺🇾

The Uruguayan national identity card (*cédula de identidad electrónica*) is a Gemalto/Thales "Classic V4" IAS/ECC platform card. On Linux, its only available middleware has been the closed-source Thales Classic Client, so there was no open stack for it. As a Uruguayan citizen, my goal is for the card to be usable with open, auditable tooling rather than only that closed-source middleware.

This PR makes OpenSC drive the card end to end over the contact interface: recognition, certificate read, PIN verification, and signing, with the signature verifying against the card's own certificate.

## Design

The subset exposed by the card over the contact interface is plain ISO 7816, so support is implemented as:

- A dedicated card driver, **`card-cedulauy.c`**, built on the generic `iso7816` operations and following the model of `card-esteid2018.c`. It selects the IAS application by AID at initialization; nothing on the card is accessible before that selection. It reselects the application after a card reset, emulates the MF (the card exposes none, so `3F00` maps to the application), and signs using `MSE SET DST`, followed by `PSO HASH` and `PSO COMPUTE DIGITAL SIGNATURE`. The card builds the DigestInfo on-card for SHA-256. For other hash-and-sign mechanisms, OpenSC hashes in software and submits the resulting DigestInfo for raw PKCS#1 v1.5 signing. Random data is read in 8-byte chunks.

- A synthetic PKCS#15 emulator, **`pkcs15-cedulauy.c`**. The card's on-card `EF(TokenInfo)` encodes one `supportedAlgorithms` entry as an empty `SEQUENCE`, where PKCS#15 expects `NULL` or an OID, so the generic binder rejects it. The emulator instead builds the PKCS#15 view, consisting of the Global PIN, signing certificate, and RSA-2048 key, from AGESIC's documented layout. The token label and serial number come from the signing certificate, and the serial number keys the file cache, which is enabled by default because the card profile is static.

Review also surfaced a possible `NULL`-destination dereference in `sc_file_dup()`, which is now guarded in the library itself.

## Card identification

| | |
|---|---|
| Card | Uruguayan eID (*cédula de identidad*), Gemalto "Classic V4" |
| ATR | `3B 7F 94 00 00 80 31 80 65 B0 85 03 00 EF 12 0F FF 82 90 00` |
| ATR mask | `FF FF 00 FF FF FF FF FF FF FF FF 00 00 00 00 00 00 FF FF FF` (TA1 and the version/batch bytes vary between batches) |
| Application AID | `A0 00 00 00 18 40 00 00 01 63 42 00` |
| Signing certificate | EF `B001` |
| Signing key | Reference `0x01`, RSA 2048 |
| Global PIN | Reference `0x11`, zero-padded to 12 bytes |

## Testing

- Two physical cards from different batches: mine (pre-2022) on an ACS ACR38U, and @nicolasgutierrezdev's (March 2026) on an Alcor Link AK9563.
- Recognition, certificate read, both cold and from the file cache, PIN verification, and signing. `pkcs11-tool --test --login` reports no errors on both cards.
- Signatures verify against the certificate's public key with OpenSSL, and @nicolasgutierrezdev signed and validated a PAdES document end to end.

## Scope and follow-ups

This PR supports the contact interface only. The following are planned as separate work:

- ID data and face image as generic PKCS#15 data objects (EFs `7001`, `7002`, `7004`, `700B`, and the SOD in `711D`, as documented by AGESIC).
- Document number as the token serial via `SC_CARDCTL_GET_SERIALNR`, weighing the privacy trade-off discussed in the review.
- Contactless support with PACE. Cards issued since late 2022 support it, and @nicolasgutierrezdev's findings will move to a dedicated issue.

## References

Card conventions come from AGESIC's official, public materials; no reverse-engineering of the closed-source middleware was involved:

- [Información Técnica de Cédula de Identidad con chip](https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/documentacion-tecnica-id-uruguay/documentacion-tecnica-id-uruguay-9) (AGESIC).
- [Documentación técnica de la cédula de identidad con chip](https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/book/7192/download) (AGESIC, compiled PDF; the APDU signing chapter includes the `AlgoID` table and a worked example).
- [Autenticación y Firma Avanzada a través de PKCS#11](https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/documentacion-tecnica-cedula-identidad-chip/documentacion-tecnica-3) (AGESIC).
- [`eIDuy/apdu-services`](https://github.com/eIDuy/apdu-services) (AGESIC reference code using Java `javax.smartcardio`).
- [`agesic-eid/Interfaz-datosci-apdu`](https://github.com/agesic-eid/Interfaz-datosci-apdu) (AGESIC reference code).

## Appendix: signing APDU sequence (contact interface, no Secure Messaging)

All commands use `CLA=00` (plain). For a standard `SHA256withRSA` signature, the driver uses algorithm reference `0x42`, with SHA-256 in the high nibble and PKCS#1 v1.5 in the low nibble. It loads the bare 32-byte SHA-256 digest, and the card builds the DigestInfo, so the result verifies as a standard RSA signature.

| Step | APDU | Notes |
|---|---|---|
| SELECT application | `00 A4 04 00 0C` + AID | Application AID |
| VERIFY PIN | `00 20 00 11 0C` + PIN zero-padded to 12 bytes | Global PIN |
| MSE SET (DST) | `00 22 41 B6 06 84 01 01 80 01 42` | Key ref `01`, algorithm `0x42` |
| PSO HASH | `00 2A 90 A0 22 90 20` + 32-byte SHA-256 digest | Load digest (tag `90`) |
| PSO COMPUTE DIGITAL SIGNATURE | `00 2A 9E 9A 00` | RSA-2048, 256-byte signature |

## Credits

- @frankmorgner contributed the PKCS#15 appinfo and emulated MF commits, and suggested the `sc_file_dup()` robustness fix.
- @nicolasgutierrezdev contributed the ATR mask, tested a second card batch end to end, and investigated the contactless interface.
- @Jakuje reviewed the final implementation and suggested cleanup around the algorithm constants and structure initialization.

Developed with assistance from Claude Code (Opus 4.8), Fable 5, and ChatGPT Sol Extra High.