### PR TITLE
card-piv.c - Fix PIV SM issue when Lc is multiple of 16

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1044,7 +1044,7 @@ piv_encode_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t *sm_apdu)
 		T87len = 0;
 		padlen = 0;
 	} else {
-		enc_datalen = (int)(((plain->datalen + 15) / 16) * 16); /* may add extra 16 bytes */
+		enc_datalen = (int)(((plain->datalen + 16) / 16) * 16); /* may add extra 16 bytes */
 		padlen = enc_datalen - (int)plain->datalen;
 		r = T87len = sc_asn1_put_tag(0x87, NULL, 1 + enc_datalen, NULL, 0, NULL);
 		if (r < 0)


### PR DESCRIPTION
Fixes #3727 

 On branch piv-sm-lc-fix
 Changes to be committed:
	modified:   src/libopensc/card-piv.c

Thanks to @frankmorgner for the fix and @laughingbro from the report

Idemia ID-One PIV 2.4.1 cards were used to test the fix.

There is still a related issue:
sm-iso.c and the current card-piv.c do not treat Lc=0 as a multiple of 16, but NIST sp800-73-5 says: 

" BER-TLV-encoded encrypted message, which consists of tag '87' followed by the length of the encoded encrypted message (Lcc + 1), the padding indicator byte ('01'), and then the encrypted data. Lcc is the length of the encrypted PIV data; it SHALL be a multiple of 16." 

The Idemia ID-One PIV 2.4.1 cards work with or without an '87' for Lc=0. 

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
