### PR TITLE
ci: Skip java applets tests under valgrind for now

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -182,7 +182,6 @@ jobs:
           cache: 'maven'
       - run: .github/setup-linux.sh ${{ matrix.target }} debug
       - run: .github/test-${{ matrix.target }}.sh ${{ matrix.ver }}
-      - run: .github/test-${{ matrix.target }}.sh ${{ matrix.ver }} valgrind
 
   test:
     name: test-${{ matrix.target }}-${{ matrix.dist }}
@@ -199,7 +198,6 @@ jobs:
       - *use_cache
       - run: .github/setup-linux.sh ${{ matrix.target }} debug
       - run: .github/test-${{ matrix.target }}.sh
-      - run: .github/test-${{ matrix.target }}.sh valgrind
 
   #######################
   ## LibreSSL pipeline ##


### PR DESCRIPTION
For some reason, these two tests time out under valgrind over last couple of weeks so skip this part for now.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
