### PR TITLE
CI: Pin IsoApplet v1 to its latest working version

### DIFF
--- a/.github/test-isoapplet.sh
+++ b/.github/test-isoapplet.sh
@@ -5,14 +5,6 @@ set -ex -o xtrace
 source .github/setup-valgrind.sh
 
 isoapplet_version="$1"
-if [ "$isoapplet_version" = "v0" ]; then
-	isoapplet_branch="main-javacard-v2.2.2"
-elif [ "$isoapplet_version" = "v1" ]; then
-	isoapplet_branch="main"
-else
-	echo "Unknown IsoApplet version: $isoapplet_version"
-	exit 1
-fi
 
 isoapplet_pkgdir="xyz/wendland/javacard/pki/isoapplet"
 
@@ -25,7 +17,17 @@ export LD_LIBRARY_PATH=/usr/local/lib
 
 # The ISO applet
 if [ ! -d IsoApplet ]; then
-	git clone https://github.com/philipWendland/IsoApplet.git --branch $isoapplet_branch --depth 1
+	if [ "$isoapplet_version" = "v0" ]; then
+		 isoapplet_branch="main-javacard-v2.2.2"
+		 git clone https://github.com/philipWendland/IsoApplet.git --branch $isoapplet_branch --depth 1
+	elif [ "$isoapplet_version" = "v1" ]; then
+		 #isoapplet_branch="main"
+		 git clone https://github.com/philipWendland/IsoApplet.git --revision 9cf87af45dc2949730a700a52a2dceb87353734c --depth 1
+	else
+		 echo "Unknown IsoApplet version: $isoapplet_version"
+		 exit 1
+	fi
+
 	# enable IsoApplet key import patch
 	sed "s/DEF_PRIVATE_KEY_IMPORT_ALLOWED = false/DEF_PRIVATE_KEY_IMPORT_ALLOWED = true/g" -i "IsoApplet/src/${isoapplet_pkgdir}/IsoApplet.java"
 fi


### PR DESCRIPTION
It is not working with jCardSim anymore, see
https://github.com/OpenSC/OpenSC/pull/3632#issuecomment-4818353292

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
