### PR TITLE
pkcs15/iasecc: tolerate missing Oberthur SDO metadata

### DIFF
--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -1717,19 +1717,31 @@ iasecc_set_security_env(struct sc_card *card,
 	sdo.sdo_class = IASECC_SDO_CLASS_RSA_PRIVATE;
 	sdo.sdo_ref  = env->key_ref[0] & ~IASECC_OBJECT_REF_LOCAL;
 	rv = iasecc_sdo_get_data(card, &sdo);
-	LOG_TEST_RET(ctx, rv, "Cannot get RSA PRIVATE SDO data");
+	if (rv == SC_ERROR_DATA_OBJECT_NOT_FOUND) {
+		sc_log(ctx, "RSA private SDO DOCP not found, using fallback security env");
+		if (env->key_size_bits && !(env->key_size_bits % 8))
+			prv->key_size = env->key_size_bits / 8;
+		else
+			prv->key_size = 0x100;
+		sign_meth = SC_AC_NONE;
+		sign_ref = SC_AC_KEY_REF_NONE;
+		auth_meth = SC_AC_NONE;
+		auth_ref = SC_AC_KEY_REF_NONE;
+	} else {
+		LOG_TEST_RET(ctx, rv, "Cannot get RSA PRIVATE SDO data");
 
-	if (sdo.docp.size.size < 2)
-		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
-	/* To made by iasecc_sdo_convert_to_file() */
-	prv->key_size = *(sdo.docp.size.value + 0) * 0x100 + *(sdo.docp.size.value + 1);
-	sc_log(ctx, "prv->key_size 0x%"SC_FORMAT_LEN_SIZE_T"X", prv->key_size);
+		if (sdo.docp.size.size < 2)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
+		/* To made by iasecc_sdo_convert_to_file() */
+		prv->key_size = *(sdo.docp.size.value + 0) * 0x100 + *(sdo.docp.size.value + 1);
+		sc_log(ctx, "prv->key_size 0x%"SC_FORMAT_LEN_SIZE_T"X", prv->key_size);
 
-	rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_PSO_COMPUTE_SIGNATURE, &sign_meth, &sign_ref);
-	LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_SIGN acl");
+		rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_PSO_COMPUTE_SIGNATURE, &sign_meth, &sign_ref);
+		LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_SIGN acl");
 
-	rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_INTERNAL_AUTHENTICATE, &auth_meth, &auth_ref);
-	LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_INT_AUTH acl");
+		rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_INTERNAL_AUTHENTICATE, &auth_meth, &auth_ref);
+		LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_INT_AUTH acl");
+	}
 
 	aflags = env->algorithm_flags;
 
@@ -2088,6 +2100,17 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struc
 	sc_log(ctx, "iasecc_pin_get_policy() reference %i", sdo.sdo_ref);
 
 	rv = iasecc_sdo_get_data(card, &sdo);
+	if (rv == SC_ERROR_DATA_OBJECT_NOT_FOUND) {
+		sc_log(ctx, "PIN policy SDO not found, using fallback policy");
+		pin->min_length = data->pin1.min_length;
+		pin->max_length = data->pin1.max_length;
+		pin->stored_length = data->pin1.len;
+		pin->tries_maximum = -1;
+		pin->tries_remaining = -1;
+		memset(pin->scbs, 0, sizeof(pin->scbs));
+		rv = SC_SUCCESS;
+		goto err;
+	}
 	LOG_TEST_GOTO_ERR(ctx, rv, "Cannot get SDO PIN data");
 
 	if (sdo.docp.acls_contact.size == 0) {

--- a/src/libopensc/pkcs15-iasecc.c
+++ b/src/libopensc/pkcs15-iasecc.c
@@ -162,6 +162,7 @@ _iasecc_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
 		case SC_CARD_TYPE_IASECC_GEMALTO:
 		case SC_CARD_TYPE_IASECC_CPX:
 		case SC_CARD_TYPE_IASECC_CPXCL:
+		case SC_CARD_TYPE_IASECC_OBERTHUR:
 			sc_log(ctx, "Warning: the %d card has an invalid DF, hot patch to be applied",
 				p15card->card->type);
 			break;

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -103,6 +103,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_IASECC_GEMALTO:
 		case SC_CARD_TYPE_IASECC_CPX:
 		case SC_CARD_TYPE_IASECC_CPXCL:
+		case SC_CARD_TYPE_IASECC_OBERTHUR:
 		case SC_CARD_TYPE_PIV_II_GENERIC:
 		case SC_CARD_TYPE_PIV_II_HIST:
 		case SC_CARD_TYPE_PIV_II_NEO:
@@ -542,4 +543,3 @@ int sc_pkcs15emu_object_add(sc_pkcs15_card_t *p15card, unsigned int type,
 
 	LOG_FUNC_RETURN(p15card->card->ctx, SC_SUCCESS);
 }
-


### PR DESCRIPTION
Handle incomplete IAS/ECC metadata on IAS/ECC v1.0.1 Oberthur cards.

Some IAS/ECC v1.0.1 Oberthur cards return `SC_ERROR_DATA_OBJECT_NOT_FOUND` for
the PIN policy SDO and for the RSA private-key SDO/DOCP. In addition, this card
type was not routed through the synthetic PKCS#15 IAS/ECC emulation path, so the
existing PRKDF fixup was never applied.

This patch fixes the issue in three places:

- add `SC_CARD_TYPE_IASECC_OBERTHUR` to the emulation-only path in
  `src/libopensc/pkcs15-syn.c`
- add `SC_CARD_TYPE_IASECC_OBERTHUR` to the existing PRKDF fixup switch in
  `src/libopensc/pkcs15-iasecc.c`
- in `src/libopensc/card-iasecc.c`, fall back when the card returns
  `SC_ERROR_DATA_OBJECT_NOT_FOUND` while reading PIN policy and RSA private-key
  SDO metadata

For the PIN policy fallback, the patch uses the PKCS#15 PIN description to
populate the policy fields. For the RSA private-key fallback, it uses a minimal
security environment so signing can proceed when the private-key DOCP is absent.

Tested card:
- IAS/ECC v1.0.1 Oberthur

Validation:
- PKCS#15 enumeration succeeds
- PKCS#11 login succeeds
- PKCS#11 signing succeeds with `RSA-PKCS`
- the generated signature was verified against the certificate public key
- Firefox certificate usage was tested successfully on macOS

##### Checklist
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [x] macOS token is tested