### PR TITLE
feat: Add native driver for G&D StarSign CUT S (ICP-Brasil A3)

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -52,6 +52,7 @@ libopensc_la_SOURCES_BASE = \
 	card-npa.c card-esteid2018.c card-esteid2025.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
 	card-lteid.c card-srbeid.c card-cedulauy.c \
+	card-starsign.c \
 	\
 	pkcs15-openpgp.c pkcs15-starcert.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c pkcs15-piv.c \
@@ -134,6 +135,7 @@ TIDY_FILES = \
 	card-npa.c card-esteid2018.c card-idprime.c \
 	card-edo.c card-nqApplet.c card-skeid.c card-eoi.c card-dtrust.c \
 	card-lteid.c card-srbeid.c card-cedulauy.c \
+	card-starsign.c \
 	\
 	pkcs15-openpgp.c pkcs15-cardos.c pkcs15-tcos.c \
 	pkcs15-actalis.c pkcs15-atrust-acos.c pkcs15-tccardos.c \

--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -61,7 +61,7 @@ libopensc_la_SOURCES_BASE = \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-cedulauy.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-eoi.c pkcs15-dtrust.c pkcs15-lteid.c \
-	pkcs15-srbeid.c compression.c sm.c aux-data.c
+	pkcs15-srbeid.c pkcs15-starsign.c compression.c sm.c aux-data.c
 
 if ENABLE_CRYPTOTOKENKIT
 # most platforms don't support objective C the way we needed.
@@ -144,7 +144,7 @@ TIDY_FILES = \
 	pkcs15-coolkey.c pkcs15-din-66291.c pkcs15-idprime.c pkcs15-nqApplet.c \
 	pkcs15-dnie.c pkcs15-gids.c pkcs15-iasecc.c pkcs15-cedulauy.c pkcs15-jpki.c pkcs15-esteid2018.c \
 	pkcs15-starcos-esign.c pkcs15-skeid.c pkcs15-dtrust.c pkcs15-lteid.c \
-	pkcs15-srbeid.c compression.c sm.c aux-data.c \
+	pkcs15-srbeid.c pkcs15-starsign.c compression.c sm.c aux-data.c \
 	#$(SOURCES)
 
 check-local:

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -29,7 +29,7 @@ OBJECTS			= \
 	card-masktech.obj card-gids.obj card-jpki.obj \
 	card-npa.obj card-esteid2018.obj card-esteid2025.obj card-idprime.obj \
 	card-edo.obj card-nqApplet.obj card-skeid.obj card-eoi.obj card-dtrust.obj \
-	card-lteid.obj card-srbeid.obj card-cedulauy.obj \
+	card-lteid.obj card-srbeid.obj card-cedulauy.obj card-starsign.obj \
 	\
 	pkcs15-openpgp.obj pkcs15-starcert.obj pkcs15-cardos.obj pkcs15-tcos.obj \
 	pkcs15-actalis.obj pkcs15-atrust-acos.obj pkcs15-tccardos.obj pkcs15-piv.obj \
@@ -38,7 +38,7 @@ OBJECTS			= \
 	pkcs15-dnie.obj pkcs15-gids.obj pkcs15-iasecc.obj pkcs15-cedulauy.obj pkcs15-jpki.obj \
 	pkcs15-esteid2018.obj pkcs15-esteid2025.obj pkcs15-idprime.obj pkcs15-nqApplet.obj \
 	pkcs15-starcos-esign.obj pkcs15-skeid.obj pkcs15-eoi.obj pkcs15-dtrust.obj \
-	pkcs15-lteid.obj pkcs15-srbeid.obj compression.obj sm.obj aux-data.obj \
+	pkcs15-lteid.obj pkcs15-srbeid.obj pkcs15-starsign.obj compression.obj sm.obj aux-data.obj \
 	$(TOPDIR)\win32\versioninfo.res
 LIBS = $(TOPDIR)\src\scconf\scconf.lib \
 	   $(TOPDIR)\src\common\common.lib \

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -1,0 +1,304 @@
+/*
+ * Support for G&D StarSign CUT S cards (A.E.T. Europe SafeSign)
+ *
+ * This driver performs the proprietary DRM handshake and logical
+ * channel selection required by the StarSign CUT S token.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "internal.h"
+#include "asn1.h"
+#include "log.h"
+
+static const struct sc_atr_table starsign_atrs[] = {
+	{ "3B:F9:96:00:00:81:31:FE:45:53:43:45:37:20:0E:00:20:20:28", NULL, NULL, SC_CARD_TYPE_STARSIGN, 0, NULL },
+	{ NULL, NULL, NULL, 0, 0, NULL }
+};
+
+static struct sc_card_operations starsign_ops;
+static struct sc_card_driver starsign_drv = {
+	"G&D StarSign CUT S",
+	"starsign",
+	&starsign_ops,
+	NULL, 0, NULL
+};
+
+static const u8 starsign_drm_string[] = "I am A.E.T. Europe B.V. SafeSign or BlueX approved software.";
+
+static int starsign_match_card(sc_card_t *card)
+{
+	int i;
+	i = _sc_match_atr(card, starsign_atrs, &card->type);
+	if (i < 0)
+		return 0;
+	return 1;
+}
+
+static int starsign_init(sc_card_t *card)
+{
+	sc_apdu_t apdu;
+	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+	int r;
+
+	card->name = "G&D StarSign CUT S";
+	card->type = SC_CARD_TYPE_STARSIGN;
+
+	/* 1. First DRM Handshake (ignore result, usually 6D 00) */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xDA, 0x01, 0x00);
+	apdu.data = starsign_drm_string;
+	apdu.datalen = sizeof(starsign_drm_string) - 1;
+	apdu.lc = apdu.datalen;
+	r = sc_transmit_apdu(card, &apdu);
+
+	/* 2. Select PKCS#15 AID (ignore result) */
+	u8 aid[] = { 0xA0, 0x00, 0x00, 0x00, 0x63, 0x50, 0x4B, 0x43, 0x53, 0x2D, 0x31, 0x35 };
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
+	apdu.data = aid;
+	apdu.datalen = sizeof(aid);
+	apdu.lc = sizeof(aid);
+	apdu.le = 256;
+	apdu.resplen = sizeof(rbuf);
+	apdu.resp = rbuf;
+	r = sc_transmit_apdu(card, &apdu);
+
+	/* 3. Second DRM Handshake (ignore result) */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xDA, 0x01, 0x00);
+	apdu.data = starsign_drm_string;
+	apdu.datalen = sizeof(starsign_drm_string) - 1;
+	apdu.lc = apdu.datalen;
+	r = sc_transmit_apdu(card, &apdu);
+
+	/* 4. Open Logical Channel 1 */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x70, 0x00, 0x00);
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rbuf);
+	apdu.le = 1;
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "Failed to transmit MANAGE CHANNEL");
+	if (apdu.sw1 == 0x6A && apdu.sw2 == 0x81) {
+		/* Channel already open, that's fine */
+		r = SC_SUCCESS;
+	} else {
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		LOG_TEST_RET(card->ctx, r, "Card refused logical channel opening");
+	}
+
+	/* 3. Force CLA=0x01 for all subsequent operations */
+	card->cla = 0x01;
+
+	/* 5. Select PKCS#15 AID again on Channel 1 */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x04, 0x00);
+	apdu.data = aid;
+	apdu.datalen = sizeof(aid);
+	apdu.lc = sizeof(aid);
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "Failed to select AID on channel 1");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r < 0) {
+		sc_log(card->ctx, "Card refused AID selection on channel 1 (SW %02X %02X), ignoring as it might be already selected", apdu.sw1, apdu.sw2);
+	}
+
+	/* Force RAW RSA (software padding) because G&D StarSign CUT cards 
+           often return 67 00 if sent unpadded hashes during C_Sign.
+           We only set SC_ALGORITHM_RSA_RAW so OpenSC pads the data to 256 bytes itself. */
+        card->caps |= SC_CARD_CAP_APDU_EXT;
+        card->max_send_size = 2048;
+        card->max_recv_size = 2048;
+        unsigned long alg_flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_HASH_MD5 | SC_ALGORITHM_RSA_HASH_SHA1 | SC_ALGORITHM_RSA_HASH_SHA256;
+				  
+	_sc_card_add_rsa_alg(card, 1024, alg_flags, 0);
+	_sc_card_add_rsa_alg(card, 2048, alg_flags, 0);
+	_sc_card_add_rsa_alg(card, 4096, alg_flags, 0);
+
+	return SC_SUCCESS;
+}
+
+static int starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file_out)
+{
+	int r = SC_SUCCESS;
+	size_t i;
+	struct sc_apdu apdu;
+
+	if (in_path->type != SC_PATH_TYPE_PATH && in_path->type != SC_PATH_TYPE_FROM_CURRENT && in_path->type != SC_PATH_TYPE_FILE_ID) {
+		sc_log(card->ctx, "STARSIGN SELECT FILE DEFERRING type=%d", in_path->type);
+		return sc_get_iso7816_driver()->ops->select_file(card, in_path, file_out);
+	}
+
+	sc_log(card->ctx, "STARSIGN SELECT FILE EXECUTING type=%d len=%zu", in_path->type, in_path->len);
+
+	if (in_path->len % 2 != 0 || in_path->len == 0)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	/* First, try to select the full path at once if it's a full path from MF */
+	if (in_path->len >= 4 && in_path->value[0] == 0x3F && in_path->value[1] == 0x00) {
+		sc_log(card->ctx, "STARSIGN SELECT FILE: Attempting full path selection from MF");
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x08, 0x0C);
+		apdu.data = in_path->value;
+		apdu.datalen = in_path->len;
+		apdu.lc = in_path->len;
+		r = sc_transmit_apdu(card, &apdu);
+		if (r == 0) r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		if (r == 0) {
+			sc_log(card->ctx, "STARSIGN SELECT FILE: Full path selection successful");
+			return 0;
+		}
+		sc_log(card->ctx, "STARSIGN SELECT FILE: Full path selection failed (%d), falling back to component-by-component", r);
+	}
+
+	/* Loop over every 2 bytes of the path */
+	for (i = 0; i < in_path->len; i += 2) {
+		unsigned short fid = (in_path->value[i] << 8) | in_path->value[i + 1];
+
+		/* DO NOT ignore 3F00! We need to select it to reset the current DF to MF.
+		   HOWEVER, G&D StarSign tokens have a bug where some certificates' absolute paths
+		   omit the 5015 DF (e.g. 3F00 3FFF 4302 13AE). If we just select 3F00, the 
+		   subsequent selection of 4302 will fail.
+		   We MUST explicitly select 5015 after 3F00, or we can just ignore 3F00 entirely
+		   AND ignore 5015 entirely, relying on the fact that we are ALREADY in the 5015
+		   applet, BUT we must reset to 5015 to prevent relative selection bugs.
+		   
+		   The safest fix is: when we see 3F00, we select 3F00 AND THEN select 5015 automatically! */
+		if (fid == 0x3F00) {
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
+			apdu.data = (const u8 *)"\x3F\x00";
+			apdu.datalen = 2; apdu.lc = 2;
+			sc_transmit_apdu(card, &apdu);
+			
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
+			apdu.data = (const u8 *)"\x50\x15";
+			apdu.datalen = 2; apdu.lc = 2;
+			sc_transmit_apdu(card, &apdu);
+			continue;
+		}
+		/* Ignore virtual/intermediate DFs that are not selectable directly on G&D StarSign */
+		if (fid == 0x3FFF) {
+			sc_log(card->ctx, "STARSIGN SELECT FILE: IGNORING virtual DF %04X", fid);
+			continue;
+		}
+
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C); /* P2=0x0C means No response/FCI expected */
+		apdu.data = &in_path->value[i];
+		apdu.datalen = 2;
+		apdu.lc = 2;
+
+		r = sc_transmit_apdu(card, &apdu);
+		if (r < 0) return r;
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		
+		if (r == SC_ERROR_FILE_NOT_FOUND) {
+			sc_log(card->ctx, "STARSIGN SELECT FILE: P1=0x00 failed, retrying with P1=0x01 (Select DF) for FID %04X", fid);
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x01, 0x0C);
+			apdu.data = &in_path->value[i];
+			apdu.datalen = 2;
+			apdu.lc = 2;
+
+			r = sc_transmit_apdu(card, &apdu);
+			if (r < 0) return r;
+			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		}
+
+		if (r == SC_ERROR_FILE_NOT_FOUND) {
+			sc_log(card->ctx, "STARSIGN SELECT FILE: P1=0x01 failed, retrying with P1=0x02 (Select EF) for FID %04X", fid);
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x02, 0x0C);
+			apdu.data = &in_path->value[i];
+			apdu.datalen = 2;
+			apdu.lc = 2;
+
+			r = sc_transmit_apdu(card, &apdu);
+			if (r < 0) return r;
+			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+		}
+
+		if (r < 0) return r;
+	}
+
+	if (file_out) {
+		sc_file_t *file = sc_file_new();
+		if (!file)
+			return SC_ERROR_OUT_OF_MEMORY;
+		file->id = (in_path->value[in_path->len - 2] << 8) | in_path->value[in_path->len - 1];
+		file->type = SC_FILE_TYPE_WORKING_EF;
+		file->ef_structure = SC_FILE_EF_TRANSPARENT;
+		file->size = 0x8000; /* Dummy size so OpenSC reads until EOF */
+		file->magic = SC_FILE_MAGIC;
+		*file_out = file;
+	}
+	return SC_SUCCESS;
+}
+
+static int starsign_set_security_env(sc_card_t *card, const sc_security_env_t *env, int res)
+{
+        sc_apdu_t apdu;
+        u8 data[6];
+        int r;
+
+        sc_log(card->ctx, "STARSIGN: set_security_env called! Operation: %d", env->operation);
+
+        data[0] = 0x84;
+        data[1] = 0x01;
+        data[2] = 0x01;
+        data[3] = 0x80;
+        data[4] = 0x01;
+        data[5] = 0x02;
+
+        sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xB6);
+        apdu.data = data;
+        apdu.datalen = 6;
+        apdu.lc = 6;
+        apdu.cla = card->cla;
+
+        r = sc_transmit_apdu(card, &apdu);
+        if (r) return r;
+        return sc_check_sw(card, apdu.sw1, apdu.sw2);
+}
+
+
+static int starsign_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
+{
+	if (data->cmd == SC_PIN_CMD_VERIFY) {
+		u8 pin_buf[15];
+		sc_apdu_t apdu;
+		int r;
+
+		if (data->pin1.len > 15)
+			return SC_ERROR_INVALID_PIN_LENGTH;
+
+		memset(pin_buf, 0x00, sizeof(pin_buf));
+		memcpy(pin_buf, data->pin1.data, data->pin1.len);
+
+		/* Force P2=02, padded to 15 bytes */
+		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x20, 0x00, 0x02);
+		apdu.data = pin_buf;
+		apdu.datalen = 15;
+		apdu.lc = 15;
+        /* Inherit card->cla (which we set to 0x01 in init) */
+        apdu.cla = card->cla;
+
+		r = sc_transmit_apdu(card, &apdu);
+		LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+		/* Save tries_left if we want to handle it (via data block maybe?), but not needed for basic verify here. */
+		return sc_check_sw(card, apdu.sw1, apdu.sw2);
+	}
+	
+	/* Fallback to default behavior for other PIN commands (unblock, etc.) */
+	return sc_get_iso7816_driver()->ops->pin_cmd(card, data);
+}
+
+struct sc_card_driver * sc_get_starsign_driver(void)
+{
+	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
+	starsign_ops = *iso_drv->ops;
+	starsign_ops.init = starsign_init;
+	starsign_ops.select_file = starsign_select_file;
+	starsign_ops.match_card = starsign_match_card;
+	starsign_ops.pin_cmd = starsign_pin_cmd;
+        starsign_ops.set_security_env = starsign_set_security_env;
+	return &starsign_drv;
+}

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -335,10 +335,38 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 		 * initial "3F00 5031" DF transition and for any top-level
 		 * DF/EF reached before that context has been established.
 		 * The card only accepts P1=0x00 (select by file ID) here --
