### PR TITLE
Clean up PKCS#11's user prompting during initialisation

### DIFF
--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -235,50 +235,6 @@ static CK_RV	set_gost3410_params(struct sc_pkcs15init_prkeyargs *,
 static CK_RV	pkcs15_create_slot(struct sc_pkcs11_card *p11card, struct pkcs15_fw_data *fw_data,
 			struct sc_pkcs15_object *auth, struct sc_app_info *app,
 			struct sc_pkcs11_slot **out);
-static int pkcs11_get_pin_callback(struct sc_profile *profile, int id,
-		const struct sc_pkcs15_auth_info *info, const char *label,
-		unsigned char *pinbuf, size_t *pinsize);
-
-static struct sc_pkcs15init_callbacks pkcs15init_callbacks = {
-	pkcs11_get_pin_callback,       /* get_pin() */
-	NULL
-};
-static char *pkcs15init_sopin = NULL;
-static size_t pkcs15init_sopin_len = 0;
-
-static int pkcs11_get_pin_callback(struct sc_profile *profile, int id,
-		const struct sc_pkcs15_auth_info *info, const char *label,
-		unsigned char *pinbuf, size_t *pinsize)
-{
-	char	*secret = NULL;
-	size_t	len = 0;
-
-	if (info->auth_type != SC_PKCS15_PIN_AUTH_TYPE_PIN)
-		return SC_ERROR_NOT_SUPPORTED;
-
-	sc_log(context, "pkcs11_get_pin_callback() auth-method %X", info->auth_method);
-	if (info->auth_method == SC_AC_CHV)   {
-		unsigned int flags = info->attrs.pin.flags;
-
-		sc_log(context, "pkcs11_get_pin_callback() PIN flags %X", flags);
-		if ((flags & SC_PKCS15_PIN_FLAG_SO_PIN) && !(flags & SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN))    {
-			if (pkcs15init_sopin_len)
-				secret = pkcs15init_sopin;
-		}
-	}
-	if (secret)
-		len = strlen(secret);
-
-	sc_log(context, "pkcs11_get_pin_callback() secret '%s'", secret ? secret : "<null>");
-
-	if (!secret)
-		return SC_ERROR_OBJECT_NOT_FOUND;
-	if (len > *pinsize)
-		return SC_ERROR_BUFFER_TOO_SMALL;
-	memcpy(pinbuf, secret, len + 1);
-	*pinsize = len;
-	return 0;
-}
 #endif
 
 /* Returns FW data corresponding to the given application or,
@@ -2151,11 +2107,6 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 			return sc_to_cryptoki_error(rc, "C_InitToken");
 		}
 
-		sc_log(context, "set pkcs15init callbacks");
-		pkcs15init_sopin = (char *)pPin;
-		pkcs15init_sopin_len = ulPinLen;
-		sc_pkcs15init_set_callbacks(&pkcs15init_callbacks);
-
 		if (p15card)   {
 			sc_log(context, "pkcs15init erase card");
 			sc_pkcs15init_erase_card(p15card, profile, NULL);
@@ -2166,14 +2117,12 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 			rc = sc_pkcs15init_bind(p11card->card, "pkcs15", NULL, NULL, &profile);
 			if (rc < 0) {
 				sc_log(context, "pkcs15init bind error %i", rc);
-				sc_pkcs15init_set_callbacks(NULL);
 				sc_unlock(p11card->card);
 				return sc_to_cryptoki_error(rc, "C_InitToken");
 			}
 
 			rc = sc_pkcs15init_finalize_profile(p11card->card, profile, NULL);
 			if (rc) {
-				sc_pkcs15init_set_callbacks(NULL);
 				sc_log(context, "Cannot finalize profile: %i", rc);
 				return sc_to_cryptoki_error(rc, "C_InitToken");
 			}
@@ -2194,12 +2143,6 @@ pkcs15_initialize(struct sc_pkcs11_slot *slot, void *ptr,
 			rc = sc_pkcs15init_add_app(p11card->card, profile, &init_args);
 			sc_log(context, "pkcs15init: create application returns %i", rc);
 		}
-
-		pkcs15init_sopin = NULL;
-		pkcs15init_sopin_len = 0;
-
-		sc_log(context, "pkcs15init: unset callbacks");
-		sc_pkcs15init_set_callbacks(NULL);
 
 		sc_log(context, "pkcs15init: unbind");
 		sc_pkcs15init_unbind(profile);

--- a/src/pkcs15init/pkcs15-lib.c
+++ b/src/pkcs15init/pkcs15-lib.c
@@ -3964,6 +3964,18 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 	if (!r && pin_obj)   {
 		memcpy(&auth_info, pin_obj->data, sizeof(auth_info));
 		sc_log(ctx, "found PIN object '%.*s'", (int) sizeof pin_obj->label, pin_obj->label);
+
+		/* Check if the PIN has been already verified and the access condition
+		 * is still open on card to avoid needless card operations and user
+		 * prompts. */
+		if (pinsize == 0) {
+			r = sc_pkcs15_get_pin_info(p15card, pin_obj);
+			/* update local copy of auth info */
+			memcpy(&auth_info, pin_obj->data, sizeof(auth_info));
+
+			if (r == SC_SUCCESS && auth_info.logged_in & SC_PIN_STATE_LOGGED_IN)
+				LOG_FUNC_RETURN(ctx, r);
+		}
 	}
 
 	if (pin_obj)   {
@@ -4015,23 +4027,7 @@ sc_pkcs15init_verify_secret(struct sc_profile *profile, struct sc_pkcs15_card *p
 	}
 
 found:
-	if (pin_obj)   {
-		/*
-		 * If pin cache is disabled or the reader is using pinpad, we can get here
-		 * with no PIN data. This is ok as we can not asynchronously invoke the prompt
-		 * (unless the pinpad is in use).
-		 * In this case, check if the PIN has been already verified and
-		 * the access condition is still open on card.
-		 */
-		if (pinsize == 0) {
-			r = sc_pkcs15_get_pin_info(p15card, pin_obj);
-			/* update local copy of auth info */
-			memcpy(&auth_info, pin_obj->data, sizeof(auth_info));
-
-			if (r == SC_SUCCESS && auth_info.logged_in & SC_PIN_STATE_LOGGED_IN)
-				LOG_FUNC_RETURN(ctx, r);
-		}
-
+	if (pin_obj) {
 		r = sc_pkcs15_verify_pin(p15card, pin_obj, use_pinpad || pinsize == 0 ? NULL : pinbuf, use_pinpad ? 0 : pinsize);
 		LOG_TEST_RET(ctx, r, "Cannot validate pkcs15 PIN");
 	}


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
