### PR TITLE
p11test: fix AES mechanism addition

### DIFF
--- a/src/tests/p11test/p11test_case_common.c
+++ b/src/tests/p11test/p11test_case_common.c
@@ -330,7 +330,9 @@ add_supported_mechs(test_cert_t *o)
 		break;
 #endif /* EVP_PKEY_SLH_DSA_SHA2_128S */
 	/* Nothing in the above enum can be used for secret keys */
-	case CKK_AES:
+	default:
+		if (o->key_type != CKK_AES)
+			break;
 		if (token.num_aes_mechs > 0 ) {
 			o->num_mechs = token.num_aes_mechs;
 			for (i = 0; i < token.num_aes_mechs; i++) {


### PR DESCRIPTION
This PR fixes a regression introduced in commit c29ad3208acaf28b880153f9848025d5f362f3c8, where the `type` and `key_type` fields of `test_cert_t` were mixed up.