### PR TITLE
card-idprime: Add EC mutual authentication / Secure Messaging for FIPS applets

### DIFF
--- a/src/libopensc/Makefile.am
+++ b/src/libopensc/Makefile.am
@@ -84,7 +84,8 @@ libopensc_la_LIBADD = $(OPENPACE_LIBS) $(OPTIONAL_OPENSSL_LIBS) \
 	$(top_builddir)/src/common/libscdl.la \
 	$(top_builddir)/src/ui/libnotify.la \
 	$(top_builddir)/src/ui/libstrings.la \
-	$(top_builddir)/src/sm/libsmeac.la
+	$(top_builddir)/src/sm/libsmeac.la \
+	$(top_builddir)/src/sm/libsmidprime.la
 if WIN32
 libopensc_la_LIBADD += -lws2_32 -lshlwapi -lcomctl32
 endif

--- a/src/libopensc/Makefile.mak
+++ b/src/libopensc/Makefile.mak
@@ -47,6 +47,7 @@ LIBS = $(TOPDIR)\src\scconf\scconf.lib \
 	   $(TOPDIR)\src\ui\notify.lib \
 	   $(TOPDIR)\src\sm\libsmiso.lib \
 	   $(TOPDIR)\src\sm\libsmeac.lib \
+	   $(TOPDIR)\src\sm\libsmidprime.lib \
 	   $(TOPDIR)\src\pkcs15init\pkcs15init.lib
 
 all: $(TOPDIR)\win32\versioninfo.res $(TARGET)

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -29,8 +29,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "asn1.h"
 #include "cardctl.h"
+#include "iso7816.h"
 #include "pkcs15.h"
+#include "sm/sm-idprime.h"
+
+#ifdef ENABLE_OPENSSL
+#include <openssl/bn.h>
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#endif
+#endif /* ENABLE_OPENSSL */
 
 static const struct sc_card_operations *iso_ops = NULL;
 
@@ -170,6 +185,20 @@ typedef struct idprime_private_data {
 	unsigned long current_op;		/* current operation set by idprime_set_security_env */
 	list_t containers;			/* list of private key containers */
 	list_t keyrefmap;			/* list of key references for private keys */
+
+	/* ECC Mutual Authentication / proprietary Secure Messaging state, mirroring
+	 * the proprietary driver's idp_maType / idp_isFIPS / idp_isFullSM. This is
+	 * detection only for now -- the SM channel itself is not implemented yet,
+	 * see idprime_probe_ecc_ma() / idprime_get_ecc_full_sm(). */
+	unsigned int ma_point_len; /* 0 if no MA reference key present, else EC point length (65/97/133) */
+	unsigned int sm_key_len;   /* AES key length (bytes) the card expects once MA is used (16 or 32) */
+	int is_fips;		   /* applet reports a FIPS-restricted operation mode */
+	int fips_identify;	   /* 0 = not FIPS, 2/3 = the two FIPS applet variants seen in app_opt bits */
+	int full_sm;		   /* mirrors idp_isFullSM: every APDU must be SM-wrapped */
+	int sm_authenticated;	   /* mutual authentication succeeded -- SM channel is active.
+				    * The card rejects re-selecting the IDPrime AID once we're
+				    * already sitting authenticated in it, so once this is set
+				    * idprime_select_idprime() must skip the re-select. */
 } idprime_private_data_t;
 
 /* For SimCList autocopy, we need to know the size of the data elements */
@@ -271,10 +300,78 @@ int idprime_add_object_to_list(list_t *list, const idprime_object_t *object)
 	return SC_SUCCESS;
 }
 
+/* Select a 2-byte file id under full SM. The generic iso7816_select_file()
+ * (used for the non-SM path) requests the FCI back via a protected Le
+ * (DO'97'), but the card rejects any SELECT command carrying that DO once
+ * mutual-authenticated -- it responds with a bare, unprotected SW=6982
+ * (i.e. it doesn't even attempt SM/MAC processing on the command). The
+ * captured proprietary driver trace confirms SELECT is always sent as
+ * Lc+data only (no Le at all) under this SM; the card still returns FCI in
+ * the encrypted response regardless of the absence of a request Le. */
+static int
+idprime_sm_select_file_by_id(sc_card_t *card, const sc_path_t *path, sc_file_t **file_out)
+{
+	sc_apdu_t apdu;
+	u8 rbuf[SC_MAX_APDU_BUFFER_SIZE];
+	const u8 *buffer;
+	unsigned int cla, tag;
+	size_t buffer_len;
+	sc_file_t *file;
+	int r;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xA4, 0x00, 0x00);
+	apdu.data = path->value;
+	apdu.datalen = apdu.lc = path->len;
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rbuf);
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS)
+		LOG_FUNC_RETURN(card->ctx, r);
+
+	if (file_out == NULL)
+		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
+
+	if (apdu.resplen < 2)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
+	switch (apdu.resp[0]) {
+	case ISO7816_TAG_FCI:
+	case ISO7816_TAG_FCP:
+		file = sc_file_new();
+		if (file == NULL)
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
+		file->path = *path;
+		if (card->ops->process_fci == NULL) {
+			sc_file_free(file);
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+		}
+		buffer = apdu.resp;
+		r = sc_asn1_read_tag(&buffer, apdu.resplen, &cla, &tag, &buffer_len);
+		if (r == SC_SUCCESS)
+			card->ops->process_fci(card, file, buffer, buffer_len);
+		*file_out = file;
+		break;
+	default:
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
+	}
+
+	return SC_SUCCESS;
+}
+
 /* This selects main IDPrime AID which is used for communication with
  * the card */
 static int idprime_select_idprime(sc_card_t *card)
 {
+	idprime_private_data_t *priv = (idprime_private_data_t *)card->drv_data;
+
+	/* Once mutual authentication has established the SM channel, the card
+	 * is already sitting authenticated inside the IDPrime AID and rejects
+	 * (SW=6982) a redundant re-select of the same AID. Skip it. */
+	if (priv && priv->sm_authenticated)
+		return SC_SUCCESS;
+
 	return iso_ops->select_file(card, &idprime_path, NULL);
 }
 
@@ -284,6 +381,7 @@ static int idprime_select_file_by_path(sc_card_t *card, const char *str_path)
 	int r;
 	sc_file_t *file = NULL;
 	sc_path_t index_path;
+	idprime_private_data_t *priv = (idprime_private_data_t *)card->drv_data;
 
 	/* First, we need to make sure the IDPrime AID is selected */
 	r = idprime_select_idprime(card);
@@ -293,7 +391,10 @@ static int idprime_select_file_by_path(sc_card_t *card, const char *str_path)
 
 	/* Returns FCI with expected length of data */
 	sc_format_path(str_path, &index_path);