-		 * it answers SW 6A82 for P1=0x01 ("select child DF"). */
-		for (i = 0; i < in_path->len; i += 2) {
+		 * it answers SW 6A82 for P1=0x01 ("select child DF"). Walk
+		 * every component except the last one this way; DF-only
+		 * selects (P2=0x0C) never return an FCI on this card, which
+		 * is fine for intermediate directories. */
+		size_t last = in_path->len - 2;
+
+		for (i = 0; i < last; i += 2) {
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
 			apdu.data = &in_path->value[i];
+			apdu.datalen = 2;
+			apdu.lc = 2;
+
+			r = sc_transmit_apdu(card, &apdu);
+			LOG_TEST_GOTO_ERR(ctx, r, "APDU transmit failed (hierarchical SELECT)");
+			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+			LOG_TEST_GOTO_ERR(ctx, r, "Hierarchical SELECT returned an error status word");
+		}
+
+		/* The final component: a bare "MF + one FID" path (len == 4,
+		 * e.g. "3F00 5031") is always a DF transition -- select it
+		 * the same way as the rest. Anything deeper always bottoms
+		 * out at a real EF on this card's layout, so select it as a
+		 * child EF instead (P1=0x02) to actually capture its FCI/real
+		 * size via starsign_select_ef_child(), instead of silently
+		 * falling back to the placeholder file->size below. */
+		if (in_path->len > 4) {
+			r = starsign_select_ef_child(card, &in_path->value[last], file);
+			LOG_TEST_GOTO_ERR(ctx, r, "SELECT of the final EF (hierarchical path) failed");
+			selected_as_ef = 1;
+		} else {
+			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
+			apdu.data = &in_path->value[last];
 			apdu.datalen = 2;
 			apdu.lc = 2;
 

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -174,6 +174,23 @@ starsign_init(sc_card_t *card)
 	card->caps |= SC_CARD_CAP_APDU_EXT;
 	card->max_send_size = 2048;
 	card->max_recv_size = 256;
+	/*
+	 * KNOWN HARDWARE LIMITATION (not fixable here): on at least one
+	 * StarSign CUT S unit, the token's built-in CCID reader declares a
+	 * firmware-fixed dwMaxCCIDMsgLen of 271 bytes (~261 usable after the
+	 * CCID header) in its USB descriptor -- see `lsusb -v` -- and does
+	 * not advertise "Extended APDU level exchange" in dwFeatures. A raw
+	 * RSA-2048 operation's 256-byte payload does not fit under that
+	 * ceiling in any standard APDU encoding (even the leanest extended
+	 * Case 3 APDU is 263 bytes), and this card separately rejects ISO
+	 * 7816-4 command chaining as a workaround (SW 6E 00). The result is
+	 * intermittent SCardTransmit failures (SCARD_E_INVALID_PARAMETER) on
+	 * raw sign/decipher through that specific reader, typically
+	 * succeeding on retry. We have no software fix for this: the only
+	 * way to avoid the 256-byte payload is the card hashing and padding
+	 * on-chip with a correct DigestInfo, which this hardware does not do
+	 * (see the SC_ALGORITHM_RSA_HASH_NONE comment above).
+	 */
 	alg_flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE;
 
 	_sc_card_add_rsa_alg(card, 1024, alg_flags, 0);

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -263,14 +263,13 @@ static int starsign_set_security_env(sc_card_t *card, const sc_security_env_t *e
 static int starsign_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 {
 	if (data->cmd == SC_PIN_CMD_VERIFY) {
-		u8 pin_buf[15];
+		u8 pin_buf[15] = {0};
 		sc_apdu_t apdu;
 		int r;
 
 		if (data->pin1.len > 15)
 			return SC_ERROR_INVALID_PIN_LENGTH;
 
-		memset(pin_buf, 0x00, sizeof(pin_buf));
 		memcpy(pin_buf, data->pin1.data, data->pin1.len);
 
 		/* Force P2=02, padded to 15 bytes */

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -1,8 +1,24 @@
 /*
- * Support for G&D StarSign CUT S cards (A.E.T. Europe SafeSign)
+ * card-starsign.c: Support for G&D StarSign CUT S cards (A.E.T. Europe SafeSign)
+ *
+ * Copyright (C) 2026 Diego Ribeiro de Souza
  *
  * This driver performs the proprietary DRM handshake and logical
  * channel selection required by the StarSign CUT S token.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifdef HAVE_CONFIG_H
@@ -21,6 +37,7 @@ static const struct sc_atr_table starsign_atrs[] = {
 		{NULL,						       NULL, NULL, 0,		      0, NULL}
 };
 
+static const struct sc_card_operations *iso_ops = NULL;
 static struct sc_card_operations starsign_ops;
 static struct sc_card_driver starsign_drv = {
 		"G&D StarSign CUT S",
@@ -200,32 +217,12 @@ starsign_init(sc_card_t *card)
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
 
-/* Extract the file size from an FCP response of the form
- * 6F <len> 80 02 <size-hi> <size-lo> ... (tag 0x80 = number of data bytes).
- * Returns 0 if the tag is not present or the buffer is too short. */
-static size_t
-starsign_parse_fcp_size(const u8 *buf, size_t len)
-{
-	size_t i;
-
-	if (len < 2 || buf[0] != 0x6F)
-		return 0;
-
-	for (i = 2; i + 3 < len;) {
-		u8 tag = buf[i];
-		u8 taglen = buf[i + 1];
-		if (tag == 0x80 && taglen == 2 && i + 3 < len)
-			return ((size_t)buf[i + 2] << 8) | buf[i + 3];
-		i += 2 + taglen;
-	}
-	return 0;
-}
-
 /* Select a 2-byte FID as a direct child EF of whatever DF is currently
- * active (P1=0x02), returning the file size reported in the FCP response
- * (if any) via `file_size`. */
+ * active (P1=0x02). If `file` is non-NULL, it is populated from the card's
+ * FCP response via the standard ISO 7816 parser (size, type, EF structure,
+ * ...) instead of a hand-rolled tag walk. */
 static int
-starsign_select_ef_child(sc_card_t *card, const u8 *fid, size_t *file_size)
+starsign_select_ef_child(sc_card_t *card, const u8 *fid, sc_file_t *file)
 {
 	sc_context_t *ctx = card->ctx;
 	struct sc_apdu apdu;
@@ -245,8 +242,8 @@ starsign_select_ef_child(sc_card_t *card, const u8 *fid, size_t *file_size)
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(ctx, r, "SELECT child EF returned an error status word");
 
-	if (file_size)
-		*file_size = starsign_parse_fcp_size(apdu.resp, apdu.resplen);
+	if (file && apdu.resplen)
+		iso_ops->process_fci(card, file, apdu.resp, apdu.resplen);
 	return SC_SUCCESS;
 }
 
@@ -260,15 +257,21 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 	int selected_as_ef = 0;
 	struct starsign_drv_data *priv = card->drv_data;
 	int has_3fff_placeholder = 0;
-	size_t resolved_size = 0;
+	sc_file_t *file = NULL;
 
 	LOG_FUNC_CALLED(ctx);
 
 	if (in_path->type != SC_PATH_TYPE_PATH && in_path->type != SC_PATH_TYPE_FROM_CURRENT && in_path->type != SC_PATH_TYPE_FILE_ID)
-		LOG_FUNC_RETURN(ctx, sc_get_iso7816_driver()->ops->select_file(card, in_path, file_out));
+		LOG_FUNC_RETURN(ctx, iso_ops->select_file(card, in_path, file_out));
 
 	if (in_path->len % 2 != 0 || in_path->len == 0)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (file_out) {
+		file = sc_file_new();
+		if (!file)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+	}
 
 	for (i = 0; i + 2 < in_path->len; i += 2) {
 		if (in_path->value[i] == 0x3F && in_path->value[i + 1] == 0xFF) {
@@ -286,8 +289,10 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 		 * already current also fails, so it is cached. */
 		const u8 *mid, *final;
 
-		if (in_path->len < 8)
-			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+		if (in_path->len < 8) {
+			r = SC_ERROR_INVALID_ARGUMENTS;
+			goto err;
+		}
 
 		mid = &in_path->value[in_path->len - 4];
 		final = &in_path->value[in_path->len - 2];
@@ -299,9 +304,9 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 			apdu.lc = 2;
 
 			r = sc_transmit_apdu(card, &apdu);
-			LOG_TEST_RET(ctx, r, "APDU transmit failed (SELECT mid DF)");
+			LOG_TEST_GOTO_ERR(ctx, r, "APDU transmit failed (SELECT mid DF)");
 			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-			LOG_TEST_RET(ctx, r, "SELECT mid DF returned an error status word");
+			LOG_TEST_GOTO_ERR(ctx, r, "SELECT mid DF returned an error status word");
 
 			if (priv) {
 				priv->mid_fid[0] = mid[0];
@@ -310,8 +315,8 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 			}
 		}
 
-		r = starsign_select_ef_child(card, final, &resolved_size);
-		LOG_TEST_RET(ctx, r, "SELECT of the final EF failed");
+		r = starsign_select_ef_child(card, final, file);
+		LOG_TEST_GOTO_ERR(ctx, r, "SELECT of the final EF failed");
 		selected_as_ef = 1;
 	} else if (in_path->len == 4 && in_path->value[0] == 0x3F && in_path->value[1] == 0x00 &&
 			priv && priv->df5031_selected &&
@@ -322,8 +327,8 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 		 * the MF on every call -- doing the latter would silently drop
 		 * back to the MF and break the "current DF" assumption the
 		 * virtual-path handling above depends on. */
-		r = starsign_select_ef_child(card, &in_path->value[2], &resolved_size);
-		LOG_TEST_RET(ctx, r, "SELECT of the direct child EF failed");
+		r = starsign_select_ef_child(card, &in_path->value[2], file);
+		LOG_TEST_GOTO_ERR(ctx, r, "SELECT of the direct child EF failed");
 		selected_as_ef = 1;
 	} else {
 		/* Genuine hierarchical navigation from the MF: used for the
@@ -338,9 +343,9 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 			apdu.lc = 2;
 
 			r = sc_transmit_apdu(card, &apdu);
-			LOG_TEST_RET(ctx, r, "APDU transmit failed (hierarchical SELECT)");
+			LOG_TEST_GOTO_ERR(ctx, r, "APDU transmit failed (hierarchical SELECT)");
 			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-			LOG_TEST_RET(ctx, r, "Hierarchical SELECT returned an error status word");
+			LOG_TEST_GOTO_ERR(ctx, r, "Hierarchical SELECT returned an error status word");
 		}
 
 		if (priv && in_path->len == 4 && in_path->value[2] == 0x50 && in_path->value[3] == 0x31)
@@ -353,30 +358,25 @@ starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file
 			priv->mid_fid_valid = 0;
 	}
 
-	if (file_out) {
-		sc_file_t *file = sc_file_new();
-		if (!file)
-			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+	if (file) {
+		/* For EF selects, iso_ops->process_fci() (called from
+		 * starsign_select_ef_child()) already populated type/size/
+		 * ef_structure from the card's real FCP response. This card
+		 * never returns a usable FCP for plain DF selects, though, so
+		 * that case is filled in by hand. */
+		if (!selected_as_ef)
+			file->type = SC_FILE_TYPE_DF;
+		if (file->size == 0)
+			file->size = 1024;
 		file->id = (in_path->value[in_path->len - 2] << 8) | in_path->value[in_path->len - 1];
-
-		/* This card never returns a usable FCP for plain DF selects, so
-		 * the type can only be inferred from how we reached this file:
-		 * a "genuine hierarchical" multi-component select landed on a
-		 * DF, everything else (an explicit child-EF select) landed on
-		 * an EF. */
-		file->type = (in_path->len > 2 && !selected_as_ef) ? SC_FILE_TYPE_DF : SC_FILE_TYPE_WORKING_EF;
-		file->ef_structure = SC_FILE_EF_TRANSPARENT;
-		/* Use the real size reported by the card's FCP response when we
-		 * have one (needed so sc_pkcs15_read_file's offset+count bounds
-		 * check does not reject legitimately large files, e.g.
-		 * certificates up to ~1.8 KB); fall back to a generous default
-		 * otherwise, since most callers here just read the whole file. */
-		file->size = resolved_size ? resolved_size : 1024;
-		file->magic = SC_FILE_MAGIC;
 		file->path = *in_path;
 		*file_out = file;
 	}
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+err:
+	sc_file_free(file);
+	LOG_FUNC_RETURN(ctx, r);
 }
 
 static int
@@ -392,7 +392,10 @@ starsign_set_security_env(sc_card_t *card, const sc_security_env_t *env, int res
 	 * standard OpenSC puts the 0x80 tag before 0x84, which this token
 	 * rejects. This was reverse engineered from a genuine capture of the
 	 * proprietary SafeSign driver: swapping the tag order, or omitting
-	 * either reference, is silently rejected by the card.
+	 * either reference, is silently rejected by the card. These are the
+	 * defaults for this card's PKCS#15 profile, which never actually
+	 * supplies a different key/algorithm reference; overridden below from
+	 * `env` when the caller does provide one explicitly.
 	 */
 	u8 sbuf[6] = {0x84, 0x01, 0x01, 0x80, 0x01, 0x02};
 
@@ -400,6 +403,11 @@ starsign_set_security_env(sc_card_t *card, const sc_security_env_t *env, int res
 
 	if (card == NULL || env == NULL)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if ((env->flags & SC_SEC_ENV_KEY_REF_PRESENT) && env->key_ref_len >= 1)
+		sbuf[2] = env->key_ref[0];
+	if (env->flags & SC_SEC_ENV_ALG_REF_PRESENT)
+		sbuf[5] = env->algorithm_ref & 0xFF;
 
 	switch (env->operation) {
 	case SC_SEC_OPERATION_AUTHENTICATE:
@@ -438,6 +446,8 @@ struct sc_card_driver *
 sc_get_starsign_driver(void)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
+	if (iso_ops == NULL)
+		iso_ops = iso_drv->ops;
 	starsign_ops = *iso_drv->ops;
 	starsign_ops.init = starsign_init;
 	starsign_ops.finish = starsign_finish;

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -298,6 +298,6 @@ struct sc_card_driver * sc_get_starsign_driver(void)
 	starsign_ops.select_file = starsign_select_file;
 	starsign_ops.match_card = starsign_match_card;
 	starsign_ops.pin_cmd = starsign_pin_cmd;
-        starsign_ops.set_security_env = starsign_set_security_env;
+	starsign_ops.set_security_env = starsign_set_security_env;
 	return &starsign_drv;
 }

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -162,9 +162,18 @@ starsign_init(sc_card_t *card)
 	 * software and hand the card an already-padded blob for a raw RSA
 	 * operation (SC_ALGORITHM_RSA_RAW).
 	 */
+	/* max_recv_size is kept at 256 (the real RSA-2048 output size) rather
+	 * than raised alongside max_send_size: iso7816_fixup_transceive_length()
+	 * only clamps apdu.le down to max_recv_size, never up, and some PKCS#11
+	 * framework callers (decipher in particular, which allocates a generic
+	 * 512-byte response buffer regardless of actual key size) request a Le
+	 * far larger than the real output. Left uncapped, that oversized Le
+	 * produces an extended APDU the reader's USB/PC-SC transport cannot
+	 * actually deliver (SCardTransmit fails with SCARD_E_INVALID_PARAMETER)
+	 * instead of the correct, transmittable 256-byte request. */
 	card->caps |= SC_CARD_CAP_APDU_EXT;
 	card->max_send_size = 2048;
-	card->max_recv_size = 2048;
+	card->max_recv_size = 256;
 	alg_flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE;
 
 	_sc_card_add_rsa_alg(card, 1024, alg_flags, 0);

--- a/src/libopensc/card-starsign.c
+++ b/src/libopensc/card-starsign.c
@@ -9,29 +9,49 @@
 #include "config.h"
 #endif
 
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "internal.h"
 #include "asn1.h"
+#include "internal.h"
 #include "log.h"
 
 static const struct sc_atr_table starsign_atrs[] = {
-	{ "3B:F9:96:00:00:81:31:FE:45:53:43:45:37:20:0E:00:20:20:28", NULL, NULL, SC_CARD_TYPE_STARSIGN, 0, NULL },
-	{ NULL, NULL, NULL, 0, 0, NULL }
+		{"3B:F9:96:00:00:81:31:FE:45:53:43:45:37:20:0E:00:20:20:28", NULL, NULL, SC_CARD_TYPE_STARSIGN, 0, NULL},
+		{NULL,						       NULL, NULL, 0,		      0, NULL}
 };
 
 static struct sc_card_operations starsign_ops;
 static struct sc_card_driver starsign_drv = {
-	"G&D StarSign CUT S",
-	"starsign",
-	&starsign_ops,
-	NULL, 0, NULL
-};
+		"G&D StarSign CUT S",
+		"starsign",
+		&starsign_ops,
+		NULL, 0, NULL};
 
 static const u8 starsign_drm_string[] = "I am A.E.T. Europe B.V. SafeSign or BlueX approved software.";
 
-static int starsign_match_card(sc_card_t *card)
+/*
+ * Tracks the currently selected working directory so select_file() can
+ * avoid redundant re-navigation:
+ *  - df5031_selected: the PKCS#15 application DF (5031) is active, so an
+ *    EF can be addressed as its direct child instead of re-navigating
+ *    from the MF.
+ *  - mid_fid/mid_fid_valid: certificate/data-object EFs are referenced by
+ *    a path such as "3F00 3FFF 4302 05A0". 0x3FFF is a placeholder the
+ *    card rejects with SW 6A82 if selected. The component right after it
+ *    (e.g. 4302) IS a real directory one level below 5031 and must be
+ *    selected once -- re-selecting it a second time while it is already
+ *    the current DF also fails with 6A82, so it is cached and only
+ *    reselected when it actually changes.
+ */
+struct starsign_drv_data {
+	int df5031_selected;
+	u8 mid_fid[2];
+	int mid_fid_valid;
+};
+
+static int
+starsign_match_card(sc_card_t *card)
 {
 	int i;
 	i = _sc_match_atr(card, starsign_atrs, &card->type);
@@ -40,24 +60,38 @@ static int starsign_match_card(sc_card_t *card)
 	return 1;
 }
 
-static int starsign_init(sc_card_t *card)
+static int
+starsign_init(sc_card_t *card)
 {
+	sc_context_t *ctx = card->ctx;
 	sc_apdu_t apdu;
 	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+	u8 aid[] = {0xA0, 0x00, 0x00, 0x00, 0x63, 0x50, 0x4B, 0x43, 0x53, 0x2D, 0x31, 0x35};
+	unsigned long alg_flags;
 	int r;
+
+	LOG_FUNC_CALLED(ctx);
 
 	card->name = "G&D StarSign CUT S";
 	card->type = SC_CARD_TYPE_STARSIGN;
 
-	/* 1. First DRM Handshake (ignore result, usually 6D 00) */
+	card->drv_data = calloc(1, sizeof(struct starsign_drv_data));
+	if (!card->drv_data)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
+
+	/* 1. DRM handshake: the card silently refuses PKCS#15 operations
+	 * unless this exact string is echoed back to it via PUT DATA
+	 * beforehand. The card does not consider the handshake mandatory at
+	 * this point (it typically answers 6D 00, "instruction not
+	 * supported"), so a failure here is not fatal. */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xDA, 0x01, 0x00);
 	apdu.data = starsign_drm_string;
 	apdu.datalen = sizeof(starsign_drm_string) - 1;
 	apdu.lc = apdu.datalen;
 	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (first DRM handshake)");
 
-	/* 2. Select PKCS#15 AID (ignore result) */
-	u8 aid[] = { 0xA0, 0x00, 0x00, 0x00, 0x63, 0x50, 0x4B, 0x43, 0x53, 0x2D, 0x31, 0x35 };
+	/* 2. Select PKCS#15 AID on the default channel. */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, 0x04, 0x00);
 	apdu.data = aid;
 	apdu.datalen = sizeof(aid);
@@ -66,238 +100,323 @@ static int starsign_init(sc_card_t *card)
 	apdu.resplen = sizeof(rbuf);
 	apdu.resp = rbuf;
 	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (AID select)");
 
-	/* 3. Second DRM Handshake (ignore result) */
+	/* 3. Second DRM handshake, now that the applet is selected -- the
+	 * card expects this exact sequence before it will accept anything
+	 * beyond basic GET DATA. */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xDA, 0x01, 0x00);
 	apdu.data = starsign_drm_string;
 	apdu.datalen = sizeof(starsign_drm_string) - 1;
 	apdu.lc = apdu.datalen;
 	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (second DRM handshake)");
 
-	/* 4. Open Logical Channel 1 */
+	/* 4. The PKCS#15 applet refuses further operations on the default
+	 * logical channel (0); open channel 1 and use it from here on. */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_2_SHORT, 0x70, 0x00, 0x00);
 	apdu.resp = rbuf;
 	apdu.resplen = sizeof(rbuf);
 	apdu.le = 1;
 
 	r = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(card->ctx, r, "Failed to transmit MANAGE CHANNEL");
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (MANAGE CHANNEL)");
+
 	if (apdu.sw1 == 0x6A && apdu.sw2 == 0x81) {
-		/* Channel already open, that's fine */
+		/* Channel already open from a previous session, that is fine. */
 		r = SC_SUCCESS;
 	} else {
 		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		LOG_TEST_RET(card->ctx, r, "Card refused logical channel opening");
+		LOG_TEST_RET(ctx, r, "Card refused logical channel opening");
 	}
 
-	/* 3. Force CLA=0x01 for all subsequent operations */
+	/* 5. Force CLA=0x01 for all subsequent operations. */
 	card->cla = 0x01;
 
-	/* 5. Select PKCS#15 AID again on Channel 1 */
+	/* 6. Re-select the PKCS#15 AID, now on channel 1. */
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x04, 0x00);
 	apdu.data = aid;
 	apdu.datalen = sizeof(aid);
 	apdu.lc = sizeof(aid);
 	r = sc_transmit_apdu(card, &apdu);
-	LOG_TEST_RET(card->ctx, r, "Failed to select AID on channel 1");
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (AID select on channel 1)");
+
 	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-	if (r < 0) {
-		sc_log(card->ctx, "Card refused AID selection on channel 1 (SW %02X %02X), ignoring as it might be already selected", apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		/* Some card firmware revisions answer SW 6A 86 here if the
+		 * applet is already selected on this channel; that is not an
+		 * error condition for us. */
+		sc_log(ctx, "Card refused AID selection on channel 1 (SW %02X %02X), ignoring as it might already be selected", apdu.sw1, apdu.sw2);
 	}
 
-	/* Force RAW RSA (software padding) because G&D StarSign CUT cards 
-           often return 67 00 if sent unpadded hashes during C_Sign.
-           We only set SC_ALGORITHM_RSA_RAW so OpenSC pads the data to 256 bytes itself. */
-        card->caps |= SC_CARD_CAP_APDU_EXT;
-        card->max_send_size = 2048;
-        card->max_recv_size = 2048;
-        unsigned long alg_flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE | SC_ALGORITHM_RSA_HASH_MD5 | SC_ALGORITHM_RSA_HASH_SHA1 | SC_ALGORITHM_RSA_HASH_SHA256;
-				  
+	/*
+	 * Signature padding: this card pads a raw hash it is handed with
+	 * PKCS#1 v1.5 (00 01 FF..FF 00 <hash>), but it does NOT prepend the
+	 * DigestInfo ASN.1/OID header a standards-compliant SHA-256 (or
+	 * MD5/SHA-1) signature requires. We verified this by decrypting a
+	 * live signature with the token's own public key: the padded block
+	 * held the bare digest with no DigestInfo prefix, so any compliant
+	 * verifier rejects it even though the card answers SW 90 00.
+	 * Advertising only SC_ALGORITHM_RSA_HASH_NONE makes OpenSC's own
+	 * crypto layer build the complete DigestInfo + PKCS#1 block in
+	 * software and hand the card an already-padded blob for a raw RSA
+	 * operation (SC_ALGORITHM_RSA_RAW).
+	 */
+	card->caps |= SC_CARD_CAP_APDU_EXT;
+	card->max_send_size = 2048;
+	card->max_recv_size = 2048;
+	alg_flags = SC_ALGORITHM_RSA_RAW | SC_ALGORITHM_RSA_PAD_PKCS1 | SC_ALGORITHM_RSA_HASH_NONE;
+
 	_sc_card_add_rsa_alg(card, 1024, alg_flags, 0);
 	_sc_card_add_rsa_alg(card, 2048, alg_flags, 0);
 	_sc_card_add_rsa_alg(card, 4096, alg_flags, 0);
 
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+/* Extract the file size from an FCP response of the form
+ * 6F <len> 80 02 <size-hi> <size-lo> ... (tag 0x80 = number of data bytes).
+ * Returns 0 if the tag is not present or the buffer is too short. */
+static size_t
+starsign_parse_fcp_size(const u8 *buf, size_t len)
+{
+	size_t i;
+
+	if (len < 2 || buf[0] != 0x6F)
+		return 0;
+
+	for (i = 2; i + 3 < len;) {
+		u8 tag = buf[i];
+		u8 taglen = buf[i + 1];
+		if (tag == 0x80 && taglen == 2 && i + 3 < len)
+			return ((size_t)buf[i + 2] << 8) | buf[i + 3];
+		i += 2 + taglen;
+	}
+	return 0;
+}
+
+/* Select a 2-byte FID as a direct child EF of whatever DF is currently
+ * active (P1=0x02), returning the file size reported in the FCP response
+ * (if any) via `file_size`. */
+static int
+starsign_select_ef_child(sc_card_t *card, const u8 *fid, size_t *file_size)
+{
+	sc_context_t *ctx = card->ctx;
+	struct sc_apdu apdu;
+	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+	int r;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0xA4, 0x02, 0x00);
+	apdu.data = fid;
+	apdu.datalen = 2;
+	apdu.lc = 2;
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rbuf);
+	apdu.le = 256;
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (SELECT child EF)");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(ctx, r, "SELECT child EF returned an error status word");
+
+	if (file_size)
+		*file_size = starsign_parse_fcp_size(apdu.resp, apdu.resplen);
 	return SC_SUCCESS;
 }
 
