### PR TITLE
PIV: enable X25519 key derivation for YubiKey 5.7+

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5829,7 +5829,7 @@ piv_match_card_continued(sc_card_t *card)
 		if (priv->yubico_version < 0x00040302)
 			priv->card_issues |= CI_VERIFY_LC0_FAIL;
 		if (priv->yubico_version >= 0x00050700) /* Also used by Token2 */
-			priv->alg_ids |= AI_RSA_4096 | AI_25519;
+			priv->alg_ids |= AI_RSA_4096 | AI_25519 | AI_X25519;
 		break;
 
 	case SC_CARD_TYPE_PIV_II_NITROKEY:
@@ -5982,7 +5982,7 @@ piv_init(sc_card_t *card)
 		flags = SC_ALGORITHM_ECDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW | SC_ALGORITHM_ECDSA_HASH_NONE;
 		ext_flags = SC_ALGORITHM_EXT_EC_NAMEDCURVE | SC_ALGORITHM_EXT_EC_UNCOMPRESES;
 		flags_eddsa = SC_ALGORITHM_EDDSA_RAW;
-		flags_xeddsa = SC_ALGORITHM_XEDDSA_RAW;
+		flags_xeddsa = SC_ALGORITHM_XEDDSA_RAW | SC_ALGORITHM_ECDH_CDH_RAW;
 
 		for (i = 0; ec_curves[i].oid.value[0] >= 0; i++) {
 			if (ec_curves[i].key_type == SC_ALGORITHM_EC) {


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->
## Summary

Enable X25519 key derivation for PIV cards that advertise X25519 support.

For YubiKey firmware 5.7.0 and newer, the PIV driver already enables Ed25519 support through `AI_25519`, but does not set the separate `AI_X25519` capability flag.

Additionally, X25519 algorithms are registered only with `SC_ALGORITHM_XEDDSA_RAW`, without the `SC_ALGORITHM_ECDH_CDH_RAW` capability required by the PKCS#11 layer to allow key derivation.

## Changes

* Set `AI_X25519` for YubiKey firmware 5.7.0 and newer.
* Add `SC_ALGORITHM_ECDH_CDH_RAW` to the X25519 algorithm flags.

`SC_ALGORITHM_XEDDSA_RAW` identifies the algorithm as X25519/X448, while `SC_ALGORITHM_ECDH_CDH_RAW` marks it as capable of raw key agreement.

## Current behavior

Before this change, deriving a shared secret with an X25519 private key stored in a YubiKey PIV slot fails:

```sh
LD_LIBRARY_PATH=/opt/opensc/lib \
pkcs11-tool \
  --module /opt/opensc/lib/opensc-pkcs11.so \
  --login \
  --derive \
  --mechanism ECDH1-DERIVE \
  --id 03 \
  --input-file /tmp/peer-x25519-pub.der \
  --output-file /tmp/secret-pkcs11-tool.bin
```

```text
Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV Attestation 9d".
Please enter User PIN:
Using derive algorithm 0x00001050 ECDH1-DERIVE
error: PKCS11 function C_DeriveKey failed: rv = CKR_KEY_TYPE_INCONSISTENT (0x63)
Aborting.
```

## New behavior

After this change, the same command succeeds:

```sh
LD_LIBRARY_PATH=/opt/opensc/lib \
pkcs11-tool \
  --module /opt/opensc/lib/opensc-pkcs11.so \
  --login \
  --derive \
  --mechanism ECDH1-DERIVE \
  --id 03 \
  --input-file /tmp/peer-x25519-pub.der \
  --output-file /tmp/secret-pkcs11-tool.bin
```

```text
Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV Attestation 9d".
Please enter User PIN:
Using derive algorithm 0x00001050 ECDH1-DERIVE
```

The resulting 32-byte shared secret was compared with a secret independently derived by OpenSSL using the peer private key and the YubiKey public key. Both values were identical.

## Test environment

* Yubico YubiKey recognized by OpenSC as `Personal Identity Verification Card`
* Firmware 5.7.1
* Mechanism: `CKM_ECDH1_DERIVE`
* Key type: X25519


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PKCS#11 module is tested
