### PR TITLE
sc-hsm: fixed memory leak during key generation

### DIFF
--- a/src/pkcs15init/pkcs15-sc-hsm.c
+++ b/src/pkcs15init/pkcs15-sc-hsm.c
@@ -325,6 +325,8 @@ static int sc_hsm_generate_key(struct sc_profile *profile, struct sc_pkcs15_card
 	}
 
 	if (pubkey != NULL) {
+		sc_pkcs15_erase_pubkey(pubkey);
+		memset(pubkey, 0, sizeof *pubkey);
 		r = sc_pkcs15emu_sc_hsm_get_public_key(p15card->card->ctx, &cvc, pubkey);
 	}
 


### PR DESCRIPTION
`sc_pkcs15init_generate_key()` already initializes the public key with suitable values for key generation. When constructing PRKD, pkcs15-sc-hsm.c uses the card's data for the public key instead of the pre-allocated data. If not freed, the pre-allocated data will be lost.

fixes https://github.com/OpenSC/OpenSC/issues/3746

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
