### PR TITLE
Add support for PKCS#15 preferred language with subtags

### DIFF
--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -154,8 +154,8 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 	u8 last_update[32], profile_indication[SC_PKCS15_MAX_LABEL_SIZE];
 	size_t lupdate_len = sizeof(last_update) - 1, pi_len = sizeof(profile_indication) - 1;
 	size_t flags_len   = sizeof(ti->flags);
-	u8 preferred_language[3];
-	size_t lang_length = sizeof(preferred_language);
+	u8 preferred_language[64];
+	size_t lang_length = sizeof(preferred_language) - 1;
 	struct sc_asn1_entry asn1_supported_algorithms[SC_MAX_SUPPORTED_ALGORITHMS + 1],
 			asn1_algo_infos[SC_MAX_SUPPORTED_ALGORITHMS][7],
 			asn1_algo_infos_parameters[SC_MAX_SUPPORTED_ALGORITHMS][3];
@@ -270,7 +270,7 @@ int sc_pkcs15_parse_tokeninfo(sc_context_t *ctx,
 		}
 	}
 	if (asn1_toki_attrs[12].flags & SC_ASN1_PRESENT) {
-		preferred_language[2] = 0;
+		preferred_language[lang_length] = 0;
 		ti->preferred_language = strdup((char *)preferred_language);
 		if (ti->preferred_language == NULL)
 			return SC_ERROR_OUT_OF_MEMORY;
@@ -300,7 +300,7 @@ sc_pkcs15_encode_tokeninfo(sc_context_t *ctx, sc_pkcs15_tokeninfo_t *ti,
 		u8 **buf, size_t *buflen)
 {
 	int r, ii;
-	size_t serial_len, mnfid_len, label_len, flags_len, last_upd_len, pi_len;
+	size_t serial_len, mnfid_len, label_len, flags_len, last_upd_len, pi_len, lang_len;
 
 	struct sc_asn1_entry asn1_toki_attrs[C_ASN1_TOKI_ATTRS_SIZE];
 	struct sc_asn1_entry asn1_tokeninfo[2];
@@ -412,7 +412,14 @@ sc_pkcs15_encode_tokeninfo(sc_context_t *ctx, sc_pkcs15_tokeninfo_t *ti,
 	else   {
 		sc_format_asn1_entry(asn1_toki_attrs + 11, NULL, NULL, 0);
 	}
-	sc_format_asn1_entry(asn1_toki_attrs + 12, NULL, NULL, 0);
+
+	if (ti->preferred_language != NULL) {
+		lang_len = strlen(ti->preferred_language);
+		sc_format_asn1_entry(asn1_toki_attrs + 12, ti->preferred_language, &lang_len, 1);
+	}
+	else   {
+		sc_format_asn1_entry(asn1_toki_attrs + 12, NULL, NULL, 0);
+	}
 
 	if (sc_valid_oid(&ti->profile_indication.oid))   {
 		sc_format_asn1_entry(asn1_profile_indication + 0, &ti->profile_indication.oid, NULL, 1);

--- a/src/libopensc/pkcs15.c
+++ b/src/libopensc/pkcs15.c
@@ -416,8 +416,7 @@ sc_pkcs15_encode_tokeninfo(sc_context_t *ctx, sc_pkcs15_tokeninfo_t *ti,
 	if (ti->preferred_language != NULL) {
 		lang_len = strlen(ti->preferred_language);
 		sc_format_asn1_entry(asn1_toki_attrs + 12, ti->preferred_language, &lang_len, 1);
-	}
-	else   {
+	} else {
 		sc_format_asn1_entry(asn1_toki_attrs + 12, NULL, NULL, 0);
 	}
 

--- a/src/ui/strings.c
+++ b/src/ui/strings.c
@@ -80,12 +80,12 @@ static const char *ui_get_config_str(struct sc_context *ctx,
 static int find_lang_str(const char *str, enum ui_langs *lang)
 {
 	if (str) {
-		if (0 == strncmp(str, "de", 2)) {
+		if (0 == strncmp(str, "de", 2) && (str[2] == '\0' || str[2] == '-' || str[2] == '_')) {
 			if (lang) {
 				*lang = DE;
 			}
 			return 1;
-		} else if (0 == strncmp(str, "en", 2)) {
+		} else if (0 == strncmp(str, "en", 2) && (str[2] == '\0' || str[2] == '-' || str[2] == '_')) {
 			if (lang) {
 				*lang = EN;
 			}


### PR DESCRIPTION
Also adds support for encoding TokenInfo with a preferred language string

Fixes https://github.com/OpenSC/OpenSC/issues/3416

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
