### PR TITLE
pkc15-init: Avoid buffer overrun when local file is smaller than requested

### DIFF
--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2580,20 +2580,20 @@ do_read_data_object(const char *name, u8 **out, size_t *outlen, size_t expected)
 		return SC_ERROR_OUT_OF_MEMORY;
 
 
-        inf = fopen(name, "rb");
-        if (inf == NULL) {
-                fprintf(stderr, "Unable to open '%s' for reading.\n", name);
-                return SC_ERROR_FILE_NOT_FOUND;
-        }
-        sz = fread(*out, 1, filesize, inf);
-        fclose(inf);
-        if (sz < 0) {
-                perror("read");
-                return SC_ERROR_FILE_NOT_FOUND;
-        }
-        if ((size_t)sz < filesize) {
-                return SC_ERROR_FILE_TOO_SMALL;
-        }
+	inf = fopen(name, "rb");
+	if (inf == NULL) {
+		fprintf(stderr, "Unable to open '%s' for reading.\n", name);
+		return SC_ERROR_FILE_NOT_FOUND;
+	}
+	sz = fread(*out, 1, filesize, inf);
+	fclose(inf);
+	if (sz < 0) {
+		perror("read");
+		return SC_ERROR_FILE_NOT_FOUND;
+	}
+	if ((size_t)sz < filesize) {
+		return SC_ERROR_FILE_TOO_SMALL;
+	}
 
 	*outlen = filesize;
 	return SC_SUCCESS;

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -2591,6 +2591,9 @@ do_read_data_object(const char *name, u8 **out, size_t *outlen, size_t expected)
                 perror("read");
                 return SC_ERROR_FILE_NOT_FOUND;
         }
+        if ((size_t)sz < filesize) {
+                return SC_ERROR_FILE_TOO_SMALL;
+        }
 
 	*outlen = filesize;
 	return SC_SUCCESS;


### PR DESCRIPTION
Originally reported by hamzacagrici@gmail.com

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
