### PR TITLE
ID Prime: Set current_op to RSA when previous operation was ECC

### DIFF
--- a/.github/vcpkg.json
+++ b/.github/vcpkg.json
@@ -13,5 +13,5 @@
       "dependencies": ["openpace"]
     }
   },
-  "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713"
+  "builtin-baseline": "7849750896c86bd7a4a02ed760812dba321a4a9b"
 }

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -1056,6 +1056,7 @@ idprime_set_security_env(struct sc_card *card,
 		} else { /* RSA-PKCS without hashing */
 			new_env.algorithm_ref = 0x1A;
 		}
+		priv->current_op = SC_ALGORITHM_RSA;
 		break;
 	case SC_SEC_OPERATION_SIGN:
 		if (env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PSS) {


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested

Signed-off-by: Raul Metsma <raul@metsma.ee>