### PR TITLE
Remove the use of SC_FORMAT_LEN_* macros

### DIFF
--- a/src/libopensc/apdu.c
+++ b/src/libopensc/apdu.c
@@ -364,10 +364,8 @@ sc_single_transmit(struct sc_card *card, struct sc_apdu *apdu)
 	if (card->reader->ops->transmit == NULL)
 		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "cannot transmit APDU");
 
-	sc_log(ctx,
-	       "CLA:%X, INS:%X, P1:%X, P2:%X, data(%"SC_FORMAT_LEN_SIZE_T"u) %p",
-	       apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen,
-	       apdu->data);
+	sc_log(ctx, "CLA:%X, INS:%X, P1:%X, P2:%X, data(%zu) %p",
+			apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen, apdu->data);
 #ifdef ENABLE_SM
 	if (card->sm_ctx.sm_mode == SM_MODE_TRANSMIT
 		   	&& (apdu->flags & SC_APDU_FLAGS_NO_SM) == 0) {
@@ -674,9 +672,8 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 
 	if (!len) {
 		apdu->cse = SC_APDU_CASE_1;
-		sc_log(ctx,
-		       "CASE_1 APDU: %"SC_FORMAT_LEN_SIZE_T"u bytes:\tins=%02x p1=%02x p2=%02x lc=%04"SC_FORMAT_LEN_SIZE_T"x le=%04"SC_FORMAT_LEN_SIZE_T"x",
-		       len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
+		sc_log(ctx, "CASE_1 APDU: %zu bytes:\tins=%02x p1=%02x p2=%02x lc=%04zx le=%04zx",
+				len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
 		return SC_SUCCESS;
 	}
 
@@ -697,9 +694,7 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 			apdu->lc += *p++;
 			len -= 3;
 			if (len < apdu->lc) {
-				sc_log(ctx,
-				       "APDU too short (need %"SC_FORMAT_LEN_SIZE_T"u more bytes)",
-				       apdu->lc - len);
+				sc_log(ctx, "APDU too short (need %zu more bytes)", apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
 			apdu->data = p;
@@ -737,9 +732,7 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 			apdu->lc = *p++;
 			len--;
 			if (len < apdu->lc) {
-				sc_log(ctx,
-				       "APDU too short (need %"SC_FORMAT_LEN_SIZE_T"u more bytes)",
-				       apdu->lc - len);
+				sc_log(ctx, "APDU too short (need %zu more bytes)", apdu->lc - len);
 				return SC_ERROR_INVALID_DATA;
 			}
 			apdu->data = p;
@@ -763,12 +756,9 @@ sc_bytes2apdu(sc_context_t *ctx, const u8 *buf, size_t len, sc_apdu_t *apdu)
 		return SC_ERROR_INVALID_DATA;
 	}
 
-	sc_log(ctx,
-	       "Case %d %s APDU, %"SC_FORMAT_LEN_SIZE_T"u bytes:\tins=%02x p1=%02x p2=%02x lc=%04"SC_FORMAT_LEN_SIZE_T"x le=%04"SC_FORMAT_LEN_SIZE_T"x",
-	       apdu->cse & SC_APDU_SHORT_MASK,
-	       (apdu->cse & SC_APDU_EXT) != 0 ? "extended" : "short",
-	       len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc,
-	       apdu->le);
+	sc_log(ctx, "Case %d %s APDU, %zu bytes:\tins=%02x p1=%02x p2=%02x lc=%04zx le=%04zx",
+			apdu->cse & SC_APDU_SHORT_MASK, (apdu->cse & SC_APDU_EXT) != 0 ? "extended" : "short",
+			len0, apdu->ins, apdu->p1, apdu->p2, apdu->lc, apdu->le);
 
 	return SC_SUCCESS;
 }

--- a/src/libopensc/asn1.c
+++ b/src/libopensc/asn1.c
@@ -228,7 +228,7 @@ static void sc_asn1_print_integer(const u8 * buf, size_t buflen)
 			a <<= 8;
 			a |= buf[i];
 		}
-		printf("%"SC_FORMAT_LEN_SIZE_T"u", a);
+		printf("%zu", a);
 	}
 }
 