-	r = iso_ops->select_file(card, &index_path, &file);
+	if (priv && priv->sm_authenticated && index_path.len == 2)
+		r = idprime_sm_select_file_by_id(card, &index_path, &file);
+	else
+		r = iso_ops->select_file(card, &index_path, &file);
 
 	if (r != SC_SUCCESS) {
 		LOG_FUNC_RETURN(card->ctx, r);
@@ -463,6 +564,7 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 		if (((memcmp(&start[4], "ksc", 3) == 0) || memcmp(&start[4], "kxc", 3) == 0)
 			&& (memcmp(&start[12], "mscp", 5) == 0)) {
 			uint8_t cert_id = 0;
+			uint8_t key_index;
 			idprime_container_t *container = NULL;
 
 			if (start[7] >= '0' && start[7] <= '9' && start[8] >= '0' && start[8] <= '9') {
@@ -475,30 +577,63 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 
 			container = (idprime_container_t *) list_seek(&priv->containers, &cert_id);
 			if (!container) {
-				/* Container map missing container with certificate ID */
+				/* Container map missing a container whose index matches the
+				 * certificate's embedded 2-digit id. This is not on its own proof
+				 * the certificate has no private key: the real driver's
+				 * idp_getKeyId() (decompiled from libIDPrimeTokenEngine.so) derives
+				 * the key reference from the container's own sequential index,
+				 * discovered by iterating containers independently of certificates
+				 * -- cert_id and container index are simply different numbers that
+				 * only happen to coincide when a card's containers and certs were
+				 * both created in matching order. Confirmed on a real FIPS
+				 * 930_PLUS eToken with exactly one populated container (index 0)
+				 * but a certificate whose embedded id is 10: the real driver still
+				 * exposes a working private key on it, using key reference
+				 * 0x31 + 0 (container index), not a formula involving cert_id=10.
+				 * We can't replicate the real driver's independent container
+				 * enumeration here, but when there is exactly one populated
+				 * container and this certificate has none, pairing them is the
+				 * only sensible choice and matches what was observed on real
+				 * hardware. */
 				sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "No corresponding container with private key found for certificate with id=%d", cert_id);
-				if (card->type != SC_CARD_TYPE_IDPRIME_940) {
-					/* For cards other than the 940, we don't know how to recognize
-					certificates missing keys other than to check
-					that there is a corresponding entry in the container map.*/
-					sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Adding certificate with fd=%d", new_object.fd);
-					idprime_add_object_to_list(&priv->pki_list, &new_object);
-					continue;
+				if (list_size(&priv->containers) == 1) {
+					container = (idprime_container_t *)list_get_at(&priv->containers, 0);
+					sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Falling back to the single populated container \"%s\" (index=%d)",
+							container->guid, container->index);
 				}
 			}
+			/* Use the container's own index when available -- it is what the key
+			 * reference formulas below are actually keyed on. When no container
+			 * was found (or matched) at all, cert_id remains the closest thing we
+			 * have to go on, matching this function's prior (pre-container-index)
+			 * behavior for that edge case. */
+			key_index = container ? container->index : cert_id;
 
 			switch (card->type) {
 			case SC_CARD_TYPE_IDPRIME_3810:
-				new_object.key_reference = 0x31 + cert_id;
+				new_object.key_reference = 0x31 + key_index;
 				break;
 			case SC_CARD_TYPE_IDPRIME_830:
-				new_object.key_reference = 0x41 + cert_id;
+				new_object.key_reference = 0x41 + key_index;
 				break;
 			case SC_CARD_TYPE_IDPRIME_930:
-				new_object.key_reference = 0x11 + cert_id * 2;
+				new_object.key_reference = 0x11 + key_index * 2;
 				break;
 			case SC_CARD_TYPE_IDPRIME_930_PLUS:
-				new_object.key_reference = 0x10 + cert_id * 2;
+				if (priv->full_sm) {
+					/* Confirmed via a live gdb hook + decompile of idp_getKeyId()
+					 * against a real FIPS/full-SM 930_PLUS eToken: this applet
+					 * variant takes idp_getKeyId()'s older/simpler branch
+					 * (container_index + 0x31), not the container_index*2 + 0x10
+					 * scheme used below for the plain (non-SM) 930_PLUS path --
+					 * the real driver picks between the two based on the
+					 * applet's own version/isNet flags, which we don't
+					 * replicate, so key it off priv->full_sm instead, since
+					 * that's exactly the class of card where this was observed. */
+					new_object.key_reference = 0x31 + key_index;
+				} else {
+					new_object.key_reference = 0x10 + key_index * 2;
+				}
 				break;
 			case SC_CARD_TYPE_IDPRIME_940: {
 					idprime_keyref_t *keyref = (idprime_keyref_t *) list_seek(&priv->keyrefmap, &cert_id);
@@ -514,10 +649,10 @@ static int idprime_process_index(sc_card_t *card, idprime_private_data_t *priv, 
 					break;
 				}
 			case SC_CARD_TYPE_IDPRIME_840:
-				new_object.key_reference = 0xf7 + cert_id;
+				new_object.key_reference = 0xf7 + key_index;
 				break;
 			default:
-				new_object.key_reference = 0x56 + cert_id;
+				new_object.key_reference = 0x56 + key_index;
 				break;
 			}
 			new_object.valid_key_ref = 1;
@@ -556,6 +691,1159 @@ done:
 
 /* CPLC has 42 bytes, but we get it with 3B header */
 #define CPLC_LENGTH 45
+
+/* Key reference of the ECC Mutual Authentication reference public key, as
+ * used by the proprietary driver's GET DATA probe (idp_getEccMAKeys()). */
+#define IDPRIME_ECC_MA_KEY_REF 2
+
+/*
+ * Recent IDPrime/eToken applets (FIPS-capable ones in particular) expose an
+ * ECC public key under a dedicated key reference, retrievable with a plain
+ * (non-SM) GET DATA. Its presence is what the proprietary driver uses to
+ * decide whether a card supports its EC-based Mutual Authentication /
+ * Secure Messaging channel (see idp_getEccMAKeys() in libIDPrimeTokenEngine.so).
+ *
+ * Older/non-FIPS applets simply don't have this key: priv->ma_point_len stays
+ * 0 and the card keeps being driven exactly as today, in the clear.
+ *
+ * Cards that *do* have it get priv->ma_point_len/sm_key_len filled in for the
+ * caller to inspect (see idprime_get_ecc_full_sm() below) -- the SM channel
+ * itself is not implemented here yet.
+ */
+static int
+idprime_probe_ecc_ma(sc_card_t *card, idprime_private_data_t *priv)
+{
+	/* GET DATA (INS 0xCB, P1=0x00 P2=0xFF) request body -- verified against
+	 * a live capture of the proprietary driver's idp_getEccExponent() call
+	 * (keyId=0x2 exponent=0x86 keyUsageTag=0xa4) on real hardware:
+	 *   00 cb 00 ff 0a a4 03 83 01 02 7f 49 02 86 00 00
+	 * i.e. TWO SIBLING top-level TLVs (each apduAddTag() call closes the
+	 * previous top-level element rather than nesting into it):
+	 *   A4 03 { 83 01 02 }        CRT for Authentication: key reference = IDPRIME_ECC_MA_KEY_REF
+	 *   7F 49 02 { 86 00 }        Public Key template: request element 0x86 (the public point)
+	 */
+	static const u8 req[] = {
+			0xA4, 0x03,
+			0x83, 0x01, IDPRIME_ECC_MA_KEY_REF,
+			0x7F, 0x49, 0x02,
+			0x86, 0x00};
+	struct sc_apdu apdu;
+	u8 rbuf[256];
+	const u8 *outer, *point;
+	size_t outer_len, point_len;
+	int r;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0xCB, 0x00, 0xFF);
+	apdu.data = req;
+	apdu.datalen = apdu.lc = sizeof(req);
+	apdu.resp = rbuf;
+	apdu.resplen = apdu.le = sizeof(rbuf);
+
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+
+	if (apdu.sw1 != 0x90 || apdu.sw2 != 0x00) {
+		/* No such reference key on this applet -- older/non-FIPS card,
+		 * nothing changes for it. */
+		sc_log(card->ctx, "No ECC Mutual Authentication reference key found (SW=%02X%02X)",
+				apdu.sw1, apdu.sw2);
+		return SC_SUCCESS;
+	}
+
+	outer = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x7F49, &outer_len);
+	if (outer == NULL) {
+		sc_log(card->ctx, "Unexpected GET DATA response, missing 7F49 template");
+		return SC_SUCCESS;
+	}
+	point = sc_asn1_find_tag(card->ctx, outer, outer_len, 0x86, &point_len);
+	if (point == NULL) {
+		sc_log(card->ctx, "Unexpected GET DATA response, missing public point");
+		return SC_SUCCESS;
+	}
+
+	priv->ma_point_len = (unsigned int)point_len;
+	/* The proprietary driver defaults to AES-128 session keys and only
+	 * upgrades to AES-256 for specific newer applet versions (major==4,
+	 * minor>4 and odd -- see idp_getEccMAKeys()). This driver doesn't parse
+	 * the applet version into that form yet, so default to AES-128. */
+	priv->sm_key_len = 16;
+
+	sc_log(card->ctx, "Card exposes an ECC Mutual Authentication reference key "
+			  "(%" SC_FORMAT_LEN_SIZE_T "u-byte point)",
+			point_len);
+
+	return SC_SUCCESS;
+}
+
+/*
+ * Mirrors idp_getAppletFipsConfig()/idp_getAppletSpecificParams(): a plain
+ * GET DATA (INS 0xCA, P1=0xDF P2=0x0A) returns a 6-byte application
+ * parameters block under tag 0xDF0A; byte 5 (app_opt) encodes the FIPS mode.
+ * Best-effort: older applets simply don't support this tag, which just
+ * leaves priv->is_fips/fips_identify at their default (not FIPS).
+ */
+static void
+idprime_get_applet_fips_config(sc_card_t *card, idprime_private_data_t *priv)
+{
+	struct sc_apdu apdu;
+	u8 rbuf[16];
+	const u8 *params;
+	size_t params_len;
+	u8 app_opt;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xCA, 0xDF, 0x0A);
+	apdu.resp = rbuf;
+	apdu.resplen = apdu.le = sizeof(rbuf);
+
+	if (sc_transmit_apdu(card, &apdu) != SC_SUCCESS || apdu.sw1 != 0x90 || apdu.sw2 != 0x00) {
+		return;
+	}
+
+	params = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0xDF0A, &params_len);
+	if (params == NULL || params_len < 6) {
+		sc_log(card->ctx, "Unexpected applet params response, missing DF0A template");
+		return;
+	}
+
+	app_opt = params[5];
+	if ((app_opt & 6) == 4) {
+		priv->is_fips = 1;
+		priv->fips_identify = 2;
+	} else if ((app_opt & 6) == 6) {
+		priv->is_fips = 1;
+		priv->fips_identify = 3;
+	}
+	sc_log(card->ctx, "applet app_opt=0x%02X -> is_fips=%d fips_identify=%d",
+			app_opt, priv->is_fips, priv->fips_identify);
+}
+
+/* True if the given short path selects successfully, i.e. the file exists. */
+static int
+idprime_file_exists(sc_card_t *card, const char *path)
+{
+	return idprime_select_file_by_path(card, path) >= 0;
+}
+
+/*
+ * Mirrors idp_GetSMACInfo(): reads 32 bytes starting at offset 0 from
+ * DF 0011 -- verified against a live capture of the proprietary driver
+ * (idp_READ_BIN(tolerantSM=1, offset=0x0, size=0x20)). That file id -- like
+ * DF 0010 used by idprime_get_ecc_full_sm() below -- was identified
+ * empirically from a captured proprietary-driver trace
+ * (idp_SELECT_FILE_BY_PATH(path=(11)/(10)) resolving directly to file ids
+ * 0x0011/0x0010); they don't follow the "02xx"/"01xx" naming used elsewhere
+ * in this driver.
+ *
+ * A missing file is not an error -- it's treated the same way the
+ * proprietary driver treats E_FILE_NOT_FOUND here, as all-zero info.
+ */
+static void
+idprime_get_sm_ac_info(sc_card_t *card, u8 *info_byte)
+{
+	u8 buf[32];
+	int r;
+
+	*info_byte = 0;
+
+	if (idprime_select_file_by_path(card, "0011") < 0) {
+		return;
+	}
+	r = iso_ops->read_binary(card, 0, buf, sizeof(buf), 0);
+	if (r < 1) {
+		return;
+	}
+	*info_byte = buf[0];
+}
+
+/*
+ * Mirrors idp_getECCFullSM(): decide whether *every* APDU must be SM-wrapped
+ * once ECC Mutual Authentication is available, using the on-card SMAC-info
+ * file (DF 0011) combined with the "CTL" file (DF 0010) presence check
+ * (idp_CheckCTL()). Client-side config overrides (MutualAuthType/FullSMMode
+ * in eToken.conf) are intentionally not reproduced here -- this always
+ * follows the on-card indication, which is what actually applies to the FIPS
+ * card this was reverse engineered against.
+ */
+static void
+idprime_get_ecc_full_sm(sc_card_t *card, idprime_private_data_t *priv)
+{
+	u8 info = 0;
+	int ctl;
+
+	idprime_get_sm_ac_info(card, &info);
+	ctl = idprime_file_exists(card, "0010");
+
+	if ((info & 0x0F) == 0) {
+		priv->full_sm = ((info & 0xF0) != 0) && ctl;
+	} else {
+		priv->full_sm = ctl ? ((info & 0xF0) != 0) : 1;
+	}
+
+	sc_log(card->ctx, "SMAC info=0x%02X ctl=%d -> full_sm=%d", info, ctl, priv->full_sm);
+}
+
+#if defined(ENABLE_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+
+static const char *
+idprime_ecc_ma_curve_name(unsigned int point_len)
+{
+	switch (point_len) {
+	case 65:
+		return "prime256v1";
+	case 97:
+		return "secp384r1";
+	case 133:
+		return "secp521r1";
+	default:
+		return NULL;
+	}
+}
+
+/*
+ * Static P-256 terminal identity, extracted from libIDPrimeTokenEngine.so's
+ * idp_getEccMAKeys() (see ETOKEN_FIPS_SM_NOTES.md section 7): a CV
+ * certificate and its corresponding ECDSA private key, both baked
+ * identically into every install of the proprietary driver (confirmed by
+ * the placeholder-looking CHR/terminal-ID 0123456789abcdef). Verified by
+ * checking d*G reproduces the certificate's public key exactly.
+ *
+ * Only the P-256 variant has been extracted so far -- P-384/P-521 cards
+ * (97/133-byte MA point) are not supported by the code below yet.
+ */
+static const u8 idprime_p256_ma_cert[205] = {
+		0x7f,
+		0x21,
+		0x81,
+		0xc9,
+		0x7f,
+		0x4e,
+		0x81,
+		0x82,
+		0x5f,
+		0x29,
+		0x01,
+		0x70,
+		0x42,
+		0x08,
+		0x46,
+		0x52,
+		0x47,
+		0x54,
+		0x4f,
+		0x00,
+		0x02,
+		0x02,
+		0x5f,
+		0x20,
+		0x0c,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x01,
+		0x23,
+		0x45,
+		0x67,
+		0x89,
+		0xab,
+		0xcd,
+		0xef,
+		0x5f,
+		0x4c,
+		0x07,
+		0xa0,
+		0x00,
+		0x00,
+		0x00,
+		0x18,
+		0x40,
+		0x01,
+		0x06,
+		0x09,
+		0x2b,
+		0x81,
+		0x22,
+		0xf4,
+		0x2a,
+		0x02,
+		0x04,
+		0x04,
+		0x04,
+		0x7f,
+		0x49,
+		0x4d,
+		0x06,
+		0x08,
+		0x2a,
+		0x86,
+		0x48,
+		0xce,
+		0x3d,
+		0x03,
+		0x01,
+		0x07,
+		0x86,
+		0x41,
+		0x04,
+		0x30,
+		0xe5,
+		0x5f,
+		0xe8,
+		0xf8,
+		0x56,
+		0xda,
+		0x1c,
+		0x72,
+		0xfe,
+		0x3a,
+		0xb1,
+		0x29,
+		0x10,
+		0x86,
+		0x8d,
+		0xee,
+		0x76,
+		0x73,
+		0xf6,
+		0xcb,
+		0x12,
+		0xa9,
+		0xd3,
+		0x2b,
+		0xe9,
+		0xbb,
+		0x86,
+		0x83,
+		0xd3,
+		0x7e,
+		0xff,
+		0xb7,
+		0x39,
+		0x92,
+		0x9a,
+		0x34,
+		0xa8,
+		0x9a,
+		0xdc,
+		0x25,
+		0x5f,
+		0x5a,
+		0xd2,
+		0xe0,
+		0xb0,
+		0x7f,
+		0xc0,
+		0xf9,
+		0x5e,
+		0x7c,
+		0xd8,
+		0x52,
+		0x5b,
+		0x20,
+		0x43,
+		0xef,
+		0xb5,
+		0x0c,
+		0x9b,
+		0x78,
+		0x8e,
+		0x79,
+		0x59,
+		0x5f,
+		0x37,
+		0x40,
+		0x4d,
+		0xce,
+		0xfe,
+		0x61,
+		0x35,
+		0xfa,
+		0x5a,
+		0xa3,
+		0xa8,
+		0x8d,
+		0xae,
+		0x25,
+		0x3d,
+		0x6f,
+		0x07,
+		0x09,
+		0x1e,
+		0x6d,
+		0x98,
+		0x5e,
+		0x28,
+		0xc8,
+		0xc3,
+		0x22,
+		0x74,
+		0x21,
+		0x9e,
+		0xa5,
+		0x84,
+		0xaf,
+		0xf5,
+		0x81,
+		0xef,
+		0x01,
+		0x0f,
+		0x1b,
+		0x53,
+		0x6f,
+		0xb1,
+		0x86,
+		0x25,
+		0x2e,
+		0xe8,
+		0x1f,
+		0x04,
+		0x3a,
+		0xa6,
+		0x33,
+		0x92,
+		0x62,
+		0x7e,
+		0xe8,
+		0x96,
+		0x88,
+		0x36,
+		0xd5,
+		0xd7,
+		0x11,
+		0x14,
+		0x6e,
+		0x86,
+		0xa0,
+		0xda,
+		0xb4,
+};
+
+static const u8 idprime_p256_ma_privkey_d[32] = {
+		0x50,
+		0x75,
+		0xa8,
+		0xf6,
+		0x68,
+		0xeb,
+		0x12,
+		0xa0,
+		0xde,
+		0x9e,
+		0x0e,
+		0x30,
+		0x59,
+		0x3b,
+		0x44,
+		0x82,
+		0x90,
+		0x14,
+		0x26,
+		0x7b,
+		0xe8,
+		0x33,
+		0x30,
+		0xf4,
+		0x64,
+		0xb3,
+		0x00,
+		0xf1,
+		0x17,
+		0x7b,
+		0xef,
+		0xba,
+};
+
+static const u8 idprime_p256_ma_terminal_id[8] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
+
+/*
+ * NIST P-256 domain parameters (p || a || b || G-uncompressed || n, 193
+ * bytes), hashed as part of the EXTERNAL AUTHENTICATE signature input
+ * below. These are the well-known, public curve constants -- not anything
+ * card- or session-specific.
+ */
+static const u8 idprime_p256_domain_params[193] = {
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0x00,
+		0x00,
+		0x00,
+		0x01,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0x00,
+		0x00,
+		0x00,
+		0x01,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xfc,
+		0x5a,
+		0xc6,
+		0x35,
+		0xd8,
+		0xaa,
+		0x3a,
+		0x93,
+		0xe7,
+		0xb3,
+		0xeb,
+		0xbd,
+		0x55,
+		0x76,
+		0x98,
+		0x86,
+		0xbc,
+		0x65,
+		0x1d,
+		0x06,
+		0xb0,
+		0xcc,
+		0x53,
+		0xb0,
+		0xf6,
+		0x3b,
+		0xce,
+		0x3c,
+		0x3e,
+		0x27,
+		0xd2,
+		0x60,
+		0x4b,
+		0x04,
+		0x6b,
+		0x17,
+		0xd1,
+		0xf2,
+		0xe1,
+		0x2c,
+		0x42,
+		0x47,
+		0xf8,
+		0xbc,
+		0xe6,
+		0xe5,
+		0x63,
+		0xa4,
+		0x40,
+		0xf2,
+		0x77,
+		0x03,
+		0x7d,
+		0x81,
+		0x2d,
+		0xeb,
+		0x33,
+		0xa0,
+		0xf4,
+		0xa1,
+		0x39,
+		0x45,
+		0xd8,
+		0x98,
+		0xc2,
+		0x96,
+		0x4f,
+		0xe3,
+		0x42,
+		0xe2,
+		0xfe,
+		0x1a,
+		0x7f,
+		0x9b,
+		0x8e,
+		0xe7,
+		0xeb,
+		0x4a,
+		0x7c,
+		0x0f,
+		0x9e,
+		0x16,
+		0x2b,
+		0xce,
+		0x33,
+		0x57,
+		0x6b,
+		0x31,
+		0x5e,
+		0xce,
+		0xcb,
+		0xb6,
+		0x40,
+		0x68,
+		0x37,
+		0xbf,
+		0x51,
+		0xf5,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xbc,
+		0xe6,
+		0xfa,
+		0xad,
+		0xa7,
+		0x17,
+		0x9e,
+		0x84,
+		0xf3,
+		0xb9,
+		0xca,
+		0xc2,
+		0xfc,
+		0x63,
+		0x25,
+		0x51,
+};
+
+/*
+ * Performs the EC key-agreement half of the proprietary "MA" (Mutual
+ * Authentication) handshake: generates an ephemeral EC keypair on the same
+ * curve as the card's MA reference key (see idprime_probe_ecc_ma() above),
+ * exchanges public points with the card via MSE:SET AT + GENERAL
+ * AUTHENTICATE, and computes the raw ECDH shared secret Z. See
+ * ETOKEN_FIPS_SM_NOTES.md section 3.1 for the reverse-engineered protocol
+ * this implements.
+ *
+ * IMPORTANT: this is only HALF of the handshake. The proprietary driver
+ * immediately follows this key agreement with a certificate-based mutual
+ * authentication (PSO:VERIFY CERTIFICATE / EXTERNAL AUTHENTICATE /
+ * GET CHALLENGE / INTERNAL AUTHENTICATE) that is NOT implemented here.
+ * Without it, a raw ECDH exchange like this one has no protection against a
+ * man in the middle -- callers MUST NOT start Secure Messaging (i.e. call
+ * idprime_sm_start()) with the Z this returns.
+ */
+static int
+idprime_ecc_ma_key_agreement(sc_card_t *card, idprime_private_data_t *priv,
+		u8 **z_out, size_t *zlen_out,
+		u8 host_x_out[32], u8 card_x_out[32])
+{
+	static const u8 mse_set_at_data[] = {0x80, 0x01, 0x4F, 0x83, 0x01, 0x03};
+	const char *curve_name;
+	struct sc_apdu apdu;
+	u8 apdu_data[256];
+	u8 rbuf[256];
+	int apdu_data_len;
+	int r;
+
+	EVP_PKEY_CTX *eph_ctx = NULL, *peer_ctx = NULL, *z_ctx = NULL;
+	EVP_PKEY *eph_pkey = NULL, *peer_pkey = NULL;
+	OSSL_PARAM eph_params[3], peer_params[3];
+	u8 *host_point = NULL;
+	size_t host_point_len = 0;
+	const u8 *card_point = NULL;
+	size_t card_point_len = 0;
+	u8 *z = NULL;
+	size_t zlen = 0;
+
+	curve_name = idprime_ecc_ma_curve_name(priv->ma_point_len);
+	if (!curve_name) {
+		sc_log(card->ctx, "Unsupported MA reference key point length %u", priv->ma_point_len);
+		return SC_ERROR_NOT_SUPPORTED;
+	}
+
+	/* MSE:SET AT -- algorithm ref 0x4F, key ref 3 */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xA4);
+	apdu.data = mse_set_at_data;
+	apdu.datalen = apdu.lc = sizeof(mse_set_at_data);
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, r, "MSE:SET AT failed");
+
+	/* Generate our ephemeral EC keypair on the card's MA curve */
+	eph_params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, (char *)curve_name, 0);
+	eph_params[1] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT,
+			"uncompressed", 0);
+	eph_params[2] = OSSL_PARAM_construct_end();
+
+	eph_ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+	if (!eph_ctx || !EVP_PKEY_keygen_init(eph_ctx) ||
+			!EVP_PKEY_CTX_set_params(eph_ctx, eph_params) ||
+			!EVP_PKEY_generate(eph_ctx, &eph_pkey) ||
+			!(host_point_len = EVP_PKEY_get1_encoded_public_key(eph_pkey, &host_point)) ||
+			host_point_len != priv->ma_point_len) {
+		sc_log_openssl(card->ctx);
+		sc_log(card->ctx, "OpenSSL failed to create ephemeral EC key");
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
+
+	apdu_data_len = idprime_sm_encode_general_authenticate(host_point, host_point_len,
+			apdu_data, sizeof(apdu_data));
+	if (apdu_data_len < 0) {
+		r = apdu_data_len;
+		goto err;
+	}
+
+	/* GENERAL AUTHENTICATE: send our point, the card returns its own
+	 * ephemeral point in the response to this same command. */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0x86, 0x00, 0x00);
+	apdu.data = apdu_data;
+	apdu.datalen = apdu.lc = (size_t)apdu_data_len;
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rbuf);
+	apdu.le = sizeof(rbuf);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r != SC_SUCCESS)
+		goto err;
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS)
+		goto err;
+
+	r = idprime_sm_decode_general_authenticate(card->ctx, apdu.resp, apdu.resplen,
+			&card_point, &card_point_len);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "Unexpected GENERAL AUTHENTICATE response");
+		goto err;
+	}
+
+	/* Wrap the card's raw point into an EVP_PKEY to derive against */
+	peer_params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, (char *)curve_name, 0);
+	peer_params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+			(void *)card_point, card_point_len);
+	peer_params[2] = OSSL_PARAM_construct_end();
+
+	peer_ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+	if (!peer_ctx || !EVP_PKEY_fromdata_init(peer_ctx) ||
+			!EVP_PKEY_fromdata(peer_ctx, &peer_pkey, EVP_PKEY_PUBLIC_KEY, peer_params)) {
+		sc_log_openssl(card->ctx);
+		sc_log(card->ctx, "OpenSSL failed to import card's ephemeral EC point");
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
+
+	/* Compute the raw ECDH shared secret Z */
+	z_ctx = EVP_PKEY_CTX_new(eph_pkey, NULL);
+	if (!z_ctx || EVP_PKEY_derive_init(z_ctx) <= 0 ||
+			EVP_PKEY_derive_set_peer(z_ctx, peer_pkey) <= 0 ||
+			EVP_PKEY_derive(z_ctx, NULL, &zlen) <= 0 ||
+			(z = malloc(zlen)) == NULL ||
+			EVP_PKEY_derive(z_ctx, z, &zlen) <= 0) {
+		sc_log_openssl(card->ctx);
+		sc_log(card->ctx, "OpenSSL failed to derive the ECDH shared secret");
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
+
+	/* Stash the X-coordinates (needed for the mutual-authentication
+	 * signature below) before the point buffers get freed. Only
+	 * meaningful for the P-256 case (32-byte X); callers must check
+	 * priv->ma_point_len == 65 before relying on these. */
+	if (host_x_out && host_point_len >= 33)
+		memcpy(host_x_out, host_point + 1, 32);
+	if (card_x_out && card_point_len >= 33)
+		memcpy(card_x_out, card_point + 1, 32);
+
+	*z_out = z;
+	*zlen_out = zlen;
+	z = NULL;
+	r = SC_SUCCESS;
+
+err:
+	if (z) {
+		sc_mem_clear(z, zlen);
+		free(z);
+	}
+	OPENSSL_free(host_point);
+	EVP_PKEY_CTX_free(eph_ctx);
+	EVP_PKEY_CTX_free(peer_ctx);
+	EVP_PKEY_CTX_free(z_ctx);
+	EVP_PKEY_free(eph_pkey);
+	EVP_PKEY_free(peer_pkey);
+	return r;
+}
+
+/*
+ * Signs a 32-byte digest with the embedded P-256 MA private key
+ * (idprime_p256_ma_privkey_d), producing a raw fixed-length r||s signature
+ * (64 bytes) as required by EXTERNAL AUTHENTICATE.
+ */
+static int
+idprime_ecc_ma_sign_digest(sc_context_t *ctx, const u8 digest[32], u8 sig_out[64])
+{
+	EVP_PKEY_CTX *keyctx = NULL;
+	EVP_PKEY *pkey = NULL;
+	OSSL_PARAM params[3];
+	BIGNUM *d_bn = NULL;
+	u8 priv_native[32];
+	u8 *der_sig = NULL;
+	size_t der_sig_len = 0;
+	const unsigned char *p;
+	ECDSA_SIG *ecdsa_sig = NULL;
+	const BIGNUM *sig_r = NULL, *sig_s = NULL;
+	int ret = SC_ERROR_INTERNAL;
+
+	d_bn = BN_bin2bn(idprime_p256_ma_privkey_d, sizeof(idprime_p256_ma_privkey_d), NULL);
+	if (!d_bn || !BN_bn2nativepad(d_bn, priv_native, sizeof(priv_native))) {
+		sc_log_openssl(ctx);
+		goto err;
+	}
+
+	params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, (char *)"prime256v1", 0);
+	params[1] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY, priv_native, sizeof(priv_native));
+	params[2] = OSSL_PARAM_construct_end();
+
+	keyctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+	if (!keyctx || !EVP_PKEY_fromdata_init(keyctx) ||
+			!EVP_PKEY_fromdata(keyctx, &pkey, EVP_PKEY_KEYPAIR, params)) {
+		sc_log_openssl(ctx);
+		goto err;
+	}
+	EVP_PKEY_CTX_free(keyctx);
+
+	keyctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+	if (!keyctx || EVP_PKEY_sign_init(keyctx) <= 0 ||
+			EVP_PKEY_sign(keyctx, NULL, &der_sig_len, digest, 32) <= 0 ||
+			(der_sig = malloc(der_sig_len)) == NULL ||
+			EVP_PKEY_sign(keyctx, der_sig, &der_sig_len, digest, 32) <= 0) {
+		sc_log_openssl(ctx);
+		goto err;
+	}
+
+	p = der_sig;
+	ecdsa_sig = d2i_ECDSA_SIG(NULL, &p, (long)der_sig_len);
+	if (!ecdsa_sig) {
+		sc_log_openssl(ctx);
+		goto err;
+	}
+	ECDSA_SIG_get0(ecdsa_sig, &sig_r, &sig_s);
+	memset(sig_out, 0, 64);
+	if (!BN_bn2binpad(sig_r, sig_out, 32) || !BN_bn2binpad(sig_s, sig_out + 32, 32)) {
+		sc_log_openssl(ctx);
+		goto err;
+	}
+
+	ret = SC_SUCCESS;
+err:
+	if (d_bn)
+		BN_clear_free(d_bn);
+	sc_mem_clear(priv_native, sizeof(priv_native));
+	free(der_sig);
+	if (ecdsa_sig)
+		ECDSA_SIG_free(ecdsa_sig);
+	EVP_PKEY_CTX_free(keyctx);
+	EVP_PKEY_free(pkey);
+	return ret;
+}
+
+/*
+ * Completes the proprietary "MA" mutual-authentication handshake on top of
+ * an already-agreed ECDH shared secret: activates Secure Messaging, sends
+ * the embedded terminal certificate (PSO:VERIFY CERTIFICATE), proves
+ * possession of the corresponding private key (EXTERNAL AUTHENTICATE,
+ * signature construction verified byte-for-byte via live dynamic
+ * instrumentation -- see ETOKEN_FIPS_SM_NOTES.md), and completes the
+ * card->terminal direction (INTERNAL AUTHENTICATE) WITHOUT verifying the
+ * card's response signature: this driver has no Gemalto CVCA root to check
+ * it against, so the resulting channel is authenticated in the
+ * terminal->card direction only. That is a known, documented limitation,
+ * not an oversight.
+ *
+ * Only implemented for the P-256 case (priv->ma_point_len == 65); other
+ * curves aren't supported since the certificate/private key were only
+ * extracted for P-256.
+ *
+ * On success, Secure Messaging (card->sm_ctx) is left ACTIVE so the caller
+ * can proceed with normal file access, transparently SM-wrapped from here
+ * on. On failure, any partially-started SM is torn back down.
+ */
+static int
+idprime_ecc_ma_mutual_auth(sc_card_t *card, idprime_private_data_t *priv)
+{
+	/* SSC starts at 1 (not 0): verified via live gdb hook of the SSC-increment
+	 * helper (see ETOKEN_FIPS_SM_NOTES.md section 9.5) -- its first call (our
+	 * idprime_sm_pre_transmit(), before the very first SM-wrapped command)
+	 * returns 2, meaning the pre-call value was already 1. */
+	static const u8 ssc_init[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+	static const u8 mse_cert_verify_data[] = {0x83, 0x01, 0x01, 0x95, 0x01, 0x80};
+	static const u8 mse_int_auth_data[] = {0x84, 0x01, 0x02, 0x95, 0x01, 0x80};
+	u8 mse_ext_auth_data[3 + sizeof(idprime_p256_ma_terminal_id) + 3];
+	/* zero-initialized: idprime_ecc_ma_key_agreement() only fills these
+	 * conditionally (host_point_len/card_point_len >= 33), which GCC can't
+	 * prove always holds here even though callers only reach this point
+	 * after confirming priv->ma_point_len == 65, causing a false-positive
+	 * -Wmaybe-uninitialized under LTO. */
+	u8 host_x[32] = {0}, card_x[32] = {0};
+	u8 *z = NULL;
+	size_t zlen = 0;
+	struct sc_apdu apdu;
+	u8 rbuf[256];
+	u8 hash_input[sizeof(host_x) + sizeof(idprime_p256_ma_terminal_id) + 8 +
+			sizeof(card_x) + sizeof(idprime_p256_domain_params)];
+	u8 digest[32];
+	u8 sig[64];
+	u8 rnd_icc[8];
+	u8 ext_auth_data[sizeof(idprime_p256_ma_terminal_id) + 64];
+	u8 rnd_ifd[8];
+	u8 int_auth_resp[128];
+	u8 check_applet_resp[32];
+	size_t off;
+	int r;
+
+	if (priv->ma_point_len != 65) {
+		sc_log(card->ctx, "Mutual authentication only implemented for P-256 MA keys");
+		return SC_ERROR_NOT_SUPPORTED;
+	}
+
+	r = idprime_ecc_ma_key_agreement(card, priv, &z, &zlen, host_x, card_x);
+	if (r != SC_SUCCESS)
+		return r;
+
+	r = idprime_sm_start(card, z, zlen, priv->sm_key_len, ssc_init);
+	sc_mem_clear(z, zlen);
+	free(z);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "Failed to start Secure Messaging: %s", sc_strerror(r));
+		return r;
+	}
+
+	/* MSE:SET AT for digital signature / certificate verification */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xB6);
+	apdu.data = mse_cert_verify_data;
+	apdu.datalen = apdu.lc = sizeof(mse_cert_verify_data);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "MSE:SET AT (cert verify) failed: %s", sc_strerror(r));
+		goto err;
+	}
+
+	/* PSO: VERIFY CERTIFICATE */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x2A, 0x00, 0xBE);
+	apdu.data = idprime_p256_ma_cert;
+	apdu.datalen = apdu.lc = sizeof(idprime_p256_ma_cert);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "PSO:VERIFY CERTIFICATE failed: %s", sc_strerror(r));
+		goto err;
+	}
+
+	/* MSE:SET AT for EXTERNAL AUTHENTICATE, carrying our terminal ID (CHR) */
+	off = 0;
+	mse_ext_auth_data[off++] = 0x83;
+	mse_ext_auth_data[off++] = sizeof(idprime_p256_ma_terminal_id);
+	memcpy(mse_ext_auth_data + off, idprime_p256_ma_terminal_id, sizeof(idprime_p256_ma_terminal_id));
+	off += sizeof(idprime_p256_ma_terminal_id);
+	mse_ext_auth_data[off++] = 0x95;
+	mse_ext_auth_data[off++] = 0x01;
+	mse_ext_auth_data[off++] = 0x80;
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xA4);
+	apdu.data = mse_ext_auth_data;
+	apdu.datalen = apdu.lc = off;
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "MSE:SET AT (external auth) failed: %s", sc_strerror(r));
+		goto err;
+	}
+
+	/* GET CHALLENGE for RND.ICC. Empirically the proprietary driver uses
+	 * CLA 0x80 here (0x8C once SM-wrapped) instead of the usual 0x00
+	 * (0x0C wrapped) elsewhere -- reason unknown, but verified against a
+	 * live capture, so replicated as-is. */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0x84, 0x00, 0x00);
+	apdu.cla = 0x80;
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rnd_icc);
+	apdu.le = sizeof(rnd_icc);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS || apdu.resplen != sizeof(rnd_icc)) {
+		sc_log(card->ctx, "GET CHALLENGE failed: %s", sc_strerror(r));
+		if (r == SC_SUCCESS)
+			r = SC_ERROR_WRONG_LENGTH;
+		goto err;
+	}
+	memcpy(rnd_icc, rbuf, sizeof(rnd_icc));
+
+	/* Build and sign the EXTERNAL AUTHENTICATE digest:
+	 *   SHA256(hostX || terminalID || RND.ICC || cardX || domainParams)
+	 * Verified via live signature verification against the card's own
+	 * public key -- see ETOKEN_FIPS_SM_NOTES.md section 7. */
+	off = 0;
+	memcpy(hash_input + off, host_x, sizeof(host_x));
+	off += sizeof(host_x);
+	memcpy(hash_input + off, idprime_p256_ma_terminal_id, sizeof(idprime_p256_ma_terminal_id));
+	off += sizeof(idprime_p256_ma_terminal_id);
+	memcpy(hash_input + off, rnd_icc, sizeof(rnd_icc));
+	off += sizeof(rnd_icc);
+	memcpy(hash_input + off, card_x, sizeof(card_x));
+	off += sizeof(card_x);
+	memcpy(hash_input + off, idprime_p256_domain_params, sizeof(idprime_p256_domain_params));
+	off += sizeof(idprime_p256_domain_params);
+	SHA256(hash_input, off, digest);
+
+	r = idprime_ecc_ma_sign_digest(card->ctx, digest, sig);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "Failed to sign EXTERNAL AUTHENTICATE digest");
+		goto err;
+	}
+
+	memcpy(ext_auth_data, idprime_p256_ma_terminal_id, sizeof(idprime_p256_ma_terminal_id));
+	memcpy(ext_auth_data + sizeof(idprime_p256_ma_terminal_id), sig, sizeof(sig));
+
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x82, 0x00, 0x00);
+	apdu.data = ext_auth_data;
+	apdu.datalen = apdu.lc = sizeof(ext_auth_data);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "EXTERNAL AUTHENTICATE failed: %s", sc_strerror(r));
+		goto err;
+	}
+	sc_log(card->ctx, "EXTERNAL AUTHENTICATE succeeded -- terminal authenticated to the card");
+
+	/* MSE:SET AT for INTERNAL AUTHENTICATE, selecting the card's own MA
+	 * key (key reference 2, the same one probed in idprime_probe_ecc_ma()) */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x22, 0x41, 0xA4);
+	apdu.data = mse_int_auth_data;
+	apdu.datalen = apdu.lc = sizeof(mse_int_auth_data);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "MSE:SET AT (internal auth) failed: %s", sc_strerror(r));
+		goto err;
+	}
+
+	/* INTERNAL AUTHENTICATE: challenge the card with our own random
+	 * RND.IFD. The card's response (its own signature, proving it holds
+	 * the card-side MA private key) is deliberately NOT verified -- see
+	 * the function comment above. */
+	if (RAND_bytes(rnd_ifd, sizeof(rnd_ifd)) != 1) {
+		sc_log_openssl(card->ctx);
+		r = SC_ERROR_INTERNAL;
+		goto err;
+	}
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_4, 0x88, 0x00, 0x00);
+	apdu.data = rnd_ifd;
+	apdu.datalen = apdu.lc = sizeof(rnd_ifd);
+	apdu.resp = int_auth_resp;
+	apdu.resplen = sizeof(int_auth_resp);
+	apdu.le = sizeof(int_auth_resp);
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "INTERNAL AUTHENTICATE failed: %s", sc_strerror(r));
+		goto err;
+	}
+	sc_log(card->ctx, "INTERNAL AUTHENTICATE succeeded (card responded, signature not verified) "
+			  "-- Secure Messaging established");
+
+	/* The handshake messages above use a trivial small-integer SSC (starting
+	 * at 1). Right as the handshake completes, the real driver switches to a
+	 * fresh SSC seeded from RND.ICC||RND.IFD for every command from here on
+	 * -- confirmed via live gdb hook of SM_AES_MAC's raw SSC argument
+	 * against the real driver, see ETOKEN_FIPS_SM_NOTES.md. Skipping this
+	 * desyncs the SSC starting with the very next command. */
+	r = idprime_sm_reseed_ssc(card, rnd_icc, rnd_ifd);
+	if (r != SC_SUCCESS)
+		goto err;
+
+	/* Mirrors idp_checkAppletEx(renew=0), which the real driver always
+	 * performs as the last step of idp_openSM_ECC_MAV() before returning.
+	 * This isn't optional bookkeeping: every SM-protected APDU advances the
+	 * card's SSC, so skipping this command here would leave our SSC one
+	 * full round trip behind the card's, and every subsequent SM command
+	 * would then fail MAC verification. The response (a proprietary status
+	 * blob followed by the applet AID) isn't otherwise used. */
+	sc_format_apdu(card, &apdu, SC_APDU_CASE_2, 0xA6, 0x00, 0x00);
+	apdu.resp = check_applet_resp;
+	apdu.resplen = sizeof(check_applet_resp);
+	/* The card is strict about this Le value (like GET CHALLENGE above) --
+	 * it must be exactly 0x15/21, matching every captured real session. */
+	apdu.le = 0x15;
+	r = sc_transmit_apdu(card, &apdu);
+	if (r == SC_SUCCESS)
+		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	if (r != SC_SUCCESS) {
+		sc_log(card->ctx, "Post-authentication applet check failed: %s", sc_strerror(r));
+		goto err;
+	}
+
+	/* We're now sitting authenticated inside the IDPrime AID; the card
+	 * rejects a redundant re-select of it, see idprime_select_idprime(). */
+	priv->sm_authenticated = 1;
+
+	return SC_SUCCESS;
+
+err:
+	sc_sm_stop(card);
+	return r;
+}
+
+#endif /* defined(ENABLE_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x30000000L */
+
 static int idprime_init(sc_card_t *card)
 {
 	int r;
@@ -615,6 +1903,46 @@ static int idprime_init(sc_card_t *card)
 	if (!priv) {
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_OUT_OF_MEMORY);
 	}
