### PR TITLE
Fixed auth_id problems with jpki

### DIFF
--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -228,8 +228,10 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		sc_format_path(jpki_pubkey_paths[i], &pubkey_info.path);
 		pubkey_info.path.type = SC_PATH_TYPE_FILE_ID;
 		pubkey_obj.flags = jpki_pubkey_flags[i];
-		pubkey_obj.auth_id.len = 1;
-		pubkey_obj.auth_id.value[0] = jpki_pubkey_auth_id[i];
+		if (jpki_pubkey_auth_id[i]) {
+			pubkey_obj.auth_id.len = 1;
+			pubkey_obj.auth_id.value[0] = jpki_pubkey_auth_id[i];
+		}
 
 		rc = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
 		if (rc < 0) {

--- a/src/libopensc/pkcs15-jpki.c
+++ b/src/libopensc/pkcs15-jpki.c
@@ -75,6 +75,7 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 			0,
 			0,
 		};
+		static int jpki_cert_auth_id[4] = { 0, 2, 0, 0 };
 		static int jpki_cert_authority[4] = {0, 0, 1, 1};
 		struct sc_pkcs15_cert_info cert_info;
 		struct sc_pkcs15_object cert_obj;
@@ -89,6 +90,10 @@ sc_pkcs15emu_jpki_init(sc_pkcs15_card_t * p15card)
 		strlcpy(cert_obj.label, jpki_cert_names[i], sizeof(cert_obj.label));
 		cert_info.authority = jpki_cert_authority[i];
 		cert_obj.flags = jpki_cert_flags[i];
+		if (jpki_cert_auth_id[i]) {
+			cert_obj.auth_id.len = 1;
+			cert_obj.auth_id.value[0] = jpki_cert_auth_id[i];
+		}
 		rc = sc_pkcs15emu_add_x509_cert(p15card, &cert_obj, &cert_info);
 		if (rc < 0) {
 			sc_pkcs15_card_clear(p15card);


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