@@ -408,9 +408,7 @@ static void print_tags_recursive(const u8 * buf0, const u8 * buf,
 		}
 		if (!((cla & SC_ASN1_TAG_CLASS) == SC_ASN1_TAG_UNIVERSAL
 					&& tag == SC_ASN1_TAG_NULL && len == 0)) {
-			printf(" (%"SC_FORMAT_LEN_SIZE_T"u byte%s)",
-					len,
-					len != 1 ? "s" : "");
+			printf(" (%zu byte%s)", len, len != 1 ? "s" : "");
 		}
 
 		if (len + hlen > bytesleft) {
@@ -557,9 +555,8 @@ const u8 *sc_asn1_skip_tag(sc_context_t *ctx, const u8 ** buf, size_t *buflen,
 		return NULL;
 	len -= (p - *buf);	/* header size */
 	if (taglen > len) {
-		sc_debug(ctx, SC_LOG_DEBUG_ASN1,
-			 "too long ASN.1 object (size %"SC_FORMAT_LEN_SIZE_T"u while only %"SC_FORMAT_LEN_SIZE_T"u available)\n",
-			 taglen, len);
+		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "too long ASN.1 object (size %zu while only %zu available)",
+				taglen, len);
 		return NULL;
 	}
 	*buflen -= (p - *buf) + taglen;
@@ -1513,9 +1510,7 @@ static int asn1_decode_entry(sc_context_t *ctx,struct sc_asn1_entry *entry,
 	case SC_ASN1_BOOLEAN:
 		if (parm != NULL) {
 			if (objlen != 1) {
-				sc_debug(ctx, SC_LOG_DEBUG_ASN1,
-					 "invalid ASN.1 object length: %"SC_FORMAT_LEN_SIZE_T"u\n",
-					 objlen);
+				sc_debug(ctx, SC_LOG_DEBUG_ASN1, "invalid ASN.1 object length: %zu", objlen);
 				r = SC_ERROR_INVALID_ASN1_OBJECT;
 			} else
 				*((int *) parm) = obj[0] ? 1 : 0;
@@ -1727,9 +1722,8 @@ static int asn1_decode(sc_context_t *ctx, struct sc_asn1_entry *asn1,
 	struct sc_asn1_entry *entry = asn1;
 	size_t left = len, objlen;
 
-	sc_debug(ctx, SC_LOG_DEBUG_ASN1,
-		 "%*.*s""called, left=%"SC_FORMAT_LEN_SIZE_T"u, depth %d%s\n",
-		 depth, depth, "", left, depth, choice ? ", choice" : "");
+	sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*s""called, left=%zu, depth %d%s",
+			depth, depth, "", left, depth, choice ? ", choice" : "");
 
 	if (!p)
 		return SC_ERROR_ASN1_OBJECT_NOT_FOUND;
@@ -1841,10 +1835,8 @@ static int asn1_encode_entry(sc_context_t *ctx, const struct sc_asn1_entry *entr
 		(entry->flags & SC_ASN1_PRESENT)? "" : " (not present)");
 	if (!(entry->flags & SC_ASN1_PRESENT))
 		goto no_object;
-	sc_debug(ctx, SC_LOG_DEBUG_ASN1,
-		 "%*.*stype=%d, tag=0x%02x, parm=%p, len=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 depth, depth, "", entry->type, entry->tag, parm,
-		 len ? *len : 0);
+	sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*stype=%d, tag=0x%02x, parm=%p, len=%zu",
+			depth, depth, "", entry->type, entry->tag, parm, len ? *len : 0);
 
 	if (entry->type == SC_ASN1_CHOICE) {
 		const struct sc_asn1_entry *list, *choice = NULL;
@@ -2034,9 +2026,7 @@ no_object:
 	if (buf)
 		free(buf);
 	if (r >= 0)
-		sc_debug(ctx, SC_LOG_DEBUG_ASN1,
-			 "%*.*slength of encoded item=%"SC_FORMAT_LEN_SIZE_T"u\n",
-			 depth, depth, "", *objlen);
+		sc_debug(ctx, SC_LOG_DEBUG_ASN1, "%*.*slength of encoded item=%zu", depth, depth, "", *objlen);
 	return r;
 }
 
@@ -2227,10 +2217,8 @@ sc_asn1_sig_value_sequence_to_rs(struct sc_context *ctx, const unsigned char *in
 	if (s_len > 0)
 		memcpy(buf + (buflen - s_len), s, s_len);
 
-	sc_log(ctx, "r(%"SC_FORMAT_LEN_SIZE_T"u): %s", halflen,
-	       sc_dump_hex(buf, halflen));
-	sc_log(ctx, "s(%"SC_FORMAT_LEN_SIZE_T"u): %s", halflen,
-	       sc_dump_hex(buf + halflen, halflen));
+	sc_log(ctx, "r(%zu): %s", halflen, sc_dump_hex(buf, halflen));
+	sc_log(ctx, "s(%zu): %s", halflen, sc_dump_hex(buf + halflen, halflen));
 
 	rv = SC_SUCCESS;
 err:

--- a/src/libopensc/aux-data.c
+++ b/src/libopensc/aux-data.c
@@ -157,9 +157,8 @@ sc_aux_data_get_md_guid(struct sc_context *ctx, struct sc_auxiliary_data *aux_da
 		strlcat(guid, "}", sizeof(guid));
 
 	if (*out_size < strlen(guid))   {
-		sc_log(ctx,
-		       "aux-data: buffer too small: out_size:%"SC_FORMAT_LEN_SIZE_T"u < guid-length:%"SC_FORMAT_LEN_SIZE_T"u",
-		       *out_size, strlen(guid));
+		sc_log(ctx, "aux-data: buffer too small: out_size:%zu < guid-length:%zu",
+				*out_size, strlen(guid));
 		LOG_FUNC_RETURN(ctx, SC_ERROR_BUFFER_TOO_SMALL);
 	}
 

--- a/src/libopensc/card-authentic.c
+++ b/src/libopensc/card-authentic.c
@@ -309,7 +309,7 @@ authentic_parse_credential_data(struct sc_context *ctx, struct sc_pin_cmd_data *
 	if (acls) {
 		rv = authentic_get_tagged_data(ctx, blob, blob_len, AUTHENTIC_TAG_DOCP_ACLS, &data, &data_len);
 		LOG_TEST_RET(ctx, rv, "failed to get ACLs");
-		sc_log(ctx, "data_len:%"SC_FORMAT_LEN_SIZE_T"u", data_len);
+		sc_log(ctx, "data_len:%zu", data_len);
 		if (data_len == 10)   {
 			for (ii=0; ii<5; ii++)   {
 				unsigned char acl = *(data + ii*2);
@@ -647,9 +647,7 @@ authentic_read_binary(struct sc_card *card, unsigned int idx,
 	int rv = SC_ERROR_INVALID_ARGUMENTS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_recv_size:%"SC_FORMAT_LEN_SIZE_T"u",
-	       idx, count, card->max_recv_size);
+	sc_log(ctx, "offs:%i,count:%zu,max_recv_size:%zu", idx, count, card->max_recv_size);
 
 	rest = count;
 	while(rest)   {
@@ -693,9 +691,7 @@ authentic_write_binary(struct sc_card *card, unsigned int idx,
 	int rv = SC_ERROR_INVALID_ARGUMENTS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
-	       idx, count, card->max_send_size);
+	sc_log(ctx, "offs:%i,count:%zu,max_send_size:%zu", idx, count, card->max_send_size);
 
 	rest = count;
 	while(rest)   {
@@ -736,9 +732,7 @@ authentic_update_binary(struct sc_card *card, unsigned int idx,
 	int rv = SC_ERROR_INVALID_ARGUMENTS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "offs:%i,count:%"SC_FORMAT_LEN_SIZE_T"u,max_send_size:%"SC_FORMAT_LEN_SIZE_T"u",
-	       idx, count, card->max_send_size);
+	sc_log(ctx, "offs:%i,count:%zu,max_send_size:%zu", idx, count, card->max_send_size);
 
 	rest = count;
 	while(rest)   {
@@ -789,14 +783,14 @@ authentic_process_fci(struct sc_card *card, struct sc_file *file,
 
 	tag = sc_asn1_find_tag(card->ctx,  buf, buflen, 0x6F, &taglen);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
+		sc_log(ctx, "  FCP length %zu", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
 
 	tag = sc_asn1_find_tag(card->ctx,  buf, buflen, 0x62, &taglen);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
+		sc_log(ctx, "  FCP length %zu", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
@@ -1182,14 +1176,10 @@ authentic_pin_change_pinpad(struct sc_card *card, unsigned reference, int *tries
 	memset(pin2_data, pin_cmd.pin2.pad_char, sizeof(pin2_data));
 	pin_cmd.pin2.data = pin2_data;
 
-	sc_log(ctx,
-	       "PIN1 lengths max/min/pad: %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-	       pin_cmd.pin1.max_length, pin_cmd.pin1.min_length,
-	       pin_cmd.pin1.pad_length);
-	sc_log(ctx,
-	       "PIN2 lengths max/min/pad: %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-	       pin_cmd.pin2.max_length, pin_cmd.pin2.min_length,
-	       pin_cmd.pin2.pad_length);
+	sc_log(ctx, "PIN1 lengths max/min/pad: %zu/%zu/%zu",
+			pin_cmd.pin1.max_length, pin_cmd.pin1.min_length, pin_cmd.pin1.pad_length);
+	sc_log(ctx, "PIN2 lengths max/min/pad: %zu/%zu/%zu",
+			pin_cmd.pin2.max_length, pin_cmd.pin2.min_length, pin_cmd.pin2.pad_length);
 
 	rv = iso_ops->pin_cmd(card, &pin_cmd);
 
@@ -1290,10 +1280,8 @@ authentic_chv_set_pinpad(struct sc_card *card, unsigned char reference)
 	memcpy(&pin_cmd.pin2, &pin_cmd.pin1, sizeof(pin_cmd.pin1));
 	memset(&pin_cmd.pin1, 0, sizeof(pin_cmd.pin1));
 
-	sc_log(ctx,
-	       "PIN2 max/min/pad %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-	       pin_cmd.pin2.max_length, pin_cmd.pin2.min_length,
-	       pin_cmd.pin2.pad_length);
+	sc_log(ctx, "PIN2 max/min/pad %zu/%zu/%zu",
+			pin_cmd.pin2.max_length, pin_cmd.pin2.min_length, pin_cmd.pin2.pad_length);
 	rv = iso_ops->pin_cmd(card, &pin_cmd);
 
 	LOG_FUNC_RETURN(ctx, rv);
@@ -1341,11 +1329,9 @@ authentic_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, st
 
 	data->flags |= SC_PIN_CMD_NEED_PADDING;
 
-	sc_log(ctx,
-	       "PIN policy: size max/min/pad %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u, tries max/left %i/%i",
-	       data->pin1.max_length, data->pin1.min_length,
-	       data->pin1.pad_length, data->pin1.max_tries,
-	       data->pin1.tries_left);
+	sc_log(ctx, "PIN policy: size max/min/pad %zu/%zu/%zu, tries max/left %i/%i",
+			data->pin1.max_length, data->pin1.min_length, data->pin1.pad_length,
+			data->pin1.max_tries, data->pin1.tries_left);
 
 	LOG_FUNC_RETURN(ctx, rv);
 }
@@ -1564,15 +1550,11 @@ authentic_manage_sdo_encode_prvkey(struct sc_card *card, struct sc_pkcs15_prkey 
 	blob_len = 0;
 
 	/* Encode public RSA key part */
-	sc_log(ctx,
-	       "modulus.len:%"SC_FORMAT_LEN_SIZE_T"u blob_len:%"SC_FORMAT_LEN_SIZE_T"u",
-	       rsa.modulus.len, blob_len);
+	sc_log(ctx, "modulus.len:%zu blob_len:%zu", rsa.modulus.len, blob_len);
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PUBLIC_MODULUS, rsa.modulus.data, rsa.modulus.len, &blob, &blob_len);
 	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Modulus encode error");
 
-	sc_log(ctx,
-	       "exponent.len:%"SC_FORMAT_LEN_SIZE_T"u blob_len:%"SC_FORMAT_LEN_SIZE_T"u",
-	       rsa.exponent.len, blob_len);
+	sc_log(ctx, "exponent.len:%zu blob_len:%zu", rsa.exponent.len, blob_len);
 	rv = authentic_update_blob(ctx, AUTHENTIC_TAG_RSA_PUBLIC_EXPONENT, rsa.exponent.data, rsa.exponent.len, &blob, &blob_len);
 	LOG_TEST_GOTO_ERR(ctx, rv, "SDO RSA Exponent encode error");
 
@@ -1689,7 +1671,7 @@ authentic_manage_sdo_generate(struct sc_card *card, struct sc_authentic_sdo *sdo
 
 	rv = authentic_manage_sdo_encode(card, sdo, SC_CARDCTL_AUTHENTIC_SDO_GENERATE, &data, &data_len);
 	LOG_TEST_RET(ctx, rv, "Cannot encode SDO data");
-	sc_log(ctx, "encoded SDO length %"SC_FORMAT_LEN_SIZE_T"u", data_len);
+	sc_log(ctx, "encoded SDO length %zu", data_len);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x47, 0x00, 0x00);
 	apdu.data = data;
@@ -1726,7 +1708,7 @@ authentic_manage_sdo(struct sc_card *card, struct sc_authentic_sdo *sdo, unsigne
 
 	rv = authentic_manage_sdo_encode(card, sdo, cmd, &data, &data_len);
 	LOG_TEST_RET(ctx, rv, "Cannot encode SDO data");
-	sc_log(ctx, "encoded SDO length %"SC_FORMAT_LEN_SIZE_T"u", data_len);
+	sc_log(ctx, "encoded SDO length %zu", data_len);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xDB, 0x3F, 0xFF);
 	apdu.data = data;
@@ -1832,9 +1814,7 @@ authentic_decipher(struct sc_card *card, const unsigned char *in, size_t in_len,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "crgram_len %"SC_FORMAT_LEN_SIZE_T"u;  outlen %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len, out_len);
+	sc_log(ctx, "crgram_len %zu;  outlen %zu", in_len, out_len);
 	if (!out || !out_len || in_len > SC_MAX_APDU_BUFFER_SIZE)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
@@ -2058,10 +2038,8 @@ authentic_sm_get_wrapped_apdu(struct sc_card *card, struct sc_apdu *plain, struc
 
 	if (!plain || !sm_apdu)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
-	sc_log(ctx,
-	       "called; CLA:%X, INS:%X, P1:%X, P2:%X, data(%"SC_FORMAT_LEN_SIZE_T"u) %p",
-	       plain->cla, plain->ins, plain->p1, plain->p2, plain->datalen,
-	       plain->data);
+	sc_log(ctx, "called; CLA:%X, INS:%X, P1:%X, P2:%X, data(%zu) %p",
+			plain->cla, plain->ins, plain->p1, plain->p2, plain->datalen, plain->data);
 	*sm_apdu = NULL;
 
 	if ((plain->cla & 0x04)

--- a/src/libopensc/card-belpic.c
+++ b/src/libopensc/card-belpic.c
@@ -196,9 +196,8 @@ static int get_carddata(sc_card_t *card, u8* carddata_loc, unsigned int carddata
 		return r;
 	}
 	if(apdu.resplen < carddataloc_len) {
-		sc_log(card->ctx,
-			 "GetCardData: card returned %"SC_FORMAT_LEN_SIZE_T"u bytes rather than expected %d\n",
-			 apdu.resplen, carddataloc_len);
+		sc_log(card->ctx, "GetCardData: card returned %zu bytes rather than expected %d",
+				apdu.resplen, carddataloc_len);
 		return SC_ERROR_WRONG_LENGTH;
 	}
 

--- a/src/libopensc/card-cac.c
+++ b/src/libopensc/card-cac.c
@@ -261,10 +261,8 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-		 "%02x %02x %02x %"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 ins, p1, p2, sendbuflen, card->max_send_size,
-		 card->max_recv_size);
+	sc_log(card->ctx, "%02x %02x %02x %zu : %zu %zu",
+			ins, p1, p2, sendbuflen, card->max_send_size, card->max_recv_size);
 
 	rbuf = rbufinitbuf;
 	rbuflen = sizeof(rbufinitbuf);
@@ -300,16 +298,14 @@ static int cac_apdu_io(sc_card_t *card, int ins, int p1, int p2,
 		 apdu.resplen = 0;
 	}
 
-	sc_log(card->ctx,
-		 "calling sc_transmit_apdu flags=%lx le=%"SC_FORMAT_LEN_SIZE_T"u, resplen=%"SC_FORMAT_LEN_SIZE_T"u, resp=%p",
-		 apdu.flags, apdu.le, apdu.resplen, apdu.resp);
+	sc_log(card->ctx, "calling sc_transmit_apdu flags=%lx le=%zu, resplen=%zu, resp=%p",
+			apdu.flags, apdu.le, apdu.resplen, apdu.resp);
 
 	/* with new adpu.c and chaining, this actually reads the whole object */
 	r = sc_transmit_apdu(card, &apdu);
 
-	sc_log(card->ctx,
-		 "result r=%d apdu.resplen=%"SC_FORMAT_LEN_SIZE_T"u sw1=%02x sw2=%02x",
-		 r, apdu.resplen, apdu.sw1, apdu.sw2);
+	sc_log(card->ctx, "result r=%d apdu.resplen=%zu sw1=%02x sw2=%02x",
+			r, apdu.resplen, apdu.sw1, apdu.sw2);
 	if (r < 0) {
 		sc_log(card->ctx, "Transmit failed");
 		goto err;
@@ -366,8 +362,7 @@ cac_get_acr(sc_card_t *card, int acr_type, u8 **out_buf, size_t *out_len)
 	if (r < 0)
 		goto fail;
 
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-	    "got %"SC_FORMAT_LEN_SIZE_T"u bytes out=%p", len, out);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "got %zu bytes out=%p", len, out);
 
 	*out_len = len;
 	*out_buf = out;
@@ -415,8 +410,8 @@ static int cac_read_file(sc_card_t *card, int file_type, u8 **out_buf, size_t *o
 
 	left = size = lebytes2ushort(count);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-		 "got %"SC_FORMAT_LEN_SIZE_T"u bytes out_ptr=%p count&=%p count[0]=0x%02x count[1]=0x%02x, len=0x%04"SC_FORMAT_LEN_SIZE_T"x (%"SC_FORMAT_LEN_SIZE_T"u)",
-		 len, out_ptr, &count, count[0], count[1], size, size);
+			"got %zu bytes out_ptr=%p count&=%p count[0]=0x%02x count[1]=0x%02x, len=0x%04zx (%zu)",
+			len, out_ptr, &count, count[0], count[1], size, size);
 	out = out_ptr = malloc(size);
 	if (out == NULL) {
 		r = SC_ERROR_OUT_OF_MEMORY;
@@ -468,9 +463,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if we didn't return it all last time, return the remainder */
 	if (priv->cached) {
-		sc_log(card->ctx,
-			 "returning cached value idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
-			 idx, count);
+		sc_log(card->ctx, "returning cached value idx=%d count=%zu", idx, count);
 		if (idx > priv->cache_buf_len) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_FILE_END_REACHED);
 		}
@@ -479,9 +472,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		LOG_FUNC_RETURN(card->ctx, (int)len);
 	}
 
-	sc_log(card->ctx,
-		 "clearing cache idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
-		 idx, count);
+	sc_log(card->ctx, "clearing cache idx=%d count=%zu", idx, count);
 	if (priv->cache_buf) {
 		free(priv->cache_buf);
 		priv->cache_buf = NULL;
@@ -526,8 +517,8 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 			/* don't crash on bad data */
 			if (val_len < len) {
-				sc_log(card->ctx, "Received too long value %"SC_FORMAT_LEN_SIZE_T"u, "
-				    "while only %"SC_FORMAT_LEN_SIZE_T"u left. Truncating", len, val_len);
+				sc_log(card->ctx, "Received too long value %zu, while only %zu left. Truncating",
+						len, val_len);
 				len = val_len;
 			}
 			/* if we run out of return space, truncate */
@@ -542,9 +533,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	case CAC_OBJECT_TYPE_CERT:
 		/* read file */
-		sc_log(card->ctx,
-			 " obj= cert_file, val_len=%"SC_FORMAT_LEN_SIZE_T"u (0x%04"SC_FORMAT_LEN_SIZE_T"x)",
-			 val_len, val_len);
+		sc_log(card->ctx, " obj= cert_file, val_len=%zu (0x%04zx)", val_len, val_len);
 		cert_len = 0;
 		cert_ptr = NULL;
 		cert_type = 0;
@@ -558,8 +547,8 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 			/* incomplete value */
 			if (val_len < len) {
-				sc_log(card->ctx, "Read incomplete value %"SC_FORMAT_LEN_SIZE_T"u, "
-				    "while only %"SC_FORMAT_LEN_SIZE_T"u left", len, val_len);
+				sc_log(card->ctx, "Read incomplete value %zu, while only %zu left",
+						len, val_len);
 				break;
 			}
 
@@ -739,11 +728,9 @@ static int cac_set_security_env(sc_card_t *card, const sc_security_env_t *env, i
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-		 "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 env->flags, env->operation, env->algorithm,
-		 env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
-		 env->key_ref_len);
+	sc_log(card->ctx, "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%zu",
+			env->flags, env->operation, env->algorithm, env->algorithm_flags, env->algorithm_ref,
+			env->key_ref[0], env->key_ref_len);
 
 	if (env->algorithm != SC_ALGORITHM_RSA) {
 		 r = SC_ERROR_NO_CARD_SUPPORT;
@@ -771,9 +758,7 @@ static int cac_rsa_op(sc_card_t *card,
 	size_t rbuflen, outplen;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 datalen, outlen);
+	sc_log(card->ctx, "datalen=%zu outlen=%zu\n", datalen, outlen);
 
 	outp = out;
 	outplen = outlen;
@@ -878,8 +863,7 @@ static int cac_parse_properties_object(sc_card_t *card, u8 type,
 		switch (tag) {
 		case CAC_TAG_OBJECT_ID:
 			if (len != 2) {
-				sc_log(card->ctx, "TAG: Object ID: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Object ID: Invalid length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
@@ -890,8 +874,7 @@ static int cac_parse_properties_object(sc_card_t *card, u8 type,
 
 		case CAC_TAG_BUFFER_PROPERTIES:
 			if (len != 5) {
-				sc_log(card->ctx, "TAG: Buffer Properties: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Buffer Properties: Invalid length %zu", len);
 				break;
 			}
 			/* First byte is "Type of Tag Supported" */
@@ -905,8 +888,7 @@ static int cac_parse_properties_object(sc_card_t *card, u8 type,
 		case CAC_TAG_PKI_PROPERTIES:
 			/* 4th byte is "Private Key Initialized" */
 			if (len != 4) {
-				sc_log(card->ctx, "TAG: PKI Properties: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: PKI Properties: Invalid length %zu", len);
 				break;
 			}
 			if (type != CAC_TAG_PKI_OBJECT) {
@@ -960,8 +942,7 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 		switch (tag) {
 		case CAC_TAG_APPLET_INFORMATION:
 			if (len != 5) {
-				sc_log(card->ctx, "TAG: Applet Information: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Applet Information: Invalid length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
@@ -973,8 +954,7 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 
 		case CAC_TAG_NUMBER_OF_OBJECTS:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: Num objects: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Num objects: Invalid length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
@@ -985,12 +965,10 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 
 		case CAC_TAG_TV_BUFFER:
 			if (len != 17) {
-				sc_log(card->ctx, "TAG: TV Object: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: TV Object: Invalid length %zu", len);
 				break;
 			}
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-			    "TAG: TV Object nr. %"SC_FORMAT_LEN_SIZE_T"u", i);
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "TAG: TV Object nr. %zu", i);
 			if (i >= CAC_MAX_OBJECTS) {
 				free(rbuf);
 				return SC_SUCCESS;
@@ -1003,12 +981,10 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 
 		case CAC_TAG_PKI_OBJECT:
 			if (len != 17) {
-				sc_log(card->ctx, "TAG: PKI Object: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: PKI Object: Invalid length %zu", len);
 				break;
 			}
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-			    "TAG: PKI Object nr. %"SC_FORMAT_LEN_SIZE_T"u", i);
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "TAG: PKI Object nr. %zu", i);
 			if (i >= CAC_MAX_OBJECTS) {
 				free(rbuf);
 				return SC_SUCCESS;
@@ -1021,17 +997,15 @@ static int cac_get_properties(sc_card_t *card, cac_properties_t *prop)
 
 		default:
 			/* ignore tags we don't understand */
-			sc_log(card->ctx, "TAG: Unknown (0x%02x), len=%"
-			    SC_FORMAT_LEN_SIZE_T"u", tag, len);
+			sc_log(card->ctx, "TAG: Unknown (0x%02x), len=%zu", tag, len);
 			break;
 		}
 	}
 	free(rbuf);
 	/* sanity */
 	if (i != prop->num_objects)
-		sc_log(card->ctx, "The announced number of objects (%zu) "
-		    "did not match reality (%"SC_FORMAT_LEN_SIZE_T"u)",
-		    prop->num_objects, i);
+		sc_log(card->ctx, "The announced number of objects (%zu) did not match reality (%zu)",
+				prop->num_objects, i);
 	prop->num_objects = i;
 
 	return SC_SUCCESS;
@@ -1264,17 +1238,15 @@ static int cac_path_from_cardurl(sc_card_t *card, sc_path_t *path, cac_card_url_
 	path->len = sizeof(val->objectID);
 	path->type = SC_PATH_TYPE_FILE_ID;
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-		 "path->aid=%x %x %x %x %x %x %x  len=%"SC_FORMAT_LEN_SIZE_T"u, path->value = %x %x len=%"SC_FORMAT_LEN_SIZE_T"u path->type=%d (%x)",
-		 path->aid.value[0], path->aid.value[1], path->aid.value[2],
-		 path->aid.value[3], path->aid.value[4], path->aid.value[5],
-		 path->aid.value[6], path->aid.len, path->value[0],
-		 path->value[1], path->len, path->type, path->type);
+			"path->aid=%x %x %x %x %x %x %x  len=%zu, path->value = %x %x len=%zu path->type=%d (%x)",
+			path->aid.value[0], path->aid.value[1], path->aid.value[2], path->aid.value[3],
+			path->aid.value[4], path->aid.value[5], path->aid.value[6], path->aid.len,
+			path->value[0], path->value[1], path->len, path->type, path->type);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-		 "rid=%x %x %x %x %x  len=%"SC_FORMAT_LEN_SIZE_T"u appid= %x %x len=%"SC_FORMAT_LEN_SIZE_T"u objid= %x %x len=%"SC_FORMAT_LEN_SIZE_T"u",
-		 val->rid[0], val->rid[1], val->rid[2], val->rid[3],
-		 val->rid[4], sizeof(val->rid), val->applicationID[0],
-		 val->applicationID[1], sizeof(val->applicationID),
-		 val->objectID[0], val->objectID[1], sizeof(val->objectID));
+			"rid=%x %x %x %x %x  len=%zu appid= %x %x len=%zu objid= %x %x len=%zu",
+			val->rid[0], val->rid[1], val->rid[2], val->rid[3], val->rid[4],
+			sizeof(val->rid), val->applicationID[0], val->applicationID[1],
+			sizeof(val->applicationID), val->objectID[0], val->objectID[1], sizeof(val->objectID));
 
 	return SC_SUCCESS;
 }
@@ -1395,10 +1367,8 @@ static int cac_parse_cuid(sc_card_t *card, cac_private_data_t *priv, cac_cuid_t 
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "manufacture id=%x", val->manufacturer_id);
 	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "cac_type=%d", val->card_type);
 	card_id_len = len - (&val->card_id - (u8 *)val);
-	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-		 "card_id=%s (%"SC_FORMAT_LEN_SIZE_T"u)",
-		 sc_dump_hex(&val->card_id, card_id_len),
-		 card_id_len);
+	sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "card_id=%s (%zu)",
+			sc_dump_hex(&val->card_id, card_id_len), card_id_len);
 	priv->cuid = *val;
 	free(priv->cac_id);
 	priv->cac_id = malloc(card_id_len);
@@ -1430,7 +1400,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 			break;
 		}
 		if (val + len > val_end) {
-			sc_log(card->ctx, "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+			sc_log(card->ctx, "Invalid length %zu", len);
 			break;
 		}
 		switch (tag) {
@@ -1442,8 +1412,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 			break;
 		case CAC_TAG_CC_VERSION_NUMBER:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: CC Version: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: CC Version: Invalid length %zu", len);
 				break;
 			}
 			/* ignore the version numbers for now */
@@ -1452,8 +1421,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 			break;
 		case CAC_TAG_GRAMMAR_VERION_NUMBER:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: Grammar Version: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Grammar Version: Invalid length %zu", len);
 				break;
 			}
 			/* ignore the version numbers for now */
@@ -1471,8 +1439,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 		 */
 		case CAC_TAG_PKCS15:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: PKCS15: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: PKCS15: Invalid length %zu", len);
 				break;
 			}
 			/* TODO should verify that this is '0'. If it's not
@@ -1482,8 +1449,7 @@ static int cac_parse_CCC(sc_card_t *card, cac_private_data_t *priv, const u8 *tl
 			break;
 		case CAC_TAG_DATA_MODEL:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: Registered Data Model Number: "
-				    "Invalid length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Registered Data Model Number: Invalid length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,"TAG: Registered Data Model Number (0x%02x)", *val);
@@ -1572,8 +1538,7 @@ static int cac_parse_ACA_service(sc_card_t *card, cac_private_data_t *priv,
 		switch (tag) {
 		case CAC_TAG_APPLET_FAMILY:
 			if (len != 5) {
-				sc_log(card->ctx, "TAG: Applet Information: "
-				    "bad length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Applet Information: bad length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
@@ -1584,8 +1549,7 @@ static int cac_parse_ACA_service(sc_card_t *card, cac_private_data_t *priv,
 			break;
 		case CAC_TAG_NUMBER_APPLETS:
 			if (len != 1) {
-				sc_log(card->ctx, "TAG: Num applets: "
-				    "bad length %"SC_FORMAT_LEN_SIZE_T"u", len);
+				sc_log(card->ctx, "TAG: Num applets: bad length %zu", len);
 				break;
 			}
 			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
@@ -1594,9 +1558,7 @@ static int cac_parse_ACA_service(sc_card_t *card, cac_private_data_t *priv,
 		case CAC_TAG_APPLET_ENTRY:
 			/* Make sure we match the outer length */
 			if (len < 3 || val[2] != len - 3) {
-				sc_log(card->ctx, "TAG: Applet Entry: "
-				    "bad length (%"SC_FORMAT_LEN_SIZE_T
-				    "u) or length of internal buffer", len);
+				sc_log(card->ctx, "TAG: Applet Entry: bad length (%zu) or length of internal buffer", len);
 				break;
 			}
 			sc_debug_hex(card->ctx, SC_LOG_DEBUG_VERBOSE,

--- a/src/libopensc/card-cac1.c
+++ b/src/libopensc/card-cac1.c
@@ -136,9 +136,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if we didn't return it all last time, return the remainder */
 	if (priv->cached) {
-		sc_log(card->ctx,
-			"returning cached value idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
-			idx, count);
+		sc_log(card->ctx, "returning cached value idx=%d count=%zu", idx, count);
 		if (idx > priv->cache_buf_len) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_FILE_END_REACHED);
 		}
@@ -147,9 +145,7 @@ static int cac_read_binary(sc_card_t *card, unsigned int idx,
 		LOG_FUNC_RETURN(card->ctx, (int)len);
 	}
 
-	sc_log(card->ctx,
-		"clearing cache idx=%d count=%"SC_FORMAT_LEN_SIZE_T"u",
-		idx, count);
+	sc_log(card->ctx, "clearing cache idx=%d count=%zu", idx, count);
 	free(priv->cache_buf);
 	priv->cache_buf = NULL;
 	priv->cache_buf_len = 0;

--- a/src/libopensc/card-cardos-common.c
+++ b/src/libopensc/card-cardos-common.c
@@ -41,7 +41,7 @@ cardos_ec_compute_shared_value(struct sc_card *card,
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "CardOS compute shared value: in-len %" SC_FORMAT_LEN_SIZE_T "u, out-len %" SC_FORMAT_LEN_SIZE_T "u", crgram_len, outlen);
+	sc_log(card->ctx, "CardOS compute shared value: in-len %zu, out-len %zu", crgram_len, outlen);
 
 	/* Ensure public key is provided in uncompressed format (indicator byte
 	 * 0x04 followed by X and Y coordinate. */

--- a/src/libopensc/card-cardos.c
+++ b/src/libopensc/card-cardos.c
@@ -299,9 +299,9 @@ static int cardos_init(sc_card_t *card)
 	/* Use Min card sizes and reader too. for V5_3 at least*/
 
 	if (card->type == SC_CARD_TYPE_CARDOS_V5_0 || card->type == SC_CARD_TYPE_CARDOS_V5_3) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "data_field_length:%"SC_FORMAT_LEN_SIZE_T"u "
-				"card->reader->max_send_size:%"SC_FORMAT_LEN_SIZE_T"u "
-				"card->reader->max_recv_size:%"SC_FORMAT_LEN_SIZE_T"u %s",
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL,
+				"data_field_length:%zu card->reader->max_send_size:%zu "
+				"card->reader->max_recv_size:%zu %s",
 				data_field_length, card->reader->max_send_size, card->reader->max_recv_size,
 				(card->caps & SC_CARD_CAP_APDU_EXT) ? "SC_CARD_CAP_APDU_EXT" : " ");
 
@@ -1489,12 +1489,8 @@ cardos_pin_cmd(struct sc_card *card, struct sc_pin_cmd_data *data)
 	data->pin_reference |= 0x80;
 
 	sc_log(ctx, "PIN_CMD(cmd:%i, ref:%i)", data->cmd, data->pin_reference);
-	sc_log(ctx,
-	       "PIN1(max:%"SC_FORMAT_LEN_SIZE_T"u, min:%"SC_FORMAT_LEN_SIZE_T"u)",
-	       data->pin1.max_length, data->pin1.min_length);
-	sc_log(ctx,
-	       "PIN2(max:%"SC_FORMAT_LEN_SIZE_T"u, min:%"SC_FORMAT_LEN_SIZE_T"u)",
-	       data->pin2.max_length, data->pin2.min_length);
+	sc_log(ctx, "PIN1(max:%zu, min:%zu)", data->pin1.max_length, data->pin1.min_length);
+	sc_log(ctx, "PIN2(max:%zu, min:%zu)", data->pin2.max_length, data->pin2.min_length);
 
 	/* FIXME: the following values depend on what pin length was
 	 * used when creating the BS objects */

--- a/src/libopensc/card-coolkey.c
+++ b/src/libopensc/card-coolkey.c
@@ -921,10 +921,8 @@ static int coolkey_apdu_io(sc_card_t *card, int cla, int ins, int p1, int p2,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-		 "%02x %02x %02x %"SC_FORMAT_LEN_SIZE_T"u : %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 ins, p1, p2, sendbuflen, card->max_send_size,
-		 card->max_recv_size);
+	sc_log(card->ctx, "%02x %02x %02x %zu : %zu %zu",
+			ins, p1, p2, sendbuflen, card->max_send_size, card->max_recv_size);
 
 	rbuf = rbufinitbuf;
 	rbuflen = sizeof(rbufinitbuf);
@@ -986,16 +984,14 @@ static int coolkey_apdu_io(sc_card_t *card, int cla, int ins, int p1, int p2,
 		 apdu.resplen = 0;
 	}
 
-	sc_log(card->ctx,
-		 "calling sc_transmit_apdu flags=%lx le=%"SC_FORMAT_LEN_SIZE_T"u, resplen=%"SC_FORMAT_LEN_SIZE_T"u, resp=%p",
-		 apdu.flags, apdu.le, apdu.resplen, apdu.resp);
+	sc_log(card->ctx, "calling sc_transmit_apdu flags=%lx le=%zu, resplen=%zu, resp=%p",
+			apdu.flags, apdu.le, apdu.resplen, apdu.resp);
 
 	/* with new adpu.c and chaining, this actually reads the whole object */
 	r = sc_transmit_apdu(card, &apdu);
 
-	sc_log(card->ctx,
-		 "result r=%d apdu.resplen=%"SC_FORMAT_LEN_SIZE_T"u sw1=%02x sw2=%02x",
-		 r, apdu.resplen, apdu.sw1, apdu.sw2);
+	sc_log(card->ctx, "result r=%d apdu.resplen=%zu sw1=%02x sw2=%02x",
+			r, apdu.resplen, apdu.sw1, apdu.sw2);
 
 	if (r < 0) {
 		sc_log(card->ctx, "Transmit failed");
@@ -1194,17 +1190,13 @@ static int coolkey_read_binary(sc_card_t *card, unsigned int idx,
 
 	/* if we've already read the data, just return it */
 	if (priv->obj->data) {
-		sc_log(card->ctx,
-			 "returning cached value idx=%u count=%"SC_FORMAT_LEN_SIZE_T"u",
-			 idx, count);
+		sc_log(card->ctx, "returning cached value idx=%u count=%zu", idx, count);
 		len = MIN(count, priv->obj->length-idx);
 		memcpy(buf, &priv->obj->data[idx], len);
 		LOG_FUNC_RETURN(card->ctx, (int)len);
 	}
 
-	sc_log(card->ctx,
-		 "clearing cache idx=%u count=%"SC_FORMAT_LEN_SIZE_T"u",
-		 idx, count);
+	sc_log(card->ctx, "clearing cache idx=%u count=%zu", idx, count);
 
 	data = malloc(priv->obj->length);
 	if (data == NULL) {
@@ -1637,11 +1629,9 @@ static int coolkey_set_security_env(sc_card_t *card, const sc_security_env_t *en
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-		 "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 env->flags, env->operation, env->algorithm,
-		 env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
-		 env->key_ref_len);
+	sc_log(card->ctx, "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%zu",
+			env->flags, env->operation, env->algorithm, env->algorithm_flags, env->algorithm_ref,
+			env->key_ref[0], env->key_ref_len);
 
 	if ((env->algorithm != SC_ALGORITHM_RSA) && (env->algorithm != SC_ALGORITHM_EC)) {
 		 r = SC_ERROR_NO_CARD_SUPPORT;
@@ -1694,8 +1684,7 @@ static int coolkey_rsa_op(sc_card_t *card, const u8 * data, size_t datalen,
 	u8 *buf_out;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx, "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		datalen, max_out_len);
+	sc_log(card->ctx, "datalen=%zu outlen=%zu\n", datalen, max_out_len);
 
 	if (datalen > 0xFFFF) {
 		r = SC_ERROR_INVALID_ARGUMENTS;
@@ -1808,9 +1797,7 @@ static int coolkey_ecc_op(sc_card_t *card,
 	u8 key_number;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "datalen=%"SC_FORMAT_LEN_SIZE_T"u outlen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 datalen, outlen);
+	sc_log(card->ctx, "datalen=%zu outlen=%zu\n", datalen, outlen);
 
 	if (datalen > sizeof(params.buf)) {
 		r = SC_ERROR_INVALID_ARGUMENTS;

--- a/src/libopensc/card-dnie.c
+++ b/src/libopensc/card-dnie.c
@@ -767,9 +767,7 @@ static int dnie_sm_free_wrapped_apdu(struct sc_card *card,
 					memcpy(plain->resp, (*sm_apdu)->resp, (*sm_apdu)->resplen);
 					plain->resplen = (*sm_apdu)->resplen;
 				} else {
-					sc_log(card->ctx, "Invalid initial length,"
-							" needed %"SC_FORMAT_LEN_SIZE_T"u bytes"
-							" but has %"SC_FORMAT_LEN_SIZE_T"u",
+					sc_log(card->ctx, "Invalid initial length, needed %zu bytes but has %zu",
 							(*sm_apdu)->resplen, plain->resplen);
 					rv = SC_ERROR_BUFFER_TOO_SMALL;
 				}
@@ -1070,9 +1068,7 @@ static int dnie_fill_cache(sc_card_t * card,unsigned long *flags)
 	/* ok: as final step, set correct cache data into dnie_priv structures */
 	GET_DNIE_PRIV_DATA(card)->cache = buffer;
 	GET_DNIE_PRIV_DATA(card)->cachelen = len;
-	sc_log(ctx,
-	       "fill_cache() done. length '%"SC_FORMAT_LEN_SIZE_T"u' bytes",
-	       len);
+	sc_log(ctx, "fill_cache() done. length '%zu' bytes", len);
 	LOG_FUNC_RETURN(ctx, (int)len);
 }
 

--- a/src/libopensc/card-epass2003.c
+++ b/src/libopensc/card-epass2003.c
@@ -1541,9 +1541,7 @@ epass2003_sm_unwrap_apdu(struct sc_card *card, struct sc_apdu *sm, struct sc_apd
 	plain->sw1 = sm->sw1;
 	plain->sw2 = sm->sw2;
 
-	sc_log(card->ctx,
-	       "unwrapped APDU: resplen %"SC_FORMAT_LEN_SIZE_T"u, SW %02X%02X",
-	       plain->resplen, plain->sw1, plain->sw2);
+	sc_log(card->ctx, "unwrapped APDU: resplen %zu, SW %02X%02X", plain->resplen, plain->sw1, plain->sw2);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
@@ -2313,8 +2311,7 @@ epass2003_process_fci(struct sc_card *card, sc_file_t * file, const u8 * buf, si
 		file->size = tag[0];
 		if (taglen == 2)
 			file->size = (file->size << 8) + tag[1];
-		sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u",
-			   file->size);
+		sc_log(ctx, "  bytes in file: %zu", file->size);
 	}
 
 	if (tag == NULL) {

--- a/src/libopensc/card-flex.c
+++ b/src/libopensc/card-flex.c
@@ -557,9 +557,7 @@ static int cryptoflex_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		if (r)
 			return r;
 		if (apdu.resplen != 4) {
-			sc_log(card->ctx,
-				 "expected 4 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
-				 apdu.resplen);
+			sc_log(card->ctx, "expected 4 bytes, got %zu.", apdu.resplen);
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 		memcpy(buf, rbuf + 2, 2);
@@ -594,9 +592,7 @@ static int cyberflex_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		if (r)
 			return r;
 		if (apdu.resplen != 6) {
-			sc_log(card->ctx,
-				 "expected 6 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
-				 apdu.resplen);
+			sc_log(card->ctx, "expected 6 bytes, got %zu.", apdu.resplen);
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 		memcpy(buf, rbuf + 4, 2);
@@ -765,13 +761,8 @@ cyberflex_construct_file_attrs(sc_card_t *card, const sc_file_t *file,
 		break;
 	}
 
-	sc_log(card->ctx,
-		 "Creating %02x:%02x, size %"SC_FORMAT_LEN_SIZE_T"u %02"SC_FORMAT_LEN_SIZE_T"x:%02"SC_FORMAT_LEN_SIZE_T"x\n",
-		 file->id >> 8,
-		 file->id & 0xFF,
-		 size,
-		 size >> 8,
-		 size & 0xFF);
+	sc_log(card->ctx, "Creating %02x:%02x, size %zu %02zx:%02zx",
+			file->id >> 8, file->id & 0xFF, size, size >> 8, size & 0xFF);
 
 	p[0] = size >> 8;
 	p[1] = size & 0xFF;
@@ -896,9 +887,7 @@ cryptoflex_compute_signature(sc_card_t *card, const u8 *data,
 	size_t i, i2;
 
 	if (data_len != 64 && data_len != 96 && data_len != 128  && data_len != 256) {
-		sc_log(card->ctx,
-			 "Illegal input length: %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 data_len);
+		sc_log(card->ctx, "Illegal input length: %zu", data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	if (outlen < data_len) {
@@ -957,9 +946,7 @@ cyberflex_compute_signature(sc_card_t *card, const u8 *data,
 	case 96:  alg_id = 0xC6; break;
 	case 128: alg_id = 0xC8; break;
 	default:
-		sc_log(card->ctx,
-			 "Illegal input length: %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 data_len);
+		sc_log(card->ctx, "Illegal input length: %zu", data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	key_id = prv->rsa_key_ref + 1; /* Why? */
@@ -1031,7 +1018,7 @@ static int flex_generate_key(sc_card_t *card, struct sc_cardctl_cryptoflex_genke
 	case 1024:	p2 = 0x80; break;
 	case 2048:	p2 = 0x00; break;
 	default:
-		sc_log(card->ctx,  "Illegal key length: %zu\n", data->key_bits);
+		sc_log(card->ctx, "Illegal key length: %zu", data->key_bits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/libopensc/card-gemsafeV1.c
+++ b/src/libopensc/card-gemsafeV1.c
@@ -439,9 +439,7 @@ static int gemsafe_compute_signature(struct sc_card *card, const u8 * data,
 
 	/* the card can sign 36 bytes of free form data */
 	if (data_len > 36) {
-		sc_log(ctx,
-			 "error: input data too long: %"SC_FORMAT_LEN_SIZE_T"u bytes\n",
-			 data_len);
+		sc_log(ctx, "error: input data too long: %zu bytes", data_len);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/libopensc/card-gids.c
+++ b/src/libopensc/card-gids.c
@@ -217,10 +217,8 @@ static int gids_get_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	size_t buffer_len = sizeof(buffer);
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 fileIdentifier, dataObjectIdentifier, response,
-		 responselen ? *responselen : 0);
+	sc_log(card->ctx, "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, response=%p, responselen=%zu",
+			fileIdentifier, dataObjectIdentifier, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_GET_DATA, (fileIdentifier&0xFF00)>>8, (fileIdentifier&0xFF));
@@ -257,9 +255,8 @@ static int gids_put_DO(sc_card_t* card, int fileIdentifier, int dataObjectIdenti
 	u8 buffer[SC_MAX_EXT_APDU_BUFFER_SIZE];
 	u8* p = buffer;
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, data=%p, datalen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 fileIdentifier, dataObjectIdentifier, data, datalen);
+	sc_log(card->ctx, "Got args: fileIdentifier=%x, dataObjectIdentifier=%x, data=%p, datalen=%zu",
+			fileIdentifier, dataObjectIdentifier, data, datalen);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, INS_PUT_DATA, (fileIdentifier&0xFF00)>>8, (fileIdentifier&0xFF));
 
@@ -285,9 +282,8 @@ static int gids_select_aid(sc_card_t* card, u8* aid, size_t aidlen, u8* response
 	int r;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "Got args: aid=%p, aidlen=%"SC_FORMAT_LEN_SIZE_T"u, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 aid, aidlen, response, responselen ? *responselen : 0);
+	sc_log(card->ctx, "Got args: aid=%p, aidlen=%zu, response=%p, responselen=%zu",
+			aid, aidlen, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_SELECT, P1_SELECT_DF_BY_NAME, P2_SELECT_FIRST_OR_ONLY_OCCURENCE);
@@ -845,9 +841,7 @@ gids_decipher(struct sc_card *card,
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "Gids decipher: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
-	       crgram_len, outlen);
+	sc_log(card->ctx, "Gids decipher: in-len %zu, out-len %zu", crgram_len, outlen);
 
 	/* INS: 0x2A  PERFORM SECURITY OPERATION
 	 * P1:  0x80  Resp: Plain value
@@ -912,9 +906,8 @@ static int gids_read_public_key (struct sc_card *card , unsigned int algorithm,
 	size_t buffersize = sizeof(buffer);
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(card->ctx,
-		 "Got args: key_reference=%x, response=%p, responselen=%"SC_FORMAT_LEN_SIZE_T"u\n",
-		 key_reference, response, responselen ? *responselen : 0);
+	sc_log(card->ctx, "Got args: key_reference=%x, response=%p, responselen=%zu",
+			key_reference, response, responselen ? *responselen : 0);
 
 	sc_format_apdu(card, &apdu,
 		response == NULL ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_4_SHORT, INS_GET_DATA, 0x3F, 0xFF);
@@ -1176,9 +1169,7 @@ gids_select_key_reference(sc_card_t *card, sc_pkcs15_prkey_info_t* key_info) {
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 		}
 		if (i > recordsnum) {
-			sc_log(card->ctx,
-				 "container num is not allowed %"SC_FORMAT_LEN_SIZE_T"u %"SC_FORMAT_LEN_SIZE_T"u",
-				 i, recordsnum);
+			sc_log(card->ctx, "container num is not allowed %zu %zu", i, recordsnum);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 		}
 	}
@@ -1316,10 +1307,8 @@ static int gids_create_keyfile(sc_card_t *card, sc_pkcs15_object_t *object) {
 	} else {
 		keymaprecordnum = (keymapbuffersize - 1) / sizeof(struct gids_keymap_record);
 		if (keymaprecordnum != recordnum) {
-			sc_log(card->ctx , "Error: Unable to create the key file because the keymap and cmapfile are inconsistent");
-			sc_log(card->ctx ,
-				 "keymaprecordnum = %"SC_FORMAT_LEN_SIZE_T"u recordnum = %"SC_FORMAT_LEN_SIZE_T"u",
-				 keymaprecordnum, recordnum);
+			sc_log(card->ctx, "Error: Unable to create the key file because the keymap and cmapfile are inconsistent");
+			sc_log(card->ctx, "keymaprecordnum = %zu recordnum = %zu", keymaprecordnum, recordnum);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 		}
 	}

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -395,10 +395,8 @@ static int iasecc_parse_ef_atr(struct sc_card *card)
 	sizes->recv =	 card->ef_atr->issuer_data[10] * 0x100 + card->ef_atr->issuer_data[11];
 	sizes->recv_sc = card->ef_atr->issuer_data[14] * 0x100 + card->ef_atr->issuer_data[15];
 
-	sc_log(ctx,
-		"EF.ATR: IO Buffer Size send/sc %"SC_FORMAT_LEN_SIZE_T"d/%"SC_FORMAT_LEN_SIZE_T"d "
-		"recv/sc %"SC_FORMAT_LEN_SIZE_T"d/%"SC_FORMAT_LEN_SIZE_T"d",
-		sizes->send, sizes->send_sc, sizes->recv, sizes->recv_sc);
+	sc_log(ctx, "EF.ATR: IO Buffer Size send/sc %zd/%zd recv/sc %zd/%zd",
+			sizes->send, sizes->send_sc, sizes->recv, sizes->recv_sc);
 
 	card->max_send_size = sizes->send;
 	card->max_recv_size = sizes->recv;
@@ -410,9 +408,7 @@ static int iasecc_parse_ef_atr(struct sc_card *card)
 	if (card->max_send_size > 0xFF)
 		card->max_send_size -= 5;
 
-	sc_log(ctx,
-	       "EF.ATR: max send/recv sizes %"SC_FORMAT_LEN_SIZE_T"X/%"SC_FORMAT_LEN_SIZE_T"X",
-	       card->max_send_size, card->max_recv_size);
+	sc_log(ctx, "EF.ATR: max send/recv sizes %zX/%zX", card->max_send_size, card->max_recv_size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -704,9 +700,7 @@ iasecc_read_binary(struct sc_card *card, unsigned int offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "iasecc_read_binary(card:%p) offs %i; count %"SC_FORMAT_LEN_SIZE_T"u",
-	       card, offs, count);
+	sc_log(ctx, "iasecc_read_binary(card:%p) offs %i; count %zu", card, offs, count);
 	if (offs > 0x7fff) {
 		sc_log(ctx, "invalid EF offset: 0x%X > 0x7FFF", offs);
 		return SC_ERROR_OFFSET_TOO_LARGE;
@@ -721,9 +715,7 @@ iasecc_read_binary(struct sc_card *card, unsigned int offs,
 	LOG_TEST_RET(ctx, rv, "APDU transmit failed");
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(ctx, rv, "iasecc_read_binary() failed");
-	sc_log(ctx,
-	       "iasecc_read_binary() apdu.resplen %"SC_FORMAT_LEN_SIZE_T"u",
-	       apdu.resplen);
+	sc_log(ctx, "iasecc_read_binary() apdu.resplen %zu", apdu.resplen);
 
 	if (apdu.resplen == IASECC_READ_BINARY_LENGTH_MAX && apdu.resplen < count)   {
 		rv = iasecc_read_binary(card, (int)(offs + apdu.resplen), buf + apdu.resplen, count - apdu.resplen, flags);
@@ -745,9 +737,7 @@ iasecc_erase_binary(struct sc_card *card, unsigned int offs, size_t count, unsig
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "iasecc_erase_binary(card:%p) count %"SC_FORMAT_LEN_SIZE_T"u",
-	       card, count);
+	sc_log(ctx, "iasecc_erase_binary(card:%p) count %zu", card, count);
 	if (!count)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "'ERASE BINARY' failed: invalid size to erase");
 
@@ -774,9 +764,7 @@ _iasecc_sm_read_binary(struct sc_card *card, unsigned int offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "iasecc_sm_read_binary() card:%p offs:%i count:%"SC_FORMAT_LEN_SIZE_T"u ",
-	       card, offs, count);
+	sc_log(ctx, "iasecc_sm_read_binary() card:%p offs:%i count:%zu ", card, offs, count);
 	if (offs > 0x7fff)
 		LOG_TEST_RET(ctx, SC_ERROR_OFFSET_TOO_LARGE, "Invalid arguments");
 
@@ -814,9 +802,7 @@ _iasecc_sm_update_binary(struct sc_card *card, unsigned int offs,
 		return SC_SUCCESS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-			"iasecc_sm_read_binary() card:%p offs:%i count:%" SC_FORMAT_LEN_SIZE_T "u ",
-			card, offs, count);
+	sc_log(ctx, "iasecc_sm_read_binary() card:%p offs:%i count:%zu ", card, offs, count);
 
 	if (prv->cache.valid && prv->cache.current_ef) {
 		entry = sc_file_get_acl_entry(prv->cache.current_ef, SC_AC_OP_UPDATE);
@@ -885,9 +871,8 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 	if (file_out)
 		*file_out = NULL;
 
-	sc_log(ctx,
-	       "iasecc_select_file(card:%p) path.len %"SC_FORMAT_LEN_SIZE_T"u; path.type %i; aid_len %"SC_FORMAT_LEN_SIZE_T"u",
-	       card, path->len, path->type, path->aid.len);
+	sc_log(ctx, "iasecc_select_file(card:%p) path.len %zu; path.type %i; aid_len %zu",
+			card, path->len, path->type, path->aid.len);
 	sc_log(ctx, "iasecc_select_file() path:%s", sc_print_path(path));
 
 	if ((!iasecc_is_cpx(card)) &&
@@ -908,9 +893,7 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 		struct sc_file *file = NULL;
 		struct sc_path ppath;
 
-		sc_log(ctx,
-		       "iasecc_select_file() select parent AID:%p/%"SC_FORMAT_LEN_SIZE_T"u",
-		       lpath.aid.value, lpath.aid.len);
+		sc_log(ctx, "iasecc_select_file() select parent AID:%p/%zu", lpath.aid.value, lpath.aid.len);
 		sc_log(ctx, "iasecc_select_file() select parent AID:%s", sc_dump_hex(lpath.aid.value, lpath.aid.len));
 		memset(&ppath, 0, sizeof(ppath));
 		memcpy(ppath.value, lpath.aid.value, lpath.aid.len);
@@ -1038,9 +1021,7 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 
 		LOG_TEST_GOTO_ERR(ctx, rv, "iasecc_select_file() check SW failed");
 
-		sc_log(ctx,
-		       "iasecc_select_file() apdu.resp %"SC_FORMAT_LEN_SIZE_T"u",
-		       apdu.resplen);
+		sc_log(ctx, "iasecc_select_file() apdu.resp %zu", apdu.resplen);
 		if (apdu.resplen)   {
 			sc_log(ctx, "apdu.resp %02X:%02X:%02X...", apdu.resp[0], apdu.resp[1], apdu.resp[2]);
 
@@ -1132,7 +1113,7 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 	tag = sc_asn1_find_tag(ctx,  buf, buflen, 0x6F, &taglen);
 	sc_log(ctx, "processing FCI: 0x6F tag %p", tag);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
+		sc_log(ctx, "  FCP length %zu", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
@@ -1140,7 +1121,7 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 	tag = sc_asn1_find_tag(ctx,  buf, buflen, 0x62, &taglen);
 	sc_log(ctx, "processing FCI: 0x62 tag %p", tag);
 	if (tag != NULL) {
-		sc_log(ctx, "  FCP length %"SC_FORMAT_LEN_SIZE_T"u", taglen);
+		sc_log(ctx, "  FCP length %zu", taglen);
 		buf = tag;
 		buflen = taglen;
 	}
@@ -1161,14 +1142,11 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 		acls = sc_asn1_find_tag(ctx, buf, buflen, IASECC_DOCP_TAG_ACLS_CONTACT, &taglen);
 
 	if (!acls)   {
-		sc_log(ctx,
-		       "ACLs not found in data(%"SC_FORMAT_LEN_SIZE_T"u) %s",
-		       buflen, sc_dump_hex(buf, buflen));
+		sc_log(ctx, "ACLs not found in data(%zu) %s", buflen, sc_dump_hex(buf, buflen));
 		LOG_TEST_RET(ctx, SC_ERROR_OBJECT_NOT_FOUND, "ACLs tag missing");
 	}
 
-	sc_log(ctx, "ACLs(%"SC_FORMAT_LEN_SIZE_T"u) '%s'", taglen,
-	       sc_dump_hex(acls, taglen));
+	sc_log(ctx, "ACLs(%zu) '%s'", taglen, sc_dump_hex(acls, taglen));
 	mask = 0x40, offs = 1;
 	for (ii = 0; ii < 7; ii++, mask /= 2)  {
 		unsigned char op = file->type == SC_FILE_TYPE_DF ? ops_DF[ii] : ops_EF[ii];
@@ -1181,7 +1159,7 @@ iasecc_process_fci(struct sc_card *card, struct sc_file *file,
 		if (!(mask & acls[0]))
 			continue;
 
-		sc_log(ctx, "ACLs mask 0x%X, offs %"SC_FORMAT_LEN_SIZE_T"u, op 0x%X, acls[offs] 0x%X", mask, offs, op, acls[offs]);
+		sc_log(ctx, "ACLs mask 0x%X, offs %zu, op 0x%X, acls[offs] 0x%X", mask, offs, op, acls[offs]);
 		if (op == 0xFF)   {
 			;
 		}
@@ -1272,9 +1250,7 @@ iasecc_fcp_encode(struct sc_card *card, struct sc_file *file, unsigned char *out
 			LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Non supported AC method");
 
 		amb |= mask;
-		sc_log(ctx,
-		       "%"SC_FORMAT_LEN_SIZE_T"u: AMB %"SC_FORMAT_LEN_SIZE_T"X; nn_smb %"SC_FORMAT_LEN_SIZE_T"u",
-		       ii, amb, nn_smb);
+		sc_log(ctx, "%zu: AMB %zX; nn_smb %zu", ii, amb, nn_smb);
 	}
 
 	/* TODO: Encode contactless ACLs and life cycle status for all IAS/ECC cards */
@@ -1723,7 +1699,7 @@ iasecc_set_security_env(struct sc_card *card,
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 	/* To made by iasecc_sdo_convert_to_file() */
 	prv->key_size = *(sdo.docp.size.value + 0) * 0x100 + *(sdo.docp.size.value + 1);
-	sc_log(ctx, "prv->key_size 0x%"SC_FORMAT_LEN_SIZE_T"X", prv->key_size);
+	sc_log(ctx, "prv->key_size 0x%zX", prv->key_size);
 
 	rv = iasecc_sdo_convert_acl(card, &sdo, SC_AC_OP_PSO_COMPUTE_SIGNATURE, &sign_meth, &sign_ref);
 	LOG_TEST_RET(ctx, rv, "Cannot convert SC_AC_OP_SIGN acl");
@@ -1759,10 +1735,8 @@ iasecc_set_security_env(struct sc_card *card,
 	}
 
 	sc_log(ctx, "senv.algorithm 0x%lX, senv.algorithm_ref 0x%lX", env->algorithm, env->algorithm_ref);
-	sc_log(ctx,
-	       "se_num %i, operation 0x%X, algorithm 0x%lX, algorithm_ref 0x%lX, flags 0x%lX; key size %"SC_FORMAT_LEN_SIZE_T"u",
-	       se_num, operation, env->algorithm, env->algorithm_ref,
-	       env->algorithm_flags, prv->key_size);
+	sc_log(ctx, "se_num %i, operation 0x%X, algorithm 0x%lX, algorithm_ref 0x%lX, flags 0x%lX; key size %zu",
+			se_num, operation, env->algorithm, env->algorithm_ref, env->algorithm_flags, prv->key_size);
 	switch (operation)  {
 	case SC_SEC_OPERATION_SIGN:
 		if (!(env->algorithm_flags & SC_ALGORITHM_RSA_PAD_PKCS1_TYPE_01))
@@ -1867,8 +1841,7 @@ iasecc_chv_verify(struct sc_card *card, struct sc_pin_cmd_data *pin_cmd, unsigne
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "Verify CHV PIN(ref:%i,len:%zu,scb:%X)", pin_cmd->pin_reference, pin_cmd->pin1.len,
-	       scb);
+	sc_log(ctx, "Verify CHV PIN(ref:%i,len:%zu,scb:%X)", pin_cmd->pin_reference, pin_cmd->pin1.len, scb);
 
 	if (scb & IASECC_SCB_METHOD_SM) {
 		rv = iasecc_sm_pin_verify(card, scb & IASECC_SCB_METHOD_MASK_REF, pin_cmd);
@@ -1957,9 +1930,8 @@ iasecc_pin_verify(struct sc_card *card, struct sc_pin_cmd_data *data)
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "Verify PIN(type:%X,ref:%i,data(len:%zu,%p)",
-	       type, reference, data->pin1.len, data->pin1.data);
+	sc_log(ctx, "Verify PIN(type:%X,ref:%i,data(len:%zu,%p)",
+			type, reference, data->pin1.len, data->pin1.data);
 
 	if (type == SC_AC_AUT)   {
 		rv =  iasecc_sm_external_authentication(card, reference, &data->pin1.tries_left);
@@ -2096,9 +2068,7 @@ iasecc_pin_get_policy (struct sc_card *card, struct sc_pin_cmd_data *data, struc
 		goto err;
 	}
 
-	sc_log(ctx,
-	       "iasecc_pin_get_policy() sdo.docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
-	       sdo.docp.size.size);
+	sc_log(ctx, "iasecc_pin_get_policy() sdo.docp.size.size %zu", sdo.docp.size.size);
 
 	memcpy(pin->scbs, sdo.docp.scbs, sizeof(pin->scbs));
 
@@ -3052,9 +3022,7 @@ iasecc_decipher(struct sc_card *card,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(card->ctx,
-	       "crgram_len %"SC_FORMAT_LEN_SIZE_T"u;  outlen %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len, out_len);
+	sc_log(card->ctx, "crgram_len %zu;  outlen %zu", in_len, out_len);
 	if (!out || !out_len || in_len > SC_MAX_APDU_BUFFER_SIZE)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
@@ -3107,9 +3075,7 @@ iasecc_qsign_data_sha1(struct sc_context *ctx, const unsigned char *in, size_t i
 	if (!in || !in_len || !out)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx,
-	       "sc_pkcs15_get_qsign_data() input data length %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len);
+	sc_log(ctx, "sc_pkcs15_get_qsign_data() input data length %zu", in_len);
 	memset(out, 0, sizeof(struct iasecc_qsign_data));
 
 	md = sc_evp_md(ctx, "SHA1");
@@ -3158,9 +3124,8 @@ iasecc_qsign_data_sha1(struct sc_context *ctx, const unsigned char *in, size_t i
 	if (md_data->num)   {
 		memcpy(out->last_block, in + in_len - md_data->num, md_data->num);
 		out->last_block_size = md_data->num;
-		sc_log(ctx, "Last block(%"SC_FORMAT_LEN_SIZE_T"u):%s",
-		       out->last_block_size,
-		       sc_dump_hex(out->last_block, out->last_block_size));
+		sc_log(ctx, "Last block(%zu):%s", out->last_block_size,
+				sc_dump_hex(out->last_block, out->last_block_size));
 	}
 
 	if (EVP_DigestFinal_ex(mdctx, out->hash, &md_out_len) != 1) {
@@ -3206,9 +3171,7 @@ iasecc_qsign_data_sha256(struct sc_context *ctx, const unsigned char *in, size_t
 	if (!in || !in_len || !out)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(ctx,
-	       "sc_pkcs15_get_qsign_data() input data length %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len);
+	sc_log(ctx, "sc_pkcs15_get_qsign_data() input data length %zu", in_len);
 	memset(out, 0, sizeof(struct iasecc_qsign_data));
 
 	md = sc_evp_md(ctx, "SHA256");
@@ -3251,9 +3214,8 @@ iasecc_qsign_data_sha256(struct sc_context *ctx, const unsigned char *in, size_t
 	if (md_data->num)   {
 		memcpy(out->last_block, in + in_len - md_data->num, md_data->num);
 		out->last_block_size = md_data->num;
-		sc_log(ctx, "Last block(%"SC_FORMAT_LEN_SIZE_T"u):%s",
-		       out->last_block_size,
-		       sc_dump_hex(out->last_block, out->last_block_size));
+		sc_log(ctx, "Last block(%zu):%s", out->last_block_size,
+				sc_dump_hex(out->last_block, out->last_block_size));
 	}
 
 	if (EVP_DigestFinal_ex(mdctx, out->hash, &md_out_len) != 1) {
@@ -3294,9 +3256,7 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	int rv = SC_SUCCESS;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "iasecc_compute_signature_dst() input length %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len);
+	sc_log(ctx, "iasecc_compute_signature_dst() input length %zu", in_len);
 	if (env->operation != SC_SEC_OPERATION_SIGN)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "It's not SC_SEC_OPERATION_SIGN");
 	else if (!(prv->key_size & 0x1E0) || (prv->key_size & ~0x1E0))
@@ -3315,9 +3275,7 @@ iasecc_compute_signature_dst(struct sc_card *card,
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Need RSA_HASH_SHA1 or RSA_HASH_SHA256 algorithm");
 	LOG_TEST_RET(ctx, rv, "Cannot get QSign data");
 
-	sc_log(ctx,
-	       "iasecc_compute_signature_dst() hash_len %"SC_FORMAT_LEN_SIZE_T"u; key_size %"SC_FORMAT_LEN_SIZE_T"u",
-	       hash_len, prv->key_size);
+	sc_log(ctx, "iasecc_compute_signature_dst() hash_len %zu; key_size %zu", hash_len, prv->key_size);
 
 	memset(sbuf, 0, sizeof(sbuf));
 	sbuf[offs++] = 0x90;
@@ -3337,9 +3295,8 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	memcpy(sbuf + offs, qsign_data.last_block, qsign_data.last_block_size);
 	offs += qsign_data.last_block_size;
 
-	sc_log(ctx,
-	       "iasecc_compute_signature_dst() offs %"SC_FORMAT_LEN_SIZE_T"u; OP(meth:%X,ref:%X)",
-	       offs, prv->op_method, prv->op_ref);
+	sc_log(ctx, "iasecc_compute_signature_dst() offs %zu; OP(meth:%X,ref:%X)",
+			offs, prv->op_method, prv->op_ref);
 	if (prv->op_method == SC_AC_SCB && (prv->op_ref & IASECC_SCB_METHOD_SM))
 		LOG_TEST_RET(ctx, SC_ERROR_NOT_SUPPORTED, "Not yet");
 
@@ -3365,9 +3322,7 @@ iasecc_compute_signature_dst(struct sc_card *card,
 	rv = sc_check_sw(card, apdu.sw1, apdu.sw2);
 	LOG_TEST_RET(ctx, rv, "Compute signature failed");
 
-	sc_log(ctx,
-	       "iasecc_compute_signature_dst() DST resplen %"SC_FORMAT_LEN_SIZE_T"u",
-	       apdu.resplen);
+	sc_log(ctx, "iasecc_compute_signature_dst() DST resplen %zu", apdu.resplen);
 	if (apdu.resplen > out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "Result buffer too small for the DST signature");
 
@@ -3449,9 +3404,7 @@ iasecc_compute_signature(struct sc_card *card,
 	env = &prv->security_env;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "inlen %"SC_FORMAT_LEN_SIZE_T"u, outlen %"SC_FORMAT_LEN_SIZE_T"u",
-	       in_len, out_len);
+	sc_log(ctx, "inlen %zu, outlen %zu", in_len, out_len);
 
 	if (env->operation == SC_SEC_OPERATION_SIGN)
 		return iasecc_compute_signature_dst(card, in, in_len, out,  out_len);
@@ -3567,14 +3520,11 @@ iasecc_get_free_reference(struct sc_card *card, struct iasecc_ctl_get_free_refer
 		if (sdo->docp.size.size < 2)
 			continue;
 		sz = *(sdo->docp.size.value + 0) * 0x100 + *(sdo->docp.size.value + 1);
-		sc_log(ctx,
-		       "SDO(idx:%i) size %"SC_FORMAT_LEN_SIZE_T"u; key_size %"SC_FORMAT_LEN_SIZE_T"u",
-		       idx, sz, ctl_data->key_size);
+		sc_log(ctx, "SDO(idx:%i) size %zu; key_size %zu", idx, sz, ctl_data->key_size);
 
 		if (sz != ctl_data->key_size / 8)   {
-			sc_log(ctx,
-			       "key index %i ignored: different key sizes %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-			       idx, sz, ctl_data->key_size / 8);
+			sc_log(ctx, "key index %i ignored: different key sizes %zu/%zu",
+					idx, sz, ctl_data->key_size / 8);
 			continue;
 		}
 

--- a/src/libopensc/card-idprime.c
+++ b/src/libopensc/card-idprime.c
@@ -593,9 +593,8 @@ static int idprime_init(sc_card_t *card)
 			break;
 		}
 	} else {
-		sc_log(card->ctx, "Failed to get CPLC data or invalid length returned, "
-			"err=%d, len=%"SC_FORMAT_LEN_SIZE_T"u",
-			r, apdu.resplen);
+		sc_log(card->ctx, "Failed to get CPLC data or invalid length returned, err=%d, len=%zu",
+				r, apdu.resplen);
 	}
 
 	/* Proprietary data -- Applet version */
@@ -967,8 +966,7 @@ static int idprime_read_binary(sc_card_t *card, unsigned int offset,
 	int size;
 	size_t sz;
 
-	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at offset %d",
-		count, offset);
+	sc_log(card->ctx, "called; %zu bytes at offset %d", count, offset);
 
 	if (!priv->cached && offset == 0) {
 		/* Read what was reported by FCI from select command */
@@ -1186,9 +1184,7 @@ idprime_decipher(struct sc_card *card,
 	}
 	LOG_FUNC_CALLED(card->ctx);
 	priv = card->drv_data;
-	sc_log(card->ctx,
-		"IDPrime decipher: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
-		crgram_len, outlen);
+	sc_log(card->ctx, "IDPrime decipher: in-len %zu, out-len %zu", crgram_len, outlen);
 
 	sbuf = malloc(crgram_len + 1);
 	if (sbuf == NULL)

--- a/src/libopensc/card-jpki.c
+++ b/src/libopensc/card-jpki.c
@@ -145,9 +145,7 @@ jpki_select_file(struct sc_card *card,
 	struct sc_file *file = NULL;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "jpki_select_file: path=%s, len=%"SC_FORMAT_LEN_SIZE_T"u",
-	       sc_print_path(path), path->len);
+	sc_log(card->ctx, "jpki_select_file: path=%s, len=%zu", sc_print_path(path), path->len);
 	if (path->len == 2 && memcmp(path->value, "\x3F\x00", 2) == 0) {
 		drvdata->selected = SELECT_MF;
 		if (file_out) {
@@ -285,11 +283,9 @@ jpki_set_security_env(sc_card_t * card,
 	sc_path_t path;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%"SC_FORMAT_LEN_SIZE_T"u",
-	       env->flags, env->operation, env->algorithm,
-	       env->algorithm_flags, env->algorithm_ref, env->key_ref[0],
-	       env->key_ref_len);
+	sc_log(card->ctx, "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%zu",
+			env->flags, env->operation, env->algorithm, env->algorithm_flags, env->algorithm_ref,
+			env->key_ref[0], env->key_ref_len);
 
 	switch (env->operation) {
 	case SC_SEC_OPERATION_SIGN:

--- a/src/libopensc/card-mcrd.c
+++ b/src/libopensc/card-mcrd.c
@@ -1007,10 +1007,8 @@ static int mcrd_compute_signature(sc_card_t * card,
 	if (datalen > 255)
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_log(card->ctx,
-		 "Will compute signature (%d) for %"SC_FORMAT_LEN_SIZE_T"u (0x%02"SC_FORMAT_LEN_SIZE_T"x) bytes using key %d algorithm %lu flags %lu\n",
-		 env->operation, datalen, datalen, env->key_ref[0],
-		 env->algorithm, env->algorithm_flags);
+	sc_log(card->ctx, "Will compute signature (%d) for %zu (0x%02zx) bytes using key %d algorithm %lu flags %lu",
+			env->operation, datalen, datalen, env->key_ref[0], env->algorithm, env->algorithm_flags);
 
 	if (env->key_ref[0] == 1) /* authentication key */
 		sc_format_apdu_ex(&apdu, 0x00, 0x88, 0, 0, data, datalen, out, MIN(0x80U, outlen));

--- a/src/libopensc/card-oberthur.c
+++ b/src/libopensc/card-oberthur.c
@@ -353,9 +353,7 @@ auth_process_fci(struct sc_card *card, struct sc_file *file,
 		else if (file->size==2048)
 			file->size = PUBKEY_2048_ASN1_SIZE;
 		else {
-			sc_log(card->ctx,
-			       "Not supported public key size: %"SC_FORMAT_LEN_SIZE_T"u",
-			       file->size);
+			sc_log(card->ctx, "Not supported public key size: %zu", file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
 		}
 		break;
@@ -517,12 +515,11 @@ auth_select_file(struct sc_card *card, const struct sc_path *in_path,
 					path.value[offs + 1] != auth_current_df->path.value[offs + 1])
 				break;
 
-		sc_log(card->ctx, "offs %"SC_FORMAT_LEN_SIZE_T"u", offs);
+		sc_log(card->ctx, "offs %zu", offs);
 		if (offs && offs < auth_current_df->path.len) {
 			size_t deep = auth_current_df->path.len - offs;
 
-			sc_log(card->ctx, "deep %"SC_FORMAT_LEN_SIZE_T"u",
-			       deep);
+			sc_log(card->ctx, "deep %zu", deep);
 			for (ii = 0; ii < deep; ii += 2) {
 				struct sc_path tmp_path;
 
@@ -737,9 +734,8 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 	unsigned char  ops[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "id %04X; size %"SC_FORMAT_LEN_SIZE_T"u; type 0x%X/0x%X",
-	       file->id, file->size, file->type, file->ef_structure);
+	sc_log(card->ctx, "id %04X; size %zu; type 0x%X/0x%X",
+			file->id, file->size, file->type, file->ef_structure);
 
 	if (*buflen < 0x18)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
@@ -813,9 +809,7 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 		else if (file->size == PUBKEY_2048_ASN1_SIZE || file->size == 2048)
 			size = 2048;
 		else {
-			sc_log(card->ctx,
-			       "incorrect RSA size %"SC_FORMAT_LEN_SIZE_T"X",
-			       file->size);
+			sc_log(card->ctx, "incorrect RSA size %zX", file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
 		}
 	} else if (file->type == SC_FILE_TYPE_INTERNAL_EF &&
@@ -827,9 +821,7 @@ encode_file_structure_V5(struct sc_card *card, const struct sc_file *file,
 		else if (file->size == 24 || file->size == 192)
 			size = 192;
 		else {
-			sc_log(card->ctx,
-			       "incorrect DES size %"SC_FORMAT_LEN_SIZE_T"u",
-			       file->size);
+			sc_log(card->ctx, "incorrect DES size %zu", file->size);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
 		}
 	}
@@ -922,9 +914,8 @@ auth_create_file(struct sc_card *card, struct sc_file *file)
 		pbuf[0] = '\0';
 	sc_log(card->ctx, " create path=%s", pbuf);
 
-	sc_log(card->ctx,
-	       "id %04X; size %"SC_FORMAT_LEN_SIZE_T"u; type 0x%X; ef 0x%X",
-	       file->id, file->size, file->type, file->ef_structure);
+	sc_log(card->ctx, "id %04X; size %zu; type 0x%X; ef 0x%X",
+			file->id, file->size, file->type, file->ef_structure);
 
 	if (file->id==0x0000 || file->id==0xFFFF || file->id==0x3FFF)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
@@ -1091,16 +1082,12 @@ auth_compute_signature(struct sc_card *card, const unsigned char *in, size_t ile
 	if (!card || !in || !out) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	} else if (ilen > 96) {
-		sc_log(card->ctx,
-		       "Illegal input length %"SC_FORMAT_LEN_SIZE_T"u",
-		       ilen);
+		sc_log(card->ctx, "Illegal input length %zu", ilen);
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "Illegal input length");
 	}
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "inlen %"SC_FORMAT_LEN_SIZE_T"u, outlen %"SC_FORMAT_LEN_SIZE_T"u",
-	       ilen, olen);
+	sc_log(card->ctx, "inlen %zu, outlen %zu", ilen, olen);
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x2A, 0x9E, 0x9A);
 	apdu.datalen = ilen;
@@ -1116,9 +1103,7 @@ auth_compute_signature(struct sc_card *card, const unsigned char *in, size_t ile
 	LOG_TEST_RET(card->ctx, rv, "Compute signature failed");
 
 	if (apdu.resplen > olen) {
-		sc_log(card->ctx,
-		       "Compute signature failed: invalid response length %"SC_FORMAT_LEN_SIZE_T"u",
-		       apdu.resplen);
+		sc_log(card->ctx, "Compute signature failed: invalid response length %zu", apdu.resplen);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_CARD_CMD_FAILED);
 	}
 
@@ -1138,9 +1123,7 @@ auth_decipher(struct sc_card *card, const unsigned char *in, size_t inlen,
 	size_t _inlen = inlen;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "crgram_len %"SC_FORMAT_LEN_SIZE_T"u;  outlen %"SC_FORMAT_LEN_SIZE_T"u",
-	       inlen, outlen);
+	sc_log(card->ctx, "crgram_len %zu;  outlen %zu", inlen, outlen);
 	if (!out || !outlen || inlen > SC_MAX_APDU_BUFFER_SIZE)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 
@@ -1296,8 +1279,7 @@ auth_generate_key(struct sc_card *card, int use_sm,
 	data->pubkey_len = apdu.resplen;
 	free(apdu.resp);
 
-	sc_log(card->ctx, "resulted public key len %"SC_FORMAT_LEN_SIZE_T"u",
-	       apdu.resplen);
+	sc_log(card->ctx, "resulted public key len %zu", apdu.resplen);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 err:
 	free(apdu.resp);
@@ -1484,8 +1466,7 @@ auth_read_component(struct sc_card *card, enum SC_CARDCTL_OBERTHUR_KEY_TYPE type
 	unsigned char resp[SC_MAX_APDU_RESP_SIZE];
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx, "num %i, outlen %"SC_FORMAT_LEN_SIZE_T"u, type %i",
-	       num, outlen, type);
+	sc_log(card->ctx, "num %i, outlen %zu, type %i", num, outlen, type);
 
 	if (!outlen || type!=SC_CARDCTL_OBERTHUR_KEY_RSA_PUBLIC)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INCORRECT_PARAMETERS);
@@ -2034,7 +2015,7 @@ write_publickey (struct sc_card *card, unsigned int offset,
 			der_size = rsa_der[1];
 	}
 
-	sc_log(card->ctx, "der_size %"SC_FORMAT_LEN_SIZE_T"u", der_size);
+	sc_log(card->ctx, "der_size %zu", der_size);
 	if (offset + len < der_size + 2)
 		LOG_FUNC_RETURN(card->ctx, (int)len);
 
@@ -2088,8 +2069,7 @@ auth_update_binary(struct sc_card *card, unsigned int offset,
 	if (!auth_current_ef)
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid auth_current_ef");
 
-	sc_log(card->ctx, "offset %i; count %"SC_FORMAT_LEN_SIZE_T"u", offset,
-	       count);
+	sc_log(card->ctx, "offset %i; count %zu", offset, count);
 	sc_log(card->ctx, "last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 
@@ -2132,10 +2112,8 @@ auth_read_binary(struct sc_card *card, unsigned int offset,
 	if (!auth_current_ef)
 		LOG_TEST_RET(card->ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid auth_current_ef");
 
-	sc_log(card->ctx,
-	       "offset %i; size %"SC_FORMAT_LEN_SIZE_T"u; flags 0x%lX",
-	       offset, count, flags ? *flags : 0);
-	sc_log(card->ctx,"last selected : magic %X; ef %X",
+	sc_log(card->ctx, "offset %i; size %zu; flags 0x%lX", offset, count, flags ? *flags : 0);
+	sc_log(card->ctx, "last selected : magic %X; ef %X",
 			auth_current_ef->magic, auth_current_ef->ef_structure);
 
 	if (offset & ~0x7FFF)
@@ -2217,9 +2195,7 @@ auth_read_record(struct sc_card *card, unsigned int nr_rec, unsigned int idx,
 	int rv = 0;
 	unsigned char recvbuf[SC_MAX_APDU_BUFFER_SIZE];
 
-	sc_log(card->ctx,
-	       "auth_read_record(): nr_rec %i; count %"SC_FORMAT_LEN_SIZE_T"u",
-	       nr_rec, count);
+	sc_log(card->ctx, "auth_read_record(): nr_rec %i; count %zu", nr_rec, count);
 
 	if (nr_rec > 0xFF || idx != 0)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);

--- a/src/libopensc/card-openpgp.c
+++ b/src/libopensc/card-openpgp.c
@@ -749,9 +749,8 @@ _pgp_add_algo(sc_card_t *card, sc_cardctl_openpgp_key_gen_store_info_t *key_info
 			SC_ALGORITHM_ONBOARD_KEY_GEN;	/* key gen on card */
 
 		_sc_card_add_rsa_alg(card, key_info->u.rsa.modulus_len, flags, 0);
-		sc_log(card->ctx, "DO %uX: Added RSA algorithm, mod_len = %"
-			SC_FORMAT_LEN_SIZE_T"u",
-			do_num, key_info->u.rsa.modulus_len);
+		sc_log(card->ctx, "DO %uX: Added RSA algorithm, mod_len = %zu",
+				do_num, key_info->u.rsa.modulus_len);
 		break;
 	case SC_OPENPGP_KEYALGO_ECDH:
 		/* The montgomery curve (curve25519) needs to go through
@@ -828,7 +827,7 @@ pgp_decode_kdf_do(sc_card_t *card, struct pgp_priv_data *priv)
 		goto out;
 	}
 	if (tag_len != 1) {
-		sc_log(card->ctx, "Unexpected KDF algorithm byte length, expects 1, got %" SC_FORMAT_LEN_SIZE_T "u", tag_len);
+		sc_log(card->ctx, "Unexpected KDF algorithm byte length, expects 1, got %zu", tag_len);
 		goto out;
 	}
 
@@ -848,7 +847,7 @@ pgp_decode_kdf_do(sc_card_t *card, struct pgp_priv_data *priv)
 		goto out;
 	}
 	if (tag_len != 1) {
-		sc_log(card->ctx, "Unexpected KDF hash algorithm byte length, expects 1, got %" SC_FORMAT_LEN_SIZE_T "u", tag_len);
+		sc_log(card->ctx, "Unexpected KDF hash algorithm byte length, expects 1, got %zu", tag_len);
 		goto out;
 	}
 
@@ -870,7 +869,7 @@ pgp_decode_kdf_do(sc_card_t *card, struct pgp_priv_data *priv)
 		goto out;
 	}
 	if (tag_len != 4) {
-		sc_log(card->ctx, "Unexpected KDF iteration count length, expects 4, got %" SC_FORMAT_LEN_SIZE_T "u", tag_len);
+		sc_log(card->ctx, "Unexpected KDF iteration count length, expects 4, got %zu", tag_len);
 		goto out;
 	}
 	pin_kdf_info->iterations = (uint32_t)bebytes2ulong(p);
@@ -2051,9 +2050,7 @@ gnuk_write_certificate(sc_card_t *card, const u8 *buf, size_t length)
 		size_t plen = MIN(length - i*256, 256);
 		u8 roundbuf[256];	/* space to build APDU data with even length for Gnuk */
 
-		sc_log(card->ctx,
-		       "Write part %"SC_FORMAT_LEN_SIZE_T"u from offset 0x%"SC_FORMAT_LEN_SIZE_T"X, len %"SC_FORMAT_LEN_SIZE_T"u",
-		       i+1, i*256, plen);
+		sc_log(card->ctx, "Write part %zu from offset 0x%zX, len %zu", i + 1, i * 256, plen);
 
 		/* 1st chunk: P1 = 0x85, further chunks: P1 = chunk no */
 		sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0xD6, (i == 0) ? 0x85 : (int)i, 0);
@@ -2170,9 +2167,7 @@ pgp_put_data(sc_card_t *card, unsigned int tag, const u8 *buf, size_t buf_len)
 	 * If we check here, the driver may be stuck to a limit version number of card.
 	 * 7F21 size is soft-coded, so we can check it. */
 	if (tag == DO_CERT && buf_len > priv->max_cert_size) {
-		sc_log(card->ctx,
-		       "Data size %"SC_FORMAT_LEN_SIZE_T"u exceeds DO size limit %"SC_FORMAT_LEN_SIZE_T"u.",
-		       buf_len, priv->max_cert_size);
+		sc_log(card->ctx, "Data size %zu exceeds DO size limit %zu.", buf_len, priv->max_cert_size);
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_WRONG_LENGTH);
 	}
 
@@ -3062,7 +3057,7 @@ pgp_calculate_and_store_fingerprint(sc_card_t *card, time_t ctime,
 		}
 	} else
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
-	sc_log(card->ctx, "pk_packet_len is %"SC_FORMAT_LEN_SIZE_T"u", pk_packet_len);
+	sc_log(card->ctx, "pk_packet_len is %zu", pk_packet_len);
 
 	fp_buffer_len = 3 + pk_packet_len;
 	p = fp_buffer = calloc(1, fp_buffer_len);
@@ -3856,8 +3851,7 @@ pgp_store_key(sc_card_t *card, sc_cardctl_openpgp_key_gen_store_info_t *key_info
 
 		/* we only support exponent of maximum 32 bits */
 		if (key_info->u.rsa.exponent_len > SC_OPENPGP_MAX_EXP_BITS) {
-			sc_log(card->ctx,
-					"Exponent %" SC_FORMAT_LEN_SIZE_T "u-bit (>32) is not supported.",
+			sc_log(card->ctx, "Exponent %zu-bit (>32) is not supported.",
 					key_info->u.rsa.exponent_len);
 			LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 		}

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -2502,7 +2502,7 @@ piv_sm_open(struct sc_card *card)
 		goto err;
 	}
 
-	sc_log(card->ctx, "debug Zlen:%" SC_FORMAT_LEN_SIZE_T "u Z[0]:0x%2.2x", Zlen, Z[0]);
+	sc_log(card->ctx, "debug Zlen:%zu Z[0]:0x%2.2x", Zlen, Z[0]);
 
 	/* Step H9 zeroize deh from step H2 */
 	EVP_PKEY_free(eph_pkey); /* OpenSSL  BN_clear_free calls OPENSSL_cleanse */
@@ -3120,9 +3120,7 @@ piv_get_data(sc_card_t *card, int enumtag, u8 **buf, size_t *buf_len)
 		alloc_buf = 1;
 	}
 
-	sc_log(card->ctx,
-			"buffer for #%d *buf=0x%p len=%" SC_FORMAT_LEN_SIZE_T "u",
-			enumtag, *buf, *buf_len);
+	sc_log(card->ctx, "buffer for #%d *buf=0x%p len=%zu", enumtag, *buf, *buf_len);
 	if (*buf == NULL && *buf_len > 0) {
 		if (*buf_len > MAX_FILE_SIZE) {
 			r = SC_ERROR_INTERNAL;
@@ -3216,8 +3214,7 @@ piv_get_cached_data(sc_card_t *card, int enumtag, u8 **buf, size_t *buf_len)
 	/* see if we have it cached */
 	if (priv->obj_cache[enumtag].flags & PIV_OBJ_CACHE_VALID) {
 
-		sc_log(card->ctx,
-				"found #%d %p:%" SC_FORMAT_LEN_SIZE_T "u %p:%" SC_FORMAT_LEN_SIZE_T "u",
+		sc_log(card->ctx, "found #%d %p:%zu %p:%zu",
 				enumtag,
 				priv->obj_cache[enumtag].obj_data,
 				priv->obj_cache[enumtag].obj_len,
@@ -3259,8 +3256,7 @@ piv_get_cached_data(sc_card_t *card, int enumtag, u8 **buf, size_t *buf_len)
 		*buf = rbuf;
 		*buf_len = r;
 
-		sc_log(card->ctx,
-				"added #%d  %p:%" SC_FORMAT_LEN_SIZE_T "u %p:%" SC_FORMAT_LEN_SIZE_T "u",
+		sc_log(card->ctx, "added #%d  %p:%zu %p:%zu",
 				enumtag,
 				priv->obj_cache[enumtag].obj_data,
 				priv->obj_cache[enumtag].obj_len,
@@ -3300,8 +3296,7 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
 
 	/* if already cached */
 	if (priv->obj_cache[enumtag].internal_obj_data && priv->obj_cache[enumtag].internal_obj_len) {
-		sc_log(card->ctx,
-				"#%d found internal %p:%" SC_FORMAT_LEN_SIZE_T "u",
+		sc_log(card->ctx, "#%d found internal %p:%zu",
 				enumtag,
 				priv->obj_cache[enumtag].internal_obj_data,
 				priv->obj_cache[enumtag].internal_obj_len);
@@ -3387,7 +3382,7 @@ piv_cache_internal_data(sc_card_t *card, int enumtag)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INTERNAL);
 	}
 
-	sc_log(card->ctx, "added #%d internal %p:%" SC_FORMAT_LEN_SIZE_T "u",
+	sc_log(card->ctx, "added #%d internal %p:%zu",
 			enumtag,
 			priv->obj_cache[enumtag].internal_obj_data,
 			priv->obj_cache[enumtag].internal_obj_len);
@@ -3436,8 +3431,7 @@ piv_read_binary(sc_card_t *card, unsigned int idx, unsigned char *buf, size_t co
 				goto err;
 			}
 			if (bodylen > body - rbuf + rbuflen) {
-				sc_log(card->ctx,
-						" ***** tag length > then data: %" SC_FORMAT_LEN_SIZE_T "u>%" SC_FORMAT_LEN_PTRDIFF_T "u+%" SC_FORMAT_LEN_SIZE_T "u",
+				sc_log(card->ctx, " ***** tag length > then data: %zu>%zu+%zu",
 						bodylen, body - rbuf, rbuflen);
 				r = SC_ERROR_INVALID_DATA;
 				goto err;
@@ -3967,7 +3961,7 @@ piv_general_mutual_authenticate(sc_card_t *card,
 
 	if (plain_text_len != witness_len) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-				"Encrypted and decrypted lengths do not match: %" SC_FORMAT_LEN_SIZE_T "u:%" SC_FORMAT_LEN_SIZE_T "u\n",
+				"Encrypted and decrypted lengths do not match: %zu:%zu\n",
 				witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -3982,7 +3976,7 @@ piv_general_mutual_authenticate(sc_card_t *card,
 	nonce = malloc(witness_len);
 	if (!nonce) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-				"OOM allocating nonce (%" SC_FORMAT_LEN_SIZE_T "u : %" SC_FORMAT_LEN_SIZE_T "u)\n",
+				"OOM allocating nonce (%zu : %zu)\n",
 				witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -3993,7 +3987,7 @@ piv_general_mutual_authenticate(sc_card_t *card,
 	if (!r) {
 		sc_log_openssl(card->ctx);
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-				"Generating random for nonce (%" SC_FORMAT_LEN_SIZE_T "u : %" SC_FORMAT_LEN_SIZE_T "u)\n",
+				"Generating random for nonce (%zu : %zu)\n",
 				witness_len, plain_text_len);
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -4117,7 +4111,7 @@ piv_general_mutual_authenticate(sc_card_t *card,
 
 	if (decrypted_reponse_len != nonce_len || memcmp(nonce, decrypted_reponse, nonce_len) != 0) {
 		sc_log(card->ctx,
-				"mutual authentication failed, card returned wrong value %" SC_FORMAT_LEN_SIZE_T "u:%" SC_FORMAT_LEN_SIZE_T "u",
+				"mutual authentication failed, card returned wrong value %zu:%zu",
 				decrypted_reponse_len, nonce_len);
 		r = SC_ERROR_DECRYPT_FAILED;
 		goto err;
@@ -4331,7 +4325,7 @@ piv_general_external_authenticate(sc_card_t *card,
 	tmplen = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
 	if (output_len != (size_t)tmplen) {
 		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Allocated and computed lengths do not match! "
-							  "Expected %" SC_FORMAT_LEN_SIZE_T "d, found: %zu\n",
+							  "Expected %zd, found: %zu\n",
 				output_len, tmplen);
 		r = SC_ERROR_INTERNAL;
 		goto err;
@@ -4417,8 +4411,7 @@ piv_get_serial_nr_from_CHUI(sc_card_t *card, sc_serial_number_t *serial)
 					gbits = gbits | guid[i]; /* if all are zero, gbits will be zero */
 				}
 			}
-			sc_log(card->ctx,
-					"fascn=%p,fascnlen=%" SC_FORMAT_LEN_SIZE_T "u,guid=%p,guidlen=%" SC_FORMAT_LEN_SIZE_T "u,gbits=%2.2x",
+			sc_log(card->ctx, "fascn=%p,fascnlen=%zu,guid=%p,guidlen=%zu,gbits=%2.2x",
 					fascn, fascnlen, guid, guidlen, gbits);
 
 			if (fascn && fascnlen == 25 && fbits) {
@@ -4678,8 +4671,7 @@ piv_set_security_env(sc_card_t *card, const sc_security_env_t *env, int se_num)
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-			"flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%" SC_FORMAT_LEN_SIZE_T "u",
+	sc_log(card->ctx, "flags=%08lx op=%d alg=%lu algf=%08lx algr=%08lx kr0=%02x, krfl=%zu",
 			env->flags, env->operation, env->algorithm, env->algorithm_flags,
 			env->algorithm_ref, env->key_ref[0], env->key_ref_len);
 
@@ -4861,8 +4853,7 @@ piv_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
 	if (priv->alg_id == 0x11 || priv->alg_id == 0x14) {
 		nLen = BYTES4BITS(priv->key_size);
 		if (outlen < 2 * nLen) {
-			sc_log(card->ctx,
-					" output too small for EC signature %" SC_FORMAT_LEN_SIZE_T "u < %" SC_FORMAT_LEN_SIZE_T "u",
+			sc_log(card->ctx, " output too small for EC signature %zu < %zu",
 					outlen, 2 * nLen);
 			r = SC_ERROR_INVALID_DATA;
 			goto err;
@@ -4877,8 +4868,7 @@ piv_compute_signature(sc_card_t *card, const u8 *data, size_t datalen,
 	} else if (priv->alg_id == 0xE0) {
 		nLen = BYTES4BITS(priv->key_size);
 		if (outlen < nLen) {
-			sc_log(card->ctx,
-					" output too small for ED signature %" SC_FORMAT_LEN_SIZE_T "u < %" SC_FORMAT_LEN_SIZE_T "u",
+			sc_log(card->ctx, " output too small for ED signature %zu < %zu",
 					outlen, nLen);
 			r = SC_ERROR_INVALID_DATA;
 			goto err;
@@ -5023,8 +5013,7 @@ piv_parse_discovery(sc_card_t *card, u8 *rbuf, size_t rbuflen, int aid_only)
 			goto err;
 		}
 
-		sc_log(card->ctx,
-				"Discovery 0x%2.2x 0x%2.2x %p:%" SC_FORMAT_LEN_SIZE_T "u",
+		sc_log(card->ctx, "Discovery 0x%2.2x 0x%2.2x %p:%zu",
 				cla_out, tag_out, body, bodylen);
 		aidlen = 0;
 		aid = sc_asn1_find_tag(card->ctx, body, bodylen, 0x4F, &aidlen);
@@ -5445,8 +5434,7 @@ piv_process_history(sc_card_t *card)
 			r = piv_cache_internal_data(card, enumtag);
 			sc_log(card->ctx, "got internal r=%d", r);
 
-			sc_log(card->ctx,
-					"Added from off card file #%d %p:%" SC_FORMAT_LEN_SIZE_T "u 0x%02X",
+			sc_log(card->ctx, "Added from off card file #%d %p:%zu 0x%02X",
 					enumtag,
 					priv->obj_cache[enumtag].obj_data,
 					priv->obj_cache[enumtag].obj_len, *keyref);
@@ -6051,8 +6039,7 @@ piv_init(sc_card_t *card)
 
 	priv->pstate = PIV_STATE_INIT;
 
-	sc_log(card->ctx,
-			"Max send = %" SC_FORMAT_LEN_SIZE_T "u recv = %" SC_FORMAT_LEN_SIZE_T "u card->type:%d, CI:%08x AI:%08x",
+	sc_log(card->ctx, "Max send = %zu recv = %zu card->type:%d, CI:%08x AI:%08x",
 			card->max_send_size, card->max_recv_size, card->type, priv->card_issues, priv->alg_ids);
 	card->cla = 0x00;
 	if (card->name == NULL)

--- a/src/libopensc/card-rtecp.c
+++ b/src/libopensc/card-rtecp.c
@@ -503,8 +503,7 @@ static int rtecp_change_reference_data(sc_card_t *card, unsigned int type,
 	if (!card || !card->ctx || !newref)
 		return SC_ERROR_INVALID_ARGUMENTS;
 
-	sc_log(card->ctx,
-		 "newlen = %"SC_FORMAT_LEN_SIZE_T"u\n", newlen);
+	sc_log(card->ctx, "newlen = %zu\n", newlen);
 	if (newlen > 0xFFFF)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ARGUMENTS);
 	if (type == SC_AC_CHV && old && oldlen != 0)

--- a/src/libopensc/card-rutoken.c
+++ b/src/libopensc/card-rutoken.c
@@ -471,7 +471,7 @@ static int rutoken_process_fci(struct sc_card *card, sc_file_t *file,
 		if (tag != NULL && taglen == 2)
 		{
 			file->size = (tag[1] << 8) | tag[0];
-			sc_log(card->ctx,  "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u", file->size);
+			sc_log(card->ctx, "  bytes in file: %zu", file->size);
 		}
 	}
 	LOG_FUNC_RETURN(card->ctx, ret);
@@ -581,9 +581,7 @@ static int set_sec_attr_from_acl(sc_card_t *card, sc_file_t *file)
 		{
 			/* AccessMode.[conv_attr[i].sec_attr_pos] */
 			attr[0] |= 1 << conv_attr[i].sec_attr_pos;
-			sc_log(card->ctx,
-				 "AccessMode.%"SC_FORMAT_LEN_SIZE_T"u, attr[0]=0x%x",
-				 conv_attr[i].sec_attr_pos, attr[0]);
+			sc_log(card->ctx, "AccessMode.%zu, attr[0]=0x%x", conv_attr[i].sec_attr_pos, attr[0]);
 			attr[1 + conv_attr[i].sec_attr_pos] = (u8)entry->method;
 			sc_log(card->ctx,  "method %u", (u8)entry->method);
 			if (entry->method == SC_AC_CHV)
@@ -1018,9 +1016,7 @@ static int rutoken_cipher_p(sc_card_t *card, const u8 * crgram, size_t crgram_le
 	sc_apdu_t apdu;
 
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-		 ": crgram_len %"SC_FORMAT_LEN_SIZE_T"u; outlen %"SC_FORMAT_LEN_SIZE_T"u",
-		 crgram_len, outlen);
+	sc_log(card->ctx, ": crgram_len %zu; outlen %zu", crgram_len, outlen);
 
 	if (!out)
 		SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, SC_ERROR_INVALID_ARGUMENTS);
@@ -1063,9 +1059,7 @@ static int rutoken_cipher_p(sc_card_t *card, const u8 * crgram, size_t crgram_le
 			}
 		}
 	} while (ret == SC_SUCCESS  &&  crgram_len != 0);
-	sc_log(card->ctx,
-		 "len out cipher %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 outlen - outlen_tail);
+	sc_log(card->ctx, "len out cipher %zu\n", outlen - outlen_tail);
 	if (ret == SC_SUCCESS)
 		ret = (outlen_tail == 0) ? (int)outlen : SC_ERROR_WRONG_LENGTH;
 	SC_FUNC_RETURN(card->ctx, SC_LOG_DEBUG_VERBOSE, ret);

--- a/src/libopensc/card-sc-hsm.c
+++ b/src/libopensc/card-sc-hsm.c
@@ -1072,9 +1072,7 @@ static int sc_hsm_decode_ecdsa_signature(sc_card_t *card,
 	int r;
 	size_t fieldsizebytes = (key_size + 7) >> 3;
 
-	sc_log(card->ctx,
-	       "Field size %"SC_FORMAT_LEN_SIZE_T"u, signature buffer size %"SC_FORMAT_LEN_SIZE_T"u",
-	       fieldsizebytes, outlen);
+	sc_log(card->ctx, "Field size %zu, signature buffer size %zu", fieldsizebytes, outlen);
 
 	r = sc_asn1_decode_ecdsa_signature(card->ctx, data, datalen, fieldsizebytes, &out, outlen);
 	LOG_FUNC_RETURN(card->ctx, r);

--- a/src/libopensc/card-starcos.c
+++ b/src/libopensc/card-starcos.c
@@ -571,8 +571,7 @@ static int process_fci_v3_4(sc_context_t *ctx, sc_file_t *file,
 	size_t taglen, len = buflen;
 	const u8 *tag = NULL, *p;
 
-	sc_log(ctx,
-		 "processing %"SC_FORMAT_LEN_SIZE_T"u FCI bytes\n", buflen);
+	sc_log(ctx, "processing %zu FCI bytes\n", buflen);
 
 	if (buflen < 2)
 		return SC_ERROR_INTERNAL;
@@ -607,8 +606,7 @@ static int process_fcp_v3_4(sc_context_t *ctx, sc_file_t *file,
 	size_t taglen, len = buflen;
 	const u8 *tag = NULL, *p;
 
-	sc_log(ctx,
-		 "processing %"SC_FORMAT_LEN_SIZE_T"u FCP bytes\n", buflen);
+	sc_log(ctx, "processing %zu FCP bytes\n", buflen);
 
 	if (buflen < 2)
 		return SC_ERROR_INTERNAL;
@@ -695,9 +693,7 @@ static int process_fcp_v3_4(sc_context_t *ctx, sc_file_t *file,
 			/* formatted EF */
 			file->record_length = (tag[2] << 8) + tag[3];
 			file->record_count = tag[4];
-			sc_log(ctx,
-				"  rec_len: %"SC_FORMAT_LEN_SIZE_T"u  rec_cnt: %"SC_FORMAT_LEN_SIZE_T"u\n\n",
-				file->record_length, file->record_count);
+			sc_log(ctx, "  rec_len: %zu  rec_cnt: %zu", file->record_length, file->record_count);
 		}
 	}
 

--- a/src/libopensc/card-tcos.c
+++ b/src/libopensc/card-tcos.c
@@ -434,9 +434,7 @@ static int tcos_list_files(sc_card_t *card, u8 *buf, size_t buflen)
 		r = sc_check_sw(card, apdu.sw1, apdu.sw2);
 		LOG_TEST_RET(ctx, r, "List Dir failed");
 		if (apdu.resplen > buflen) return SC_ERROR_BUFFER_TOO_SMALL;
-		sc_log(ctx,
-			"got %"SC_FORMAT_LEN_SIZE_T"u %s-FileIDs\n",
-			apdu.resplen / 2, p1 == 1 ? "DF" : "EF");
+		sc_log(ctx, "got %zu %s-FileIDs", apdu.resplen / 2, p1 == 1 ? "DF" : "EF");
 
 		memcpy(buf, apdu.resp, apdu.resplen);
 		buf += apdu.resplen;
@@ -493,9 +491,7 @@ static int tcos_set_security_env(sc_card_t *card, const sc_security_env_t *env, 
 		sc_log(ctx,
 			"No Key-Reference in SecEnvironment\n");
 	else
-		sc_log(ctx,
-			"Key-Reference %02X (len=%"SC_FORMAT_LEN_SIZE_T"u)\n",
-			env->key_ref[0], env->key_ref_len);
+		sc_log(ctx, "Key-Reference %02X (len=%zu)", env->key_ref[0], env->key_ref_len);
 	/* Key-Reference 0x80 ?? */
 	default_key= !(env->flags & SC_SEC_ENV_KEY_REF_PRESENT) || (env->key_ref_len==1 && env->key_ref[0]==0x80);
 	sc_log(ctx, "TCOS3:%d PKCS1 type 01:%d PKCS1 type 02: %d\n", tcos3,

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -375,13 +375,11 @@ int sc_connect_card(sc_reader_t *reader, sc_card_t **card_out)
 	card->max_recv_size = sc_get_max_recv_size(card);
 	card->max_send_size = sc_get_max_send_size(card);
 
-	sc_log(ctx,
-	       "card info name:'%s', type:%i, flags:0x%lX, max_send/recv_size:%"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-	       card->name, card->type, card->flags, card->max_send_size,
-	       card->max_recv_size);
+	sc_log(ctx, "card info name:'%s', type:%i, flags:0x%lX, max_send/recv_size:%zu/%zu",
+			card->name, card->type, card->flags, card->max_send_size, card->max_recv_size);
 
 #ifdef ENABLE_SM
-        /* Check, if secure messaging module present. */
+	/* Check, if secure messaging module present. */
 	r = sc_card_sm_check(card);
 	if (r)   {
 		sc_log(ctx, "cannot load secure messaging module");
@@ -566,9 +564,8 @@ int sc_create_file(sc_card_t *card, sc_file_t *file)
 	if (r != SC_SUCCESS)
 		pbuf[0] = '\0';
 
-	sc_log(card->ctx,
-	       "called; type=%d, path=%s, id=%04i, size=%"SC_FORMAT_LEN_SIZE_T"u",
-	       in_path->type, pbuf, file->id, file->size);
+	sc_log(card->ctx, "called; type=%d, path=%s, id=%04i, size=%zu",
+			in_path->type, pbuf, file->id, file->size);
 	/* ISO 7816-4: "Number of data bytes in the file, including structural information if any"
 	 * can not be bigger than two bytes */
 	if (file->size > 0xFFFF)
@@ -612,8 +609,7 @@ int sc_read_binary(sc_card_t *card, unsigned int idx,
 	if (card == NULL || card->ops == NULL || buf == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
-	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
-	       count, idx);
+	sc_log(card->ctx, "called; %zu bytes at index %d", count, idx);
 	if (count == 0)
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 
@@ -674,8 +670,7 @@ int sc_write_binary(sc_card_t *card, unsigned int idx,
 	if (card == NULL || card->ops == NULL || buf == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
-	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
-	       count, idx);
+	sc_log(card->ctx, "called; %zu bytes at index %d", count, idx);
 	if (count == 0)
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 
@@ -722,8 +717,7 @@ int sc_update_binary(sc_card_t *card, unsigned int idx,
 	if (card == NULL || card->ops == NULL || buf == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
-	sc_log(card->ctx, "called; %"SC_FORMAT_LEN_SIZE_T"u bytes at index %d",
-	       count, idx);
+	sc_log(card->ctx, "called; %zu bytes at index %d", count, idx);
 	if (count == 0)
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 
@@ -777,9 +771,7 @@ int sc_erase_binary(struct sc_card *card, unsigned int idx, size_t count,  unsig
 	if (card == NULL || card->ops == NULL) {
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
-	sc_log(card->ctx,
-	       "called; erase %"SC_FORMAT_LEN_SIZE_T"u bytes from offset %d",
-	       count, idx);
+	sc_log(card->ctx, "called; erase %zu bytes from offset %d", count, idx);
 	if (count == 0)
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 

--- a/src/libopensc/cwa-dnie.c
+++ b/src/libopensc/cwa-dnie.c
@@ -535,8 +535,7 @@ int dnie_read_file(sc_card_t * card,
 		goto dnie_read_file_err;
 	}
 	/* call sc_read_binary() to retrieve data */
-	sc_log(ctx, "read_binary(): expected '%"SC_FORMAT_LEN_SIZE_T"u' bytes",
-	       fsize);
+	sc_log(ctx, "read_binary(): expected '%zu' bytes", fsize);
 	res = sc_read_binary(card, 0, data, fsize, 0L);
 	if (res < 0) {		/* read_binary returns number of bytes read */
 		res = SC_ERROR_CARD_CMD_FAILED;

--- a/src/libopensc/cwa14890.c
+++ b/src/libopensc/cwa14890.c
@@ -91,20 +91,26 @@ static void cwa_trace_apdu(sc_card_t * card, sc_apdu_t * apdu, int flag)
 		if (apdu->datalen > 0) {	/* apdu data to show */
 			sc_hex_dump(apdu->data, apdu->datalen, buf, sizeof(buf));
 			sc_log(card->ctx,
-			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02"SC_FORMAT_LEN_SIZE_T"X Le: %02"SC_FORMAT_LEN_SIZE_T"X DATA: [%5"SC_FORMAT_LEN_SIZE_T"u bytes]\n%s======================================================================\n",
-			       apdu->cla, apdu->ins, apdu->p1, apdu->p2,
-			       apdu->lc, apdu->le, apdu->datalen, buf);
+					"\nAPDU before encode: ==================================================\n"
+					"CLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02zX Le: %02zX DATA: [%5zu bytes]\n"
+					"%s======================================================================\n",
+					apdu->cla, apdu->ins, apdu->p1, apdu->p2,
+					apdu->lc, apdu->le, apdu->datalen, buf);
 		} else {	/* apdu data field is empty */
 			sc_log(card->ctx,
-			       "\nAPDU before encode: ==================================================\nCLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02"SC_FORMAT_LEN_SIZE_T"X Le: %02"SC_FORMAT_LEN_SIZE_T"X (NO DATA)\n======================================================================\n",
-			       apdu->cla, apdu->ins, apdu->p1, apdu->p2,
-			       apdu->lc, apdu->le);
+					"\nAPDU before encode: ==================================================\n"
+					"CLA: %02X INS: %02X P1: %02X P2: %02X Lc: %02zX Le: %02zX (NO DATA)\n"
+					"======================================================================\n",
+					apdu->cla, apdu->ins, apdu->p1, apdu->p2,
+					apdu->lc, apdu->le);
 		}
 	} else {		/* apdu response */
 		sc_hex_dump(apdu->resp, apdu->resplen, buf, sizeof(buf));
 		sc_log(card->ctx,
-		       "\nAPDU response after decode: ==========================================\nSW1: %02X SW2: %02X RESP: [%5"SC_FORMAT_LEN_SIZE_T"u bytes]\n%s======================================================================\n",
-		       apdu->sw1, apdu->sw2, apdu->resplen, buf);
+				"\nAPDU response after decode: ==========================================\n"
+				"SW1: %02X SW2: %02X RESP: [%5zu bytes]\n"
+				"%s======================================================================\n",
+				apdu->sw1, apdu->sw2, apdu->resplen, buf);
 	}
 }
 
@@ -289,8 +295,8 @@ static int cwa_parse_tlv(sc_card_t * card,
 		tlv->len = tag_len;
 		tlv->data = (u8 *)p;
 		tlv->buflen = header_len + tag_len;
-		sc_log(ctx, "Found Tag: '0x%02X': Length: '%"SC_FORMAT_LEN_SIZE_T"u' Value:\n%s",
-		       tlv->tag, tlv->len, sc_dump_hex(tlv->data, tlv->len));
+		sc_log(ctx, "Found Tag: '0x%02X': Length: '%zu' Value:\n%s",
+				tlv->tag, tlv->len, sc_dump_hex(tlv->data, tlv->len));
 		/* set index to next Tag to jump to */
 		p += tag_len;
 		left -= tag_len;
@@ -1677,7 +1683,7 @@ int cwa_encode_apdu(sc_card_t * card,
 
 	/* compose and add computed MAC TLV to result buffer */
 	tlv_len = (card->atr.value[15] >= DNIE_30_VERSION)? 8 : 4;
-	sc_log(ctx, "Using TLV length: %"SC_FORMAT_LEN_SIZE_T"u", tlv_len);
+	sc_log(ctx, "Using TLV length: %zu", tlv_len);
 	res = cwa_compose_tlv(card, 0x8E, tlv_len, macbuf, &apdubuf, &apdulen);
 	if (res != SC_SUCCESS) {
 		msg = "Encode APDU compose_tlv(0x87) failed";

--- a/src/libopensc/ef-atr.c
+++ b/src/libopensc/ef-atr.c
@@ -64,10 +64,8 @@ sc_parse_ef_atr_content(struct sc_card *card, unsigned char *buf, size_t buflen)
 		ef_atr.df_selection =  *(tag + 0);
 		ef_atr.unit_size = *(tag + 1);
 		ef_atr.card_capabilities = *(tag + 2);
-		sc_log(ctx,
-		       "EF.ATR: DF selection %X, unit_size %"SC_FORMAT_LEN_SIZE_T"X, card caps %X",
-		       ef_atr.df_selection, ef_atr.unit_size,
-		       ef_atr.card_capabilities);
+		sc_log(ctx, "EF.ATR: DF selection %X, unit_size %zX, card caps %X",
+				ef_atr.df_selection, ef_atr.unit_size, ef_atr.card_capabilities);
 	}
 
 	if (ef_atr.card_capabilities & ISO7816_CAP_EXTENDED_LENGTH_INFO) {
@@ -79,10 +77,8 @@ sc_parse_ef_atr_content(struct sc_card *card, unsigned char *buf, size_t buflen)
 			 * We skip parsing the nested DOs and jump directly to the numbers */
 			ef_atr.max_command_apdu = bebytes2ushort(tag + 2);
 			ef_atr.max_response_apdu = bebytes2ushort(tag + 6);
-			sc_log(ctx,
-			       "EF.ATR: Biggest command APDU %"SC_FORMAT_LEN_SIZE_T"u bytes, response APDU %"SC_FORMAT_LEN_SIZE_T"u",
-			       ef_atr.max_command_apdu,
-			       ef_atr.max_response_apdu);
+			sc_log(ctx, "EF.ATR: Biggest command APDU %zu bytes, response APDU %zu",
+					ef_atr.max_command_apdu, ef_atr.max_response_apdu);
 		}
 	}
 

--- a/src/libopensc/iasecc-sdo.c
+++ b/src/libopensc/iasecc-sdo.c
@@ -321,7 +321,7 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "data_len %"SC_FORMAT_LEN_SIZE_T"u", data_len);
+	sc_log(ctx, "data_len %zu", data_len);
 
 	if (data_len < 1)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
@@ -335,9 +335,7 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 
 		data += size_size + 1;
 		data_len = size;
-		sc_log(ctx,
-		       "IASECC_SDO_TEMPLATE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %d",
-		       size, size_size);
+		sc_log(ctx, "IASECC_SDO_TEMPLATE: size %zu, size_size %d", size, size_size);
 
 		if (data_len < 3)
 			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
@@ -356,15 +354,11 @@ iasecc_se_parse(struct sc_card *card, unsigned char *data, size_t data_len, stru
 
 		data += 3 + size_size;
 		data_len = size;
-		sc_log(ctx,
-		       "IASECC_SDO_TEMPLATE SE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %d",
-		       size, size_size);
+		sc_log(ctx, "IASECC_SDO_TEMPLATE SE: size %zu, size_size %d", size, size_size);
 	}
 
 	if (*data != IASECC_SDO_CLASS_SE)   {
-		sc_log(ctx,
-		       "Invalid SE tag 0x%X; data length %"SC_FORMAT_LEN_SIZE_T"u",
-		       *data, data_len);
+		sc_log(ctx, "Invalid SE tag 0x%X; data length %zu", *data, data_len);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_UNKNOWN_DATA_RECEIVED);
 	}
 
@@ -444,9 +438,7 @@ iasecc_parse_get_tlv(struct sc_card *card, unsigned char *data, size_t data_len,
 
 	tlv->on_card = 1;
 
-	sc_log(ctx,
-	       "iasecc_parse_get_tlv() parsed %"SC_FORMAT_LEN_SIZE_T"u bytes",
-	       tag_len + size_len + tlv->size);
+	sc_log(ctx, "iasecc_parse_get_tlv() parsed %zu bytes", tag_len + size_len + tlv->size);
 	return (int)(tag_len + size_len + tlv->size);
 }
 
@@ -465,9 +457,8 @@ iasecc_parse_chv(struct sc_card *card, unsigned char *data, size_t data_len, str
 		rv = iasecc_parse_get_tlv(card, data + offs, data_len - offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_chv() get and parse TLV error");
 
-		sc_log(ctx,
-		       "iasecc_parse_chv() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       rv, tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_parse_chv() get and parse TLV returned %i; tag %X; size %zu",
+				rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_CHV_TAG_SIZE_MAX) {
 			free(chv->size_max.value);
@@ -504,9 +495,8 @@ iasecc_parse_prvkey(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, data_len - offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_prvkey() get and parse TLV error");
 
-		sc_log(ctx,
-		       "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       rv, tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %zu",
+				rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_PRVKEY_TAG_COMPULSORY) {
 			free(prvkey->compulsory.value);
@@ -537,9 +527,8 @@ iasecc_parse_pubkey(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, data_len - offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_pubkey() get and parse TLV error");
 
-		sc_log(ctx,
-		       "iasecc_parse_pubkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       rv, tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_parse_pubkey() get and parse TLV returned %i; tag %X; size %zu",
+				rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_PUBKEY_TAG_N) {
 			free(pubkey->n.value);
@@ -582,9 +571,8 @@ iasecc_parse_keyset(struct sc_card *card, unsigned char *data, size_t data_len, 
 		rv = iasecc_parse_get_tlv(card, data + offs, data_len - offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_keyset() get and parse TLV error");
 
-		sc_log(ctx,
-		       "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       rv, tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_parse_prvkey() get and parse TLV returned %i; tag %X; size %zu",
+				rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_SDO_KEYSET_TAG_COMPULSORY) {
 			free(keyset->compulsory.value);
@@ -615,9 +603,8 @@ iasecc_parse_docp(struct sc_card *card, unsigned char *data, size_t data_len, st
 		rv = iasecc_parse_get_tlv(card, data + offs, data_len - offs, &tlv);
 		LOG_TEST_RET(ctx, rv, "iasecc_parse_get_tlv() get and parse TLV error");
 
-		sc_log(ctx,
-		       "iasecc_parse_docp() parse_get_tlv returned %i; tag %X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       rv, tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_parse_docp() parse_get_tlv returned %i; tag %X; size %zu",
+				rv, tlv.tag, tlv.size);
 
 		if (tlv.tag == IASECC_DOCP_TAG_ACLS)   {
 			int _rv = iasecc_parse_docp(card, tlv.value, tlv.size, sdo);
@@ -690,9 +677,8 @@ iasecc_sdo_parse_data(struct sc_card *card, unsigned char *data, size_t data_len
 
 	sc_log(ctx, "iasecc_sdo_parse_data() tlv.tag 0x%X", tlv.tag);
 	if (tlv.tag == IASECC_DOCP_TAG)   {
-		sc_log(ctx,
-		       "iasecc_sdo_parse_data() parse IASECC_DOCP_TAG: 0x%X; size %"SC_FORMAT_LEN_SIZE_T"u",
-		       tlv.tag, tlv.size);
+		sc_log(ctx, "iasecc_sdo_parse_data() parse IASECC_DOCP_TAG: 0x%X; size %zu",
+				tlv.tag, tlv.size);
 		rv = iasecc_parse_docp(card, tlv.value, tlv.size, sdo);
 		sc_log(ctx, "iasecc_sdo_parse_data() parsed IASECC_DOCP_TAG rv %i", rv);
 		free(tlv.value);
@@ -790,9 +776,7 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 			LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_DATA);
 		}
 		data_len = size;
-		sc_log(ctx,
-		       "IASECC_SDO_TEMPLATE: size %"SC_FORMAT_LEN_SIZE_T"u, size_size %d",
-		       size, size_size);
+		sc_log(ctx, "IASECC_SDO_TEMPLATE: size %zu, size_size %d", size, size_size);
 	}
 
 	if (data_len < 4 || *data != IASECC_SDO_TAG_HEADER)
@@ -810,9 +794,7 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 	if (data_len != size + size_size + 3)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: invalid SDO data size");
 
-	sc_log(ctx,
-	       "sz %"SC_FORMAT_LEN_SIZE_T"u, sz_size %d",
-	       size, size_size);
+	sc_log(ctx, "sz %zu, sz_size %d", size, size_size);
 
 	offs = 3 + size_size;
 	for (; offs < data_len;)   {
@@ -828,9 +810,8 @@ iasecc_sdo_parse(struct sc_card *card, unsigned char *data, size_t data_len, str
 	if (offs != data_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: not totally parsed");
 
-	sc_log(ctx,
-	       "docp.acls_contact.size %"SC_FORMAT_LEN_SIZE_T"u, docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
-	       sdo->docp.acls_contact.size, sdo->docp.size.size);
+	sc_log(ctx, "docp.acls_contact.size %zu, docp.size.size %zu",
+			sdo->docp.acls_contact.size, sdo->docp.size.size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -869,9 +850,7 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 	if (data_len != size + size_size + 3)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: invalid SDO data size");
 
-	sc_log(ctx,
-	       "sz %"SC_FORMAT_LEN_SIZE_T"u, sz_size %d",
-	       size, size_size);
+	sc_log(ctx, "sz %zu, sz_size %d", size, size_size);
 
 	offs = 3 + size_size;
 	for (; offs < data_len;)   {
@@ -884,9 +863,8 @@ iasecc_sdo_allocate_and_parse(struct sc_card *card, unsigned char *data, size_t 
 	if (offs != data_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "parse error: not totally parsed");
 
-	sc_log(ctx,
-	       "docp.acls_contact.size %"SC_FORMAT_LEN_SIZE_T"u; docp.size.size %"SC_FORMAT_LEN_SIZE_T"u",
-	       sdo->docp.acls_contact.size, sdo->docp.size.size);
+	sc_log(ctx, "docp.acls_contact.size %zu; docp.size.size %zu",
+			sdo->docp.acls_contact.size, sdo->docp.size.size);
 
 	LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 }
@@ -1190,9 +1168,8 @@ iasecc_sdo_encode_rsa_update(struct sc_context *ctx, struct iasecc_sdo *sdo, str
 		sc_log(ctx, "prv_key.compulsory.on_card %i", sdo->data.prv_key.compulsory.on_card);
 		if (!sdo->data.prv_key.compulsory.on_card)   {
 			if (sdo->data.prv_key.compulsory.value)   {
-				sc_log(ctx,
-				       "sdo_prvkey->data.prv_key.compulsory.size %"SC_FORMAT_LEN_SIZE_T"u",
-				       sdo->data.prv_key.compulsory.size);
+				sc_log(ctx, "sdo_prvkey->data.prv_key.compulsory.size %zu",
+						sdo->data.prv_key.compulsory.size);
 				sdo_update->fields[index].parent_tag = IASECC_SDO_PRVKEY_TAG;
 				sdo_update->fields[index].tag = IASECC_SDO_PRVKEY_TAG_COMPULSORY;
 				sdo_update->fields[index].value = sdo->data.prv_key.compulsory.value;

--- a/src/libopensc/iasecc-sm.c
+++ b/src/libopensc/iasecc-sm.c
@@ -316,9 +316,8 @@ iasecc_sm_initialize(struct sc_card *card, unsigned se_num, unsigned cmd)
 
 	rdata.free(&rdata);
 
-	sc_log(ctx, "MA data(len:%"SC_FORMAT_LEN_SIZE_T"u) '%s'",
-	       cwa_session->mdata_len,
-	       sc_dump_hex(cwa_session->mdata, cwa_session->mdata_len));
+	sc_log(ctx, "MA data(len:%zu) '%s'", cwa_session->mdata_len,
+			sc_dump_hex(cwa_session->mdata, cwa_session->mdata_len));
 	if (cwa_session->mdata_len != 0x48)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "iasecc_sm_initialize() invalid MUTUAL AUTHENTICATE result data");
 
@@ -353,9 +352,7 @@ iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 	for (rapdu = rdata->data; rapdu; rapdu = rapdu->next)   {
 		struct sc_apdu *apdu = &rapdu->apdu;
 
-		sc_log(ctx,
-		       "iasecc_sm_cmd() apdu->ins:0x%X, resplen %"SC_FORMAT_LEN_SIZE_T"u",
-		       apdu->ins, apdu->resplen);
+		sc_log(ctx, "iasecc_sm_cmd() apdu->ins:0x%X, resplen %zu", apdu->ins, apdu->resplen);
 		if (!apdu->ins)
 			break;
 		rv = sc_transmit_apdu(card, apdu);
@@ -369,9 +366,7 @@ iasecc_sm_cmd(struct sc_card *card, struct sc_remote_data *rdata)
 			sc_log(ctx, "iasecc_sm_cmd() APDU error rv:%i", rv);
 			break;
 		}
-		sc_log(ctx,
-		       "iasecc_sm_cmd() apdu->resplen %"SC_FORMAT_LEN_SIZE_T"u",
-		       apdu->resplen);
+		sc_log(ctx, "iasecc_sm_cmd() apdu->resplen %zu", apdu->resplen);
 	}
 
 	LOG_FUNC_RETURN(ctx, rv);
@@ -562,9 +557,7 @@ iasecc_sm_create_file(struct sc_card *card, unsigned se_num, unsigned char *fcp,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "iasecc_sm_create_file() SE#%i, fcp(%"SC_FORMAT_LEN_SIZE_T"u) '%s'",
-	       se_num, fcp_len, sc_dump_hex(fcp, fcp_len));
+	sc_log(ctx, "iasecc_sm_create_file() SE#%i, fcp(%zu) '%s'", se_num, fcp_len, sc_dump_hex(fcp, fcp_len));
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_CREATE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_create_file() SM INITIALIZE failed");
@@ -599,9 +592,7 @@ iasecc_sm_read_binary(struct sc_card *card, unsigned se_num, size_t offs, unsign
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "SM read binary: acl:%X, offs:%"SC_FORMAT_LEN_SIZE_T"u, count:%"SC_FORMAT_LEN_SIZE_T"u",
-	       se_num, offs, count);
+	sc_log(ctx, "SM read binary: acl:%X, offs:%zu, count:%zu", se_num, offs, count);
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_READ);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_read_binary() SM INITIALIZE failed");
@@ -640,9 +631,7 @@ iasecc_sm_update_binary(struct sc_card *card, unsigned se_num, size_t offs,
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "SM update binary: acl:%X, offs:%"SC_FORMAT_LEN_SIZE_T"u, count:%"SC_FORMAT_LEN_SIZE_T"u",
-	       se_num, offs, count);
+	sc_log(ctx, "SM update binary: acl:%X, offs:%zu, count:%zu", se_num, offs, count);
 
 	rv = iasecc_sm_initialize(card, se_num, SM_CMD_FILE_UPDATE);
 	LOG_TEST_RET(ctx, rv, "iasecc_sm_update_binary() SM INITIALIZE failed");

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -462,13 +462,13 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 					}
 					if (size > MAX_FILE_SIZE) {
 						file->size = MAX_FILE_SIZE;
-						sc_log(ctx, "  file size truncated, encoded length: %"SC_FORMAT_LEN_SIZE_T"u", size);
+						sc_log(ctx, "  file size truncated, encoded length: %zu", size);
 					} else {
 						file->size = size;
 					}
 				}
 
-				sc_log(ctx, "  bytes in file: %"SC_FORMAT_LEN_SIZE_T"u", file->size);
+				sc_log(ctx, "  bytes in file: %zu", file->size);
 				break;
 
 			case 0x82:
@@ -508,8 +508,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 							file->record_length = (length > 3)
 								? bebytes2ushort(p+2)
 								: p[2];
-							sc_log(ctx, "  record length: %"SC_FORMAT_LEN_SIZE_T"u",
-								file->record_length);
+							sc_log(ctx, "  record length: %zu", file->record_length);
 						}
 
 						/* number of records */
@@ -517,8 +516,7 @@ iso7816_process_fci(struct sc_card *card, struct sc_file *file,
 							file->record_count = (length > 5)
 								? bebytes2ushort(p+4)
 								: p[4];
-							sc_log(ctx, "  records: %"SC_FORMAT_LEN_SIZE_T"u",
-								file->record_count);
+							sc_log(ctx, "  records: %zu", file->record_count);
 						}
 					}
 
@@ -1106,9 +1104,7 @@ iso7816_compute_signature(struct sc_card *card,
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "ISO7816 compute signature: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
-	       datalen, outlen);
+	sc_log(card->ctx, "ISO7816 compute signature: in-len %zu, out-len %zu", datalen, outlen);
 
 	/* INS: 0x2A  PERFORM SECURITY OPERATION
 	 * P1:  0x9E  Resp: Digital Signature
@@ -1148,9 +1144,7 @@ iso7816_decipher(struct sc_card *card,
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	LOG_FUNC_CALLED(card->ctx);
-	sc_log(card->ctx,
-	       "ISO7816 decipher: in-len %"SC_FORMAT_LEN_SIZE_T"u, out-len %"SC_FORMAT_LEN_SIZE_T"u",
-	       crgram_len, outlen);
+	sc_log(card->ctx, "ISO7816 decipher: in-len %zu, out-len %zu", crgram_len, outlen);
 
 	sbuf = malloc(crgram_len + 1);
 	if (sbuf == NULL)

--- a/src/libopensc/log.c
+++ b/src/libopensc/log.c
@@ -349,13 +349,10 @@ void _sc_debug_hex(sc_context_t *ctx, int type, const char *file, int line,
 	sc_hex_dump(data, len, buf, blen);
 
 	if (label)
-		sc_do_log(ctx, type, file, line, func,
-			"\n%s (%"SC_FORMAT_LEN_SIZE_T"u byte%s):\n%s",
-			label, len, len==1?"":"s", buf);
+		sc_do_log(ctx, type, file, line, func, "\n%s (%zu byte%s):\n%s", label, len,
+				len == 1 ? "" : "s", buf);
 	else
-		sc_do_log(ctx, type, file, line, func,
-			"%"SC_FORMAT_LEN_SIZE_T"u byte%s:\n%s",
-			len, len==1?"":"s", buf);
+		sc_do_log(ctx, type, file, line, func, "%zu byte%s:\n%s", len, len == 1 ? "" : "s", buf);
 
 	free(buf);
 }

--- a/src/libopensc/muscle.c
+++ b/src/libopensc/muscle.c
@@ -56,9 +56,7 @@ int msc_list_objects(sc_card_t* card, u8 next, mscfs_file_t* file) {
 	if(apdu.resplen == 0) /* No more left */
 		return 0;
 	if (apdu.resplen != 14) {
-		sc_log(card->ctx,
-			 "expected 14 bytes, got %"SC_FORMAT_LEN_SIZE_T"u.\n",
-			 apdu.resplen);
+		sc_log(card->ctx, "expected 14 bytes, got %zu.\n", apdu.resplen);
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 	memcpy(file->objectId.id, fileData, 4);
@@ -78,9 +76,7 @@ int msc_partial_read_object(sc_card_t *card, msc_id objectId, int offset, u8 *da
 
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_4_SHORT, 0x56, 0x00, 0x00);
 
-	sc_log(card->ctx,
-		"READ: Offset: %x\tLength: %"SC_FORMAT_LEN_SIZE_T"u\n", offset,
-		 dataLength);
+	sc_log(card->ctx, "READ: Offset: %x\tLength: %zu\n", offset, dataLength);
 	memcpy(buffer, objectId.id, 4);
 	ulong2bebytes(buffer + 4, offset);
 	buffer[8] = (u8)dataLength;
@@ -188,9 +184,7 @@ int msc_partial_update_object(sc_card_t *card, msc_id objectId, size_t offset, c
 	sc_format_apdu(card, &apdu, SC_APDU_CASE_3_SHORT, 0x54, 0x00, 0x00);
 	apdu.lc = dataLength + 9;
 	if (card->ctx->debug >= 2)
-		sc_log(card->ctx,
-			 "WRITE: Offset: %zx\tLength: %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 offset, dataLength);
+		sc_log(card->ctx, "WRITE: Offset: %zx\tLength: %zu\n", offset, dataLength);
 
 	memcpy(buffer, objectId.id, 4);
 	ulong2bebytes(buffer + 4, offset);

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -44,15 +44,6 @@ extern "C" {
 #include "libopensc/sm.h"
 #endif
 
-#if defined(_WIN32) && !(defined(__MINGW32__) && defined (__MINGW_PRINTF_FORMAT))
-#define SC_FORMAT_LEN_SIZE_T "I"
-#define SC_FORMAT_LEN_PTRDIFF_T "I"
-#else
-/* hope SUSv3 ones work */
-#define SC_FORMAT_LEN_SIZE_T "z"
-#define SC_FORMAT_LEN_PTRDIFF_T "t"
-#endif
-
 #define SC_SEC_OPERATION_DECIPHER	0x0001
 #define SC_SEC_OPERATION_SIGN		0x0002
 #define SC_SEC_OPERATION_AUTHENTICATE	0x0003

--- a/src/libopensc/pkcs15-cac.c
+++ b/src/libopensc/pkcs15-cac.c
@@ -260,9 +260,8 @@ static int sc_pkcs15emu_cac_init(sc_pkcs15_card_t *p15card)
 		}
 		cert_info.path.count = (int)cert_der.len;
 
-		sc_log(card->ctx,
-			 "cert len=%"SC_FORMAT_LEN_SIZE_T"u, cert_info.path.count=%d r=%d\n",
-			 cert_der.len, cert_info.path.count, r);
+		sc_log(card->ctx, "cert len=%zu, cert_info.path.count=%d r=%d",
+				cert_der.len, cert_info.path.count, r);
 		sc_log_hex(card->ctx, "cert", cert_der.value, cert_der.len);
 
 		/* cache it using the PKCS15 emulation objects */

--- a/src/libopensc/pkcs15-cache.c
+++ b/src/libopensc/pkcs15-cache.c
@@ -76,7 +76,7 @@ static int generate_cache_filename(struct sc_pkcs15_card *p15card,
 	}
 
 	if (SC_SUCCESS == sc_card_ctl(p15card->card, SC_CARDCTL_GET_CHANGE_COUNTER, &change_counter))
-		snprintf(dir + strlen(dir), sizeof(dir) - strlen(dir), "_%" SC_FORMAT_LEN_SIZE_T "u", change_counter);
+		snprintf(dir + strlen(dir), sizeof(dir) - strlen(dir), "_%zu", change_counter);
 
 	if (path->aid.len &&
 		(path->type == SC_PATH_TYPE_FILE_ID || path->type == SC_PATH_TYPE_PATH))   {
@@ -235,9 +235,7 @@ int sc_pkcs15_cache_file(struct sc_pkcs15_card *p15card,
 	c = fwrite(buf, 1, bufsize, f);
 	fclose(f);
 	if (c != bufsize) {
-		sc_log(p15card->card->ctx,
-			 "fwrite() wrote only %"SC_FORMAT_LEN_SIZE_T"u bytes",
-			 c);
+		sc_log(p15card->card->ctx, "fwrite() wrote only %zu bytes", c);
 		unlink(fname);
 		return SC_ERROR_INTERNAL;
 	}

--- a/src/libopensc/pkcs15-gemsafeV1.c
+++ b/src/libopensc/pkcs15-gemsafeV1.c
@@ -188,12 +188,10 @@ static int gemsafe_get_cert_len(sc_card_t *card)
 	 * (allocated EF space is much greater!)
 	 */
 	objlen = (((size_t) ibuf[0]) << 8) | ibuf[1];
-	sc_log(card->ctx, "Stored object is of size: %"SC_FORMAT_LEN_SIZE_T"u",
-	       objlen);
+	sc_log(card->ctx, "Stored object is of size: %zu", objlen);
 	if (objlen < 1 || objlen > GEMSAFE_MAX_OBJLEN) {
-	    sc_log(card->ctx, "Invalid object size: %"SC_FORMAT_LEN_SIZE_T"u",
-		   objlen);
-	    return SC_ERROR_INTERNAL;
+		sc_log(card->ctx, "Invalid object size: %zu", objlen);
+		return SC_ERROR_INTERNAL;
 	}
 
 	/* It looks like the first thing in the block is a table of

--- a/src/libopensc/pkcs15-gids.c
+++ b/src/libopensc/pkcs15-gids.c
@@ -50,9 +50,7 @@ static int sc_pkcs15emu_gids_add_prkey(sc_pkcs15_card_t * p15card, sc_cardctl_gi
 	sc_pkcs15_object_t cert_obj;
 	int r;
 	char ch_tmp[10];
-	sc_log(card->ctx,
-		"Got args: containerIndex=%"SC_FORMAT_LEN_SIZE_T"x\n",
-		 container->containernum);
+	sc_log(card->ctx, "Got args: containerIndex=%zx\n", container->containernum);
 
 	memset(&prkey_info, 0, sizeof(prkey_info));
 	memset(&prkey_obj,  0, sizeof(prkey_obj));

--- a/src/libopensc/pkcs15-idprime.c
+++ b/src/libopensc/pkcs15-idprime.c
@@ -221,9 +221,8 @@ static int sc_pkcs15emu_idprime_init(sc_pkcs15_card_t *p15card)
 		}
 		cert_info.path.count = (int)cert_der.len;
 
-		sc_log(card->ctx,
-			 "cert len=%"SC_FORMAT_LEN_SIZE_T"u, cert_info.path.count=%d r=%d\n",
-			 cert_der.len, cert_info.path.count, r);
+		sc_log(card->ctx, "cert len=%zu, cert_info.path.count=%d r=%d",
+				cert_der.len, cert_info.path.count, r);
 		sc_log_hex(card->ctx, "cert", cert_der.value, cert_der.len);
 
 		/* cache it using the PKCS15 emulation objects */

--- a/src/libopensc/pkcs15-oberthur.c
+++ b/src/libopensc/pkcs15-oberthur.c
@@ -415,9 +415,7 @@ sc_oberthur_parse_containers (struct sc_pkcs15_card *p15card,
 		struct container *cont;
 		unsigned char *ptr =  buff + offs + 2;
 
-		sc_log(ctx,
-		       "parse contaniers offs:%"SC_FORMAT_LEN_SIZE_T"u, len:%"SC_FORMAT_LEN_SIZE_T"u",
-		       offs, len);
+		sc_log(ctx, "parse contaniers offs:%zu, len:%zu", offs, len);
 		if (*(buff + offs) != 'R')
 			return SC_ERROR_INVALID_DATA;
 
@@ -1130,9 +1128,8 @@ sc_pkcs15emu_oberthur_init(struct sc_pkcs15_card * p15card)
 				&oberthur_infos[ii].content, &oberthur_infos[ii].len, 1);
 		LOG_TEST_GOTO_ERR(ctx, rv, "Oberthur init failed: read oberthur file error");
 
-		sc_log(ctx,
-		       "Oberthur init: parse %s file, content length %"SC_FORMAT_LEN_SIZE_T"u",
-		       oberthur_infos[ii].name, oberthur_infos[ii].len);
+		sc_log(ctx, "Oberthur init: parse %s file, content length %zu",
+				oberthur_infos[ii].name, oberthur_infos[ii].len);
 		rv = oberthur_infos[ii].parser(p15card, oberthur_infos[ii].content, oberthur_infos[ii].len,
 				oberthur_infos[ii].postpone_allowed);
 		LOG_TEST_GOTO_ERR(ctx, rv, "Oberthur init failed: parse error");

--- a/src/libopensc/pkcs15-pin.c
+++ b/src/libopensc/pkcs15-pin.c
@@ -349,10 +349,8 @@ int sc_pkcs15_verify_pin_with_session_pin(struct sc_pkcs15_card *p15card,
 	struct sc_pin_cmd_data data;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "PIN(type:%X; method:%X; value(%p:%"SC_FORMAT_LEN_SIZE_T"u)",
-	       auth_info->auth_type, auth_info->auth_method,
-	       pincode, pinlen);
+	sc_log(ctx, "PIN(type:%X; method:%X; value(%p:%zu)",
+			auth_info->auth_type, auth_info->auth_method, pincode, pinlen);
 	card = p15card->card;
 
 	if (pinlen > SC_MAX_PIN_SIZE) {

--- a/src/libopensc/pkcs15-prkey.c
+++ b/src/libopensc/pkcs15-prkey.c
@@ -493,8 +493,7 @@ sc_pkcs15_prkey_attrs_from_cert(struct sc_pkcs15_card *p15card, struct sc_pkcs15
 
 	key_info = (struct sc_pkcs15_prkey_info *) key_object->data;
 
-	sc_log(ctx, "CertValue(%"SC_FORMAT_LEN_SIZE_T"u) %p",
-	       cert_object->content.len, cert_object->content.value);
+	sc_log(ctx, "CertValue(%zu) %p", cert_object->content.len, cert_object->content.value);
 	mem = BIO_new_mem_buf(cert_object->content.value, (int)cert_object->content.len);
 	if (!mem) {
 		sc_log_openssl(ctx);

--- a/src/libopensc/pkcs15-pubkey.c
+++ b/src/libopensc/pkcs15-pubkey.c
@@ -667,11 +667,11 @@ sc_pkcs15_decode_pubkey_ec(sc_context_t *ctx,
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ASN1_OBJECT);
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "ecpoint_len:%" SC_FORMAT_LEN_SIZE_T "u", ecpoint_len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "ecpoint_len:%zu", ecpoint_len);
 	/* if from bit string */
 	if (asn1_ec_pointQ[1].flags & SC_ASN1_PRESENT)
 		ecpoint_len = BYTES4BITS(ecpoint_len);
-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "ecpoint_len:%" SC_FORMAT_LEN_SIZE_T "u", ecpoint_len);
+	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "ecpoint_len:%zu", ecpoint_len);
 
 	if (*ecpoint_data != 0x04) {
 		free(ecpoint_data);
@@ -1332,9 +1332,8 @@ sc_pkcs15_pubkey_from_spki_fields(struct sc_context *ctx, struct sc_pkcs15_pubke
 	unsigned char *tmp_buf = NULL;
 	int r;
 
-	sc_log(ctx,
-	       "sc_pkcs15_pubkey_from_spki_fields() called: %p:%"SC_FORMAT_LEN_SIZE_T"u\n%s",
-	       buf, buflen, sc_dump_hex(buf, buflen));
+	sc_log(ctx, "sc_pkcs15_pubkey_from_spki_fields() called: %p:%zu\n%s",
+			buf, buflen, sc_dump_hex(buf, buflen));
 
 	if (buflen < 1) {
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "subjectPublicKeyInfo can not be empty");
@@ -1635,8 +1634,7 @@ sc_pkcs15_fix_ec_parameters(struct sc_context *ctx, struct sc_ec_parameters *ecp
 
 		ecparams->field_length = ec_curve_infos[ii].size;
 		ecparams->key_type = ec_curve_infos[ii].key_type;
-		sc_log(ctx, "Curve length %" SC_FORMAT_LEN_SIZE_T "u key_type %d",
-				ecparams->field_length, ecparams->key_type);
+		sc_log(ctx, "Curve length %zu key_type %d", ecparams->field_length, ecparams->key_type);
 		if (mapped_string) {
 			/* replace the printable string version with the oid */
 			if (ecparams->der.value)
@@ -1666,8 +1664,7 @@ sc_pkcs15_fix_ec_parameters(struct sc_context *ctx, struct sc_ec_parameters *ecp
 
 		ecparams->field_length = ec_curve_infos[ii].size;
 		ecparams->key_type = ec_curve_infos[ii].key_type;
-		sc_log(ctx, "Curve length %" SC_FORMAT_LEN_SIZE_T "u key_type %d",
-				ecparams->field_length, ecparams->key_type);
+		sc_log(ctx, "Curve length %zu key_type %d", ecparams->field_length, ecparams->key_type);
 
 		if (ecparams->der.value == NULL || ecparams->der.len == 0) {
 			free(ecparams->der.value); /* just in case */

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -194,9 +194,8 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_RSA:
 			*alg_info_out = sc_card_find_rsa_alg(p15card->card, prkey->modulus_length);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				       "Card does not support RSA with key length %"SC_FORMAT_LEN_SIZE_T"u",
-				       prkey->modulus_length);
+				sc_log(ctx, "Card does not support RSA with key length %zu",
+						prkey->modulus_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_RSA;
@@ -206,9 +205,8 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_GOSTR3410:
 			*alg_info_out = sc_card_find_gostr3410_alg(p15card->card, prkey->modulus_length);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				       "Card does not support GOSTR3410 with key length %"SC_FORMAT_LEN_SIZE_T"u",
-				       prkey->modulus_length);
+				sc_log(ctx, "Card does not support GOSTR3410 with key length %zu",
+						prkey->modulus_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_GOSTR3410;
@@ -218,9 +216,8 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_EDDSA:
 			*alg_info_out = sc_card_find_eddsa_alg(p15card->card, prkey->field_length, NULL);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				       "Card does not support EDDSA with field_size %"SC_FORMAT_LEN_SIZE_T"u",
-				       prkey->field_length);
+				sc_log(ctx, "Card does not support EDDSA with field_size %zu",
+						prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_EDDSA;
@@ -230,9 +227,8 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_XEDDSA:
 			*alg_info_out = sc_card_find_xeddsa_alg(p15card->card, prkey->field_length, NULL);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				       "Card does not support XEDDSA with field_size %"SC_FORMAT_LEN_SIZE_T"u",
-				       prkey->field_length);
+				sc_log(ctx, "Card does not support XEDDSA with field_size %zu",
+						prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_XEDDSA;
@@ -242,9 +238,8 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 		case SC_PKCS15_TYPE_PRKEY_EC:
 			*alg_info_out = sc_card_find_ec_alg(p15card->card, prkey->field_length, NULL);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				       "Card does not support EC with field_size %"SC_FORMAT_LEN_SIZE_T"u",
-				       prkey->field_length);
+				sc_log(ctx, "Card does not support EC with field_size %zu",
+						prkey->field_length);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_EC;
@@ -259,9 +254,7 @@ static int format_senv(struct sc_pkcs15_card *p15card,
 			*alg_info_out = sc_card_find_alg(p15card->card, SC_ALGORITHM_AES,
 					skey->value_len, NULL);
 			if (*alg_info_out == NULL) {
-				sc_log(ctx,
-				"Card does not support AES with key length %"SC_FORMAT_LEN_SIZE_T"u",
-				skey->value_len);
+				sc_log(ctx, "Card does not support AES with key length %zu", skey->value_len);
 				LOG_FUNC_RETURN(ctx, SC_ERROR_NOT_SUPPORTED);
 			}
 			senv_out->algorithm = SC_ALGORITHM_AES;

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -2518,7 +2518,7 @@ sc_pkcs15_read_file(struct sc_pkcs15_card *p15card, const struct sc_path *in_pat
 			if(file->record_length > 0) {
 				if(file->record_length > MAX_FILE_SIZE) {
 					len = MAX_FILE_SIZE;
-					sc_log(ctx, "  record size truncated, encoded length: %"SC_FORMAT_LEN_SIZE_T"u", file->record_length);
+					sc_log(ctx, "  record size truncated, encoded length: %zu", file->record_length);
 				} else {
 					len = file->record_length;
 				}

--- a/src/libopensc/reader-pcsc.c
+++ b/src/libopensc/reader-pcsc.c
@@ -1274,8 +1274,7 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 				}
 			}
 			else {
-				sc_log(ctx,
-						"Returned PIN properties structure has bad length (%lu/%"SC_FORMAT_LEN_SIZE_T"u)",
+				sc_log(ctx, "Returned PIN properties structure has bad length (%lu/%zu)",
 						(unsigned long)rcount,
 						sizeof(PIN_PROPERTIES_STRUCTURE));
 			}
@@ -1318,26 +1317,24 @@ static void detect_reader_features(sc_reader_t *reader, SCARDHANDLE card_handle)
 	}
 
 	if (max_send_size > 0) {
-		sc_log(ctx, "Reader supports sending %"SC_FORMAT_LEN_SIZE_T"u bytes of data",
-				max_send_size);
+		sc_log(ctx, "Reader supports sending %zu bytes of data", max_send_size);
 		if (!priv->gpriv->force_max_send_size)
 			reader->max_send_size = max_send_size;
 		else
-			sc_log(ctx, "Sending is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
-					" in configuration file", reader->max_send_size);
+			sc_log(ctx, "Sending is limited to %zu bytes of data  in configuration file",
+					reader->max_send_size);
 	} else {
 		sc_log(ctx, "Assuming that the reader supports sending "
 				"short length APDUs only");
 	}
 
 	if (max_recv_size > 0) {
-		sc_log(ctx, "Reader supports receiving %"SC_FORMAT_LEN_SIZE_T"u bytes of data",
-				max_recv_size);
+		sc_log(ctx, "Reader supports receiving %zu bytes of data", max_recv_size);
 		if (!priv->gpriv->force_max_recv_size)
 			reader->max_recv_size = max_recv_size;
 		else
-			sc_log(ctx, "Receiving is limited to %"SC_FORMAT_LEN_SIZE_T"u bytes of data"
-					" in configuration file", reader->max_recv_size);
+			sc_log(ctx, "Receiving is limited to %zu bytes of data in configuration file",
+					reader->max_recv_size);
 	} else {
 		sc_log(ctx, "Assuming that the reader supports receiving "
 				"short length APDUs only");
@@ -1685,7 +1682,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 			r = SC_ERROR_INTERNAL;
 			goto out;
 		} else {
-			sc_log(ctx, "PC/SC event listener %" SC_FORMAT_LEN_SIZE_T "d", states->pcsc_wait_ctx_index);
+			sc_log(ctx, "PC/SC event listener %zd", states->pcsc_wait_ctx_index);
 		}
 
 		count = sc_ctx_get_reader_count(ctx);
@@ -1741,7 +1738,7 @@ static int pcsc_wait_for_event(sc_context_t *ctx, unsigned int event_mask, sc_re
 		states = *reader_states;
 
 		if (states->pcsc_wait_ctx_index >= ARRAY_SIZE(gpriv->pcsc_wait_ctx)) {
-			sc_log(ctx, "PC/SC event listener %" SC_FORMAT_LEN_SIZE_T "d not available", states->pcsc_wait_ctx_index);
+			sc_log(ctx, "PC/SC event listener %zd not available", states->pcsc_wait_ctx_index);
 			r = SC_ERROR_INTERNAL;
 			goto out;
 		}

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -297,8 +297,7 @@ static void loghex(PCARD_DATA pCardData, int level, PBYTE data, size_t len)
 	unsigned int i, a;
 	unsigned char * p;
 
-	logprintf(pCardData, level, "--- %p:%"SC_FORMAT_LEN_SIZE_T"u\n",
-		  data, len);
+	logprintf(pCardData, level, "--- %p:%zu\n", data, len);
 
 	if (data == NULL || len <= 0) return;
 
@@ -444,14 +443,12 @@ check_card_reader_status(PCARD_DATA pCardData, const char *name)
 	logprintf(pCardData, 7, "sizeof(size_t):%u sizeof(ULONG_PTR):%u sizeof(__int3264):%u sizeof pCardData->hSCardCtx:%u\n",
 		(unsigned)sizeof(size_t), (unsigned)sizeof(ULONG_PTR), (unsigned)sizeof(__int3264), (unsigned)sizeof(pCardData->hSCardCtx));
 
-	logprintf(pCardData, 1, "pCardData->hSCardCtx:0x%08"SC_FORMAT_LEN_SIZE_T"X hScard:0x%08"SC_FORMAT_LEN_SIZE_T"X\n",
-		(size_t)pCardData->hSCardCtx,
-		(size_t)pCardData->hScard);
+	logprintf(pCardData, 1, "pCardData->hSCardCtx:0x%08zX hScard:0x%08zX\n",
+			(size_t)pCardData->hSCardCtx, (size_t)pCardData->hScard);
 
 	if (pCardData->hSCardCtx != vs->hSCardCtx || pCardData->hScard != vs->hScard) {
-		logprintf(pCardData, 1, "HANDLES CHANGED from  vs->hSCardCtx:0x%08"SC_FORMAT_LEN_SIZE_T"X vs->hScard:0x%08"SC_FORMAT_LEN_SIZE_T"X\n",
-			(size_t)vs->hSCardCtx,
-			(size_t)vs->hScard);
+		logprintf(pCardData, 1, "HANDLES CHANGED from  vs->hSCardCtx:0x%08zX vs->hScard:0x%08zX\n",
+				(size_t)vs->hSCardCtx, (size_t)vs->hScard);
 		if (vs->ctx) {
 			if (1 == pcsc_check_reader_handles(vs->ctx, vs->reader, &pCardData->hSCardCtx, &pCardData->hScard)) {
 				_sc_delete_reader(vs->ctx, vs->reader);
@@ -1464,8 +1461,7 @@ md_set_cardid(PCARD_DATA pCardData, struct md_file *file)
 			return dwret;
 	}
 
-	logprintf(pCardData, 3, "cardid(%"SC_FORMAT_LEN_SIZE_T"u)\n",
-		  file->size);
+	logprintf(pCardData, 3, "cardid(%zu)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1654,8 +1650,7 @@ md_set_cardcf(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "'cardcf' content(%"SC_FORMAT_LEN_SIZE_T"u)\n",
-		  file->size);
+	logprintf(pCardData, 3, "'cardcf' content(%zu)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1673,7 +1668,7 @@ md_set_cardapps(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "mscp(%"SC_FORMAT_LEN_SIZE_T"u)\n", file->size);
+	logprintf(pCardData, 3, "mscp(%zu)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -1951,9 +1946,8 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 				cont->size_key_exchange = prkey_info->field_length;
 		}
 
-		logprintf(pCardData, 7,
-			  "Container[%i]'s key-exchange:%"SC_FORMAT_LEN_SIZE_T"u, sign:%"SC_FORMAT_LEN_SIZE_T"u\n",
-			  ii, cont->size_key_exchange, cont->size_sign);
+		logprintf(pCardData, 7, "Container[%i]'s key-exchange:%zu, sign:%zu\n",
+				ii, cont->size_key_exchange, cont->size_sign);
 
 		cont->id = prkey_info->id;
 		cont->prkey_obj = prkey_objs[ii];
@@ -2160,7 +2154,7 @@ md_set_cmapfile(PCARD_DATA pCardData, struct md_file *file)
 	if (dwret != SCARD_S_SUCCESS)
 		return dwret;
 
-	logprintf(pCardData, 3, "cmap(%"SC_FORMAT_LEN_SIZE_T"u)\n", file->size);
+	logprintf(pCardData, 3, "cmap(%zu)\n", file->size);
 	loghex(pCardData, 3, file->blob, file->size);
 	return SCARD_S_SUCCESS;
 }
@@ -3277,11 +3271,9 @@ DWORD WINAPI CardDeleteContext(__inout PCARD_DATA  pCardData)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
 	logprintf(pCardData, 1,
-		  "\nP:%lu T:%lu pCardData:%p hScard=0x%08"SC_FORMAT_LEN_SIZE_T"X hSCardCtx=0x%08"SC_FORMAT_LEN_SIZE_T"X CardDeleteContext\n",
-		  (unsigned long)GetCurrentProcessId(),
-		  (unsigned long)GetCurrentThreadId(), pCardData,
-		  (size_t)pCardData->hScard,
-		  (size_t)pCardData->hSCardCtx);
+			"\nP:%lu T:%lu pCardData:%p hScard=0x%08zX hSCardCtx=0x%08zX CardDeleteContext\n",
+			(unsigned long)GetCurrentProcessId(), (unsigned long)GetCurrentThreadId(), pCardData,
+			(size_t)pCardData->hScard, (size_t)pCardData->hSCardCtx);
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	if(!vs)
@@ -3734,8 +3726,8 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 					break;
 				default:
 					logprintf(pCardData, 3,
-						  "Unable to match the ECC public size to one of Microsoft algorithm %"SC_FORMAT_LEN_SIZE_T"u\n",
-						  cont->size_sign);
+							"Unable to match the ECC public size to one of Microsoft algorithm %zu\n",
+							cont->size_sign);
 					ret = SCARD_F_INTERNAL_ERROR;
 					goto err;
 				}
@@ -3775,8 +3767,8 @@ DWORD WINAPI CardGetContainerInfo(__in PCARD_DATA pCardData, __in BYTE bContaine
 					break;
 				default:
 					logprintf(pCardData, 3,
-						  "Unable to match the ECC public size to one of Microsoft algorithm %"SC_FORMAT_LEN_SIZE_T"u\n",
-						  cont->size_key_exchange);
+							"Unable to match the ECC public size to one of Microsoft algorithm %zu\n",
+							cont->size_key_exchange);
 					ret = SCARD_F_INTERNAL_ERROR;
 					goto err;
 				}
@@ -4636,9 +4628,8 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 	prkey_info = (struct sc_pkcs15_prkey_info *)(pkey->data);
 	alg_info = sc_card_find_rsa_alg(vs->p15card->card, (unsigned int) prkey_info->modulus_length);
 	if (!alg_info)   {
-		logprintf(pCardData, 2,
-			  "Cannot get appropriate RSA card algorithm for key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-			  prkey_info->modulus_length);
+		logprintf(pCardData, 2, "Cannot get appropriate RSA card algorithm for key size %zu\n",
+				prkey_info->modulus_length);
 		pCardData->pfnCspFree(pbuf);
 		pCardData->pfnCspFree(pbuf2);
 		dwret = SCARD_F_INTERNAL_ERROR;
@@ -4971,9 +4962,7 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 				pInfo->cbSignedData = 132;
 				break;
 			default:
-				logprintf(pCardData, 0,
-					  "unknown ECC key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-					  prkey_info->field_length);
+				logprintf(pCardData, 0, "unknown ECC key size %zu\n", prkey_info->field_length);
 				dwret = SCARD_E_INVALID_VALUE;
 				goto err;
 		}
@@ -5036,12 +5025,9 @@ DWORD WINAPI CardSignData(__in PCARD_DATA pCardData, __inout PCARD_SIGNING_INFO 
 		loghex(pCardData, 7, pInfo->pbSignedData, pInfo->cbSignedData);
 	}
 
-	logprintf(pCardData, 3,
-		  "CardSignData, dwVersion=%lu, name=%S, hScard=0x%08"SC_FORMAT_LEN_SIZE_T"X, hSCardCtx=0x%08"SC_FORMAT_LEN_SIZE_T"X\n",
-		  (unsigned long)pCardData->dwVersion,
-		  NULLWSTR(pCardData->pwszCardName),
-		  (size_t)pCardData->hScard,
-		  (size_t)pCardData->hSCardCtx);
+	logprintf(pCardData, 3, "CardSignData, dwVersion=%lu, name=%S, hScard=0x%08zX, hSCardCtx=0x%08zX\n",
+			(unsigned long)pCardData->dwVersion, NULLWSTR(pCardData->pwszCardName),
+			(size_t)pCardData->hScard, (size_t)pCardData->hSCardCtx);
 
 err:
 	unlock(pCardData);
@@ -5987,9 +5973,7 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 			logprintf(pCardData, 2, "generating session pin failed");
 		} else {
 			if (*ppbSessionPin != NULL && session_pin_len > 0) {
-				logprintf(pCardData, 2,
-					  "generated session pin with %"SC_FORMAT_LEN_SIZE_T"u bytes",
-					  session_pin_len);
+				logprintf(pCardData, 2, "generated session pin with %zu bytes", session_pin_len);
 
 				*pcbSessionPin = session_pin_len;
 			} else {
@@ -7024,12 +7008,9 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
 		  (unsigned long)GetCurrentProcessId(),
 		  (unsigned long)GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1,
-		  "CardAcquireContext, dwVersion=%lu, name=%S,hScard=0x%08"SC_FORMAT_LEN_SIZE_T"X, hSCardCtx=0x%08"SC_FORMAT_LEN_SIZE_T"X\n",
-		  (unsigned long)pCardData->dwVersion,
-		  NULLWSTR(pCardData->pwszCardName),
-		  (size_t)pCardData->hScard,
-		  (size_t)pCardData->hSCardCtx);
+	logprintf(pCardData, 1, "CardAcquireContext, dwVersion=%lu, name=%S,hScard=0x%08zX, hSCardCtx=0x%08zX\n",
+			(unsigned long)pCardData->dwVersion, NULLWSTR(pCardData->pwszCardName),
+			(size_t)pCardData->hScard, (size_t)pCardData->hSCardCtx);
 
 	vs->hScard = pCardData->hScard;
 	vs->hSCardCtx = pCardData->hSCardCtx;

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -677,7 +677,7 @@ CK_RV sc_pkcs11_verify_data(const CK_BYTE_PTR pubkey, CK_ULONG pubkey_len,
 					res = EVP_VerifyFinal(md_ctx, signat_tmp, (unsigned int) signat_len_tmp, pkey);
 				} else {
 					sc_log(context, "sc_asn1_sig_value_rs_to_sequence failed r:%d "
-							"or output too long signat_len_tmp:%"SC_FORMAT_LEN_SIZE_T"u",
+							"or output too long signat_len_tmp:%zu",
 							r, signat_len_tmp);
 					res = -1;
 				}

--- a/src/pkcs15init/pkcs15-authentic.c
+++ b/src/pkcs15init/pkcs15-authentic.c
@@ -249,9 +249,8 @@ authentic_pkcs15_new_file(struct sc_profile *profile, struct sc_card *card,
 		file->path.count = -1;
 	}
 
-	sc_log(ctx, "file(size:%"SC_FORMAT_LEN_SIZE_T"u,type:%i/%i,id:%04X), path(type:%X,'%s')",
-	       file->size, file->type, file->ef_structure, file->id,
-	       file->path.type, sc_print_path(&file->path));
+	sc_log(ctx, "file(size:%zu,type:%i/%i,id:%04X), path(type:%X,'%s')", file->size, file->type,
+			file->ef_structure, file->id, file->path.type, sc_print_path(&file->path));
 	if (out)
 		*out = file;
 	else
@@ -525,10 +524,8 @@ authentic_pkcs15_create_key(struct sc_profile *profile, struct sc_pkcs15_card *p
 	int	 rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "create private key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,usage:%X,access:%X,ref:%X)",
-	       keybits, key_info->usage, key_info->access_flags,
-	       key_info->key_reference);
+	sc_log(ctx, "create private key(keybits:%zu,usage:%X,access:%X,ref:%X)",
+			keybits, key_info->usage, key_info->access_flags, key_info->key_reference);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 256))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "Invalid RSA key size");
 
@@ -618,10 +615,8 @@ authentic_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15c
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "generate key(bits:%"SC_FORMAT_LEN_SIZE_T"u,path:%s,AuthID:%s\n",
-	       keybits, sc_print_path(&key_info->path),
-	       sc_pkcs15_print_id(&object->auth_id));
+	sc_log(ctx, "generate key(bits:%zu,path:%s,AuthID:%s",
+			keybits, sc_print_path(&key_info->path), sc_pkcs15_print_id(&object->auth_id));
 
 	if (!object->content.value || object->content.len != sizeof(struct sc_authentic_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -685,10 +680,8 @@ authentic_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "Store IAS/ECC key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,AuthID:%s,path:%s)",
-	       keybits, sc_pkcs15_print_id(&object->auth_id),
-	       sc_print_path(&key_info->path));
+	sc_log(ctx, "Store IAS/ECC key(keybits:%zu,AuthID:%s,path:%s)",
+			keybits, sc_pkcs15_print_id(&object->auth_id), sc_print_path(&key_info->path));
 
 	if (!object->content.value || object->content.len != sizeof(struct sc_authentic_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -734,8 +727,7 @@ authentic_pkcs15_delete_rsa_sdo (struct sc_profile *profile, struct sc_pkcs15_ca
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx, "delete SDO RSA key (ref:%i,size:%"SC_FORMAT_LEN_SIZE_T"u)",
-	       key_info->key_reference, key_info->modulus_length);
+	sc_log(ctx, "delete SDO RSA key (ref:%i,size:%zu)", key_info->key_reference, key_info->modulus_length);
 
 	rv = authentic_pkcs15_new_file(profile, p15card->card, SC_PKCS15_TYPE_PRKEY_RSA, key_info->key_reference, &file);
 	LOG_TEST_GOTO_ERR(ctx, rv, "PRKEY_RSA instantiation file error");

--- a/src/pkcs15init/pkcs15-cardos.c
+++ b/src/pkcs15init/pkcs15-cardos.c
@@ -490,9 +490,7 @@ cardos_store_pin(sc_profile_t *profile, sc_card_t *card,
 	 * "no padding required". */
 	maxlen = MIN(profile->pin_maxlen, sizeof(pinpadded));
 	if (pin_len > maxlen) {
-		sc_log(card->ctx,
-			 "invalid pin length: %"SC_FORMAT_LEN_SIZE_T"u (max %u)\n",
-			 pin_len, maxlen);
+		sc_log(card->ctx, "invalid pin length: %zu (max %u)", pin_len, maxlen);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	memcpy(pinpadded, pin, pin_len);

--- a/src/pkcs15init/pkcs15-cflex.c
+++ b/src/pkcs15init/pkcs15-cflex.c
@@ -292,9 +292,7 @@ cflex_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card, sc_pkcs15_obj
 	case 1024: size = 326; break;
 	case 2048: size = 646; break;
 	default:
-		sc_log(p15card->card->ctx,
-			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 key_info->modulus_length);
+		sc_log(p15card->card->ctx, "Unsupported key size %zu", key_info->modulus_length);
 		r = SC_ERROR_INVALID_ARGUMENTS;
 		goto out;
 	}

--- a/src/pkcs15init/pkcs15-entersafe.c
+++ b/src/pkcs15init/pkcs15-entersafe.c
@@ -367,10 +367,7 @@ static int entersafe_store_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 		 ( keybits > 2048 ) ||
 		 ( keybits % 0x20 ) )
 	{
-		sc_debug(card->ctx,
-			 SC_LOG_DEBUG_NORMAL,
-			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 keybits);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Unsupported key size %zu", keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -417,10 +414,7 @@ static int entersafe_generate_key(sc_profile_t *profile, sc_pkcs15_card_t *p15ca
 		 ( keybits > 2048 ) ||
 		 ( keybits % 0x20 ) )
 	{
-		sc_debug(card->ctx,
-			 SC_LOG_DEBUG_NORMAL,
-			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 keybits);
+		sc_debug(card->ctx, SC_LOG_DEBUG_NORMAL, "Unsupported key size %zu", keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 

--- a/src/pkcs15init/pkcs15-epass2003.c
+++ b/src/pkcs15init/pkcs15-epass2003.c
@@ -387,10 +387,8 @@ cosm_new_file(struct sc_profile *profile, struct sc_card *card,
 	file->type = SC_FILE_TYPE_INTERNAL_EF;
 	file->ef_structure = structure;
 
-	sc_log(card->ctx,
-		 "file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X, path_len %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 file->size, file->type, file->ef_structure, file->id,
-		 file->path.len);
+	sc_log(card->ctx, "file size %zu; ef type %i/%i; id %04X, path_len %zu\n",
+			file->size, file->type, file->ef_structure, file->id, file->path.len);
 	sc_log(card->ctx,  "file path: %s",
 		 sc_print_path(&(file->path)));
 	*out = file;
@@ -427,14 +425,9 @@ static int epass2003_pkcs15_store_key(struct sc_profile *profile,
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
-	sc_log(card->ctx,
-		 "index %"SC_FORMAT_LEN_SIZE_T"u; id %s\n", idx,
-		 sc_pkcs15_print_id(&key_info->id));
-	if (key->algorithm != SC_ALGORITHM_RSA
-	    || key->algorithm != SC_ALGORITHM_RSA)
-		LOG_TEST_RET(card->ctx,
-			    SC_ERROR_NOT_SUPPORTED,
-			    "store key: only support RSA");
+	sc_log(card->ctx, "index %zu; id %s\n", idx, sc_pkcs15_print_id(&key_info->id));
+	if (key->algorithm != SC_ALGORITHM_RSA || key->algorithm != SC_ALGORITHM_RSA)
+		LOG_TEST_RET(card->ctx, SC_ERROR_NOT_SUPPORTED, "store key: only support RSA");
 
 	sc_log(card->ctx,
 		 "store key: with ID:%s and path:%s",
@@ -457,13 +450,9 @@ static int epass2003_pkcs15_store_key(struct sc_profile *profile,
 	LOG_TEST_RET(card->ctx, r,
 		    "create key: failed to create key file");
 
-	sc_log(card->ctx,
-		 "index %"SC_FORMAT_LEN_SIZE_T"u; keybits %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 idx, keybits);
+	sc_log(card->ctx, "index %zu; keybits %zu", idx, keybits);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 0x20)) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
-			 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-			 keybits);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL, "Unsupported key size %zu", keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -541,9 +530,7 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
 		    "create key: failed to create key file");
 
-	sc_log(card->ctx,
-		 "index %u; keybits %"SC_FORMAT_LEN_SIZE_T"u\n",
-		 idx, keybits);
+	sc_log(card->ctx, "index %u; keybits %zu", idx, keybits);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 0x20)) {
 		if(obj->type == SC_PKCS15_TYPE_PRKEY_EC && keybits == 256)
 		{
@@ -551,9 +538,7 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 		}
 		else
 		{
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
-				 "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-				 keybits);
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE_TOOL, "Unsupported key size %zu\n", keybits);
 			r = SC_ERROR_INVALID_ARGUMENTS;
 			goto err;
 		}
@@ -563,18 +548,15 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	path.len -= 2;
 
 	r = sc_select_file(card, &path, &tfile);
-	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
-		    "generate key: no private object DF");
+	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r, "generate key: no private object DF");
 
-	r = sc_pkcs15init_authenticate(profile, p15card, tfile,
-				       SC_AC_OP_CRYPTO);
+	r = sc_pkcs15init_authenticate(profile, p15card, tfile, SC_AC_OP_CRYPTO);
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
-		    "generate key: pkcs15init_authenticate(SC_AC_OP_CRYPTO) failed");
+			"generate key: pkcs15init_authenticate(SC_AC_OP_CRYPTO) failed");
 
-	r = sc_pkcs15init_authenticate(profile, p15card, tfile,
-				       SC_AC_OP_CREATE);
+	r = sc_pkcs15init_authenticate(profile, p15card, tfile, SC_AC_OP_CREATE);
 	SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
-		    "generate key: pkcs15init_authenticate(SC_AC_OP_CREATE) failed");
+			"generate key: pkcs15init_authenticate(SC_AC_OP_CREATE) failed");
 
 	if (obj->type != SC_PKCS15_TYPE_PRKEY_RSA )
 	{
@@ -595,23 +577,19 @@ static int epass2003_pkcs15_generate_key(struct sc_profile *profile,
 	pukf->id = pukf->path.value[pukf->path.len - 2] * 0x100
 	    + pukf->path.value[pukf->path.len - 1];
 
-	sc_log(card->ctx,
-		 "public key size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X; path: %s",
-		 pukf->size, pukf->type, pukf->ef_structure, pukf->id,
-		 sc_print_path(&pukf->path));
+	sc_log(card->ctx, "public key size %zu; ef type %i/%i; id %04X; path: %s",
+			pukf->size, pukf->type, pukf->ef_structure, pukf->id, sc_print_path(&pukf->path));
 
 	r = sc_select_file(p15card->card, &pukf->path, NULL);
 	/* if exist, delete */
 	if (r == SC_SUCCESS) {
-		r = sc_pkcs15init_authenticate(profile, p15card, pukf,
-		       SC_AC_OP_DELETE);
+		r = sc_pkcs15init_authenticate(profile, p15card, pukf, SC_AC_OP_DELETE);
 		SC_TEST_GOTO_ERR(card->ctx, SC_LOG_DEBUG_VERBOSE, r,
-		    "generate key - pubkey: pkcs15init_authenticate(SC_AC_OP_DELETE) failed");
+				"generate key - pubkey: pkcs15init_authenticate(SC_AC_OP_DELETE) failed");
 
 		r = sc_pkcs15init_delete_by_path(profile, p15card, &pukf->path);
 		if (r != SC_SUCCESS) {
-			sc_log(card->ctx,
-				 "generate key: failed to delete existing key file\n");
+			sc_log(card->ctx, "generate key: failed to delete existing key file");
 			goto err;
 		}
 	}

--- a/src/pkcs15init/pkcs15-iasecc.c
+++ b/src/pkcs15init/pkcs15-iasecc.c
@@ -236,9 +236,8 @@ iasecc_pkcs15_new_file(struct sc_profile *profile, struct sc_card *card,
 	file->path.value[file->path.len - 1] = file->id & 0xFF;
 	file->path.count = -1;
 
-	sc_log(ctx,
-	       "file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X\n",
-	       file->size, file->type, file->ef_structure, file->id);
+	sc_log(ctx, "file size %zu; ef type %i/%i; id %04X",
+			file->size, file->type, file->ef_structure, file->id);
 	sc_log(ctx, "path type %X; path '%s'", file->path.type, sc_print_path(&file->path));
 
 	if (out)
@@ -931,10 +930,8 @@ iasecc_pkcs15_fix_private_key_attributes(struct sc_profile *profile, struct sc_p
 
 	sc_log(ctx, "SDO(class:%X,ref:%X,usage:%X)",
 			sdo_prvkey->sdo_class, sdo_prvkey->sdo_ref, sdo_prvkey->usage);
-	sc_log(ctx, "SDO ACLs(%"SC_FORMAT_LEN_SIZE_T"u):%s",
-	       sdo_prvkey->docp.acls_contact.size,
-	       sc_dump_hex(sdo_prvkey->docp.acls_contact.value,
-			   sdo_prvkey->docp.acls_contact.size));
+	sc_log(ctx, "SDO ACLs(%zu):%s", sdo_prvkey->docp.acls_contact.size,
+			sc_dump_hex(sdo_prvkey->docp.acls_contact.value, sdo_prvkey->docp.acls_contact.size));
 	sc_log(ctx, "SDO AMB:%X, SCBS:%s", sdo_prvkey->docp.amb,
 			sc_dump_hex(sdo_prvkey->docp.scbs, IASECC_MAX_SCBS));
 
@@ -1071,13 +1068,10 @@ iasecc_pkcs15_create_key(struct sc_profile *profile, struct sc_pkcs15_card *p15c
 	int	 rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "create private key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,usage:%X,access:%X,ref:%X)",
-	       keybits, key_info->usage, key_info->access_flags,
-	       key_info->key_reference);
+	sc_log(ctx, "create private key(keybits:%zu,usage:%X,access:%X,ref:%X)",
+			keybits, key_info->usage, key_info->access_flags, key_info->key_reference);
 	if (keybits < 1024 || keybits > 2048 || (keybits % 256))   {
-		sc_log(ctx, "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u",
-		       keybits);
+		sc_log(ctx, "Unsupported key size %zu", keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -1135,10 +1129,8 @@ iasecc_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15card
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "generate key(bits:%"SC_FORMAT_LEN_SIZE_T"u,path:%s,AuthID:%s\n",
-	       keybits, sc_print_path(&key_info->path),
-	       sc_pkcs15_print_id(&object->auth_id));
+	sc_log(ctx, "generate key(bits:%zu,path:%s,AuthID:%s",
+			keybits, sc_print_path(&key_info->path), sc_pkcs15_print_id(&object->auth_id));
 
 	if (!object->content.value || object->content.len != sizeof(struct iasecc_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -1148,8 +1140,7 @@ iasecc_pkcs15_generate_key(struct sc_profile *profile, sc_pkcs15_card_t *p15card
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "'Magic' control failed for SDO PrvKey");
 
 	if (keybits < 1024 || keybits > 2048 || (keybits%0x100))   {
-		sc_log(ctx, "Unsupported key size %"SC_FORMAT_LEN_SIZE_T"u\n",
-		       keybits);
+		sc_log(ctx, "Unsupported key size %zu\n", keybits);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 
@@ -1231,10 +1222,8 @@ iasecc_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p15ca
 	int rv;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "Store IAS/ECC key(keybits:%"SC_FORMAT_LEN_SIZE_T"u,AuthID:%s,path:%s)",
-	       keybits, sc_pkcs15_print_id(&object->auth_id),
-	       sc_print_path(&key_info->path));
+	sc_log(ctx, "Store IAS/ECC key(keybits:%zu,AuthID:%s,path:%s)",
+			keybits, sc_pkcs15_print_id(&object->auth_id), sc_print_path(&key_info->path));
 
 	if (!object->content.value || object->content.len != sizeof(struct iasecc_sdo))
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "Invalid PrKey SDO data");
@@ -1245,10 +1234,8 @@ iasecc_pkcs15_store_key(struct sc_profile *profile, struct sc_pkcs15_card *p15ca
 	if (sdo_prvkey->magic != SC_CARDCTL_IASECC_SDO_MAGIC)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_DATA, "'Magic' control failed for SDO PrvKey");
 
-	sc_log(ctx,
-	       "key compulsory attr(size:%"SC_FORMAT_LEN_SIZE_T"u,on_card:%i)",
-	       sdo_prvkey->data.prv_key.compulsory.size,
-	       sdo_prvkey->data.prv_key.compulsory.on_card);
+	sc_log(ctx, "key compulsory attr(size:%zu,on_card:%i)", sdo_prvkey->data.prv_key.compulsory.size,
+			sdo_prvkey->data.prv_key.compulsory.on_card);
 
 	rv = sc_profile_get_parent(profile, "private-key", &file);
 	LOG_TEST_RET(ctx, rv, "cannot instantiate parent DF of the private key");

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -2210,10 +2210,8 @@ sc_pkcs15init_store_certificate(struct sc_pkcs15_card *p15card,
 		cert_info->path = existing_path;
 	}
 
-	sc_log(ctx, "Store cert(%.*s,ID:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
-	       (int) sizeof object->label, object->label,
-	       sc_pkcs15_print_id(&cert_info->id), args->der_encoded.value,
-	       args->der_encoded.len);
+	sc_log(ctx, "Store cert(%.*s,ID:%s,der(%p,%zu))", (int)sizeof(object->label), object->label,
+			sc_pkcs15_print_id(&cert_info->id), args->der_encoded.value, args->der_encoded.len);
 
 	if (!profile->pkcs15.direct_certificates)
 		r = sc_pkcs15init_store_data(p15card, profile, object, &args->der_encoded, &cert_info->path);
@@ -2774,17 +2772,14 @@ prkey_bits(struct sc_pkcs15_card *p15card, struct sc_pkcs15_prkey *key)
 		return (int)sc_pkcs15init_keybits(&key->u.rsa.modulus);
 	case SC_ALGORITHM_GOSTR3410:
 		if (sc_pkcs15init_keybits(&key->u.gostr3410.d) > SC_PKCS15_GOSTR3410_KEYSIZE) {
-			sc_log(ctx,
-			       "Unsupported key (keybits %"SC_FORMAT_LEN_SIZE_T"u)",
-			       sc_pkcs15init_keybits(&key->u.gostr3410.d));
+			sc_log(ctx, "Unsupported key (keybits %zu)", sc_pkcs15init_keybits(&key->u.gostr3410.d));
 			return SC_ERROR_OBJECT_NOT_VALID;
 		}
 		return SC_PKCS15_GOSTR3410_KEYSIZE;
 	case SC_ALGORITHM_EC:
 	case SC_ALGORITHM_EDDSA:
 	case SC_ALGORITHM_XEDDSA:
-		sc_log(ctx, "Private EC type key length %" SC_FORMAT_LEN_SIZE_T "u",
-				key->u.ec.params.field_length);
+		sc_log(ctx, "Private EC type key length %zu", key->u.ec.params.field_length);
 		if (key->u.ec.params.field_length == 0)   {
 			sc_log(ctx, "Invalid EC key length");
 			return SC_ERROR_OBJECT_NOT_VALID;
@@ -3114,8 +3109,7 @@ select_object_path(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	if (!name)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 
-	sc_log(ctx, "key-domain.%s @%s (auth_id.len=%"SC_FORMAT_LEN_SIZE_T"u)",
-	       name, sc_print_path(path), obj->auth_id.len);
+	sc_log(ctx, "key-domain.%s @%s (auth_id.len=%zu)", name, sc_print_path(path), obj->auth_id.len);
 
 	index_id.len = 1;
 	for (index = TEMPLATE_INSTANTIATE_MIN_INDEX; index <= TEMPLATE_INSTANTIATE_MAX_INDEX; index++)   {
@@ -3973,10 +3967,8 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 	}
 
 	if (pin_obj)   {
-		sc_log(ctx,
-		       "PIN object '%.*s'; pin_obj->content.len:%"SC_FORMAT_LEN_SIZE_T"u",
-		       (int) sizeof pin_obj->label, pin_obj->label,
-		       pin_obj->content.len);
+		sc_log(ctx, "PIN object '%.*s'; pin_obj->content.len:%zu",
+				(int)sizeof(pin_obj->label), pin_obj->label, pin_obj->content.len);
 		if (pin_obj->content.value && pin_obj->content.len)   {
 			if (pin_obj->content.len > sizeof(pinbuf))
 				LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "PIN buffer is too small");
@@ -3995,9 +3987,7 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 		if (callbacks.get_pin)   {
 			pinsize = sizeof(pinbuf);
 			r = callbacks.get_pin(profile, pin_id, &auth_info, label, pinbuf, &pinsize);
-			sc_log(ctx,
-			       "'get_pin' callback returned %i; pinsize:%"SC_FORMAT_LEN_SIZE_T"u",
-			       r, pinsize);
+			sc_log(ctx, "'get_pin' callback returned %i; pinsize:%zu", r, pinsize);
 		}
 		break;
 	case SC_AC_SCB:
@@ -4268,10 +4258,8 @@ sc_pkcs15init_update_file(struct sc_profile *profile,
 	}
 
 	if (selected_file->size < datalen) {
-		sc_log(ctx,
-		       "File %s too small (require %zu, have %"SC_FORMAT_LEN_SIZE_T"u)",
-		       sc_print_path(&file->path), datalen,
-		       selected_file->size);
+		sc_log(ctx, "File %s too small (require %zu, have %zu)",
+				sc_print_path(&file->path), datalen, selected_file->size);
 		sc_file_free(selected_file);
 		LOG_TEST_RET(ctx, SC_ERROR_FILE_TOO_SMALL, "Update file failed");
 	}
@@ -4507,15 +4495,11 @@ sc_pkcs15init_qualify_pin(struct sc_card *card, const char *pin_name,
 	pin_attrs = &auth_info->attrs.pin;
 
 	if (pin_len < pin_attrs->min_length) {
-		sc_log(ctx,
-		       "%s too short (min length %"SC_FORMAT_LEN_SIZE_T"u)",
-		       pin_name, pin_attrs->min_length);
+		sc_log(ctx, "%s too short (min length %zu)", pin_name, pin_attrs->min_length);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_LENGTH);
 	}
 	if (pin_len > pin_attrs->max_length) {
-		sc_log(ctx,
-		       "%s too long (max length %"SC_FORMAT_LEN_SIZE_T"u)",
-		       pin_name, pin_attrs->max_length);
+		sc_log(ctx, "%s too long (max length %zu)", pin_name, pin_attrs->max_length);
 		LOG_FUNC_RETURN(ctx, SC_ERROR_WRONG_LENGTH);
 	}
 

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -317,10 +317,8 @@ myeid_create_pin(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 	int r;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-	       "PIN('%s',ref:%i,flags:0x%X,pin_len:%"SC_FORMAT_LEN_SIZE_T"u,puk_len:%"SC_FORMAT_LEN_SIZE_T"u)\n",
-	       pin_obj->label, auth_info->attrs.pin.reference,
-	       auth_info->attrs.pin.flags, pin_len, puk_len);
+	sc_log(ctx, "PIN('%s',ref:%i,flags:0x%X,pin_len:%zu,puk_len:%zu)", pin_obj->label,
+			auth_info->attrs.pin.reference, auth_info->attrs.pin.flags, pin_len, puk_len);
 
 	if (auth_info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
 		return SC_ERROR_OBJECT_NOT_VALID;
@@ -881,10 +879,8 @@ myeid_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 		else if (object->type == SC_PKCS15_TYPE_PRKEY_EC) {
 			struct sc_ec_parameters *ecparams = (struct sc_ec_parameters *)key_info->params.data;
 
-			sc_log(ctx,
-			       "curve '%s', len %"SC_FORMAT_LEN_SIZE_T"u, oid '%s'",
-			       ecparams->named_curve, ecparams->field_length,
-			       sc_dump_oid(&(ecparams->id)));
+			sc_log(ctx, "curve '%s', len %zu, oid '%s'", ecparams->named_curve,
+					ecparams->field_length, sc_dump_oid(&(ecparams->id)));
 			pubkey->algorithm = SC_ALGORITHM_EC;
 
 			r = sc_select_file(card, &file->path, NULL);

--- a/src/pkcs15init/pkcs15-oberthur-awp.c
+++ b/src/pkcs15init/pkcs15-oberthur-awp.c
@@ -171,9 +171,8 @@ awp_new_file(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 				ifile->path.value[ifile->path.len-2] |= 0x01;
 			}
 
-			sc_log(ctx,
-				 "info_file(id:%04X,size:%"SC_FORMAT_LEN_SIZE_T"u,rlen:%"SC_FORMAT_LEN_SIZE_T"u)",
-				 ifile->id, ifile->size, ifile->record_length);
+			sc_log(ctx, "info_file(id:%04X,size:%zu,rlen:%zu)",
+					ifile->id, ifile->size, ifile->record_length);
 			*info_out = ifile;
 		}
 		else   {
@@ -182,9 +181,7 @@ awp_new_file(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 	}
 
 	if (ofile)   {
-		sc_log(ctx,
-			 "obj file %04X; size %"SC_FORMAT_LEN_SIZE_T"u; ",
-			 ofile->id, ofile->size);
+		sc_log(ctx, "obj file %04X; size %zu; ", ofile->id, ofile->size);
 		if (obj_out)
 			*obj_out = ofile;
 		else
@@ -277,7 +274,7 @@ awp_create_container_record (struct sc_pkcs15_card *p15card, struct sc_profile *
 	unsigned char *buff = NULL;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,  "container file(file-id:%X,rlen:%"SC_FORMAT_LEN_SIZE_T"u,rcount:%"SC_FORMAT_LEN_SIZE_T"u)",
+	sc_log(ctx, "container file(file-id:%X,rlen:%zu,rcount:%zu)",
 			list_file->id, list_file->record_length, list_file->record_count);
 
 	buff = malloc(list_file->record_length);
@@ -325,14 +322,14 @@ awp_create_container(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 
 	rv = awp_new_file(p15card, profile, COSM_CONTAINER_LIST, 0, &clist, NULL);
 	LOG_TEST_RET(ctx, rv, "Create container failed");
-	sc_log(ctx,  "container cfile(rcount:%"SC_FORMAT_LEN_SIZE_T"u,rlength:%"SC_FORMAT_LEN_SIZE_T"u)", clist->record_count, clist->record_length);
+	sc_log(ctx, "container cfile(rcount:%zu,rlength:%zu)", clist->record_count, clist->record_length);
 
 	rv = sc_select_file(p15card->card, &clist->path, &file);
 	LOG_TEST_RET(ctx, rv, "Create container failed: cannot select container's list");
 	file->record_length = clist->record_length;
 
-	sc_log(ctx,  "container file(rcount:%"SC_FORMAT_LEN_SIZE_T"u,rlength:%"SC_FORMAT_LEN_SIZE_T"u)", file->record_count, file->record_length);
-	sc_log(ctx,  "Append new record %"SC_FORMAT_LEN_SIZE_T"u for private key", file->record_count + 1);
+	sc_log(ctx, "container file(rcount:%zu,rlength:%zu)", file->record_count, file->record_length);
+	sc_log(ctx, "Append new record %zu for private key", file->record_count + 1);
 
 	rv = awp_create_container_record(p15card, profile, file, acc);
 
@@ -353,10 +350,8 @@ awp_update_container_entry (struct sc_pkcs15_card *p15card, struct sc_profile *p
 	unsigned char *buff = NULL;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_log(ctx,
-		 "update container entry(type:%X,id %i,rec %"SC_FORMAT_LEN_SIZE_T"u,offs %i",
-		 type, file_id, rec, offs);
-	sc_log(ctx,  "container file(file-id:%X,rlen:%"SC_FORMAT_LEN_SIZE_T"u,rcount:%"SC_FORMAT_LEN_SIZE_T"u)",
+	sc_log(ctx, "update container entry(type:%X,id %i,rec %zu,offs %i", type, file_id, rec, offs);
+	sc_log(ctx, "container file(file-id:%X,rlen:%zu,rcount:%zu)",
 			list_file->id, list_file->record_length, list_file->record_count);
 
 	buff = malloc(list_file->record_length);
@@ -489,7 +484,7 @@ awp_update_container(struct sc_pkcs15_card *p15card, struct sc_profile *profile,
 		for (rec_offs=0; !rv && rec_offs<12; rec_offs+=6)   {
 			int offs;
 
-			sc_log(ctx,  "rec %zu; rec_offs %d", rec, rec_offs);
+			sc_log(ctx, "rec %zu; rec_offs %d", rec, rec_offs);
 			offs = (int)rec*AWP_CONTAINER_RECORD_LEN + rec_offs;
 			if (*(list + offs + 2))   {
 				unsigned char *buff = NULL;
@@ -742,9 +737,7 @@ awp_update_object_list(struct sc_pkcs15_card *p15card, struct sc_profile *profil
 		goto done;
 	}
 
-	sc_log(ctx,
-		 "ii %i, rv %i; %X; %"SC_FORMAT_LEN_SIZE_T"u",
-		 ii, rv, file->id, file->size);
+	sc_log(ctx, "ii %i, rv %i; %X; %zu", ii, rv, file->id, file->size);
 	*(buff + ii) = COSM_LIST_TAG;
 	*(buff + ii + 1) = (file->id >> 8) & 0xFF;
 	*(buff + ii + 2) = file->id & 0xFF;
@@ -800,9 +793,7 @@ awp_encode_key_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *obj
 	/*
 	 * Oberthur saves modulus value without tag and length.
 	 */
-	sc_log(ctx,
-		 "pubkey->modulus.len %"SC_FORMAT_LEN_SIZE_T"u",
-		 pubkey->modulus.len);
+	sc_log(ctx, "pubkey->modulus.len %zu", pubkey->modulus.len);
 	ki->modulus.value = malloc(pubkey->modulus.len);
 	if (!ki->modulus.value)   {
 		r = SC_ERROR_OUT_OF_MEMORY;
@@ -942,10 +933,8 @@ awp_encode_cert_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 
 	cert_info = (struct sc_pkcs15_cert_info *)obj->data;
 
-	sc_log(ctx,
-		 "Encode cert(%s,id:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
-		 obj->label, sc_pkcs15_print_id(&cert_info->id),
-		 obj->content.value, obj->content.len);
+	sc_log(ctx, "Encode cert(%s,id:%s,der(%p,%zu))", obj->label, sc_pkcs15_print_id(&cert_info->id),
+			obj->content.value, obj->content.len);
 	memset(&pubkey, 0, sizeof(pubkey));
 
 	ci->label.value = (unsigned char *)strdup(obj->label);
@@ -1130,10 +1119,8 @@ awp_encode_data_info(struct sc_pkcs15_card *p15card, struct sc_pkcs15_object *ob
 
 	data_info = (struct sc_pkcs15_data_info *)obj->data;
 
-	sc_log(ctx,
-		 "Encode data(%s,id:%s,der(%p,%"SC_FORMAT_LEN_SIZE_T"u))",
-		 obj->label, sc_pkcs15_print_id(&data_info->id),
-		 obj->content.value, obj->content.len);
+	sc_log(ctx, "Encode data(%s,id:%s,der(%p,%zu))", obj->label, sc_pkcs15_print_id(&data_info->id),
+			obj->content.value, obj->content.len);
 
 	di->flags = 0x0000;
 
@@ -1407,8 +1394,7 @@ awp_update_df_create_cert(struct sc_pkcs15_card *p15card, struct sc_profile *pro
 	LOG_TEST_RET(ctx, rv, "COSM new file error");
 
 	memset(&icert, 0, sizeof(icert));
-	sc_log(ctx,
-		 "Cert Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
+	sc_log(ctx, "Cert Der(%p,%zu)", der.value, der.len);
 	rv = awp_encode_cert_info(p15card, obj, &icert);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "'Create Cert' update DF failed: cannot encode info");
 
@@ -1421,7 +1407,7 @@ awp_update_df_create_cert(struct sc_pkcs15_card *p15card, struct sc_profile *pro
 	rv = awp_update_container(p15card, profile, SC_PKCS15_TYPE_CERT_X509, &icert.id, obj_id, &prvkey_id);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "'Create Cert' update DF failed: cannot update container");
 
-	sc_log(ctx,  "PrvKeyID:%04X", prvkey_id);
+	sc_log(ctx, "PrvKeyID:%04X", prvkey_id);
 
 	if (prvkey_id)
 		rv = awp_update_key_info(p15card, profile, prvkey_id, &icert);
@@ -1497,8 +1483,7 @@ awp_update_df_create_prvkey(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "New private key info file error");
 
 	pubkey.algorithm = SC_ALGORITHM_RSA;
-	sc_log(ctx,
-		 "PrKey Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
+	sc_log(ctx, "PrKey Der(%p,%zu)", der.value, der.len);
 	rv = sc_pkcs15_decode_pubkey(ctx, &pubkey, der.value, der.len);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "AWP 'update private key' DF failed: decode public key error");
 
@@ -1552,8 +1537,7 @@ awp_update_df_create_pubkey(struct sc_pkcs15_card *p15card, struct sc_profile *p
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "New public key info file error");
 
 	pubkey.algorithm = SC_ALGORITHM_RSA;
-	sc_log(ctx,
-		 "PrKey Der(%p,%"SC_FORMAT_LEN_SIZE_T"u)", der.value, der.len);
+	sc_log(ctx, "PrKey Der(%p,%zu)", der.value, der.len);
 	rv = sc_pkcs15_decode_pubkey(ctx, &pubkey, der.value, der.len);
 	SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_VERBOSE, rv, "AWP 'update public key' DF failed: decode public key error");
 

--- a/src/pkcs15init/pkcs15-oberthur.c
+++ b/src/pkcs15init/pkcs15-oberthur.c
@@ -280,9 +280,7 @@ cosm_create_reference_data(struct sc_profile *profile, struct sc_pkcs15_card *p1
 	};
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
-	sc_log(ctx,
-		 "pin lens %"SC_FORMAT_LEN_SIZE_T"u/%"SC_FORMAT_LEN_SIZE_T"u",
-		 pin_len, puk_len);
+	sc_log(ctx, "pin lens %zu/%zu", pin_len, puk_len);
 	if (!pin || pin_len>0x40)
 		return SC_ERROR_INVALID_ARGUMENTS;
 	if (puk && !puk_len)
@@ -538,9 +536,8 @@ cosm_new_file(struct sc_profile *profile, struct sc_card *card,
 		file->ef_structure = structure;
 	}
 
-	sc_log(card->ctx,
-		 "cosm_new_file() file size %"SC_FORMAT_LEN_SIZE_T"u; ef type %i/%i; id %04X",
-		 file->size, file->type, file->ef_structure, file->id);
+	sc_log(card->ctx, "cosm_new_file() file size %zu; ef type %i/%i; id %04X",
+			file->size, file->type, file->ef_structure, file->id);
 	*out = file;
 
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);

--- a/src/pkcs15init/pkcs15-openpgp.c
+++ b/src/pkcs15init/pkcs15-openpgp.c
@@ -548,9 +548,7 @@ static int openpgp_store_data(struct sc_pkcs15_card *p15card, struct sc_profile 
 
 		LOG_TEST_RET(card->ctx, r, "Cannot select cert file");
 		r = sc_pkcs15init_authenticate(profile, p15card, file, SC_AC_OP_UPDATE);
-		sc_log(card->ctx,
-		       "Data to write is %"SC_FORMAT_LEN_SIZE_T"u long",
-		       content->len);
+		sc_log(card->ctx, "Data to write is %zu long", content->len);
 		if (r >= 0 && content->len)
 			r = sc_put_data(p15card->card, tag, (const unsigned char *) content->value, content->len);
 		break;

--- a/src/pkcs15init/pkcs15-rtecp.c
+++ b/src/pkcs15init/pkcs15-rtecp.c
@@ -331,7 +331,7 @@ static int rtecp_create_key(sc_profile_t *profile, sc_pkcs15_card_t *p15card,
 				&& key_info->modulus_length
 				!= SC_PKCS15_GOSTR3410_KEYSIZE))
 	{
-		sc_log(ctx, "Unsupported key size %" SC_FORMAT_LEN_SIZE_T "u\n", key_info->modulus_length);
+		sc_log(ctx, "Unsupported key size %zu\n", key_info->modulus_length);
 		return SC_ERROR_INVALID_ARGUMENTS;
 	}
 	if (obj->type == SC_PKCS15_TYPE_PRKEY_GOSTR3410)

--- a/src/pkcs15init/pkcs15-setcos.c
+++ b/src/pkcs15init/pkcs15-setcos.c
@@ -517,9 +517,8 @@ setcos_generate_key(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 
 		keybits = ((raw_pubkey[0] * 256) + raw_pubkey[1]);  /* modulus bit length */
 		if (keybits != key_info->modulus_length)  {
-			sc_log(ctx,
-				 "key-size from card[%"SC_FORMAT_LEN_SIZE_T"u] does not match[%"SC_FORMAT_LEN_SIZE_T"u]\n",
-				 keybits, key_info->modulus_length);
+			sc_log(ctx, "key-size from card[%zu] does not match[%zu]",
+					keybits, key_info->modulus_length);
 			LOG_TEST_RET(ctx, SC_ERROR_PKCS15INIT, "Failed to generate key");
 		}
 		memcpy(pubkey->u.rsa.modulus.data, &raw_pubkey[2], pubkey->u.rsa.modulus.len);

--- a/src/sm/sm-common.c
+++ b/src/sm/sm-common.c
@@ -536,9 +536,8 @@ sm_encrypt_des_cbc3(struct sc_context *ctx, unsigned char *key,
 	size_t data_len;
 
 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_SM);
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM encrypt_des_cbc3: not_force_pad:%i,in_len:%"SC_FORMAT_LEN_SIZE_T"u",
-	       not_force_pad, in_len);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM encrypt_des_cbc3: not_force_pad:%i,in_len:%zu",
+			not_force_pad, in_len);
 	if (!out || !out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "SM encrypt_des_cbc3: invalid input arguments");
 
@@ -558,9 +557,8 @@ sm_encrypt_des_cbc3(struct sc_context *ctx, unsigned char *key,
 	memcpy(data + in_len, "\x80\0\0\0\0\0\0\0", 8);
 	data_len = in_len + (not_force_pad ? 7 : 8);
 	data_len -= (data_len%8);
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM encrypt_des_cbc3: data to encrypt (len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
-	       data_len, sc_dump_hex(data, data_len));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM encrypt_des_cbc3: data to encrypt (len:%zu,%s)",
+			data_len, sc_dump_hex(data, data_len));
 
 	*out_len = data_len;
 	*out = calloc(data_len + 8, sizeof(unsigned char));

--- a/src/sm/sm-eac.c
+++ b/src/sm/sm-eac.c
@@ -293,8 +293,8 @@ static int eac_mse(sc_card_t *card,
 		goto err;
 
 	if (apdu.resplen) {
-		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "MSE:Set AT response data should be empty "
-				"(contains %"SC_FORMAT_LEN_SIZE_T"u bytes)", apdu.resplen);
+		sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
+				"MSE:Set AT response data should be empty (contains %zu bytes)", apdu.resplen);
 		r = SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		goto err;
 	}

--- a/src/sm/sm-iso.c
+++ b/src/sm/sm-iso.c
@@ -584,10 +584,8 @@ static int sm_decrypt(const struct iso_sm_ctx *ctx, sc_card_t *card,
 		}
 
 		if (apdu->resplen < (size_t) r || (r && !apdu->resp)) {
-			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE,
-					"Response of SM APDU %"SC_FORMAT_LEN_SIZE_T"u byte%s too long",
-					r-apdu->resplen,
-					r-apdu->resplen < 2 ? "" : "s");
+			sc_debug(card->ctx, SC_LOG_DEBUG_VERBOSE, "Response of SM APDU %zu byte%s too long",
+					r - apdu->resplen, r - apdu->resplen < 2 ? "" : "s");
 			r = SC_ERROR_OUT_OF_MEMORY;
 			goto err;
 		}

--- a/src/smm/sm-card-authentic.c
+++ b/src/smm/sm-card-authentic.c
@@ -130,8 +130,7 @@ sm_authentic_get_apdus(struct sc_context *ctx, struct sm_info *sm_info,
 	if (!sm_info)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get APDUs: rdata:%p, init_len:%"SC_FORMAT_LEN_SIZE_T"u",
-	       rdata, init_len);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get APDUs: rdata:%p, init_len:%zu", rdata, init_len);
 	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get APDUs: serial %s",
 			sc_dump_hex(sm_info->serialnr.value, sm_info->serialnr.len));
 

--- a/src/smm/sm-card-iasecc.c
+++ b/src/smm/sm-card-iasecc.c
@@ -64,12 +64,11 @@ sm_iasecc_get_apdu_read_binary(struct sc_context *ctx, struct sm_info *sm_info, 
 	if (!cmd_data || !cmd_data->data)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-        if (!rdata || !rdata->alloc)
+	if (!rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM get 'READ BINARY' APDUs: offset:%"SC_FORMAT_LEN_SIZE_T"u,size:%"SC_FORMAT_LEN_SIZE_T"u",
-	       cmd_data->offs, cmd_data->count);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get 'READ BINARY' APDUs: offset:%zu,size:%zu",
+			cmd_data->offs, cmd_data->count);
 	offs = cmd_data->offs;
 	while (cmd_data->count > data_offs)   {
 		size_t sz = (cmd_data->count - data_offs) > SM_MAX_DATA_SIZE ? SM_MAX_DATA_SIZE : (cmd_data->count - data_offs);
@@ -110,19 +109,18 @@ sm_iasecc_get_apdu_update_binary(struct sc_context *ctx, struct sm_info *sm_info
 	if (!cmd_data || !cmd_data->data)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-        if (!rdata || !rdata->alloc)
+	if (!rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM get 'UPDATE BINARY' APDUs: offset:%"SC_FORMAT_LEN_SIZE_T"u,size:%"SC_FORMAT_LEN_SIZE_T"u",
-	       cmd_data->offs, cmd_data->count);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get 'UPDATE BINARY' APDUs: offset:%zu,size:%zu",
+			cmd_data->offs, cmd_data->count);
 	offs = cmd_data->offs;
 	while (data_offs < cmd_data->count)   {
 		size_t sz = (cmd_data->count - data_offs) > SM_MAX_DATA_SIZE ? SM_MAX_DATA_SIZE : (cmd_data->count - data_offs);
 		struct sc_remote_apdu *rapdu = NULL;
 
  		rv = rdata->alloc(rdata, &rapdu);
-	        LOG_TEST_RET(ctx, rv, "SM get 'UPDATE BINARY' APDUs: cannot allocate remote APDU");
+		LOG_TEST_RET(ctx, rv, "SM get 'UPDATE BINARY' APDUs: cannot allocate remote APDU");
 
 		rapdu->apdu.cse = SC_APDU_CASE_3_SHORT;
 		rapdu->apdu.cla = 0x00;
@@ -161,11 +159,10 @@ sm_iasecc_get_apdu_create_file(struct sc_context *ctx, struct sm_info *sm_info, 
 	if (!cmd_data || !cmd_data->data || !rdata || !rdata->alloc)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM get 'CREATE FILE' APDU: FCP(%"SC_FORMAT_LEN_SIZE_T"u) %s",
-	       cmd_data->size, sc_dump_hex(cmd_data->data,cmd_data->size));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM get 'CREATE FILE' APDU: FCP(%zu) %s",
+			cmd_data->size, sc_dump_hex(cmd_data->data, cmd_data->size));
 
- 	rv = rdata->alloc(rdata, &rapdu);
+	rv = rdata->alloc(rdata, &rapdu);
 	LOG_TEST_RET(ctx, rv, "SM get 'UPDATE BINARY' APDUs: cannot allocate remote APDU");
 
 	rapdu->apdu.cse = SC_APDU_CASE_3_SHORT;
@@ -513,8 +510,7 @@ sm_iasecc_get_apdus(struct sc_context *ctx, struct sm_info *sm_info,
 	if (!sm_info)
 		LOG_FUNC_RETURN(ctx, SC_ERROR_INVALID_ARGUMENTS);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM IAS/ECC get APDUs: init_len:%"SC_FORMAT_LEN_SIZE_T"u",
-	       init_len);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM IAS/ECC get APDUs: init_len:%zu", init_len);
 	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM IAS/ECC get APDUs: rdata:%p", rdata);
 	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM IAS/ECC get APDUs: serial %s", sc_dump_hex(sm_info->serialnr.value, sm_info->serialnr.len));
 
@@ -588,12 +584,11 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 
 	LOG_FUNC_CALLED(ctx);
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "IAS/ECC decode answer() rdata length %i, out length %"SC_FORMAT_LEN_SIZE_T"u",
-	       rdata->length, out_len);
-        for (rapdu = rdata->data; rapdu; rapdu = rapdu->next)   {
-                unsigned char *decrypted;
-                size_t decrypted_len;
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "IAS/ECC decode answer() rdata length %i, out length %zu",
+			rdata->length, out_len);
+	for (rapdu = rdata->data; rapdu; rapdu = rapdu->next) {
+		unsigned char *decrypted;
+		size_t decrypted_len;
 		unsigned char resp_data[SC_MAX_APDU_BUFFER_SIZE];
 		size_t resp_len = sizeof(resp_data);
 		unsigned char status[2] = {0, 0};
@@ -601,16 +596,15 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 		unsigned char ticket[8];
 		size_t ticket_len = sizeof(ticket);
 
-		sc_debug(ctx, SC_LOG_DEBUG_SM,
-		       "IAS/ECC decode response(%"SC_FORMAT_LEN_SIZE_T"u) %s",
-		       rapdu->apdu.resplen, sc_dump_hex(rapdu->apdu.resp, rapdu->apdu.resplen));
+		sc_debug(ctx, SC_LOG_DEBUG_SM, "IAS/ECC decode response(%zu) %s",
+				rapdu->apdu.resplen, sc_dump_hex(rapdu->apdu.resp, rapdu->apdu.resplen));
 
 		sc_copy_asn1_entry(c_asn1_iasecc_sm_data_object, asn1_iasecc_sm_data_object);
 		sc_format_asn1_entry(asn1_iasecc_sm_data_object + 0, resp_data, &resp_len, 0);
 		sc_format_asn1_entry(asn1_iasecc_sm_data_object + 1, status, &status_len, 0);
 		sc_format_asn1_entry(asn1_iasecc_sm_data_object + 2, ticket, &ticket_len, 0);
 
-        	rv = sc_asn1_decode(ctx, asn1_iasecc_sm_data_object, rapdu->apdu.resp, rapdu->apdu.resplen, NULL, NULL);
+		rv = sc_asn1_decode(ctx, asn1_iasecc_sm_data_object, rapdu->apdu.resp, rapdu->apdu.resplen, NULL, NULL);
 		LOG_TEST_RET(ctx, rv, "IAS/ECC decode answer(s): ASN1 decode error");
 
 		sc_debug(ctx, SC_LOG_DEBUG_SM, "IAS/ECC decode response() SW:%02X%02X, MAC:%s", status[0], status[1], sc_dump_hex(ticket, ticket_len));
@@ -630,10 +624,8 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 					&decrypted, &decrypted_len);
 			LOG_TEST_RET(ctx, rv, "IAS/ECC decode answer(s): cannot decrypt card answer data");
 
-			sc_debug(ctx, SC_LOG_DEBUG_SM,
-			       "IAS/ECC decrypted data(%"SC_FORMAT_LEN_SIZE_T"u) %s",
-			       decrypted_len,
-			       sc_dump_hex(decrypted, decrypted_len));
+			sc_debug(ctx, SC_LOG_DEBUG_SM, "IAS/ECC decrypted data(%zu) %s",
+					decrypted_len, sc_dump_hex(decrypted, decrypted_len));
 			while (decrypted_len > 0 && *(decrypted + decrypted_len - 1) == 0x00) {
 				decrypted_len--;
 			}
@@ -652,8 +644,8 @@ sm_iasecc_decode_card_data(struct sc_context *ctx, struct sm_info *sm_info, stru
 
 				offs += decrypted_len;
 				sc_debug(ctx, SC_LOG_DEBUG_SM,
-				       "IAS/ECC decode card answer(s): out_len/offs %"SC_FORMAT_LEN_SIZE_T"u/%i",
-				       out_len, offs);
+						"IAS/ECC decode card answer(s): out_len/offs %zu/%i",
+						out_len, offs);
 			}
 
 			free(decrypted);

--- a/src/smm/sm-cwa14890.c
+++ b/src/smm/sm-cwa14890.c
@@ -141,9 +141,8 @@ sm_cwa_decode_authentication_data(struct sc_context *ctx, struct sm_cwa_keyset *
 	rv = sm_decrypt_des_cbc3(ctx, keyset->enc, session_data->mdata, session_data->mdata_len, &decrypted, &decrypted_len);
 	LOG_TEST_RET(ctx, rv, "sm_ecc_decode_auth_data() DES CBC3 decrypt error");
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "sm_ecc_decode_auth_data() decrypted(%"SC_FORMAT_LEN_SIZE_T"u) %s",
-	       decrypted_len, sc_dump_hex(decrypted, decrypted_len));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "sm_ecc_decode_auth_data() decrypted(%zu) %s",
+			decrypted_len, sc_dump_hex(decrypted, decrypted_len));
 
 	if (memcmp(decrypted, session_data->icc.rnd, 8)) {
 		free(decrypted);
@@ -269,16 +268,14 @@ sm_cwa_initialize(struct sc_context *ctx, struct sm_info *sm_info, struct sc_rem
 	rv = sm_encrypt_des_cbc3(ctx, cwa_keyset->enc, buf, offs, &encrypted, &encrypted_len, 1);
 	LOG_TEST_RET(ctx, rv, "_encrypt_des_cbc3() failed");
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "ENCed(%"SC_FORMAT_LEN_SIZE_T"u) %s", encrypted_len,
-	       sc_dump_hex(encrypted, encrypted_len));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "ENCed(%zu) %s", encrypted_len, sc_dump_hex(encrypted, encrypted_len));
 
 	memcpy(buf, encrypted, encrypted_len);
 	offs = (int)encrypted_len;
 
 	rv = sm_cwa_get_mac(ctx, cwa_keyset->mac, &icv, buf, offs, &cblock, 1);
 	LOG_TEST_GOTO_ERR(ctx, rv, "sm_ecc_get_mac() failed");
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "MACed(%"SC_FORMAT_LEN_SIZE_T"u) %s", sizeof(cblock),
-	       sc_dump_hex(cblock, sizeof(cblock)));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "MACed(%zu) %s", sizeof(cblock), sc_dump_hex(cblock, sizeof(cblock)));
 
 	apdu->cse = SC_APDU_CASE_4_SHORT;
 	apdu->cla = 0x00;
@@ -310,17 +307,15 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	int rv, mac_len = 0;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "securize APDU (cla:%X,ins:%X,p1:%X,p2:%X,data(%"SC_FORMAT_LEN_SIZE_T"u):%p)",
-	       apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen,
-	       apdu->data);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "securize APDU (cla:%X,ins:%X,p1:%X,p2:%X,data(%zu):%p)",
+			apdu->cla, apdu->ins, apdu->p1, apdu->p2, apdu->datalen, apdu->data);
 
 	sm_incr_ssc(session_data->ssc, sizeof(session_data->ssc));
 
 	rv = sm_encrypt_des_cbc3(ctx, session_data->session_enc, apdu->data, apdu->datalen, &encrypted, &encrypted_len, 0);
 	LOG_TEST_RET(ctx, rv, "securize APDU: DES CBC3 encryption failed");
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "encrypted data (len:%"SC_FORMAT_LEN_SIZE_T"u, %s)",
-	       encrypted_len, sc_dump_hex(encrypted, encrypted_len));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "encrypted data (len:%zu, %s)",
+			encrypted_len, sc_dump_hex(encrypted, encrypted_len));
 
 	offs = 0;
 	if (apdu->ins & 0x01)   {
@@ -339,8 +334,8 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	memcpy(edfb_data + offs, encrypted, encrypted_len);
 	offs += encrypted_len;
 	edfb_len = offs;
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "securize APDU: EDFB(len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
-	       edfb_len, sc_dump_hex(edfb_data, edfb_len));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "securize APDU: EDFB(len:%zu,%s)",
+			edfb_len, sc_dump_hex(edfb_data, edfb_len));
 
 	free(encrypted);
 	encrypted = NULL;
@@ -391,8 +386,7 @@ sm_cwa_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info, struct sc_
 	sbuf[offs++] = 8;
 	memcpy(sbuf + offs, cblock, 8);
 	offs += 8;
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "securize APDU: SM data(len:%"SC_FORMAT_LEN_SIZE_T"u,%s)",
-	       offs, sc_dump_hex(sbuf, offs));
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "securize APDU: SM data(len:%zu,%s)", offs, sc_dump_hex(sbuf, offs));
 
 	if (offs > sizeof(rapdu->sbuf))
 		LOG_TEST_RET(ctx, SC_ERROR_BUFFER_TOO_SMALL, "securize APDU: buffer too small for encrypted data");

--- a/src/smm/sm-global-platform.c
+++ b/src/smm/sm-global-platform.c
@@ -308,9 +308,7 @@ sm_gp_encrypt_command_data(struct sc_context *ctx, unsigned char *session_key,
 	if (!out || !out_len)
 		LOG_TEST_RET(ctx, SC_ERROR_INVALID_ARGUMENTS, "SM GP encrypt command data error");
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM GP encrypt command data(len:%"SC_FORMAT_LEN_SIZE_T"u,%p)",
-	       in_len, in);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM GP encrypt command data(len:%zu,%p)", in_len, in);
 	if (in==NULL || in_len==0)   {
 		*out = NULL;
 		*out_len = 0;
@@ -353,9 +351,8 @@ sm_gp_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info,
 
 	apdu_data = (unsigned char *)apdu->data;
 	sc_debug(ctx, SC_LOG_DEBUG_SM,
-	       "SM GP securize APDU(cse:%X,cla:%X,ins:%X,data(len:%"SC_FORMAT_LEN_SIZE_T"u,%p),lc:%"SC_FORMAT_LEN_SIZE_T"u,GP level:%X,GP index:%X",
-	       apdu->cse, apdu->cla, apdu->ins, apdu->datalen, apdu->data,
-	       apdu->lc, gp_level, gp_index);
+			"SM GP securize APDU(cse:%X,cla:%X,ins:%X,data(len:%zu,%p),lc:%zu,GP level:%X,GP index:%X",
+			apdu->cse, apdu->cla, apdu->ins, apdu->datalen, apdu->data, apdu->lc, gp_level, gp_index);
 
 	if (gp_level == 0 || (apdu->cla & 0x04))
 		return 0;
@@ -376,9 +373,7 @@ sm_gp_securize_apdu(struct sc_context *ctx, struct sm_info *sm_info,
 			LOG_TEST_GOTO_ERR(ctx, rv, "SM GP securize APDU: not enough place for encrypted data");
 		}
 
-		sc_debug(ctx, SC_LOG_DEBUG_SM,
-		       "SM GP securize APDU: encrypted length %"SC_FORMAT_LEN_SIZE_T"u",
-		       encrypted_len);
+		sc_debug(ctx, SC_LOG_DEBUG_SM, "SM GP securize APDU: encrypted length %zu", encrypted_len);
 	}
 	else   {
 		LOG_TEST_RET(ctx, SC_ERROR_SM_INVALID_LEVEL, "SM GP securize APDU: invalid SM level");

--- a/src/smm/smm-local.c
+++ b/src/smm/smm-local.c
@@ -87,7 +87,7 @@ sm_gp_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM type:%X, KMC(%"SC_FORMAT_LEN_SIZE_T"u) %s",
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM type:%X, KMC(%zu) %s",
 			sm_info->sm_type, hex_len, sc_dump_hex(hex, hex_len));
 	if (hex_len != 16 && hex_len != 48 )
 		return SC_ERROR_INVALID_DATA;
@@ -136,8 +136,7 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_SM_KEYSET_NOT_FOUND;
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "keyset::enc(%"SC_FORMAT_LEN_SIZE_T"u) %s", strlen(value),
-			value);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "keyset::enc(%zu) %s", strlen(value), value);
 	if (strlen(value) == 16)   {
 		memcpy(cwa_keyset->enc, value, 16);
 	}
@@ -149,8 +148,7 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 
-		sc_debug(ctx, SC_LOG_DEBUG_SM, "ENC(%"SC_FORMAT_LEN_SIZE_T"u) %s", hex_len,
-				sc_dump_hex(hex, hex_len));
+		sc_debug(ctx, SC_LOG_DEBUG_SM, "ENC(%zu) %s", hex_len, sc_dump_hex(hex, hex_len));
 		if (hex_len != 16)
 			return SC_ERROR_INVALID_DATA;
 
@@ -170,8 +168,7 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 		return SC_ERROR_SM_KEYSET_NOT_FOUND;
 	}
 
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "keyset::mac(%"SC_FORMAT_LEN_SIZE_T"u) %s", strlen(value),
-			value);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "keyset::mac(%zu) %s", strlen(value), value);
 	if (strlen(value) == 16)   {
 		memcpy(cwa_keyset->mac, value, 16);
 	}
@@ -183,8 +180,7 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 			return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 		}
 
-		sc_debug(ctx, SC_LOG_DEBUG_SM, "MAC(%"SC_FORMAT_LEN_SIZE_T"u) %s", hex_len,
-				sc_dump_hex(hex, hex_len));
+		sc_debug(ctx, SC_LOG_DEBUG_SM, "MAC(%zu) %s", hex_len, sc_dump_hex(hex, hex_len));
 		if (hex_len != 16)
 			return SC_ERROR_INVALID_DATA;
 
@@ -208,9 +204,7 @@ sm_cwa_config_get_keyset(struct sc_context *ctx, struct sm_info *sm_info)
 	}
 
 	if (hex_len != sizeof(cwa_session->ifd.sn))   {
-		sc_debug(ctx, SC_LOG_DEBUG_VERBOSE,
-				"SM get 'ifd_serial': invalid IFD serial length: %"SC_FORMAT_LEN_SIZE_T"u",
-				hex_len);
+		sc_debug(ctx, SC_LOG_DEBUG_VERBOSE, "SM get 'ifd_serial': invalid IFD serial length: %zu", hex_len);
 		return SC_ERROR_UNKNOWN_DATA_RECEIVED;
 	}
 
@@ -320,8 +314,7 @@ finalize(struct sc_context *ctx, struct sm_info *sm_info, struct sc_remote_data 
 	int rv = SC_ERROR_INTERNAL;
 
 	LOG_FUNC_CALLED(ctx);
-	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM finalize: out buffer(%"SC_FORMAT_LEN_SIZE_T"u) %p",
-			out_len, out);
+	sc_debug(ctx, SC_LOG_DEBUG_SM, "SM finalize: out buffer(%zu) %p", out_len, out);
 	if (!sm_info || !rdata)
 		LOG_FUNC_RETURN(ctx, SC_SUCCESS);
 

--- a/src/tools/cardos-tool.c
+++ b/src/tools/cardos-tool.c
@@ -408,11 +408,10 @@ static int cardos_sm4h(const unsigned char *in, size_t inlen, unsigned char
 	unsigned int i,j;
 	EVP_CIPHER_CTX *cctx = NULL;
 	int tmplen = 0;
-	unsigned char key1[8], key2[8]; 
+	unsigned char key1[8], key2[8];
 
 	if (keylen != 16) {
-		printf("key has wrong size, need 16 bytes, got %"SC_FORMAT_LEN_SIZE_T"d. aborting.\n",
-		       keylen);
+		printf("key has wrong size, need 16 bytes, got %zd. aborting.\n", keylen);
 		return 0;
 	}
 
@@ -443,7 +442,7 @@ static int cardos_sm4h(const unsigned char *in, size_t inlen, unsigned char
 	/* prepare des ctx */
 	memcpy(key1, key, 8);
 	memcpy(key2, key + 8, 8);
-	
+
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	if (!legacy_provider) {
 		if (!(legacy_provider = OSSL_PROVIDER_try_load(NULL, "legacy", 1))) {
@@ -465,7 +464,7 @@ static int cardos_sm4h(const unsigned char *in, size_t inlen, unsigned char
 		EVP_CIPHER_CTX_free(cctx);
 		return 0;
 	}
-    
+
 	/* first block: XOR with IV and encrypt with key A IV is 8 bytes 00 */
 	for (i=0; i < 8; i++) des_in[i] = mac_input[i]^00;
 	if (!EVP_EncryptUpdate(cctx, des_out, &tmplen, des_in, 8)) {
@@ -622,7 +621,7 @@ static int cardos_sm4h(const unsigned char *in, size_t inlen, unsigned char
 		/* copy encrypted bytes into output */
 		for (i=0; i < 8; i++) out[5+8*j+i] = des_out[i];
 	}
-	
+
 	EVP_CIPHER_CTX_free(cctx);
 	if (verbose)	{
 		printf ("Unencrypted APDU:\n");
@@ -718,8 +717,7 @@ static int cardos_format(const char *opt_startkey)
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
-		       apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1045,8 +1043,7 @@ static int cardos_change_startkey(const char *change_startkey_apdu)
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
-		       apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1131,8 +1128,7 @@ change_startkey:
 	if (check_apdu(&apdu))
 		return 1;
 	if (apdu.resplen < 0x04) {
-		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %"SC_FORMAT_LEN_SIZE_T"u\n",
-		       apdu.resplen);
+		printf("expected 4-6 bytes form GET DATA for startkey data, but got only %zu\n", apdu.resplen);
 		printf("aborting\n");
 		return 1;
 	}
@@ -1199,7 +1195,7 @@ int main(int argc, char *argv[])
 			util_print_usage_and_die(app_name, options, option_help, NULL);
 		}
 	}
-	
+
 	if (action_count == 0)
 		util_print_usage_and_die(app_name, options, option_help, NULL);
 

--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -388,7 +388,7 @@ static int print_info(sc_card_t *card) {
 				if (r < 0) {
 					printf("      unable to read the file: %s\n", sc_strerror(r));
 				} else {
-					printf("      Size: %"SC_FORMAT_LEN_SIZE_T"u\n", size);
+					printf("      Size: %zu\n", size);
 				}
 				printf("\n");
 				if (strcmp(records[i].directory, "mscp") == 0 && strcmp(records[i].filename, "cmapfile") == 0 ) {

--- a/src/tools/goid-tool.c
+++ b/src/tools/goid-tool.c
@@ -568,8 +568,7 @@ int paccess_main(struct sc_context *ctx, sc_card_t *card, struct gengetopt_args_
                         card->max_recv_size = max_command_size;
                         card->max_send_size = max_command_size;
                         sc_debug(ctx, SC_LOG_DEBUG_VERBOSE_TOOL,
-                                "Maximum data length in command message %"SC_FORMAT_LEN_SIZE_T"u bytes",
-                                max_command_size);
+                                "Maximum data length in command message %zu bytes", max_command_size);
                     }
                     break;
             }

--- a/src/tools/openpgp-tool.c
+++ b/src/tools/openpgp-tool.c
@@ -394,8 +394,7 @@ static int do_info(sc_card_t *card, const struct ef_name_map *map)
 			return EXIT_FAILURE;
 		}
 		if (r != (signed) count || (size_t) r < map[i].offset + map[i].length) {
-			util_error("%s: expecting %"SC_FORMAT_LEN_SIZE_T"d bytes, got only %d",
-				map[i].ef, count, r);
+			util_error("%s: expecting %zd bytes, got only %d", map[i].ef, count, r);
 			return EXIT_FAILURE;
 		}
 		if (map[i].offset > 0) {

--- a/src/tools/opensc-asn1.c
+++ b/src/tools/opensc-asn1.c
@@ -40,8 +40,7 @@ main (int argc, char **argv)
 		if (!fread_to_eof(cmdline.inputs[i], &buf, &buflen))
 			continue;
 
-		printf("Parsing '%s' (%"SC_FORMAT_LEN_SIZE_T"u byte%s)\n",
-				cmdline.inputs[i], buflen, buflen == 1 ? "" : "s");
+		printf("Parsing '%s' (%zu byte%s)\n", cmdline.inputs[i], buflen, buflen == 1 ? "" : "s");
 		sc_asn1_print_tags(buf, buflen);
 	}
 

--- a/src/tools/opensc-explorer.c
+++ b/src/tools/opensc-explorer.c
@@ -241,8 +241,7 @@ static char *path_to_filename(const sc_path_t *path, const char sep, size_t rec)
 	}
 	/* single record: append record-number */
 	if (rec > 0)
-		j += sprintf(buf+j, "%c%"SC_FORMAT_LEN_SIZE_T"u",
-				(sep == '-') ? '_' : '-', rec);
+		j += sprintf(buf + j, "%c%zu", (sep == '-') ? '_' : '-', rec);
 	buf[j] = '\0';
 
 	return buf;
@@ -966,7 +965,7 @@ static int do_info(int argc, char **argv)
 	if (file->sid)
 		printf(", SFI %02X", file->sid);
 	printf("\n\n%-25s%s\n", "File path:", path_to_filename(&path, '/', 0));
-	printf("%-25s%"SC_FORMAT_LEN_SIZE_T"u bytes\n", "File size:", file->size);
+	printf("%-25s%zu bytes\n", "File size:", file->size);
 
 	if (file->type == SC_FILE_TYPE_DF) {
 		static const id2str_t ac_ops_df[] = {
@@ -1019,12 +1018,10 @@ static int do_info(int argc, char **argv)
 		printf("%-25s%s\n", "EF structure:", ef_type);
 
 		if (file->record_count > 0)
-			printf("%-25s%"SC_FORMAT_LEN_SIZE_T"u\n",
-				"Number of records:", file->record_count);
+			printf("%-25s%zu\n", "Number of records:", file->record_count);
 
 		if (file->record_length > 0)
-			printf("%-25s%"SC_FORMAT_LEN_SIZE_T"u bytes\n",
-				"Max. record size:", file->record_length);
+			printf("%-25s%zu bytes\n", "Max. record size:", file->record_length);
 
 		ac_ops = ac_ops_ef;
 	}
@@ -1599,8 +1596,8 @@ static int do_get_record(int argc, char **argv)
 		size_t written = fwrite(buf, 1, (size_t) r, outf);
 
 		if (written != count) {
-			fprintf(stderr, "Cannot write to file %s (only %"SC_FORMAT_LEN_SIZE_T"u of %"SC_FORMAT_LEN_SIZE_T"u bytes written)",
-				filename, written, count);
+			fprintf(stderr, "Cannot write to file %s (only %zu of %zu bytes written)",
+					filename, written, count);
 			goto err;
 		}
 	}
@@ -1609,8 +1606,7 @@ static int do_get_record(int argc, char **argv)
 		fwrite("\n", 1, 1, outf);
 	}
 	else {
-		printf("Total of %"SC_FORMAT_LEN_SIZE_T"u bytes read from %s and saved to %s.\n",
-		       count, argv[0], filename);
+		printf("Total of %zu bytes read from %s and saved to %s.\n", count, argv[0], filename);
 	}
 
 	err = 0;
@@ -1711,14 +1707,14 @@ static int do_update_record(int argc, char **argv)
 	}
 
 	if (rec < 1 || rec > file->record_count) {
-		fprintf(stderr, "Invalid record number %"SC_FORMAT_LEN_SIZE_T"u\n", rec);
+		fprintf(stderr, "Invalid record number %zu\n", rec);
 		goto err;
 	}
 
 	r = sc_read_record(card, (unsigned)rec, 0, buf, sizeof(buf), SC_RECORD_BY_REC_NR);
 	if (r < 0) {
-		fprintf(stderr, "Cannot read record %"SC_FORMAT_LEN_SIZE_T"u of %04X: %s\n",
-			rec, file->id, sc_strerror(r));
+		fprintf(stderr, "Cannot read record %zu of %04X: %s\n",
+				rec, file->id, sc_strerror(r));
 		goto err;
 	}
 
@@ -1740,14 +1736,11 @@ static int do_update_record(int argc, char **argv)
 		r = sc_update_record(card, (unsigned)rec, 0, buf, buflen, SC_RECORD_BY_REC_NR);
 	sc_unlock(card);
 	if (r < 0) {
-		fprintf(stderr, "Cannot update record %"SC_FORMAT_LEN_SIZE_T"u of %04X: %s\n.",
-			rec, file->id, sc_strerror(r));
+		fprintf(stderr, "Cannot update record %zu of %04X: %s\n.", rec, file->id, sc_strerror(r));
 		goto err;
 	}
 
-	printf("Total of %d bytes written to %04X's record %"SC_FORMAT_LEN_SIZE_T"u "
-		"at offset %"SC_FORMAT_LEN_SIZE_T"u.\n",
-		r, file->id, rec, offs);
+	printf("Total of %d bytes written to %04X's record %zu at offset %zu.\n", r, file->id, rec, offs);
 
 	err = 0;
 err:
@@ -1874,8 +1867,7 @@ static int do_random(int argc, char **argv)
 	count = atoi(argv[0]);
 
 	if (count < 0 || (size_t) count > sizeof(buffer)) {
-		fprintf(stderr, "Number must be in range 0..%"SC_FORMAT_LEN_SIZE_T"u\n",
-			sizeof(buffer));
+		fprintf(stderr, "Number must be in range 0..%zu\n", sizeof(buffer));
 		return -1;
 	}
 
@@ -1925,11 +1917,10 @@ static int do_random(int argc, char **argv)
 #ifdef _WIN32
 			_setmode(fileno(stdout), _O_TEXT);
 #endif
-			printf("\nTotal of %"SC_FORMAT_LEN_SIZE_T"u random bytes written\n", written);
+			printf("\nTotal of %zu random bytes written\n", written);
 		}
 		else
-			printf("Total of %"SC_FORMAT_LEN_SIZE_T"u random bytes written to %s\n",
-				written, filename);
+			printf("Total of %zu random bytes written to %s\n", written, filename);
 
 		fclose(outf);
 
@@ -2152,8 +2143,7 @@ static int do_asn1(int argc, char **argv)
 			goto err;
 		}
 		if ((size_t) r != file->size) {
-			fprintf(stderr, "WARNING: expecting %"SC_FORMAT_LEN_SIZE_T"u, got %d bytes.\n",
-				 file->size, r);
+			fprintf(stderr, "WARNING: expecting %zu, got %d bytes.\n", file->size, r);
 			/* some cards return a bogus value for file length.
 			 * As long as the actual length is not higher
 			 * than the expected length, continue */

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -542,8 +542,7 @@ static int list_data_objects(void)
 					return 1;
 				}
 				sc_pkcs15_free_data_object(data_object);
-				printf("  Size:%5"SC_FORMAT_LEN_SIZE_T"u",
-				       cinfo->data.len);
+				printf("  Size:%5zu", cinfo->data.len);
 			} else {
 				printf("  AuthID:%-3s", sc_pkcs15_print_id(&objs[i]->auth_id));
 			}

--- a/src/tools/westcos-tool.c
+++ b/src/tools/westcos-tool.c
@@ -639,9 +639,7 @@ int main(int argc, char *argv[])
 
 			file->path = path;
 
-			printf("File key creation %s, size %"SC_FORMAT_LEN_SIZE_T"d.\n",
-			       file->path.value,
-			       file->size);
+			printf("File key creation %s, size %zd.\n", file->path.value, file->size);
 
 			r = sc_create_file(card, file);
 			if(r) goto out;
@@ -656,7 +654,7 @@ int main(int argc, char *argv[])
 			}
 		}
 
-		printf("Private key length is %"SC_FORMAT_LEN_SIZE_T"d\n", lg);
+		printf("Private key length is %zd\n", lg);
 
 		printf("Write private key.\n");
 		r = sc_update_binary(card,0,pdata,lg,0);
@@ -707,7 +705,7 @@ int main(int argc, char *argv[])
 		free(dst->exponent.data);
 		if(r) goto out;
 
-		printf("Public key length %"SC_FORMAT_LEN_SIZE_T"d\n", lg);
+		printf("Public key length %zd\n", lg);
 
 		sc_format_path("3F000002", &path);
 		r = sc_select_file(card, &path, NULL);


### PR DESCRIPTION
This existed only for VS2013, which did not support standard %zu format string for size_t. Since VS2015, this is also supported and there is no more need for this shenanigans.

Replaced mostly mechanically with

    sed -i 's/" *SC_FORMAT_LEN_SIZE_T *"/z/g' file

and cleaned up manually to avoid too much line splitting for short log lines.

Fixes: #3769

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