-static int starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file_out)
+static int
+starsign_select_file(sc_card_t *card, const sc_path_t *in_path, sc_file_t **file_out)
 {
+	sc_context_t *ctx = card->ctx;
 	int r = SC_SUCCESS;
 	size_t i;
 	struct sc_apdu apdu;
+	int selected_as_ef = 0;
+	struct starsign_drv_data *priv = card->drv_data;
+	int has_3fff_placeholder = 0;
+	size_t resolved_size = 0;
 
-	if (in_path->type != SC_PATH_TYPE_PATH && in_path->type != SC_PATH_TYPE_FROM_CURRENT && in_path->type != SC_PATH_TYPE_FILE_ID) {
-		sc_log(card->ctx, "STARSIGN SELECT FILE DEFERRING type=%d", in_path->type);
-		return sc_get_iso7816_driver()->ops->select_file(card, in_path, file_out);
-	}
+	LOG_FUNC_CALLED(ctx);
 
-	sc_log(card->ctx, "STARSIGN SELECT FILE EXECUTING type=%d len=%zu", in_path->type, in_path->len);
+	if (in_path->type != SC_PATH_TYPE_PATH && in_path->type != SC_PATH_TYPE_FROM_CURRENT && in_path->type != SC_PATH_TYPE_FILE_ID)
+		LOG_FUNC_RETURN(ctx, sc_get_iso7816_driver()->ops->select_file(card, in_path, file_out));
 
 	if (in_path->len % 2 != 0 || in_path->len == 0)
-		return SC_ERROR_INVALID_ARGUMENTS;
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	/* First, try to select the full path at once if it's a full path from MF */
-	if (in_path->len >= 4 && in_path->value[0] == 0x3F && in_path->value[1] == 0x00) {
-		sc_log(card->ctx, "STARSIGN SELECT FILE: Attempting full path selection from MF");
-		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x08, 0x0C);
-		apdu.data = in_path->value;
-		apdu.datalen = in_path->len;
-		apdu.lc = in_path->len;
-		r = sc_transmit_apdu(card, &apdu);
-		if (r == 0) r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		if (r == 0) {
-			sc_log(card->ctx, "STARSIGN SELECT FILE: Full path selection successful");
-			return 0;
+	for (i = 0; i + 2 < in_path->len; i += 2) {
+		if (in_path->value[i] == 0x3F && in_path->value[i + 1] == 0xFF) {
+			has_3fff_placeholder = 1;
+			break;
 		}
-		sc_log(card->ctx, "STARSIGN SELECT FILE: Full path selection failed (%d), falling back to component-by-component", r);
 	}
 
-	/* Loop over every 2 bytes of the path */
-	for (i = 0; i < in_path->len; i += 2) {
-		unsigned short fid = (in_path->value[i] << 8) | in_path->value[i + 1];
+	if (has_3fff_placeholder) {
+		/* Certificate/data-object virtual path: "3F00 3FFF <mid> <final>".
+		 * 0x3FFF itself is never selected (confirmed against a genuine
+		 * SafeSign APDU capture: the proprietary driver never sends a
+		 * SELECT for it either). <mid> (e.g. 4302) is a real directory
+		 * and must be selected -- but re-selecting it while it is
+		 * already current also fails, so it is cached. */
+		const u8 *mid, *final;
 
-		/* DO NOT ignore 3F00! We need to select it to reset the current DF to MF.
-		   HOWEVER, G&D StarSign tokens have a bug where some certificates' absolute paths
-		   omit the 5015 DF (e.g. 3F00 3FFF 4302 13AE). If we just select 3F00, the 
-		   subsequent selection of 4302 will fail.
-		   We MUST explicitly select 5015 after 3F00, or we can just ignore 3F00 entirely
-		   AND ignore 5015 entirely, relying on the fact that we are ALREADY in the 5015
-		   applet, BUT we must reset to 5015 to prevent relative selection bugs.
-		   
-		   The safest fix is: when we see 3F00, we select 3F00 AND THEN select 5015 automatically! */
-		if (fid == 0x3F00) {
+		if (in_path->len < 8)
+			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+		mid = &in_path->value[in_path->len - 4];
+		final = &in_path->value[in_path->len - 2];
+
+		if (!priv || !priv->mid_fid_valid || priv->mid_fid[0] != mid[0] || priv->mid_fid[1] != mid[1]) {
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
-			apdu.data = (const u8 *)"\x3F\x00";
-			apdu.datalen = 2; apdu.lc = 2;
-			sc_transmit_apdu(card, &apdu);
-			
+			apdu.data = mid;
+			apdu.datalen = 2;
+			apdu.lc = 2;
+
+			r = sc_transmit_apdu(card, &apdu);
+			LOG_TEST_RET(ctx, r, "APDU transmit failed (SELECT mid DF)");
+			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+			LOG_TEST_RET(ctx, r, "SELECT mid DF returned an error status word");
+
+			if (priv) {
+				priv->mid_fid[0] = mid[0];
+				priv->mid_fid[1] = mid[1];
+				priv->mid_fid_valid = 1;
+			}
+		}
+
+		r = starsign_select_ef_child(card, final, &resolved_size);
+		LOG_TEST_RET(ctx, r, "SELECT of the final EF failed");
+		selected_as_ef = 1;
+	} else if (in_path->len == 4 && in_path->value[0] == 0x3F && in_path->value[1] == 0x00 &&
+			priv && priv->df5031_selected &&
+			!(in_path->value[2] == 0x50 && in_path->value[3] == 0x31)) {
+		/* Once the PKCS#15 application DF (5031) has been entered, every
+		 * other EF beneath it (TokenInfo, ODF/AODF/PrKDF/CDF/DODF, ...)
+		 * is addressed as a direct child instead of re-navigating from
+		 * the MF on every call -- doing the latter would silently drop
+		 * back to the MF and break the "current DF" assumption the
+		 * virtual-path handling above depends on. */
+		r = starsign_select_ef_child(card, &in_path->value[2], &resolved_size);
+		LOG_TEST_RET(ctx, r, "SELECT of the direct child EF failed");
+		selected_as_ef = 1;
+	} else {
+		/* Genuine hierarchical navigation from the MF: used for the
+		 * initial "3F00 5031" DF transition and for any top-level
+		 * DF/EF reached before that context has been established.
+		 * The card only accepts P1=0x00 (select by file ID) here --
+		 * it answers SW 6A82 for P1=0x01 ("select child DF"). */
+		for (i = 0; i < in_path->len; i += 2) {
 			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C);
-			apdu.data = (const u8 *)"\x50\x15";
-			apdu.datalen = 2; apdu.lc = 2;
-			sc_transmit_apdu(card, &apdu);
-			continue;
-		}
-		/* Ignore virtual/intermediate DFs that are not selectable directly on G&D StarSign */
-		if (fid == 0x3FFF) {
-			sc_log(card->ctx, "STARSIGN SELECT FILE: IGNORING virtual DF %04X", fid);
-			continue;
-		}
-
-		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x0C); /* P2=0x0C means No response/FCI expected */
-		apdu.data = &in_path->value[i];
-		apdu.datalen = 2;
-		apdu.lc = 2;
-
-		r = sc_transmit_apdu(card, &apdu);
-		if (r < 0) return r;
-		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		
-		if (r == SC_ERROR_FILE_NOT_FOUND) {
-			sc_log(card->ctx, "STARSIGN SELECT FILE: P1=0x00 failed, retrying with P1=0x01 (Select DF) for FID %04X", fid);
-			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x01, 0x0C);
 			apdu.data = &in_path->value[i];
 			apdu.datalen = 2;
 			apdu.lc = 2;
 
 			r = sc_transmit_apdu(card, &apdu);
-			if (r < 0) return r;
+			LOG_TEST_RET(ctx, r, "APDU transmit failed (hierarchical SELECT)");
 			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+			LOG_TEST_RET(ctx, r, "Hierarchical SELECT returned an error status word");
 		}
 
-		if (r == SC_ERROR_FILE_NOT_FOUND) {
-			sc_log(card->ctx, "STARSIGN SELECT FILE: P1=0x01 failed, retrying with P1=0x02 (Select EF) for FID %04X", fid);
-			sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x02, 0x0C);
-			apdu.data = &in_path->value[i];
-			apdu.datalen = 2;
-			apdu.lc = 2;
-
-			r = sc_transmit_apdu(card, &apdu);
-			if (r < 0) return r;
-			r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-		}
-
-		if (r < 0) return r;
+		if (priv && in_path->len == 4 && in_path->value[2] == 0x50 && in_path->value[3] == 0x31)
+			priv->df5031_selected = 1;
+		/* Genuine top-level navigation leaves whatever DF the path
+		 * landed on; the cached "mid DF" is no longer necessarily
+		 * selected, so drop it and let the next virtual-path SELECT
+		 * reselect it explicitly. */
+		if (priv)
+			priv->mid_fid_valid = 0;
 	}
 
 	if (file_out) {
 		sc_file_t *file = sc_file_new();
 		if (!file)
-			return SC_ERROR_OUT_OF_MEMORY;
+			LOG_FUNC_RETURN(ctx, SC_ERROR_OUT_OF_MEMORY);
 		file->id = (in_path->value[in_path->len - 2] << 8) | in_path->value[in_path->len - 1];
-		file->type = SC_FILE_TYPE_WORKING_EF;
+
+		/* This card never returns a usable FCP for plain DF selects, so
+		 * the type can only be inferred from how we reached this file:
+		 * a "genuine hierarchical" multi-component select landed on a
+		 * DF, everything else (an explicit child-EF select) landed on
+		 * an EF. */
+		file->type = (in_path->len > 2 && !selected_as_ef) ? SC_FILE_TYPE_DF : SC_FILE_TYPE_WORKING_EF;
 		file->ef_structure = SC_FILE_EF_TRANSPARENT;
-		file->size = 0x8000; /* Dummy size so OpenSC reads until EOF */
+		/* Use the real size reported by the card's FCP response when we
+		 * have one (needed so sc_pkcs15_read_file's offset+count bounds
+		 * check does not reject legitimately large files, e.g.
+		 * certificates up to ~1.8 KB); fall back to a generous default
+		 * otherwise, since most callers here just read the whole file. */
+		file->size = resolved_size ? resolved_size : 1024;
 		file->magic = SC_FILE_MAGIC;
+		file->path = *in_path;
 		*file_out = file;
 	}
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+static int
+starsign_set_security_env(sc_card_t *card, const sc_security_env_t *env, int res)
+{
+	sc_context_t *ctx = card->ctx;
+	sc_apdu_t apdu;
+	int r;
+	u8 p2;
+	/*
+	 * StarSign CUT S hardware specifically requires the exact MSE: SET
+	 * payload below (Key Reference = 01, Algorithm Reference = 02) --
+	 * standard OpenSC puts the 0x80 tag before 0x84, which this token
+	 * rejects. This was reverse engineered from a genuine capture of the
+	 * proprietary SafeSign driver: swapping the tag order, or omitting
+	 * either reference, is silently rejected by the card.
+	 */
+	u8 sbuf[6] = {0x84, 0x01, 0x01, 0x80, 0x01, 0x02};
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (card == NULL || env == NULL)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	switch (env->operation) {
+	case SC_SEC_OPERATION_AUTHENTICATE:
+		p2 = 0xA4;
+		break;
+	case SC_SEC_OPERATION_DECIPHER:
+	case SC_SEC_OPERATION_DERIVE:
+		p2 = 0xB8;
+		break;
+	case SC_SEC_OPERATION_SIGN:
+		p2 = 0xB6;
+		break;
+	default:
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+	}
+
+	sc_format_apdu_ex(&apdu, card->cla, 0x22, 0x41, p2, sbuf, sizeof(sbuf), NULL, 0);
+
+	sc_log(ctx, "MSE SET constructed payload=84 01 %02X 80 01 %02X", sbuf[2], sbuf[5]);
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(ctx, r, "APDU transmit failed (MSE SET)");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_FUNC_RETURN(ctx, r);
+}
+
+static int
+starsign_finish(sc_card_t *card)
+{
+	free(card->drv_data);
+	card->drv_data = NULL;
 	return SC_SUCCESS;
 }
 
