### PR TITLE
Expose Uruguayan eID identity data as PKCS#15 data objects

### DIFF
--- a/src/libopensc/pkcs15-cedulauy.c
+++ b/src/libopensc/pkcs15-cedulauy.c
@@ -10,6 +10,7 @@
  *   - signing certificate  EF B001
  *   - signing key          reference 0x01 (RSA 2048)
  *   - Global PIN           reference 0x11 (VERIFY 00 20 00 11)
+ *   - identity data        EFs 7001/7002/7004/700B under DF 7000
  * References: AGESIC "Documentación técnica de la cédula de identidad con chip"
  * and the AGESIC reference code at https://github.com/eIDuy/apdu-services .
  *
@@ -50,12 +51,27 @@ static const unsigned char cedulauy_aid[] = {
 #define CEDULAUY_PIN_REF  0x11	 /* Global PIN reference */
 #define CEDULAUY_OBJ_ID	  0x01	 /* links cert <-> prkey */
 
+/* Public identity data files under DF 7000 (AGESIC layout), all readable
+ * without PIN.  They are exposed as raw PKCS#15 data objects carrying the
+ * BER-TLV content documented by AGESIC; callers parse the tags themselves.
+ * EF 711D (the ICAO SOD) is not exposed: it is absent on earlier batches. */
+static const struct {
+	const char *path; /* absolute path; the MF is emulated by the driver */
+	const char *label;
+} cedulauy_data_files[] = {
+		{"3F0070007001", "Numero de documento"},
+		{"3F0070007002", "Datos biograficos"  },
+		{"3F0070007004", "Fotografia"	     },
+		{"3F007000700B", "MRZ"		      },
+};
+
 static int
 sc_pkcs15emu_cedulauy_init(struct sc_pkcs15_card *p15card)
 {
 	struct sc_context *ctx = p15card->card->ctx;
 	struct sc_aid aid;
 	int r;
+	size_t i;
 
 	struct sc_pkcs15_auth_info pin_info = {0};
 	struct sc_pkcs15_object pin_obj = {0};
@@ -159,6 +175,18 @@ sc_pkcs15emu_cedulauy_init(struct sc_pkcs15_card *p15card)
 	strlcpy(prkey_obj.label, "Clave de Firma", sizeof prkey_obj.label);
 	r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
 	LOG_TEST_RET(ctx, r, "Cannot add signing private key object");
+
+	/* Public identity data objects (DF 7000), readable without PIN. */
+	for (i = 0; i < sizeof cedulauy_data_files / sizeof cedulauy_data_files[0]; i++) {
+		struct sc_pkcs15_data_info dinfo = {0};
+		struct sc_pkcs15_object dobj = {0};
+
+		sc_format_path(cedulauy_data_files[i].path, &dinfo.path);
+		strlcpy(dinfo.app_label, cedulauy_data_files[i].label, sizeof dinfo.app_label);
+		strlcpy(dobj.label, cedulauy_data_files[i].label, sizeof dobj.label);
+		r = sc_pkcs15emu_add_data_object(p15card, &dobj, &dinfo);
+		LOG_TEST_RET(ctx, r, "Cannot add identity data object");
+	}
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }


### PR DESCRIPTION
## Summary

Follow-up to #3729 (Uruguayan eID / cédula de identidad support). That PR added the
card driver and the signing PKCS#15 view. This one exposes the card's **public identity
data**, which @frankmorgner suggested exposing during that review.

The cédula stores the cardholder's public data in transparent EFs under DF 7000,
readable over the contact interface **without a PIN** (the same data printed on the card):

| EF | Content |
|---|---|
| `7001` | Document number |
| `7002` | Biographic data (names, surnames, nationality, dates, place of birth) |
| `7004` | Facial image (JPEG) |
| `700B` | MRZ |

The synthetic PKCS#15 emulator now registers each of these as a **data object** carrying
the raw BER-TLV content, so any PKCS#11 application can read them through the standard API
(`pkcs15-tool --list-data-objects`, `pkcs11-tool --read-object --type data`) instead of
driving the card's APDUs directly. The paths are absolute (the MF is emulated by the
driver) and the objects carry no `auth_id`, since the data is public.

It is one commit touching a single file (`pkcs15-cedulauy.c`), modelled on `pkcs15-itacns.c`.

## Scope and follow-ups

- **EF 711D (the ICAO SOD)** is not exposed. It was not found over the contact interface
  on any card tested, and most likely lives on the contactless (eMRTD) side, read via NFC
  after PACE. It belongs with the contactless work, not here.
- **Per-field parsing** is left for later. The objects hold the raw TLV blob and the
  consumer parses it; splitting EF 7002 into individual fields is a separate step.
- **Contactless / NFC** support (PACE) remains the other planned follow-up.

## Testing

- Two physical cards from different batches: mine (pre-2022) and @nicolasgutierrezdev's
  (2026). `pkcs15-tool --list-data-objects` reads all four objects on both.
- `pkcs11-tool --test --login` still reports **no errors**, so exposing the data objects
  did not affect the signing path from #3729.

## References

Card conventions come from AGESIC's public materials (no reverse-engineering of any
proprietary middleware):

- Documentación técnica de la cédula de identidad con chip (AGESIC, PDF, whose data-layout
  chapter has the per-EF TLV tables): https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/book/7192/download
- Reference code eIDuy/apdu-services (AGESIC): https://github.com/eIDuy/apdu-services

## Credits

- @nicolasgutierrezdev tested on a second card batch.
- @frankmorgner suggested exposing the image and ID data as generic PKCS#15 data
  objects during the #3729 review.

Developed with assistance from Claude Code (Fable 5).
