### PR TITLE
card-jpki: Use sc_file_free() to release virtual MF

### DIFF
--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -83,9 +83,7 @@ jpki_finish(sc_card_t * card)
 
 	LOG_FUNC_CALLED(card->ctx);
 	if (drvdata) {
-		if (drvdata->mf) {
-			free(drvdata->mf);
-		}
+		sc_file_free(drvdata->mf);
 		free(drvdata);
 		card->drv_data = NULL;
 	}


### PR DESCRIPTION
## Summary

`jpki_finish()` released `drvdata->mf` with a plain `free()`. However, the
file is created via `sc_file_new()` in `jpki_init()` and has five ACL
entries attached through `sc_file_add_acl_entry()` (`SELECT`, `LIST_FILES`,
`LOCK`, `DELETE`, `CREATE`).

`free()` only releases the top-level `sc_file_t` struct, leaking the linked
ACL entries (and any `*_attr` allocations). This is a resource leak and an
API contract violation.

## Fix

Use `sc_file_free()`, which clears the ACL entries and sub-allocations
before freeing the struct. `sc_file_free()` handles `NULL` internally, so
the explicit NULL check is dropped as well.

Found during a review of the JPKI driver. This is a leak / correctness fix,
not a memory-corruption issue.