-static int starsign_set_security_env(sc_card_t *card, const sc_security_env_t *env, int res)
-{
-        sc_apdu_t apdu;
-        u8 data[6];
-        int r;
-
-        sc_log(card->ctx, "STARSIGN: set_security_env called! Operation: %d", env->operation);
-
-        data[0] = 0x84;
-        data[1] = 0x01;
-        data[2] = 0x01;
-        data[3] = 0x80;
-        data[4] = 0x01;
-        data[5] = 0x02;
-
-        sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xB6);
-        apdu.data = data;
-        apdu.datalen = 6;
-        apdu.lc = 6;
-        apdu.cla = card->cla;
-
-        r = sc_transmit_apdu(card, &apdu);
-        if (r) return r;
-        return sc_check_sw(card, apdu.sw1, apdu.sw2);
-}
-
-
-static int starsign_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
-{
-	if (data->cmd == SC_PIN_CMD_VERIFY) {
-		u8 pin_buf[15] = {0};
-		sc_apdu_t apdu;
-		int r;
-
-		if (data->pin1.len > 15)
-			return SC_ERROR_INVALID_PIN_LENGTH;
-
-		memcpy(pin_buf, data->pin1.data, data->pin1.len);
-
-		/* Force P2=02, padded to 15 bytes */
-		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x20, 0x00, 0x02);
-		apdu.data = pin_buf;
-		apdu.datalen = 15;
-		apdu.lc = 15;
-        /* Inherit card->cla (which we set to 0x01 in init) */
-        apdu.cla = card->cla;
-
-		r = sc_transmit_apdu(card, &apdu);
-		LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
-		/* Save tries_left if we want to handle it (via data block maybe?), but not needed for basic verify here. */
-		return sc_check_sw(card, apdu.sw1, apdu.sw2);
-	}
-	
-	/* Fallback to default behavior for other PIN commands (unblock, etc.) */
-	return sc_get_iso7816_driver()->ops->pin_cmd(card, data);
-}
-
-struct sc_card_driver * sc_get_starsign_driver(void)
+struct sc_card_driver *
+sc_get_starsign_driver(void)
 {
 	struct sc_card_driver *iso_drv = sc_get_iso7816_driver();
 	starsign_ops = *iso_drv->ops;
 	starsign_ops.init = starsign_init;
-	starsign_ops.select_file = starsign_select_file;
+	starsign_ops.finish = starsign_finish;
 	starsign_ops.match_card = starsign_match_card;
-	starsign_ops.pin_cmd = starsign_pin_cmd;
+	starsign_ops.select_file = starsign_select_file;
 	starsign_ops.set_security_env = starsign_set_security_env;
 	return &starsign_drv;
 }

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -290,6 +290,9 @@ enum {
 
 	/* Uruguayan eID card (cedula de identidad) */
 	SC_CARD_TYPE_CEDULAUY = 45000,
+
+	/* G&D StarSign CUT S (ICP-Brasil A3) */
+	SC_CARD_TYPE_STARSIGN = 46000,
 };
 
 extern sc_card_driver_t *sc_get_default_driver(void);

