### PR TITLE
sm-iso: fix response buffer sizing and Le in sm_encrypt

### DIFF
--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -476,10 +476,6 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	r = sc_asn1_put_tag(SC_ASN1_TAG_CONTEXT|0x07, NULL, cryptogram_len, NULL, 0, NULL);
 	if (r < 0)
 		goto err;
-	/* No upper limit is imposed here: this is the size of the buffer we
-	 * allocate ourselves, not something that goes on the wire. What the card
-	 * can actually return is bounded by its own internal restrictions, not by
-	 * the maximum transceive size. */
 	sm_apdu->resplen = 4 + 2 + mac_len + (size_t) r;
 	if (apdu->cse & SC_APDU_EXT) {
 		sm_apdu->cse = SC_APDU_CASE_4_EXT;

--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -280,7 +280,8 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	struct sc_asn1_entry sm_capdu[5];
 	u8 *p, *le = NULL, *sm_data = NULL, *fdata = NULL, *mac_data = NULL,
 	   *asn1 = NULL, *mac = NULL, *resp_data = NULL;
-	size_t sm_data_len, fdata_len, mac_data_len, asn1_len, mac_len, le_len;
+	size_t sm_data_len, fdata_len, mac_data_len, asn1_len, mac_len, le_len,
+	       cryptogram_len;
 	int r;
 	sc_apdu_t *sm_apdu = NULL;
 
@@ -466,22 +467,28 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	sm_apdu->data = sm_data;
 	sm_apdu->datalen = sm_data_len;
 	sm_apdu->lc = sm_data_len;
-	sm_apdu->le = 0;
 	/* for encrypted APDUs we usually get authenticated status bytes (4B), a
-	 * MAC (2B without data) and a cryptogram with padding indicator (2B tag
-	 * and indicator, max. 2B/3B ASN.1 length, without data). The cryptogram is
-	 * always padded to the block size. */
+	 * MAC (2B without data) and a cryptogram preceded by the padding-content
+	 * indicator (1B). The cryptogram is always padded to the block size and
+	 * the size of its tag and length is whatever ASN.1 needs to encode that
+	 * much data, independent of the APDU being short or extended. */
+	cryptogram_len = 1 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
+	r = sc_asn1_put_tag(SC_ASN1_TAG_CONTEXT|0x07, NULL, cryptogram_len, NULL, 0, NULL);
+	if (r < 0)
+		goto err;
+	/* No upper limit is imposed here: this is the size of the buffer we
+	 * allocate ourselves, not something that goes on the wire. What the card
+	 * can actually return is bounded by its own internal restrictions, not by
+	 * the maximum transceive size. */
+	sm_apdu->resplen = 4 + 2 + mac_len + (size_t) r;
 	if (apdu->cse & SC_APDU_EXT) {
 		sm_apdu->cse = SC_APDU_CASE_4_EXT;
-		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 3 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
-		if (sm_apdu->resplen > SC_MAX_EXT_APDU_RESP_SIZE)
-			sm_apdu->resplen = SC_MAX_EXT_APDU_RESP_SIZE;
+		sm_apdu->le = SC_MAX_EXT_APDU_RESP_SIZE;
 	} else {
 		sm_apdu->cse = SC_APDU_CASE_4_SHORT;
-		sm_apdu->resplen = 4 + 2 + mac_len + 2 + 2 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
-		if (sm_apdu->resplen > SC_MAX_APDU_RESP_SIZE)
-			sm_apdu->resplen = SC_MAX_APDU_RESP_SIZE;
+		sm_apdu->le = SC_MAX_APDU_RESP_SIZE;
 	}
+
 	resp_data = calloc(1, sm_apdu->resplen);
 	if (!resp_data) {
 		r = SC_ERROR_OUT_OF_MEMORY;

--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -281,7 +281,7 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	u8 *p, *le = NULL, *sm_data = NULL, *fdata = NULL, *mac_data = NULL,
 	   *asn1 = NULL, *mac = NULL, *resp_data = NULL;
 	size_t sm_data_len, fdata_len, mac_data_len, asn1_len, mac_len, le_len,
-	       cryptogram_len;
+			cryptogram_len;
 	int r;
 	sc_apdu_t *sm_apdu = NULL;
 
@@ -472,11 +472,11 @@ static int sm_encrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 	 * indicator (1B). The cryptogram is always padded to the block size and
 	 * the size of its tag and length is whatever ASN.1 needs to encode that
 	 * much data, independent of the APDU being short or extended. */
-	cryptogram_len = 1 + ((apdu->resplen+1)/ctx->block_length+1)*ctx->block_length;
-	r = sc_asn1_put_tag(SC_ASN1_TAG_CONTEXT|0x07, NULL, cryptogram_len, NULL, 0, NULL);
+	cryptogram_len = 1 + ((apdu->resplen + 1) / ctx->block_length + 1) * ctx->block_length;
+	r = sc_asn1_put_tag(SC_ASN1_TAG_CONTEXT | 0x07, NULL, cryptogram_len, NULL, 0, NULL);
 	if (r < 0)
 		goto err;
-	sm_apdu->resplen = 4 + 2 + mac_len + (size_t) r;
+	sm_apdu->resplen = 4 + 2 + mac_len + (size_t)r;
 	if (apdu->cse & SC_APDU_EXT) {
 		sm_apdu->cse = SC_APDU_CASE_4_EXT;
 		sm_apdu->le = SC_MAX_EXT_APDU_RESP_SIZE;


### PR DESCRIPTION
# sm-iso: fix response buffer sizing and Le in sm_encrypt

`sm_encrypt()` built the SM APDU with `le = 0` and a response buffer whose size was
capped at the maximum short/extended APDU response size. Both are wrong when the
wrapped response does not fit in a single transfer.

## Problem

- `sc_apdu_t.le` is the number of expected bytes, not its encoding. `0` means "no
  data expected", so `sc_get_response()` drops everything announced by a `61xx` and
  the chained part of the response is never fetched.
- `resplen` assumed a fixed 2 or 3 byte ASN.1 length for the cryptogram and then
  clamped the total to `SC_MAX_APDU_RESP_SIZE` / `SC_MAX_EXT_APDU_RESP_SIZE`. A
  larger cryptogram was silently truncated instead of failing.

## Changes

- Derive the cryptogram tag+length overhead from `sc_asn1_put_tag()` instead of
  hardcoding it. Tag `0x85` (odd INS) encodes to the same size as `0x87`.
- Remove the cap on `resplen`. This buffer is allocated locally and never goes on
  the wire; what the card can return is bounded by the card, not by the maximum
  transceive size.
- Set `le` to `SC_MAX_APDU_RESP_SIZE` (short) or `SC_MAX_EXT_APDU_RESP_SIZE`
  (extended). A short APDU cannot ask for more than 256 bytes at once, the
  remainder is fetched with GET RESPONSE.

## Notes

See #3736 for context

Tested reading an RSA signature over SM, where the wrapped reply is 291 bytes and
previously did not survive the chaining handling. Applying the patch fixes this bug.