### PR TITLE
pkcs11: added missing error handling of decrypt_init

### DIFF
--- a/src/pkcs11/mechanism.c
+++ b/src/pkcs11/mechanism.c
@@ -945,18 +945,15 @@ sc_pkcs11_encr_init(struct sc_pkcs11_session *session,
 		operation->mechanism.pParameter = &operation->mechanism_params;
 	}
 	rv = mt->encrypt_init(operation, key);
-	if (rv != CKR_OK)
-		goto out;
 
 	/* Validate the mechanism parameters */
-	if (key->ops->init_params) {
+	if (rv == CKR_OK && key->ops->init_params) {
 		rv = key->ops->init_params(operation->session, &operation->mechanism);
-		if (rv != CKR_OK)
-			goto out;
 	}
-	LOG_FUNC_RETURN(context, (int)rv);
-out:
-	session_stop_operation(session, SC_PKCS11_OPERATION_ENCRYPT);
+
+	if (rv != CKR_OK)
+		session_stop_operation(session, SC_PKCS11_OPERATION_ENCRYPT);
+
 	LOG_FUNC_RETURN(context, (int)rv);
 }
 
@@ -1079,14 +1076,14 @@ sc_pkcs11_decr_init(struct sc_pkcs11_session *session,
 	rv = mt->decrypt_init(operation, key);
 
 	/* Validate the mechanism parameters */
-	if (key->ops->init_params) {
+	if (rv == CKR_OK && key->ops->init_params) {
 		rv = key->ops->init_params(operation->session, &operation->mechanism);
 	}
 
 	if (rv != CKR_OK)
 		session_stop_operation(session, SC_PKCS11_OPERATION_DECRYPT);
 
-	return rv;
+	LOG_FUNC_RETURN(context, (int)rv);
 }
 
 CK_RV


### PR DESCRIPTION
rewrites sc_pkcs11_encr_init to not use `goto`

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