--- a/src/libopensc/cards.h
+++ b/src/libopensc/cards.h
@@ -329,6 +329,7 @@ extern sc_card_driver_t *sc_get_npa_driver(void);
 extern sc_card_driver_t *sc_get_esteid2018_driver(void);
 extern sc_card_driver_t *sc_get_esteid2025_driver(void);
 extern sc_card_driver_t *sc_get_idprime_driver(void);
+extern sc_card_driver_t *sc_get_starsign_driver(void);
 extern sc_card_driver_t *sc_get_edo_driver(void);
 extern sc_card_driver_t *sc_get_nqApplet_driver(void);
 extern sc_card_driver_t *sc_get_skeid_driver(void);

--- a/src/libopensc/ctx.c
+++ b/src/libopensc/ctx.c
@@ -136,6 +136,7 @@ static const struct _sc_driver_entry internal_card_drivers[] = {
 	{ "masktech",	(void *(*)(void)) sc_get_masktech_driver },
 	{ "idprime",	(void *(*)(void)) sc_get_idprime_driver },
 	{ "cedulauy",	(void *(*)(void)) sc_get_cedulauy_driver },
+	{ "starsign",	(void *(*)(void)) sc_get_starsign_driver },
 #if defined(ENABLE_SM) && defined(ENABLE_OPENPACE)
 	{ "edo",        (void *(*)(void)) sc_get_edo_driver },
 	{ "lteid", (void *(*)(void)) sc_get_lteid_driver },

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -63,10 +63,10 @@ static const struct {
 	const char *path;
 	const char *label;
 } starsign_certs[4] = {
-		{"3f003fff43020114", "Signature Certificate"},
-		{"3f003fff430205a0", "Intermediate CA Certificate 1"},
-		{"3f003fff430213ae", "Intermediate CA Certificate 2"},
-		{"3f003fff43021371", "Root CA Certificate"},
+		{"3f0043020114", "Signature Certificate"},
+		{"3f00430205a0", "Intermediate CA Certificate 1"},
+		{"3f00430213ae", "Intermediate CA Certificate 2"},
+		{"3f0043021371", "Root CA Certificate"},
 };
 
 static int

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -203,7 +203,20 @@ starsign_add_keys(struct sc_pkcs15_card *p15card)
 
 	/* Legacy key from a previous certificate cycle: no live certificate,
 	 * kept only so it doesn't silently vanish for holders who still have
-	 * one provisioned. Real hardware exposes it at key_reference 0. */
+	 * one provisioned. Real hardware exposes it at key_reference 0.
+	 *
+	 * Deliberately no paired native pubkey object here (unlike the current
+	 * key below). A holder who has renewed their ICP-Brasil certificate and
+	 * cleared the old one via the standard SafeSign/XCA workflow -- normal,
+	 * expected lifecycle, not a corner case -- no longer has any on-card EF
+	 * backing this key's public half. Declaring a native pubkey_info for it
+	 * anyway makes the generic PKCS#11 layer try to read modulus bytes that
+	 * don't exist, which fails with SC_ERROR_INTERNAL (-1400). The private
+	 * key object alone is still useful (matches hardware reality, doesn't
+	 * disappear for holders who haven't cleared the old cycle); it just
+	 * won't be discoverable by PKCS#11 clients that only enumerate via
+	 * public keys (e.g. XCA) -- acceptable, since without a certificate it
+	 * can't be used for anything verifiable anyway. */
 	struct sc_pkcs15_prkey_info legacy_prkey_info = {
 			.id = starsign_id_legacy,
 			.usage = SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_SIGN |
@@ -219,20 +232,6 @@ starsign_add_keys(struct sc_pkcs15_card *p15card)
 			.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE,
 	};
 
-	struct sc_pkcs15_pubkey_info pubkey_info = {
-			.id = starsign_id_legacy, /* pairs with the legacy key, per real hardware */
-			.usage = SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_WRAP |
-				 SC_PKCS15_PRKEY_USAGE_VERIFY | SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER,
-			.access_flags = SC_PKCS15_PRKEY_ACCESS_LOCAL,
-			.native = 1,
-			.key_reference = 0,
-			.modulus_length = 2048,
-	};
-	struct sc_pkcs15_object pubkey_obj = {
-			.auth_id = {.value = {0x02}, .len = 1},
-			.flags = SC_PKCS15_CO_FLAG_MODIFIABLE,
-	};
-
 	strlcpy(prkey_obj.label, "Signature Key", sizeof(prkey_obj.label));
 	r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
 	LOG_TEST_RET(card->ctx, r, "Could not add current private key object");
@@ -240,10 +239,6 @@ starsign_add_keys(struct sc_pkcs15_card *p15card)
 	strlcpy(legacy_prkey_obj.label, "Legacy Key", sizeof(legacy_prkey_obj.label));
 	r = sc_pkcs15emu_add_rsa_prkey(p15card, &legacy_prkey_obj, &legacy_prkey_info);
 	LOG_TEST_RET(card->ctx, r, "Could not add legacy private key object");
-
-	strlcpy(pubkey_obj.label, "Legacy Public Key", sizeof(pubkey_obj.label));
-	r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
-	LOG_TEST_RET(card->ctx, r, "Could not add public key object");
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -1,0 +1,93 @@
+/*
+ * Support for G&D StarSign CUT S tokens.
+ * This handles PKCS#15 bootstrap quirks, specifically injecting
+ * the correct PIN reference which the token's AODF omits.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "internal.h"
+#include "pkcs15.h"
+
+static int
+starsign_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
+{
+	struct sc_context *ctx = p15card->card->ctx;
+	struct sc_pkcs15_object *pin_objs[32];
+	int rv, count, i;
+
+	LOG_FUNC_CALLED(ctx);
+
+	if (!df)
+		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+
+	if (df->enumerated)
+		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+
+	rv = sc_pkcs15_parse_df(p15card, df);
+	if (rv < 0)
+		LOG_FUNC_RETURN(ctx, rv);
+
+	if (df->type == SC_PKCS15_AODF) {
+		/* The token's AODF entries omit the PIN reference and length
+		 * restrictions the ISO7816 driver needs to build a correct
+		 * VERIFY APDU. Patch them here instead of hardcoding the PIN
+		 * reference in card-starsign.c's pin_cmd, so the standard
+		 * iso7816 pin_cmd() implementation can be used unmodified. */
+		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH_PIN, pin_objs, sizeof(pin_objs) / sizeof(pin_objs[0]));
+		if (rv >= 0) {
+			count = rv;
+			for (i = 0; i < count; i++) {
+				struct sc_pkcs15_auth_info *pin_info = (struct sc_pkcs15_auth_info *)pin_objs[i]->data;
+				pin_info->attrs.pin.reference = 0x02;
+				pin_info->attrs.pin.max_length = 15;
+				pin_info->attrs.pin.pad_char = '\0';
+				pin_info->attrs.pin.flags |= SC_PKCS15_PIN_FLAG_INITIALIZED;
+			}
+		}
+	} else if (df->type == SC_PKCS15_PRKDF) {
+		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY_RSA, pin_objs, sizeof(pin_objs) / sizeof(pin_objs[0]));
+		if (rv >= 0) {
+			count = rv;
+			for (i = 0; i < count; i++) {
+				struct sc_pkcs15_prkey_info *prkey_info = (struct sc_pkcs15_prkey_info *)pin_objs[i]->data;
+				/* Force key reference to 0x01 if it's 0x00 or missing */
+				if (prkey_info->key_reference == 0x00) {
+					sc_log(ctx, "Patching PRKEY reference to 0x01");
+					prkey_info->key_reference = 0x01;
+				}
+				/* Force modulus length if 0 */
+				if (prkey_info->modulus_length == 0) {
+					sc_log(ctx, "Patching PRKEY modulus length to 2048");
+					prkey_info->modulus_length = 2048;
+				}
+			}
+		}
+	}
+
+	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+}
+
+static int
+sc_pkcs15emu_starsign_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+{
+	int rv;
+
+	LOG_FUNC_CALLED(p15card->card->ctx);
+
+	/* Set the hook BEFORE parsing so it runs when parsing the AODF. */
+	p15card->ops.parse_df = starsign_parse_df;
+
+	rv = sc_pkcs15_bind_internal(p15card, aid);
+	LOG_FUNC_RETURN(p15card->card->ctx, rv);
+}
+
+int
+sc_pkcs15emu_starsign_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
+{
+	if (p15card->card->type == SC_CARD_TYPE_STARSIGN)
+		return sc_pkcs15emu_starsign_init(p15card, aid);
+	return SC_ERROR_WRONG_CARD;
+}

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -63,10 +63,10 @@ static const struct {
 	const char *path;
 	const char *label;
 } starsign_certs[4] = {
-		{"3f0043020114", "Signature Certificate"},
+		{"3f0043020114", "Signature Certificate"	},
 		{"3f00430205a0", "Intermediate CA Certificate 1"},
 		{"3f00430213ae", "Intermediate CA Certificate 2"},
-		{"3f0043021371", "Root CA Certificate"},
+		{"3f0043021371", "Root CA Certificate"	      },
 };
 
 static int
