### PR TITLE
pkcs11-tool: validate the object ID length before storing it

### DIFF
--- a/src/tools/pkcs11-tool.c
+++ b/src/tools/pkcs11-tool.c
@@ -9619,11 +9619,11 @@ static CK_SESSION_HANDLE test_kpgen_certwrite(CK_SLOT_ID slot, CK_SESSION_HANDLE
 		fprintf(stderr, "ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return session;
 	}
-	opt_object_id_len = (size_t) i;
-	if (opt_object_id_len > sizeof(opt_object_id)) {
+	if ((size_t)i > sizeof(opt_object_id)) {
 		fprintf(stderr, "ERR: object ID too long\n");
 		return session;
 	}
+	opt_object_id_len = (size_t)i;
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */
@@ -9807,11 +9807,11 @@ static void test_ec(CK_SLOT_ID slot, CK_SESSION_HANDLE session)
 		printf("ERR: newly generated private key has no (or an empty) CKA_ID\n");
 		return;
 	}
-	opt_object_id_len = (size_t)i;
-	if (opt_object_id_len > sizeof(opt_object_id)) {
+	if ((size_t)i > sizeof(opt_object_id)) {
 		fprintf(stderr, "ERR: object ID too long\n");
 		return;
 	}
+	opt_object_id_len = (size_t)i;
 	memcpy(opt_object_id, tmp, opt_object_id_len);
 
 	/* This is done in NSS */


### PR DESCRIPTION
814f745b assigns the token-supplied CKA_ID length to the global opt_object_id_len before checking it against the destination size, so the rejection path returns with the oversized value still in the global.

main() runs the requested test actions sequentially rather than exclusively, so a following action reaches gen_keypair(), which pairs that stale length with the 100-byte opt_object_id buffer in both CKA_ID attribute templates. The overflowing memcpy is prevented, but C_GenerateKeyPair() is then handed a 100-byte buffer described as being longer.

Check the length before publishing it to the global, at both sites. On rejection the global keeps the previously validated --id length, which still describes the contents of the buffer.

Same approach as the URI hunk of 814f745b, which avoids the problem by using `util_fatal()`; here a `return` is kept so the behaviour of the test paths is unchanged apart from not leaving a stale length behind. Happy to switch to `util_fatal()` for consistency if you prefer.

Fixes #3799

##### Testing

No card was used: this touches only the `--moz-cert` / `--test-ec` paths in
`pkcs11-tool`, and reaching the affected code needs a PKCS#11 module that reports an
oversized `CKA_ID`, which I have not built. The change was verified by inspection
against master and with `git-clang-format --diff --commit upstream/master`, which
reports no changes.

I am happy to write a minimal stub module and post a before/after run if you would
like the behaviour demonstrated rather than argued.

##### Checklist
- [ ] Documentation is added or updated