+	/* Assigned early (rather than at the end of this function, as before)
+	 * so that idprime_select_idprime() can reach priv->sm_authenticated
+	 * via card->drv_data while the rest of idprime_init() below is still
+	 * running. Safe on any early failure return in this function: init()
+	 * failing means sc_connect_card() calls sc_card_free() rather than
+	 * card->ops->finish(), and sc_card_free() never touches drv_data. */
+	card->drv_data = priv;
+
+	/* Detect whether this applet requires the proprietary EC-based Mutual
+	 * Authentication / Secure Messaging channel. Cards without the MA
+	 * reference key are driven exactly as before. Cards that have it get
+	 * their idp_maType/idp_isFIPS/idp_isFullSM state mirrored into priv;
+	 * cards that require full SM go through the mutual-authentication
+	 * handshake so the rest of this function (container map, index file,
+	 * etc.) can proceed transparently over the now-active SM channel. */
+	r = idprime_probe_ecc_ma(card, priv);
+	if (r != SC_SUCCESS) {
+		idprime_free_private_data(priv);
+		LOG_FUNC_RETURN(card->ctx, r);
+	}
+	if (priv->ma_point_len > 0) {
+		idprime_get_applet_fips_config(card, priv);
+		idprime_get_ecc_full_sm(card, priv);
+		if (priv->full_sm) {
+			sc_log(card->ctx, "Card requires full Secure Messaging (is_fips=%d fips_identify=%d "
+					  "sm_key_len=%u) -- performing mutual authentication",
+					priv->is_fips,
+					priv->fips_identify, priv->sm_key_len);
+#if defined(ENABLE_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+			r = idprime_ecc_ma_mutual_auth(card, priv);
+#else
+			r = SC_ERROR_NOT_SUPPORTED;
+#endif
+			if (r != SC_SUCCESS) {
+				sc_log(card->ctx, "Mutual authentication failed: %s", sc_strerror(r));
+				idprime_free_private_data(priv);
+				LOG_FUNC_RETURN(card->ctx, r);
+			}
+		}
+	}
 
 	/* Select and process container file */
 	r = idprime_select_file_by_path(card, "0204");;