@@ -99,17 +99,17 @@ starsign_add_pins(struct sc_pkcs15_card *p15card)
 			.tries_left = -1,
 			.max_tries = -1,
 			.attrs = {.pin = {
-					.reference = 0x01,
-					.flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
-						 SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
-						 SC_PKCS15_PIN_FLAG_SO_PIN | SC_PKCS15_PIN_FLAG_DISABLE_ALLOW |
-						 SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
-					.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-					.min_length = 4,
-					.stored_length = 15,
-					.max_length = 15,
-					.pad_char = 0x00}}
-	};
+						  .reference = 0x01,
+						  .flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
+							   SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
+							   SC_PKCS15_PIN_FLAG_SO_PIN | SC_PKCS15_PIN_FLAG_DISABLE_ALLOW |
+							   SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
+						  .type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+						  .min_length = 4,
+						  .stored_length = 15,
+						  .max_length = 15,
+						  .pad_char = 0x00}}
+	    };
 	struct sc_pkcs15_object so_pin_obj = {.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE};
 
 	struct sc_pkcs15_auth_info user_pin_info = {
@@ -118,16 +118,16 @@ starsign_add_pins(struct sc_pkcs15_card *p15card)
 			.tries_left = -1,
 			.max_tries = -1,
 			.attrs = {.pin = {
-					.reference = 0x02,
-					.flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
-						 SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
-						 SC_PKCS15_PIN_FLAG_DISABLE_ALLOW | SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
-					.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
-					.min_length = 4,
-					.stored_length = 15,
-					.max_length = 15,
-					.pad_char = 0x00}}
-	};
+						  .reference = 0x02,
+						  .flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
+							   SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
+							   SC_PKCS15_PIN_FLAG_DISABLE_ALLOW | SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
+						  .type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+						  .min_length = 4,
+						  .stored_length = 15,
+						  .max_length = 15,
+						  .pad_char = 0x00}}
+	    };
 	/* Points at the SO Pin's own id: the SO Pin can unblock/reset this one. */
 	struct sc_pkcs15_object user_pin_obj = {
 			.auth_id = {.value = {0x01}, .len = 1},

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -1,7 +1,24 @@
 /*
- * Support for G&D StarSign CUT S tokens.
+ * pkcs15-starsign.c: PKCS#15 bootstrap quirks for G&D StarSign CUT S tokens
+ *
+ * Copyright (C) 2026 Diego Ribeiro de Souza
+ *
  * This handles PKCS#15 bootstrap quirks, specifically injecting
  * the correct PIN reference which the token's AODF omits.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifdef HAVE_CONFIG_H

--- a/src/libopensc/pkcs15-starsign.c
+++ b/src/libopensc/pkcs15-starsign.c
@@ -1,10 +1,22 @@
 /*
- * pkcs15-starsign.c: PKCS#15 bootstrap quirks for G&D StarSign CUT S tokens
+ * pkcs15-starsign.c: static PKCS#15 profile for G&D StarSign CUT S tokens
  *
  * Copyright (C) 2026 Diego Ribeiro de Souza
  *
- * This handles PKCS#15 bootstrap quirks, specifically injecting
- * the correct PIN reference which the token's AODF omits.
+ * The card's own AODF/PrKDF entries are confusing enough (missing PIN
+ * reference, zeroed key references) that patching them after a generic
+ * sc_pkcs15_parse_df() made card-starsign.c's SELECT logic hard to justify.
+ * Per review feedback from the OpenSC maintainer, this instead supplies the
+ * card's PKCS#15 layout as static, internal data (see pkcs15-esteid2025.c
+ * for the same pattern) for every field that is structural -- i.e. fixed by
+ * the StarSign CUT S / SafeSign applet across every token of this model,
+ * regardless of cardholder. Confirmed against physical hardware via a debug
+ * trace of the previously-working dynamic discovery path.
+ *
+ * Fields that are genuinely per-cardholder (token label, serial number,
+ * manufacturer ID) are NOT hardcoded here -- they are read from the card's
+ * own EF(TokenInfo) at runtime, same as any other OpenSC card driver, so
+ * this works correctly for every StarSign CUT S holder, not just one.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,86 +37,244 @@
 #include "config.h"
 #endif
 
+#include <string.h>
+
+#include "common/compat_strlcpy.h"
 #include "internal.h"
 #include "pkcs15.h"
 
+/* EF(TokenInfo): direct child of the MF, same FID on every StarSign CUT S
+ * token. Its *content* (label, serial, manufacturer) is cardholder-specific
+ * and is read from the card below, not hardcoded. */
+#define STARSIGN_TOKENINFO_PATH "3f005032"
+
+/* Correlation IDs assigned by this driver -- purely internal bookkeeping to
+ * link a certificate to its private/public key object. They are not read
+ * from the card (the card's own CDF stores the cardholder's name as the ID,
+ * which must not end up hardcoded into a driver shared by every StarSign
+ * user) and do not need to match any value stored on the card. */
+static const struct sc_pkcs15_id starsign_id_current = {.value = {0x01}, .len = 1};
+static const struct sc_pkcs15_id starsign_id_legacy = {.value = {0x02}, .len = 1};
+
+/* Certificate slots: MF -> [virtual 0x3FFF placeholder, never selected] ->
+ * DF 4302 -> EF <final>. This 4-slot layout (leaf, two intermediates, root)
+ * is fixed by the applet; only the DER content of each EF is personal. */
+static const struct {
+	const char *path;
+	const char *label;
+} starsign_certs[4] = {
+		{"3f003fff43020114", "Signature Certificate"},
+		{"3f003fff430205a0", "Intermediate CA Certificate 1"},
+		{"3f003fff430213ae", "Intermediate CA Certificate 2"},
+		{"3f003fff43021371", "Root CA Certificate"},
+};
+
 static int
-starsign_parse_df(struct sc_pkcs15_card *p15card, struct sc_pkcs15_df *df)
+starsign_read_tokeninfo(struct sc_pkcs15_card *p15card)
 {
-	struct sc_context *ctx = p15card->card->ctx;
-	struct sc_pkcs15_object *pin_objs[32];
-	int rv, count, i;
+	sc_card_t *card = p15card->card;
+	sc_path_t path;
+	u8 buf[512];
+	int r;
 
-	LOG_FUNC_CALLED(ctx);
+	sc_format_path(STARSIGN_TOKENINFO_PATH, &path);
+	r = sc_select_file(card, &path, NULL);
+	LOG_TEST_RET(card->ctx, r, "Selecting EF(TokenInfo) failed");
 
-	if (!df)
-		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
+	r = sc_read_binary(card, 0, buf, sizeof(buf), 0);
+	LOG_TEST_RET(card->ctx, r, "Reading EF(TokenInfo) failed");
 
-	if (df->enumerated)
-		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
-
-	rv = sc_pkcs15_parse_df(p15card, df);
-	if (rv < 0)
-		LOG_FUNC_RETURN(ctx, rv);
-
-	if (df->type == SC_PKCS15_AODF) {
-		/* The token's AODF entries omit the PIN reference and length
-		 * restrictions the ISO7816 driver needs to build a correct
-		 * VERIFY APDU. Patch them here instead of hardcoding the PIN
-		 * reference in card-starsign.c's pin_cmd, so the standard
-		 * iso7816 pin_cmd() implementation can be used unmodified. */
-		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_AUTH_PIN, pin_objs, sizeof(pin_objs) / sizeof(pin_objs[0]));
-		if (rv >= 0) {
-			count = rv;
-			for (i = 0; i < count; i++) {
-				struct sc_pkcs15_auth_info *pin_info = (struct sc_pkcs15_auth_info *)pin_objs[i]->data;
-				pin_info->attrs.pin.reference = 0x02;
-				pin_info->attrs.pin.max_length = 15;
-				pin_info->attrs.pin.pad_char = '\0';
-				pin_info->attrs.pin.flags |= SC_PKCS15_PIN_FLAG_INITIALIZED;
-			}
-		}
-	} else if (df->type == SC_PKCS15_PRKDF) {
-		rv = sc_pkcs15_get_objects(p15card, SC_PKCS15_TYPE_PRKEY_RSA, pin_objs, sizeof(pin_objs) / sizeof(pin_objs[0]));
-		if (rv >= 0) {
-			count = rv;
-			for (i = 0; i < count; i++) {
-				struct sc_pkcs15_prkey_info *prkey_info = (struct sc_pkcs15_prkey_info *)pin_objs[i]->data;
-				/* Force key reference to 0x01 if it's 0x00 or missing */
-				if (prkey_info->key_reference == 0x00) {
-					sc_log(ctx, "Patching PRKEY reference to 0x01");
-					prkey_info->key_reference = 0x01;
-				}
-				/* Force modulus length if 0 */
-				if (prkey_info->modulus_length == 0) {
-					sc_log(ctx, "Patching PRKEY modulus length to 2048");
-					prkey_info->modulus_length = 2048;
-				}
-			}
-		}
-	}
-
-	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
+	return sc_pkcs15_parse_tokeninfo(card->ctx, p15card->tokeninfo, buf, (size_t)r);
 }
 
 static int
