### PR TITLE
pkcs15-crypt, pkcs15-init, pkcs15-tool: bind "generic" app by default

### DIFF
--- a/src/tools/pkcs15-crypt.c
+++ b/src/tools/pkcs15-crypt.c
@@ -510,7 +510,9 @@ int main(int argc, char *argv[])
 		r = sc_pkcs15_bind(card, &aid, &p15card);
 	}
 	else   {
-		r = sc_pkcs15_bind(card, NULL, &p15card);
+		struct sc_app_info *app_generic = sc_pkcs15_get_application_by_type(card, "generic");
+		struct sc_aid *aid = app_generic ? &app_generic->aid : NULL;
+		r = sc_pkcs15_bind(card, aid, &p15card);
 	}
 	if (r) {
 		fprintf(stderr, "PKCS #15 binding failed: %s\n", sc_strerror(r));

--- a/src/tools/pkcs15-init.c
+++ b/src/tools/pkcs15-init.c
@@ -516,7 +516,9 @@ main(int argc, char **argv)
 				r = sc_pkcs15_bind(g_card, &aid, &g_p15card);
 			}
 			else   {
-				r = sc_pkcs15_bind(g_card, NULL, &g_p15card);
+				struct sc_app_info *app_generic = sc_pkcs15_get_application_by_type(g_card, "generic");
+				struct sc_aid *aid = app_generic ? &app_generic->aid : NULL;
+				r = sc_pkcs15_bind(g_card, aid, &g_p15card);
 			}
 			if (r) {
 				fprintf(stderr, "PKCS#15 binding failed: %s\n", sc_strerror(r));

--- a/src/tools/pkcs15-tool.c
+++ b/src/tools/pkcs15-tool.c
@@ -2400,7 +2400,9 @@ int main(int argc, char *argv[])
 		r = sc_pkcs15_bind(card, &aid, &p15card);
 	}
 	else   {
-		r = sc_pkcs15_bind(card, NULL, &p15card);
+		struct sc_app_info *app_generic = sc_pkcs15_get_application_by_type(card, "generic");
+		struct sc_aid *aid = app_generic ? &app_generic->aid : NULL;
+		r = sc_pkcs15_bind(card, aid, &p15card);
 	}
 
 	if (r) {


### PR DESCRIPTION
This selects a known PKCS#15 application on the card rather than picking the first on the list of enumerated applications

fixes https://github.com/OpenSC/OpenSC/issues/3759

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
