### PR TITLE
p11test: prevent memory leak on test error

### DIFF
--- a/src/tests/p11test/p11test_helpers.c
+++ b/src/tests/p11test/p11test_helpers.c
@@ -62,6 +62,18 @@ initialize_cryptoki(token_info_t *info)
 	return 0;
 }
 
+int finalize_token(token_info_t *info)
+{
+	CK_FUNCTION_LIST_PTR function_pointer = info->function_pointer;
+
+	info->session_handle = 0;
+	debug_print("Closing all sessions");
+	function_pointer->C_CloseAllSessions(info->slot_id);
+	debug_print("Finalize CRYPTOKI");
+	function_pointer->C_Finalize(NULL_PTR);
+	return 0;
+}
+
 int token_initialize(void **state)
 {
 	token_info_t *info = (token_info_t *) *state;
@@ -161,18 +173,6 @@ int prepare_token(token_info_t *info)
 	return 0;
 }
 
-int finalize_token(token_info_t *info)
-{
-	CK_FUNCTION_LIST_PTR function_pointer = info->function_pointer;
-
-	info->session_handle = 0;
-	debug_print("Closing all sessions");
-	function_pointer->C_CloseAllSessions(info->slot_id);
-	debug_print("Finalize CRYPTOKI");
-	function_pointer->C_Finalize(NULL_PTR);
-	return 0;
-}
-
 int user_login_setup(void **state)
 {
 	token_info_t *info = (token_info_t *) *state;
@@ -230,4 +230,3 @@ int token_cleanup(void **state)
 	finalize_token(info);
 	return 0;
 }
-

--- a/src/tests/p11test/p11test_helpers.c
+++ b/src/tests/p11test/p11test_helpers.c
@@ -80,6 +80,7 @@ void logfile_init(token_info_t *info)
 
 	if ((info->log.fd = fopen(token.log.outfile, "w")) == NULL) {
 		fail_msg("Couldn't open file for test results.");
+		finalize_token(info);
 		exit(1);
 	}
 	fprintf(info->log.fd, "{\n\"time\": 0,\n\"results\": [");
@@ -180,6 +181,7 @@ int user_login_setup(void **state)
 
 	if (prepare_token(info)) {
 		fail_msg("Could not prepare token.\n");
+		finalize_token(info);
 		exit(1);
 	}
 
@@ -189,6 +191,7 @@ int user_login_setup(void **state)
 
 	if (rv != CKR_OK) {
 		fail_msg("Could not login to token with user PIN '%s'\n", token.pin);
+		finalize_token(info);
 		exit(1);
 	}
 
@@ -213,6 +216,7 @@ int token_setup(void **state)
 
 	if (prepare_token(info)) {
 		fail_msg("Could not prepare token.\n");
+		finalize_token(info);
 		exit(1);
 	}
 


### PR DESCRIPTION
before exiting, call C_Finalize to not show any valgrind errors hiding the real problems.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