-sc_pkcs15emu_starsign_init(struct sc_pkcs15_card *p15card, struct sc_aid *aid)
+starsign_add_pins(struct sc_pkcs15_card *p15card)
 {
-	int rv;
+	sc_card_t *card = p15card->card;
+	int r;
 
-	LOG_FUNC_CALLED(p15card->card->ctx);
+	struct sc_pkcs15_auth_info so_pin_info = {
+			.auth_id = {.value = {0x01}, .len = 1},
+			.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN,
+			.tries_left = -1,
+			.max_tries = -1,
+			.attrs = {.pin = {
+					.reference = 0x01,
+					.flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
+						 SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
+						 SC_PKCS15_PIN_FLAG_SO_PIN | SC_PKCS15_PIN_FLAG_DISABLE_ALLOW |
+						 SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
+					.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+					.min_length = 4,
+					.stored_length = 15,
+					.max_length = 15,
+					.pad_char = 0x00}}
+	};
+	struct sc_pkcs15_object so_pin_obj = {.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE};
 
-	/* Set the hook BEFORE parsing so it runs when parsing the AODF. */
-	p15card->ops.parse_df = starsign_parse_df;
+	struct sc_pkcs15_auth_info user_pin_info = {
+			.auth_id = {.value = {0x02}, .len = 1},
+			.auth_type = SC_PKCS15_PIN_AUTH_TYPE_PIN,
+			.tries_left = -1,
+			.max_tries = -1,
+			.attrs = {.pin = {
+					.reference = 0x02,
+					.flags = SC_PKCS15_PIN_FLAG_CASE_SENSITIVE | SC_PKCS15_PIN_FLAG_LOCAL |
+						 SC_PKCS15_PIN_FLAG_INITIALIZED | SC_PKCS15_PIN_FLAG_NEEDS_PADDING |
+						 SC_PKCS15_PIN_FLAG_DISABLE_ALLOW | SC_PKCS15_PIN_FLAG_EXCHANGE_REF_DATA,
+					.type = SC_PKCS15_PIN_TYPE_ASCII_NUMERIC,
+					.min_length = 4,
+					.stored_length = 15,
+					.max_length = 15,
+					.pad_char = 0x00}}
+	};
+	/* Points at the SO Pin's own id: the SO Pin can unblock/reset this one. */
+	struct sc_pkcs15_object user_pin_obj = {
+			.auth_id = {.value = {0x01}, .len = 1},
+			.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE,
+	};
 
-	rv = sc_pkcs15_bind_internal(p15card, aid);
-	LOG_FUNC_RETURN(p15card->card->ctx, rv);
+	sc_format_path("3f00", &user_pin_info.path);
+	strlcpy(user_pin_obj.label, "User Pin", sizeof(user_pin_obj.label));
+	r = sc_pkcs15emu_add_pin_obj(p15card, &user_pin_obj, &user_pin_info);
+	LOG_TEST_RET(card->ctx, r, "Could not add User PIN object");
+
+	sc_format_path("3f00", &so_pin_info.path);
+	strlcpy(so_pin_obj.label, "SO Pin", sizeof(so_pin_obj.label));
+	r = sc_pkcs15emu_add_pin_obj(p15card, &so_pin_obj, &so_pin_info);
+	LOG_TEST_RET(card->ctx, r, "Could not add SO PIN object");
+
+	return SC_SUCCESS;
+}
+
+static int
+starsign_add_certs(struct sc_pkcs15_card *p15card)
+{
+	sc_card_t *card = p15card->card;
+	int i, r;
+
+	for (i = 0; i < 4; i++) {
+		struct sc_pkcs15_cert_info cert_info = {0};
+		struct sc_pkcs15_object cert_obj = {0};
+
+		if (i == 0) {
+			/* Leaf certificate: correlates to the current signing key. */
+			cert_info.id = starsign_id_current;
+		} else {
+			/* CA-chain certs don't correlate to any key on this token;
+			 * give each a distinct id (0x03, 0x04, 0x05) so they don't
+			 * collide with each other or with the key ids (0x01, 0x02). */
+			cert_info.id.value[0] = 0x02 + i;
+			cert_info.id.len = 1;
+		}
+		cert_info.authority = 0;
+		sc_format_path(starsign_certs[i].path, &cert_info.path);
+
+		strlcpy(cert_obj.label, starsign_certs[i].label, sizeof(cert_obj.label));
+		cert_obj.flags = SC_PKCS15_CO_FLAG_MODIFIABLE;
+
+		r = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
+		LOG_TEST_RET(card->ctx, r, "Could not add certificate object");
+	}
+
+	return SC_SUCCESS;
+}
+
+static int
+starsign_add_keys(struct sc_pkcs15_card *p15card)
+{
+	sc_card_t *card = p15card->card;
+	int r;
+
+	/* Current signing key: the only one with a live matching certificate. */
+	struct sc_pkcs15_prkey_info prkey_info = {
+			.id = starsign_id_current,
+			.usage = SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_SIGN |
+				 SC_PKCS15_PRKEY_USAGE_SIGNRECOVER | SC_PKCS15_PRKEY_USAGE_UNWRAP,
+			.access_flags = SC_PKCS15_PRKEY_ACCESS_SENSITIVE | SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE,
+			.native = 1,
+			.key_reference = 1,
+			.modulus_length = 2048,
+	};
+	struct sc_pkcs15_object prkey_obj = {
+			.auth_id = {.value = {0x02}, .len = 1}, /* linked to the User Pin */
+			.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE,
+	};
+
+	/* Legacy key from a previous certificate cycle: no live certificate,
+	 * kept only so it doesn't silently vanish for holders who still have
+	 * one provisioned. Real hardware exposes it at key_reference 0. */
+	struct sc_pkcs15_prkey_info legacy_prkey_info = {
+			.id = starsign_id_legacy,
+			.usage = SC_PKCS15_PRKEY_USAGE_DECRYPT | SC_PKCS15_PRKEY_USAGE_SIGN |
+				 SC_PKCS15_PRKEY_USAGE_SIGNRECOVER | SC_PKCS15_PRKEY_USAGE_UNWRAP,
+			.access_flags = SC_PKCS15_PRKEY_ACCESS_SENSITIVE | SC_PKCS15_PRKEY_ACCESS_EXTRACTABLE |
+					SC_PKCS15_PRKEY_ACCESS_ALWAYSSENSITIVE | SC_PKCS15_PRKEY_ACCESS_LOCAL,
+			.native = 1,
+			.key_reference = 0,
+			.modulus_length = 2048,
+	};
+	struct sc_pkcs15_object legacy_prkey_obj = {
+			.auth_id = {.value = {0x02}, .len = 1},
+			.flags = SC_PKCS15_CO_FLAG_PRIVATE | SC_PKCS15_CO_FLAG_MODIFIABLE,
+	};
+
+	struct sc_pkcs15_pubkey_info pubkey_info = {
+			.id = starsign_id_legacy, /* pairs with the legacy key, per real hardware */
+			.usage = SC_PKCS15_PRKEY_USAGE_ENCRYPT | SC_PKCS15_PRKEY_USAGE_WRAP |
+				 SC_PKCS15_PRKEY_USAGE_VERIFY | SC_PKCS15_PRKEY_USAGE_VERIFYRECOVER,
+			.access_flags = SC_PKCS15_PRKEY_ACCESS_LOCAL,
+			.native = 1,
+			.key_reference = 0,
+			.modulus_length = 2048,
+	};
+	struct sc_pkcs15_object pubkey_obj = {
+			.auth_id = {.value = {0x02}, .len = 1},
+			.flags = SC_PKCS15_CO_FLAG_MODIFIABLE,
+	};
+
+	strlcpy(prkey_obj.label, "Signature Key", sizeof(prkey_obj.label));
+	r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+	LOG_TEST_RET(card->ctx, r, "Could not add current private key object");
+
+	strlcpy(legacy_prkey_obj.label, "Legacy Key", sizeof(legacy_prkey_obj.label));
+	r = sc_pkcs15emu_add_rsa_prkey(p15card, &legacy_prkey_obj, &legacy_prkey_info);
+	LOG_TEST_RET(card->ctx, r, "Could not add legacy private key object");
+
+	strlcpy(pubkey_obj.label, "Legacy Public Key", sizeof(pubkey_obj.label));
+	r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
+	LOG_TEST_RET(card->ctx, r, "Could not add public key object");
+
+	return SC_SUCCESS;
+}
+
+static int
+sc_pkcs15emu_starsign_init(struct sc_pkcs15_card *p15card)
+{
+	sc_card_t *card = p15card->card;
+	int r;
+
+	LOG_FUNC_CALLED(card->ctx);
+
+	r = starsign_read_tokeninfo(p15card);
+	LOG_TEST_RET(card->ctx, r, "Could not read EF(TokenInfo)");
+
+	r = starsign_add_pins(p15card);
+	LOG_TEST_RET(card->ctx, r, "Could not add PIN objects");
+
+	r = starsign_add_certs(p15card);
+	LOG_TEST_RET(card->ctx, r, "Could not add certificate objects");
+
+	r = starsign_add_keys(p15card);
+	LOG_TEST_RET(card->ctx, r, "Could not add key objects");
+
+	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
 int
 sc_pkcs15emu_starsign_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *aid)
 {
 	if (p15card->card->type == SC_CARD_TYPE_STARSIGN)
-		return sc_pkcs15emu_starsign_init(p15card, aid);
+		return sc_pkcs15emu_starsign_init(p15card);
 	return SC_ERROR_WRONG_CARD;
 }

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -66,6 +66,7 @@ struct sc_pkcs15_emulator_handler builtin_emulators[] = {
 	{ "dtrust",     sc_pkcs15emu_dtrust_init_ex },
 	{ "lteid",      sc_pkcs15emu_lteid_init_ex },
 	{ "srbeid",     sc_pkcs15emu_srbeid_init_ex },
+	{ "starsign",   sc_pkcs15emu_starsign_init_ex },
 	{ NULL, NULL }
 };
 