@@ -663,8 +1991,6 @@ static int idprime_init(sc_card_t *card)
 		idprime_free_private_data(priv);
 		LOG_FUNC_RETURN(card->ctx, r);
 	}
-
-	card->drv_data = priv;
 
 	switch (card->type) {
 	case SC_CARD_TYPE_IDPRIME_3810:

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -920,6 +920,19 @@ iso7816_get_response(struct sc_card *card, size_t *count, u8 *buf)
 	apdu.resp    = buf;
 	/* don't call GET RESPONSE recursively */
 	apdu.flags  |= SC_APDU_FLAGS_NO_GET_RESP;
+	/* GET RESPONSE fetches the leftover tail bytes of a response that's
+	 * already in flight (e.g. after SW=61xx) -- it isn't a new logical
+	 * command and must not get its own SM envelope on top of whatever
+	 * command it's completing, matching how real SM-capable cards expect
+	 * it (confirmed against a captured proprietary Gemalto/IDPrime driver
+	 * session, which always sends GET RESPONSE unprotected even mid an
+	 * active SM session). Without this, once SM is active any response
+	 * too big for a single short-form transfer (e.g. an RSA-2048
+	 * signature) fails: the GET RESPONSE APDU built here would otherwise
+	 * get SM-wrapped by sc_transmit_apdu(), the card would reject/not
+	 * understand that framing, and the SM layer would then fail trying to
+	 * decrypt a reply that was never SM-protected to begin with. */
+	apdu.flags |= SC_APDU_FLAGS_NO_SM;
 
 	r = sc_transmit_apdu(card, &apdu);
 	LOG_TEST_RET(card->ctx, r, "APDU transmit failed");

--- a/src/minidriver/Makefile.mak
+++ b/src/minidriver/Makefile.mak
@@ -10,6 +10,7 @@ LIBS = $(TOPDIR)\src\libopensc\opensc_a.lib \
 	   $(TOPDIR)\src\ui\notify.lib \
 	   $(TOPDIR)\src\sm\libsmiso.lib \
 	   $(TOPDIR)\src\sm\libsmeac.lib \
+	   $(TOPDIR)\src\sm\libsmidprime.lib \
 	   $(TOPDIR)\src\pkcs15init\pkcs15init.lib
 
 all: $(TARGET)

--- a/src/pkcs11/Makefile.mak
+++ b/src/pkcs11/Makefile.mak
@@ -17,6 +17,7 @@ LIBS = $(TOPDIR)\src\libopensc\opensc_a.lib \
 	   $(TOPDIR)\src\ui\notify.lib \
 	   $(TOPDIR)\src\sm\libsmiso.lib \
 	   $(TOPDIR)\src\sm\libsmeac.lib \
+	   $(TOPDIR)\src\sm\libsmidprime.lib \
 	   $(TOPDIR)\src\pkcs15init\pkcs15init.lib
 LIBS3 = $(TOPDIR)\src\common\libpkcs11.lib $(TOPDIR)\src\common\libscdl.lib $(TOPDIR)\src\common\common.lib
 

--- a/src/sm/Makefile.am
+++ b/src/sm/Makefile.am
@@ -3,12 +3,13 @@
 MAINTAINERCLEANFILES = Makefile.in
 EXTRA_DIST = Makefile.mak
 
-noinst_LTLIBRARIES = libsmiso.la libsmeac.la
+noinst_LTLIBRARIES = libsmiso.la libsmeac.la libsmidprime.la
 
 noinst_HEADERS = \
 		 sm-iso-internal.h \
 		 sm-iso.h \
-		 sm-eac.h
+		 sm-eac.h \
+		 sm-idprime.h
 
 if ENABLE_OPENSSL
 noinst_LTLIBRARIES += libsm.la
@@ -27,3 +28,12 @@ libsmiso_la_SOURCES = sm-iso.c
 libsmeac_la_SOURCES = sm-eac.c
 libsmeac_la_LIBADD = $(OPENPACE_LIBS) $(OPENSSL_LIBS) libsmiso.la
 libsmeac_la_CFLAGS = $(OPENPACE_CFLAGS) $(OPENSSL_CFLAGS) -I$(top_srcdir)/src
+
+libsmidprime_la_SOURCES = sm-idprime.c sm-idprime.h
+# NOTE: libsmiso.la is intentionally not in LIBADD here -- it's already
+# pulled into libopensc via libsmeac.la, and a libtool convenience library
+# (noinst_LTLIBRARIES) fully embeds its LIBADD members rather than linking
+# them lazily, so adding it again causes duplicate-symbol errors when both
+# libsmeac.la and libsmidprime.la are linked into the same target.
+libsmidprime_la_LIBADD = $(OPENSSL_LIBS)
+libsmidprime_la_CFLAGS = $(OPENSSL_CFLAGS) -I$(top_srcdir)/src

--- a/src/sm/Makefile.mak
+++ b/src/sm/Makefile.mak
@@ -9,7 +9,10 @@ OBJECTS1 = sm-iso.obj
 TARGET2 = libsmeac.lib
 OBJECTS2 = sm-eac.obj
 
-all: $(TARGET) $(TARGET1) $(TARGET2)
+TARGET3 = libsmidprime.lib
+OBJECTS3 = sm-idprime.obj
+
+all: $(TARGET) $(TARGET1) $(TARGET2) $(TARGET3)
 
 !INCLUDE $(TOPDIR)\win32\Make.rules.mak
 
@@ -28,3 +31,6 @@ $(TARGET1): $(OBJECTS1)
 
 $(TARGET2): $(OBJECTS2)
         lib $(LIBFLAGS) /out:$(TARGET2) $(OBJECTS2)
+
+$(TARGET3): $(OBJECTS3)
+        lib $(LIBFLAGS) /out:$(TARGET3) $(OBJECTS3)

--- a/src/sm/sm-idprime.c
+++ b/src/sm/sm-idprime.c
@@ -1,0 +1,548 @@
+/*
+ * sm-idprime.c: proprietary EC-based Secure Messaging used by newer/FIPS
+ * Gemalto IDPrime / SafeNet eToken applets.
+ *
+ * See sm-idprime.h and ETOKEN_FIPS_SM_NOTES.md (repository root) for the
+ * full reverse-engineering writeup this is based on. In short, once session
+ * keys exist, every APDU is wrapped exactly like textbook ISO 7816-4 SM
+ * (DO'87'/'97'/'8E'/'99', ISO/IEC 9797-1 padding method 2) with:
+ *   - confidentiality: AES-CBC, IV = AES-ECB-Encrypt(KSKEnc, SSC)
+ *   - integrity: AES-CMAC(KSKMac, data), except the CBC-MAC chaining value
+ *     is seeded with SSC instead of zero (SSC is incremented once per APDU
+ *     direction, i.e. twice per command/response round trip)
+ * This file implements exactly that on top of OpenSC's generic SM
+ * encoder/decoder (sm-iso.c), which already produces byte-for-byte the same
+ * DO layout and CLA handling.
+ *
+ * STATUS: scaffolding, not validated against real hardware yet.
+ *
+ * Copyright (C) 2026 David Hardening <contact@hardening-consulting.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef ENABLE_OPENSSL /* empty file without openssl */
+#include <openssl/evp.h>
+#include <openssl/sha.h>
+
+#include "libopensc/asn1.h"
+#include "libopensc/errors.h"
+#include "libopensc/internal.h"
+#include "sm-idprime.h"
+#include "sm-iso.h"
+
+#define IDPRIME_SM_BLOCK_LEN 16
+
+struct idprime_sm_ctx {
+	u8 kenc[IDPRIME_SM_KEY_LEN_AES256];
+	u8 kmac[IDPRIME_SM_KEY_LEN_AES256];
+	size_t key_len; /* IDPRIME_SM_KEY_LEN_AES128 or _AES256 */
+	u8 ssc[IDPRIME_SM_BLOCK_LEN];
+};
+
+static const EVP_CIPHER *
+idprime_sm_ecb_cipher(size_t key_len)
+{
+	return key_len == IDPRIME_SM_KEY_LEN_AES256 ? EVP_aes_256_ecb() : EVP_aes_128_ecb();
+}
+
+static const EVP_CIPHER *
+idprime_sm_cbc_cipher(size_t key_len)
+{
+	return key_len == IDPRIME_SM_KEY_LEN_AES256 ? EVP_aes_256_cbc() : EVP_aes_128_cbc();
+}
+
+/* Single-block (no padding) AES-ECB encryption, used both directly for ICV
+ * derivation and as the primitive CMAC subkey generation/chaining is built
+ * from. */
+static int
+idprime_sm_ecb_block(const u8 *key, size_t key_len,
+		const u8 in[IDPRIME_SM_BLOCK_LEN], u8 out[IDPRIME_SM_BLOCK_LEN])
+{
+	EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+	int outl = 0, len2 = 0, ok = 0;
+
+	if (!ctx)
+		return 0;
+	if (!EVP_EncryptInit_ex(ctx, idprime_sm_ecb_cipher(key_len), NULL, key, NULL))
+		goto err;
+	if (!EVP_CIPHER_CTX_set_padding(ctx, 0))
+		goto err;
+	if (!EVP_EncryptUpdate(ctx, out, &outl, in, IDPRIME_SM_BLOCK_LEN))
+		goto err;
+	if (!EVP_EncryptFinal_ex(ctx, out + outl, &len2))
+		goto err;
+	ok = 1;
+err:
+	EVP_CIPHER_CTX_free(ctx);
+	return ok;
+}
+
+/* Multiply-by-x in GF(2^128) with the standard AES-CMAC reduction
+ * polynomial (Rb = 0x87), used for K1/K2 subkey generation (NIST SP800-38B
+ * / RFC 4493). Treats the 16-byte string as a big-endian 128-bit integer. */
+static void
+idprime_sm_gf128_double(const u8 in[IDPRIME_SM_BLOCK_LEN], u8 out[IDPRIME_SM_BLOCK_LEN])
+{
+	int i;
+	u8 msb = in[0] & 0x80;
+
+	for (i = 0; i < IDPRIME_SM_BLOCK_LEN - 1; i++)
+		out[i] = (u8)((in[i] << 1) | (in[i + 1] >> 7));
+	out[IDPRIME_SM_BLOCK_LEN - 1] = (u8)(in[IDPRIME_SM_BLOCK_LEN - 1] << 1);
+	if (msb)
+		out[IDPRIME_SM_BLOCK_LEN - 1] ^= 0x87;
+}
+
+static int
+idprime_sm_cmac_subkeys(const u8 *key, size_t key_len,
+		u8 k1[IDPRIME_SM_BLOCK_LEN], u8 k2[IDPRIME_SM_BLOCK_LEN])
+{
+	u8 zero[IDPRIME_SM_BLOCK_LEN];
+	u8 l[IDPRIME_SM_BLOCK_LEN];
+	int ok;
+
+	memset(zero, 0, sizeof zero);
+	ok = idprime_sm_ecb_block(key, key_len, zero, l);
+	if (ok) {
+		idprime_sm_gf128_double(l, k1);
+		idprime_sm_gf128_double(k1, k2);
+	}
+	sc_mem_clear(l, sizeof l);
+	return ok;
+}
+
+/*
+ * AES-CMAC over already block-aligned data (the caller -- sm-iso.c -- always
+ * hands us data padded with ISO/IEC 9797-1 method 2 beforehand, so this
+ * never needs the "short final block" / K2 case of textbook CMAC), except
+ * the initial CBC-MAC chaining value is NOT zero (as in textbook CMAC) and
+ * NOT the raw SSC either -- it's the SSC run through one extra AES-ECB
+ * encryption under Kmac first:
+ *   state0 = AES-Encrypt(Kmac, SSC)
+ * then proceed with standard CMAC block chaining (K1/K2 whitening on the
+ * last block) from state0. L (the CMAC subkey-generation value,
+ * AES-Encrypt(Kmac, 0^128)) is NOT involved in state0 at all -- it's used
+ * only for K1/K2, a fully separate computation.
+ *
+ * This construction (and specifically that state0 is SSC *encrypted*, not
+ * SSC used directly, nor XORed with L first) was confirmed by directly
+ * hooking the proprietary driver's etCryptoEcb() calls with gdb and
+ * observing the literal block sequence during a real SM_AES_MAC() call --
+ * see ETOKEN_FIPS_SM_NOTES.md section 9.6. Two earlier, plausible-looking
+ * but wrong guesses (state0 = SSC with no extra encryption; state0 =
+ * AES-Encrypt(Kmac, L XOR SSC)) were both ruled out by that same capture.
+ */
+static int
+idprime_sm_cmac_ssc(const struct idprime_sm_ctx *sctx,
+		const u8 *data, size_t datalen, u8 mac[IDPRIME_SM_BLOCK_LEN])
+{
+	u8 k1[IDPRIME_SM_BLOCK_LEN], k2[IDPRIME_SM_BLOCK_LEN];
+	u8 state[IDPRIME_SM_BLOCK_LEN];
+	u8 block[IDPRIME_SM_BLOCK_LEN];
+	size_t nblocks, i, b;
+	int ok = 0;
+
+	if (datalen == 0 || datalen % IDPRIME_SM_BLOCK_LEN != 0)
+		return 0;
+
+	if (!idprime_sm_cmac_subkeys(sctx->kmac, sctx->key_len, k1, k2))
+		return 0;
+	(void)k2; /* only used for the short-final-block case, which never occurs here */
+
+	if (!idprime_sm_ecb_block(sctx->kmac, sctx->key_len, sctx->ssc, state))
+		goto done;
+
+	nblocks = datalen / IDPRIME_SM_BLOCK_LEN;
+
+	for (i = 0; i + 1 < nblocks; i++) {
+		const u8 *in_block = data + i * IDPRIME_SM_BLOCK_LEN;
+		for (b = 0; b < IDPRIME_SM_BLOCK_LEN; b++)
+			block[b] = state[b] ^ in_block[b];
+		if (!idprime_sm_ecb_block(sctx->kmac, sctx->key_len, block, state))
+			goto done;
+	}
+
+	{
+		const u8 *last = data + (nblocks - 1) * IDPRIME_SM_BLOCK_LEN;
+		for (b = 0; b < IDPRIME_SM_BLOCK_LEN; b++)
+			block[b] = state[b] ^ last[b] ^ k1[b];
+	}
+	ok = idprime_sm_ecb_block(sctx->kmac, sctx->key_len, block, mac);
+
+done:
+	sc_mem_clear(k1, sizeof k1);
+	sc_mem_clear(k2, sizeof k2);
+	sc_mem_clear(state, sizeof state);
+	sc_mem_clear(block, sizeof block);
+	return ok;
+}
+
+static int
+idprime_sm_icv(const struct idprime_sm_ctx *sctx, u8 icv[IDPRIME_SM_BLOCK_LEN])
+{
+	return idprime_sm_ecb_block(sctx->kenc, sctx->key_len, sctx->ssc, icv);
+}
+
+static void
+idprime_sm_incr_ssc(u8 ssc[IDPRIME_SM_BLOCK_LEN])
+{
+	int i;
+
+	for (i = IDPRIME_SM_BLOCK_LEN - 1; i >= 0; i--) {
+		if (++ssc[i] != 0)
+			break;
+	}
+}
+
+static int
+idprime_sm_encrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+		const u8 *data, size_t datalen, u8 **enc)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+	EVP_CIPHER_CTX *cctx = NULL;
+	u8 icv[IDPRIME_SM_BLOCK_LEN];
+	u8 *out = NULL;
+	int outl = 0, len2 = 0;
+	int r = SC_ERROR_INTERNAL;
+
+	if (!sctx || !data || datalen == 0 || datalen % IDPRIME_SM_BLOCK_LEN != 0)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	if (!idprime_sm_icv(sctx, icv))
+		return SC_ERROR_INTERNAL;
+
+	out = malloc(datalen);
+	if (!out) {
+		r = SC_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+
+	cctx = EVP_CIPHER_CTX_new();
+	if (!cctx)
+		goto err;
+	if (!EVP_EncryptInit_ex(cctx, idprime_sm_cbc_cipher(sctx->key_len), NULL, sctx->kenc, icv))
+		goto err;
+	if (!EVP_CIPHER_CTX_set_padding(cctx, 0))
+		goto err;
+	if (!EVP_EncryptUpdate(cctx, out, &outl, data, (int)datalen))
+		goto err;
+	if (!EVP_EncryptFinal_ex(cctx, out + outl, &len2))
+		goto err;
+
+	*enc = out;
+	r = outl + len2;
+	out = NULL;
+err:
+	free(out);
+	if (cctx)
+		EVP_CIPHER_CTX_free(cctx);
+	sc_mem_clear(icv, sizeof icv);
+	return r;
+}
+
+static int
+idprime_sm_decrypt(sc_card_t *card, const struct iso_sm_ctx *ctx,
+		const u8 *enc, size_t enclen, u8 **data)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+	EVP_CIPHER_CTX *cctx = NULL;
+	u8 icv[IDPRIME_SM_BLOCK_LEN];
+	u8 *out = NULL;
+	int outl = 0, len2 = 0;
+	int r = SC_ERROR_INTERNAL;
+
+	if (!sctx || !enc || enclen == 0 || enclen % IDPRIME_SM_BLOCK_LEN != 0)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	if (!idprime_sm_icv(sctx, icv))
+		return SC_ERROR_INTERNAL;
+
+	out = malloc(enclen);
+	if (!out) {
+		r = SC_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+
+	cctx = EVP_CIPHER_CTX_new();
+	if (!cctx)
+		goto err;
+	if (!EVP_DecryptInit_ex(cctx, idprime_sm_cbc_cipher(sctx->key_len), NULL, sctx->kenc, icv))
+		goto err;
+	if (!EVP_CIPHER_CTX_set_padding(cctx, 0))
+		goto err;
+	if (!EVP_DecryptUpdate(cctx, out, &outl, enc, (int)enclen))
+		goto err;
+	if (!EVP_DecryptFinal_ex(cctx, out + outl, &len2))
+		goto err;
+
+	*data = out;
+	r = outl + len2;
+	out = NULL;
+err:
+	free(out);
+	if (cctx)
+		EVP_CIPHER_CTX_free(cctx);
+	sc_mem_clear(icv, sizeof icv);
+	return r;
+}
+
+static int
+idprime_sm_authenticate(sc_card_t *card, const struct iso_sm_ctx *ctx,
+		const u8 *data, size_t datalen, u8 **outdata)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+	u8 *mac;
+
+	if (!sctx || !data)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	mac = malloc(IDPRIME_SM_BLOCK_LEN);
+	if (!mac)
+		return SC_ERROR_OUT_OF_MEMORY;
+
+	if (!idprime_sm_cmac_ssc(sctx, data, datalen, mac)) {
+		free(mac);
+		return SC_ERROR_INTERNAL;
+	}
+
+	*outdata = mac;
+	return IDPRIME_SM_BLOCK_LEN;
+}
+
+static int
+idprime_sm_verify_authentication(sc_card_t *card, const struct iso_sm_ctx *ctx,
+		const u8 *mac, size_t maclen, const u8 *macdata, size_t macdatalen)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+	u8 computed[IDPRIME_SM_BLOCK_LEN];
+	int r;
+
+	if (!sctx || !mac || maclen != IDPRIME_SM_BLOCK_LEN || !macdata)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	if (!idprime_sm_cmac_ssc(sctx, macdata, macdatalen, computed))
+		return SC_ERROR_INTERNAL;
+
+	r = (memcmp(mac, computed, IDPRIME_SM_BLOCK_LEN) == 0) ? SC_SUCCESS : SC_ERROR_SM_INVALID_CHECKSUM;
+	sc_mem_clear(computed, sizeof computed);
+	return r;
+}
+
+/* SSC is incremented once per APDU direction: once here before encrypting
+ * the command (used as-is by the ICV/MAC derivation for the request), and
+ * again in idprime_sm_post_transmit() before decrypting/verifying the
+ * response -- i.e. twice per command/response round trip. */
+static int
+idprime_sm_pre_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx, sc_apdu_t *apdu)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+
+	if (!sctx)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	idprime_sm_incr_ssc(sctx->ssc);
+	return SC_SUCCESS;
+}
+
+static int
+idprime_sm_post_transmit(sc_card_t *card, const struct iso_sm_ctx *ctx, sc_apdu_t *sm_apdu)
+{
+	struct idprime_sm_ctx *sctx = ctx ? ctx->priv_data : NULL;
+
+	if (!sctx)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	idprime_sm_incr_ssc(sctx->ssc);
+	return SC_SUCCESS;
+}
+
+static void
+idprime_sm_clear_free(const struct iso_sm_ctx *ctx)
+{
+	if (ctx && ctx->priv_data) {
+		sc_mem_clear(ctx->priv_data, sizeof(struct idprime_sm_ctx));
+		free(ctx->priv_data);
+	}
+}
+
+/* Mirrors ComputeKSKEnc_MAC(): see sm-idprime.h for the exact construction. */
+static int
+idprime_sm_kdf(const u8 *z, size_t zlen, uint32_t counter, size_t key_len,
+		u8 out[IDPRIME_SM_KEY_LEN_AES256])
+{
+	EVP_MD_CTX *ctx;
+	u8 counter_be[4];
+	u8 digest[SHA256_DIGEST_LENGTH];
+	u8 domain_sep = 0x20;
+	unsigned int digest_len = 0;
+	int ok = 0;
+
+	counter_be[0] = (u8)(counter >> 24);
+	counter_be[1] = (u8)(counter >> 16);
+	counter_be[2] = (u8)(counter >> 8);
+	counter_be[3] = (u8)counter;
+
+	ctx = EVP_MD_CTX_new();
+	if (!ctx)
+		return 0;
+	if (!EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
+		goto err;
+
+	if (key_len == IDPRIME_SM_KEY_LEN_AES128) {
+		if (!EVP_DigestUpdate(ctx, z, zlen) || !EVP_DigestUpdate(ctx, counter_be, sizeof counter_be))
+			goto err;
+	} else {
+		if (!EVP_DigestUpdate(ctx, counter_be, sizeof counter_be) ||
+				!EVP_DigestUpdate(ctx, z, zlen) ||
+				!EVP_DigestUpdate(ctx, &domain_sep, 1))
+			goto err;
+	}
+	if (!EVP_DigestFinal_ex(ctx, digest, &digest_len) || digest_len != sizeof digest)
+		goto err;
+
+	memcpy(out, digest, key_len);
+	ok = 1;
+err:
+	EVP_MD_CTX_free(ctx);
+	sc_mem_clear(digest, sizeof digest);
+	return ok;
+}
+
+int
+idprime_sm_start(sc_card_t *card, const u8 *shared_secret, size_t shared_secret_len,
+		size_t key_len, const u8 ssc_init[IDPRIME_SM_BLOCK_LEN])
+{
+	struct iso_sm_ctx *sctx = NULL;
+	struct idprime_sm_ctx *priv = NULL;
+	int r;
+
+	if (!card || !shared_secret || shared_secret_len == 0 || !ssc_init ||
+			(key_len != IDPRIME_SM_KEY_LEN_AES128 && key_len != IDPRIME_SM_KEY_LEN_AES256)) {
+		return SC_ERROR_INVALID_ARGUMENTS;
+	}
+
+	priv = calloc(1, sizeof *priv);
+	if (!priv)
+		return SC_ERROR_OUT_OF_MEMORY;
+	priv->key_len = key_len;
+	memcpy(priv->ssc, ssc_init, sizeof priv->ssc);
+
+	if (!idprime_sm_kdf(shared_secret, shared_secret_len, 1, key_len, priv->kenc) ||
+			!idprime_sm_kdf(shared_secret, shared_secret_len, 2, key_len, priv->kmac)) {
+		sc_mem_clear(priv, sizeof *priv);
+		free(priv);
+		return SC_ERROR_INTERNAL;
+	}
+
+	sctx = iso_sm_ctx_create();
+	if (!sctx) {
+		sc_mem_clear(priv, sizeof *priv);
+		free(priv);
+		return SC_ERROR_OUT_OF_MEMORY;
+	}
+	sctx->priv_data = priv;
+	sctx->padding_indicator = SM_ISO_PADDING;
+	sctx->block_length = IDPRIME_SM_BLOCK_LEN;
+	sctx->authenticate = idprime_sm_authenticate;
+	sctx->verify_authentication = idprime_sm_verify_authentication;
+	sctx->encrypt = idprime_sm_encrypt;
+	sctx->decrypt = idprime_sm_decrypt;
+	sctx->pre_transmit = idprime_sm_pre_transmit;
+	sctx->post_transmit = idprime_sm_post_transmit;
+	sctx->clear_free = idprime_sm_clear_free;
+
+	r = iso_sm_start(card, sctx);
+	if (r != SC_SUCCESS) {
+		/* ownership of sctx (and thus priv, via clear_free) only transfers
+		 * to the card on success */
+		iso_sm_ctx_clear_free(sctx);
+	}
+	return r;
+}
+
+int
+idprime_sm_reseed_ssc(sc_card_t *card, const u8 rnd_icc[8], const u8 rnd_ifd[8])
+{
+	struct iso_sm_ctx *sctx;
+	struct idprime_sm_ctx *priv;
+
+	if (!card || !rnd_icc || !rnd_ifd)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	sctx = card->sm_ctx.info.cmd_data;
+	if (!sctx || !sctx->priv_data)
+		return SC_ERROR_INVALID_ARGUMENTS;
+	priv = sctx->priv_data;
+
+	memcpy(priv->ssc, rnd_icc, 8);
+	memcpy(priv->ssc + 8, rnd_ifd, 8);
+	return SC_SUCCESS;
+}
+
+int
+idprime_sm_encode_general_authenticate(const u8 *point, size_t point_len,
+		u8 *out, size_t out_max)
+{
+	int inner_len, r;
+	u8 *p;
+
+	if (!point || point_len == 0 || !out)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	inner_len = sc_asn1_put_tag(0x85, point, point_len, NULL, 0, NULL);
+	if (inner_len < 0)
+		return inner_len;
+
+	r = sc_asn1_put_tag(0x7C, NULL, (size_t)inner_len, NULL, 0, NULL);
+	if (r < 0)
+		return r;
+	if ((size_t)r > out_max)
+		return SC_ERROR_BUFFER_TOO_SMALL;
+
+	p = out;
+	r = sc_asn1_put_tag(0x7C, NULL, (size_t)inner_len, out, out_max, &p);
+	if (r != SC_SUCCESS)
+		return r;
+	r = sc_asn1_put_tag(0x85, point, point_len, p, out_max - (size_t)(p - out), &p);
+	if (r != SC_SUCCESS)
+		return r;
+
+	return (int)(p - out);
+}
+
+int
+idprime_sm_decode_general_authenticate(sc_context_t *ctx, const u8 *resp, size_t resplen,
+		const u8 **point, size_t *point_len)
+{
+	const u8 *body;
+	size_t bodylen;
+
+	if (!ctx || !resp || !point || !point_len)
+		return SC_ERROR_INVALID_ARGUMENTS;
+
+	body = sc_asn1_find_tag(ctx, resp, resplen, 0x7C, &bodylen);
+	if (body == NULL)
+		return SC_ERROR_SM_NO_SESSION_KEYS;
+
+	*point = sc_asn1_find_tag(ctx, body, bodylen, 0x85, point_len);
+	if (*point == NULL || *point_len == 0)
+		return SC_ERROR_SM_NO_SESSION_KEYS;
+
+	return SC_SUCCESS;
+}
+
+#endif /* ENABLE_OPENSSL */

--- a/src/sm/sm-idprime.h
+++ b/src/sm/sm-idprime.h
@@ -1,0 +1,125 @@
+/*
+ * sm-idprime.h: proprietary EC-based Secure Messaging used by newer/FIPS
+ * Gemalto IDPrime / SafeNet eToken applets ("MA" in the vendor's own
+ * naming).
+ *
+ * Reverse-engineered from libIDPrimeTokenEngine.so's idp_openSM_ECC_MAV(),
+ * ComputeKSKEnc_MAC(), idp_apdu_SM_IN()/idp_apdu_SM_OUT() -- see
+ * ETOKEN_FIPS_SM_NOTES.md in the repository root for the full writeup this
+ * is based on.
+ *
+ * This only implements the *transport* on top of already-established
+ * session keys, by wiring OpenSC's generic ISO 7816-4 SM encoder/decoder
+ * (sm-iso.c) to an AES-CBC/AES-CMAC implementation matching the proprietary
+ * driver's byte format. The EC key agreement and certificate-based mutual
+ * authentication handshake that establishes those session keys is NOT
+ * implemented here -- see card-idprime.c's idprime_get_ecc_full_sm() for
+ * where this would need to be triggered from once that handshake exists.
+ *
+ * STATUS: scaffolding, not validated against real hardware yet.
+ *
+ * Copyright (C) 2026 David Hardening <contact@hardening-consulting.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef _SM_IDPRIME_H
+#define _SM_IDPRIME_H
+
+#include "libopensc/opensc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** AES session key length (bytes) the card expects, mirroring idp_maType 0x10 */
+#define IDPRIME_SM_KEY_LEN_AES128 16
+/** AES session key length (bytes) the card expects, mirroring idp_maType 0x20 */
+#define IDPRIME_SM_KEY_LEN_AES256 32
+
+/**
+ * @brief Derives the two AES session keys from an ECDH shared secret and
+ * starts Secure Messaging on \a card.
+ *
+ * Key derivation mirrors ComputeKSKEnc_MAC() in libIDPrimeTokenEngine.so:
+ *   - key_len == IDPRIME_SM_KEY_LEN_AES128:
+ *         K = SHA256(shared_secret || BE32(counter))[0:16]
+ *   - key_len == IDPRIME_SM_KEY_LEN_AES256:
+ *         K = SHA256(BE32(counter) || shared_secret || 0x20)[0:32]
+ * with counter=1 for the encryption key (KSKEnc) and counter=2 for the MAC
+ * key (KSKMac).
+ *
+ * @param card
+ * @param shared_secret     raw ECDH shared secret (x-coordinate only)
+ * @param shared_secret_len
+ * @param key_len           IDPRIME_SM_KEY_LEN_AES128 or _AES256
+ * @param ssc_init           initial 16-byte send sequence counter (the
+ *                           proprietary driver seeds this as RND.ICC || RND.IFD
+ *                           after the mutual-authentication handshake completes)
+ *
+ * @return SC_SUCCESS, or an error code if the card or arguments are invalid
+ */
+int idprime_sm_start(sc_card_t *card, const u8 *shared_secret, size_t shared_secret_len,
+		size_t key_len, const u8 ssc_init[16]);
+
+/**
+ * @brief Reseeds the send sequence counter of an already-active idprime SM
+ * session to \c rnd_icc \c || \c rnd_ifd.
+ *
+ * The proprietary driver uses a trivial small-integer SSC (starting at 1)
+ * for the handshake messages themselves (MSE:SET AT, PSO:VERIFY CERTIFICATE,
+ * GET CHALLENGE, EXTERNAL/INTERNAL AUTHENTICATE), then -- right as the
+ * handshake completes and the connection moves into normal operation --
+ * replaces it with the concatenation of RND.ICC (the card's GET CHALLENGE
+ * response) and RND.IFD (the terminal's own nonce sent in INTERNAL
+ * AUTHENTICATE). Both values are already known to card and host by then, so
+ * this reseed needs no extra round trip. Confirmed via live gdb hook of
+ * SM_AES_MAC's raw SSC argument against the real driver (see
+ * ETOKEN_FIPS_SM_NOTES.md) -- skipping this desyncs the SSC from the very
+ * first post-handshake command onward and every subsequent SM command fails.
+ *
+ * @param card
+ * @param rnd_icc 8-byte RND.ICC from GET CHALLENGE
+ * @param rnd_ifd 8-byte RND.IFD sent in INTERNAL AUTHENTICATE
+ *
+ * @return SC_SUCCESS, or an error code if no idprime SM session is active
+ */
+int idprime_sm_reseed_ssc(sc_card_t *card, const u8 rnd_icc[8], const u8 rnd_ifd[8]);
+
+/**
+ * @brief Builds the GENERAL AUTHENTICATE request body for the EC key
+ * agreement step: \c 7C \c { \c 85 \c = \c point \c } (Dynamic Authentication
+ * Data template carrying the caller's raw uncompressed EC point).
+ *
+ * @return number of bytes written to \a out, or a negative SC_ERROR_* code
+ */
+int idprime_sm_encode_general_authenticate(const u8 *point, size_t point_len,
+		u8 *out, size_t out_max);
+
+/**
+ * @brief Extracts the card's ephemeral EC point from a GENERAL AUTHENTICATE
+ * response of the same \c 7C \c { \c 85 \c = \c point \c } shape.
+ *
+ * @param[out] point      set to point inside \a resp (not a copy)
+ * @param[out] point_len
+ *
+ * @return SC_SUCCESS or an error code
+ */
+int idprime_sm_decode_general_authenticate(sc_context_t *ctx, const u8 *resp, size_t resplen,
+		const u8 **point, size_t *point_len);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -466,21 +466,62 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	sm_apdu->data = sm_data;
 	sm_apdu->datalen = sm_data_len;
 	sm_apdu->lc = sm_data_len;
-	sm_apdu->le = 0;
 	/* for encrypted APDUs we usually get authenticated status bytes (4B), a
 	 * MAC (2B without data) and a cryptogram with padding indicator (2B tag
 	 * and indicator, max. 2B/3B ASN.1 length, without data). The cryptogram is
 	 * always padded to the block size. */
 	if (apdu->cse & SC_APDU_EXT) {
 		sm_apdu->cse = SC_APDU_CASE_4_EXT;
-		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 3 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
+		/* apdu.c's sc_get_response() bails out immediately ("no data
+		 * expected") whenever apdu->le == 0, which used to unconditionally
+		 * discard the SW=61xx continuation data of any response that
+		 * didn't fit in a single transfer -- confirmed against a real
+		 * card: a 256-byte RSA-2048 signature comes back SM-wrapped as a
+		 * first 256-byte transfer (SW=61xx) plus a GET RESPONSE for the
+		 * rest, and with le hardcoded to 0 that second part was silently
+		 * dropped even after the resplen buffer fix below. apdu->resplen
+		 * itself isn't a valid Le (it's a buffer *capacity*, e.g. 4096 for
+		 * a generously-sized caller buffer, which sc_check_apdu() would
+		 * reject as Le), so clamp to the largest Le this cse can encode --
+		 * the actual wire Le byte(s) only ever need to ask for "as much as
+		 * this transfer can carry"; anything beyond that is what GET
+		 * RESPONSE chaining is for. */
+		sm_apdu->le = apdu->resplen == 0 ? 0 : 65536;
+		/* +1: DO'87's content is the 1-byte padding-content indicator
+		 * followed by the padded cryptogram, not the padded cryptogram
+		 * alone (see the "Padding-content indicator followed by
+		 * cryptogram" DO built in sm_encrypt() above) -- this formula only
+		 * counted the latter, under-allocating the response buffer by
+		 * exactly 1 byte. Harmless for responses that fit in a single
+		 * transfer (the missing byte is simply never written into,
+		 * unnoticed), but fatal once GET RESPONSE chaining is needed: the
+		 * reassembled buffer ends up 1 byte short of a complete DO'8E',
+		 * which then parses as "MAC absent" plus leftover trailing data,
+		 * i.e. SC_ERROR_UNKNOWN_DATA_RECEIVED (confirmed against a real
+		 * card while completing the RSA-2048 signature fix above). */
+		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 3 + 1 + ((apdu->resplen + 1) / ctx->block_length + 1) * ctx->block_length;
 		if (sm_apdu->resplen > SC_MAX_EXT_APDU_RESP_SIZE)
 			sm_apdu->resplen = SC_MAX_EXT_APDU_RESP_SIZE;
 	} else {
 		sm_apdu->cse = SC_APDU_CASE_4_SHORT;
-		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 2 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
-		if (sm_apdu->resplen > SC_MAX_APDU_RESP_SIZE)
-			sm_apdu->resplen = SC_MAX_APDU_RESP_SIZE;
+		sm_apdu->le = apdu->resplen == 0 ? 0 : 256;
+		/* +1: see the identical comment in the extended-APDU branch above. */
+		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 2 + 1 + ((apdu->resplen + 1) / ctx->block_length + 1) * ctx->block_length;
+		/* SC_MAX_APDU_RESP_SIZE (256) is the limit for a *single* short-form
+		 * transfer, not for the fully reassembled response -- a short-form
+		 * APDU whose wrapped/padded size exceeds that is expected to still
+		 * work via the standard T=0 GET RESPONSE chaining that apdu.c
+		 * already performs transparently on SW=61xx (sc_get_response()).
+		 * Capping the buffer here to SC_MAX_APDU_RESP_SIZE silently
+		 * truncated the reassembled data (confirmed against a real card:
+		 * a 256-byte RSA-2048 signature response needs ~277 SM-wrapped
+		 * bytes, comes back chained as a 256-byte initial transfer plus a
+		 * GET RESPONSE for the remaining SW2 bytes, and the second chunk
+		 * was being silently dropped because this buffer was already full
+		 * from the first chunk alone) -- use the same generous extended
+		 * bound as the SC_APDU_EXT branch above instead. */
+		if (sm_apdu->resplen > SC_MAX_EXT_APDU_RESP_SIZE)
+			sm_apdu->resplen = SC_MAX_EXT_APDU_RESP_SIZE;
 	}
 	resp_data = calloc(1, sm_apdu->resplen);
 	if (!resp_data) {
@@ -513,7 +554,7 @@ static int sm_decrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	int r;
 	struct sc_asn1_entry sm_rapdu[5];
 	struct sc_asn1_entry my_sm_rapdu[5];
-	u8 sw[2], mac[8], fdata[SC_MAX_EXT_APDU_BUFFER_SIZE];
+	u8 sw[2], mac[MAX_SM_MAC_LEN], fdata[SC_MAX_EXT_APDU_BUFFER_SIZE];
 	size_t sw_len = sizeof sw, mac_len = sizeof mac, fdata_len = sizeof fdata,
 		   buf_len, asn1_len, fdata_offset = 0;
 	const u8 *buf;

--- a/src/sm/sm-iso.h
+++ b/src/sm/sm-iso.h
@@ -50,6 +50,11 @@ extern "C" {
 /** @brief Padding indicator: use no padding */
 #define SM_NO_PADDING  0x02
 
+/** @brief maximum length of the Cryptographic Checksum (DO'8E') this module
+ * can receive in a response APDU. Sized for a full AES block (16 bytes,
+ * e.g. AES-CMAC); DES-based 8-byte MAC schemes fit within this too. */
+#define MAX_SM_MAC_LEN 16
+
 /** @brief Secure messaging context
  *
  * This module provides *encoding and decoding* of secure messaging APDUs. The

--- a/src/smm/Makefile.mak
+++ b/src/smm/Makefile.mak
@@ -13,6 +13,7 @@ LIBS = $(TOPDIR)\src\sm\libsm.lib \
 	   $(TOPDIR)\src\ui\notify.lib \
 	   $(TOPDIR)\src\sm\libsmiso.lib \
 	   $(TOPDIR)\src\sm\libsmeac.lib \
+	   $(TOPDIR)\src\sm\libsmidprime.lib \
 	   $(TOPDIR)\src\pkcs15init\pkcs15init.lib
 
 all: $(TARGET)


### PR DESCRIPTION
Pushed as draft for review, as claude worked on the generated code I'm aware that lots of comments aren't meaningful and should be reworked (claude tends to think that explaining its iterations are useful in code's comment).

Newer/FIPS IDPrime applets (seen on a SafeNet eToken 5300, reported as SC_CARD_TYPE_IDPRIME_930_PLUS) require every APDU to be wrapped in a proprietary AES-CBC/AES-CMAC Secure Messaging channel once an EC-based mutual authentication reference key is present ("full SM" mode). Without this, the driver could detect such cards but not actually talk to them beyond the initial SELECT.

This adds:
  - Detection of the MA reference key and the FIPS/full-SM applet configuration (idprime_probe_ecc_ma, idprime_get_applet_fips_config, idprime_get_ecc_full_sm). Cards without the MA key are unaffected and keep using the existing, unmodified code path.
  - The mutual-authentication handshake itself (EC key agreement via GENERAL AUTHENTICATE, PSO:VERIFY CERTIFICATE against an embedded CV certificate, EXTERNAL/INTERNAL AUTHENTICATE) in card-idprime.c.
  - sm-idprime.c/.h: a new SM transport implementing the derived AES-CBC encryption and AES-CMAC authentication, wired into the existing generic ISO 7816-4 SM encoder/decoder (sm-iso.c) via struct iso_sm_ctx.
  - Post-handshake quirks required by this applet, all confirmed against a real card: the SSC is reseeded to RND.ICC||RND.IFD once the handshake completes; the AID must not be re-selected once authenticated; SELECT FILE must not carry a protected Le under SM.
  - Correct key-reference derivation for private keys on this applet variant, which is keyed off the container's own index rather than the certificate's embedded id, with a fallback for containers that don't line up 1:1 with certificates.

Getting large operations (e.g. an RSA-2048 signature) working under this SM channel exposed four bugs in the shared SM/ISO7816 framework, since GET RESPONSE chaining under active SM had apparently never been exercised before:
  - sm-iso.c: the reassembled-response buffer was capped at the single-transfer short-form limit (256 bytes) instead of the size needed once GET RESPONSE chaining is used to exceed it.
  - sm-iso.c: the wrapped APDU's Le was hardcoded to 0, which made sc_get_response() skip GET RESPONSE entirely regardless of the buffer fix above.
  - sm-iso.c: the response buffer size formula was off by one byte (the padding-content indicator inside DO'87' wasn't counted), silently truncating the last byte of DO'8E' once chaining was involved.
  - iso7816.c: iso7816_get_response() didn't mark its own APDU SC_APDU_FLAGS_NO_SM, so once GET RESPONSE actually started firing it got wrongly re-wrapped in SM instead of going out in the clear.

Also fixes a related pre-existing bug in sm-iso.c: sm_decrypt()'s MAC buffer was sized for 8-byte (DES-class) MACs even though the module's own documented design assumes AES-length MACs; AES-CMAC responses were overflowing it.

Verified end-to-end against real hardware: object enumeration, PIN login, and RSA-2048 signing (signature independently verified against the card's own certificate).