--- a/src/libopensc/pkcs15-syn.c
+++ b/src/libopensc/pkcs15-syn.c
@@ -132,6 +132,7 @@ int sc_pkcs15_is_emulation_only(sc_card_t *card)
 		case SC_CARD_TYPE_DTRUST_V5_4_MULTI:
 		case SC_CARD_TYPE_LTEID:
 		case SC_CARD_TYPE_CEDULAUY:
+		case SC_CARD_TYPE_STARSIGN:
 			return 1;
 		default:
 			return 0;

--- a/src/libopensc/pkcs15-syn.h
+++ b/src/libopensc/pkcs15-syn.h
@@ -61,6 +61,7 @@ int sc_pkcs15emu_eoi_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_dtrust_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_lteid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 int sc_pkcs15emu_srbeid_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
+int sc_pkcs15emu_starsign_init_ex(sc_pkcs15_card_t *p15card, struct sc_aid *);
 
 struct sc_pkcs15_emulator_handler {
 	const char *name;


### PR DESCRIPTION
﻿This PR introduces a native driver (`card-starsign.c`) for the G&D StarSign CUT S token, heavily used in Brazil for ICP-Brasil A3 certificates (e.g., judicial systems).

Previously, these tokens required the buggy proprietary SafeSign middleware. During our reverse engineering, we discovered a few peculiarities that prevented OpenSC from natively communicating with the applet:

1. **Initialization Attestation:** The card requires a specific string (`I am A.E.T. Europe B.V. SafeSign or BlueX approved software.`) sent via `PUT DATA` upon reset to unlock complex commands.
2. **Virtual paths for certificates/data objects:** Certificate and data-object EFs are referenced by paths containing a fictitious `0x3FFF` placeholder (e.g. `3F00 3FFF 4302 05A0`). The card answers `SW 6A82` if `0x3FFF` is ever selected directly — it isn't a real file. The directory right after it (e.g. `4302`) is real and must be selected once (cached, since re-selecting it while already current also fails). The real file size is read from the card's own FCP response rather than assumed.
3. **Logical Channels:** It strictly requires operations to run on Channel 1 (`MANAGE CHANNEL`).
4. **Signature padding:** the card pads a raw hash it is handed with PKCS#1 v1.5, but does not prepend the DigestInfo ASN.1/OID header a standards-compliant signature requires. We advertise `SC_ALGORITHM_RSA_HASH_NONE` only, so OpenSC's own crypto layer builds the correct DigestInfo + PKCS#1 block in software before handing the card an already-padded blob for `SC_ALGORITHM_RSA_RAW`.

This driver allows the token to work out-of-the-box on Linux systems, circumventing the proprietary middleware.

> **Note to reviewers:** The full reverse engineering research, APDU traffic dumps, and documentation behind these discoveries are available in my companion repository: https://github.com/DiegoRibeirodeSouza/starsign-driver-en

Fixes #2580

##### Checklist
- [x] Documentation is added or updated (see companion repository linked above)
- [x] New files have a LGPL 2.1 license statement
- [x] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS token is tested

