### PR TITLE
myeid: alternative way to unblock user PINs using another PIN marked with the unblockingPin flag

### DIFF
--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -693,6 +693,7 @@ static int myeid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 			global_unblocker_verif_data.cmd = SC_PIN_CMD_VERIFY;
 			global_unblocker_verif_data.pin1 = data->pin1;
 			global_unblocker_verif_data.pin_reference = data->puk_reference;
+			global_unblocker_verif_data.flags = data->flags;
 			r = iso_ops->pin_cmd(card, &global_unblocker_verif_data);
 			LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
 

--- a/src/libopensc/card-myeid.c
+++ b/src/libopensc/card-myeid.c
@@ -1,7 +1,7 @@
 /*
  * card-myeid.c
  *
- * Copyright (C) 2008-2019 Aventra Ltd.
+ * Copyright (C) 2008-2026 Aventra Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -669,14 +669,57 @@ static int myeid_pin_cmd(sc_card_t *card, struct sc_pin_cmd_data *data)
 
 	LOG_FUNC_CALLED(card->ctx);
 
-	sc_log(card->ctx, "ref (%d), pin1 len(%zu), pin2 len (%zu)\n",
-			data->pin_reference, data->pin1.len, data->pin2.len);
+	sc_log(card->ctx, "cmd (%d), ref (%d), pin1 len(%zu), pin2 len (%zu), puk ref (%d)\n",
+			data->cmd, data->pin_reference, data->pin1.len, data->pin2.len, data->puk_reference);
 
 	if(data->pin1.len > 8 || data->pin2.len > 8)
 		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_PIN_LENGTH);
 
 	data->pin1.pad_length = data->pin2.pad_length = 8;
 	data->pin1.pad_char = data->pin2.pad_char = 0xFF;
+
+	if (data->cmd == SC_PIN_CMD_UNBLOCK) {
+		/* In case the PUK reference is set, the PIN is being unblocked implicitly using a global unblocker PIN instead of the
+		directly associated PUK. In this case, we must issue a VERIFY command first and then the RESET RETRY COUNTER command with only
+		the new PIN in the data field. */
+
+		struct sc_pin_cmd_data global_unblocker_verif_data;
+		int r;
+
+		if (data->puk_reference != 0) {
+			/* Call the iso driver to do the VERIFY */
+			memset(&global_unblocker_verif_data, 0, sizeof(global_unblocker_verif_data));
+			global_unblocker_verif_data.pin_type = SC_AC_CHV;
+			global_unblocker_verif_data.cmd = SC_PIN_CMD_VERIFY;
+			global_unblocker_verif_data.pin1 = data->pin1;
+			global_unblocker_verif_data.pin_reference = data->puk_reference;
+			r = iso_ops->pin_cmd(card, &global_unblocker_verif_data);
+			LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+
+			if (r != SC_SUCCESS)
+				LOG_FUNC_RETURN(card->ctx, r);
+
+			memset(&data->pin1, 0, sizeof(struct sc_pin_cmd_pin));
+			data->flags |= SC_PIN_CMD_IMPLICIT_CHANGE;
+			struct sc_apdu apdu;
+			u8 buf[SC_MAX_APDU_BUFFER_SIZE];
+
+			/* Let iso driver build the RESET RETRY COUNTER APDU, but we'll have to modify it before transmitting it. */
+			r = iso7816_build_pin_apdu(card, &apdu, data, buf, sizeof(buf));
+
+			if (r != SC_SUCCESS)
+				LOG_FUNC_RETURN(card->ctx, r);
+
+			/* MyEID's implementation of unblocking a PIN implicitly contradicts with ISO 7816-4 here. The iso driver properly sets P2=0x02
+			while MyEID expects 0x00 */
+			apdu.p1 = 0x00;
+
+			r = sc_transmit_apdu(card, &apdu);
+
+			LOG_TEST_RET(card->ctx, r, "APDU transmit failed");
+			LOG_FUNC_RETURN(card->ctx, sc_check_sw(card, apdu.sw1, apdu.sw2));
+		}
+	}
 
 	if (data->cmd == SC_PIN_CMD_VERIFY && priv->card_state == SC_FILE_STATUS_CREATION) {
 		sc_log(card->ctx, "Card in creation state, no need to verify");

--- a/src/pkcs15init/Makefile.am
+++ b/src/pkcs15init/Makefile.am
@@ -20,7 +20,7 @@ dist_pkgdata_DATA = \
 	epass2003.profile \
 	rutoken_ecp.profile \
 	rutoken_lite.profile \
-	myeid.profile \
+	myeid.profile myeid_so_unblock.profile myeid_unblock_with_other_pin.profile myeid_unblocking_pin.profile\
 	authentic.profile \
 	iasecc.profile \
 	ias_adele_admin1.profile ias_adele_admin2.profile ias_adele_common.profile \

--- a/src/pkcs15init/myeid_so_unblock.profile
+++ b/src/pkcs15init/myeid_so_unblock.profile
@@ -1,0 +1,240 @@
+#
+# PKCS15 r/w profile for MyEID cards
+#
+# This is a special version of the MyEID profile, which enables unblocking user PINs using the SO-PIN
+# This configuration is not strictly ISO 7816-15 compliant, because by the standard unblockingPin and soPin flags should not be set in the same authentication object
+# Use profiles "myeid_unblocking_pin" and "myeid_unblock_with_other_pin" to set up a card with a separate unblocking PIN. 
+# The purpose of these special profiles is to enable configuring MyEID so that a PUK code associated with a user PIN can be changed after initialization.
+
+cardinfo {
+	label           = "MyEID";
+	manufacturer    = "Aventra Ltd.";
+	min-pin-length	= 4;
+	max-pin-length	= 8;
+	pin-encoding	= ascii-numeric;
+   	pin-pad-char	= 0xFF;
+}
+
+#
+# The following controls some aspects of the PKCS15 we put onto
+# the card.
+#
+pkcs15 {
+    # Put certificates into the CDF itself?
+    direct-certificates = no;
+    # Put the DF length into the ODF file?
+    encode-df-length    = no;
+    # Have a lastUpdate field in the EF(TokenInfo)?
+    do-last-update	    = no;
+}
+
+option default {
+    macros {
+        #protected   = READ=NONE, UPDATE=CHV1, DELETE=CHV2;
+        #unprotected = READ=NONE, UPDATE=CHV1, DELETE=CHV1;
+		
+	unusedspace-size = 510;
+	odf-size	     = 255;
+	aodf-size	     = 255;
+	cdf-size	     = 1530;
+	cdf-trusted-size = 510;
+	prkdf-size	     = 1530;
+	pukdf-size	     = 1530;
+	skdf-size	     = 1530;
+	dodf-size	     = 1530;
+    }
+}
+
+# Define reasonable limits for PINs and PUK
+# Note that we do not set a file path or reference
+# here; that is done dynamically.
+# This version of the profile sets the auth-if of user PIN to point to the SO-PIN. With this configuration, the driver applies the "allow global unblocking" flag to the PIN, allowing it to be unblocked with SO-PIN
+PIN user-pin {
+    auth-id = FF;
+    reference  = 1;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, needs-padding;
+}
+
+PIN user-puk {
+    reference  =3;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+    flags      = needs-padding;
+}
+
+# This version of the profile allows using so-pin to unblock other PINs.
+PIN so-pin {
+    reference  = 3;
+    auth-id    = FF;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, soPin, needs-padding, unblockingPin;
+}
+
+PIN so-puk {
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+   flags       = needs-padding;
+}
+
+# Additional filesystem info.
+# This is added to the file system info specified in the
+# main profile.
+filesystem {
+    DF MF {
+        path  = 3F00;
+        type  = DF;
+        acl	  = CREATE=$PIN, DELETE=$SOPIN;
+
+    	# This is the DIR file
+        EF DIR {	    
+    	    file-id   = 2F00;
+            structure = transparent;
+	        size      = 128;
+	        acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+	    }
+        DF PKCS15-AppDF {
+ 	        type      = DF;
+	        file-id   = 5015;
+	        aid       = A0:00:00:00:63:50:4B:43:53:2D:31:35;
+            acl       = DELETE=$PIN, CREATE=$PIN;
+	    
+            EF PKCS15-ODF {
+        	    file-id   = 5031;
+                structure = transparent;
+        	    size      = $odf-size;
+	            acl       = READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+        	}
+
+            EF PKCS15-TokenInfo {
+        	   file-id	  = 5032;
+        	   size		  = 160;
+	           structure  = transparent;
+        	   acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-UnusedSpace {
+                file-id	  = 5033;
+                structure = transparent;
+                size	  = $unusedspace-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-AODF {
+                file-id	  = 4401;
+                structure = transparent;
+                size	  = $aodf-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PrKDF {
+                file-id	  = 4402;
+                structure = transparent;
+                size	  = $prkdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PuKDF {
+                file-id	  = 4404;
+                structure = transparent;
+                size	  = $pukdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-SKDF {
+                file-id	  = 4407;
+                structure = transparent;
+                size	  = $skdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF {
+                file-id	  = 4403;
+                structure = transparent;
+                size	  = $cdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF-TRUSTED {
+                file-id	  = 4405;
+                structure = transparent;
+                size	  = $cdf-trusted-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-DODF {
+                file-id	  = 4406;
+                structure = transparent;
+                size	  = $dodf-size;
+                acl       = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+            
+            EF template-private-key {
+                type      = internal-ef;
+                file-id   = 4B01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-secret-key {
+                type      = internal-ef;
+                file-id   = 4D01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-public-key {
+                structure = transparent;
+                file-id	  = 5501;
+                acl	      = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+
+            EF template-certificate {
+                file-id   = 4301;
+                structure = transparent;
+                acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+            }
+
+            template key-domain {
+                # This is a dummy entry - pkcs15-init insists that
+                # this is present
+                EF private-key {
+                    file-id   = 4B01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF public-key {
+                    file-id   = 5501;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF secret-key {
+                    file-id   = 4D01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+		
+                # Certificate template
+                EF certificate {
+                    file-id	  = 4301;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF privdata {
+                    file-id   = 4501;
+                    structure = transparent;
+                    acl       = READ=$PIN, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF data {
+                    file-id   = 4601;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+            }
+	    }
+    }
+}

--- a/src/pkcs15init/myeid_unblock_with_other_pin.profile
+++ b/src/pkcs15init/myeid_unblock_with_other_pin.profile
@@ -1,0 +1,240 @@
+#
+# PKCS15 r/w profile for MyEID cards
+#
+# This is a special version of the MyEID profile, which allows user PINs to be unblocked using another PIN.
+# In MyEID, PINs always have a directly associated PUK, but it is possible to allow unblocking PINs also using other PINs. 
+# Use this profile in case you need a PUK that can be changed after initialization.
+# Use "myeid_unblocking_pin" profile to create the Unblocking PIN and set auth-id of the user PIN in this profile with the auth-id of the Unblocking PIN.
+
+cardinfo {
+	label           = "MyEID";
+	manufacturer    = "Aventra Ltd.";
+	min-pin-length	= 4;
+	max-pin-length	= 8;
+	pin-encoding	= ascii-numeric;
+   	pin-pad-char	= 0xFF;
+}
+
+#
+# The following controls some aspects of the PKCS15 we put onto
+# the card.
+#
+pkcs15 {
+    # Put certificates into the CDF itself?
+    direct-certificates = no;
+    # Put the DF length into the ODF file?
+    encode-df-length    = no;
+    # Have a lastUpdate field in the EF(TokenInfo)?
+    do-last-update	    = no;
+}
+
+option default {
+    macros {
+        #protected   = READ=NONE, UPDATE=CHV1, DELETE=CHV2;
+        #unprotected = READ=NONE, UPDATE=CHV1, DELETE=CHV1;
+		
+	unusedspace-size = 510;
+	odf-size	     = 255;
+	aodf-size	     = 255;
+	cdf-size	     = 1530;
+	cdf-trusted-size = 510;
+	prkdf-size	     = 1530;
+	pukdf-size	     = 1530;
+	skdf-size	     = 1530;
+	dodf-size	     = 1530;
+    }
+}
+
+# Define reasonable limits for PINs and PUK
+# Note that we do not set a file path or reference
+# here; that is done dynamically.
+# This version of the profile sets the auth-if of user PIN to point to PIN #4. With this configuration, the driver applies the "allow global unblocking" flag to the PIN, allowing it to be unblocked with the PIN pointed by the auth-id
+# Create the unblocking PIN using profile 'myeid_unblocking_pin'
+PIN user-pin {
+    auth-id = 4;
+    reference  = 1;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, needs-padding;
+}
+
+PIN user-puk {
+    reference  =3;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+    flags      = needs-padding;
+}
+
+PIN so-pin {
+    reference  = 3;
+    auth-id    = FF;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, soPin, needs-padding;
+}
+
+PIN so-puk {
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+   flags       = needs-padding;
+}
+
+# Additional filesystem info.
+# This is added to the file system info specified in the
+# main profile.
+filesystem {
+    DF MF {
+        path  = 3F00;
+        type  = DF;
+        acl	  = CREATE=$PIN, DELETE=$SOPIN;
+
+    	# This is the DIR file
+        EF DIR {	    
+    	    file-id   = 2F00;
+            structure = transparent;
+	        size      = 128;
+	        acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+	    }
+        DF PKCS15-AppDF {
+ 	        type      = DF;
+	        file-id   = 5015;
+	        aid       = A0:00:00:00:63:50:4B:43:53:2D:31:35;
+            acl       = DELETE=$PIN, CREATE=$PIN;
+	    
+            EF PKCS15-ODF {
+        	    file-id   = 5031;
+                structure = transparent;
+        	    size      = $odf-size;
+	            acl       = READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+        	}
+
+            EF PKCS15-TokenInfo {
+        	   file-id	  = 5032;
+        	   size		  = 160;
+	           structure  = transparent;
+        	   acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-UnusedSpace {
+                file-id	  = 5033;
+                structure = transparent;
+                size	  = $unusedspace-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-AODF {
+                file-id	  = 4401;
+                structure = transparent;
+                size	  = $aodf-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PrKDF {
+                file-id	  = 4402;
+                structure = transparent;
+                size	  = $prkdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PuKDF {
+                file-id	  = 4404;
+                structure = transparent;
+                size	  = $pukdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-SKDF {
+                file-id	  = 4407;
+                structure = transparent;
+                size	  = $skdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF {
+                file-id	  = 4403;
+                structure = transparent;
+                size	  = $cdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF-TRUSTED {
+                file-id	  = 4405;
+                structure = transparent;
+                size	  = $cdf-trusted-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-DODF {
+                file-id	  = 4406;
+                structure = transparent;
+                size	  = $dodf-size;
+                acl       = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+            
+            EF template-private-key {
+                type      = internal-ef;
+                file-id   = 4B01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-secret-key {
+                type      = internal-ef;
+                file-id   = 4D01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-public-key {
+                structure = transparent;
+                file-id	  = 5501;
+                acl	      = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+
+            EF template-certificate {
+                file-id   = 4301;
+                structure = transparent;
+                acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+            }
+
+            template key-domain {
+                # This is a dummy entry - pkcs15-init insists that
+                # this is present
+                EF private-key {
+                    file-id   = 4B01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF public-key {
+                    file-id   = 5501;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF secret-key {
+                    file-id   = 4D01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+		
+                # Certificate template
+                EF certificate {
+                    file-id	  = 4301;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF privdata {
+                    file-id   = 4501;
+                    structure = transparent;
+                    acl       = READ=$PIN, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF data {
+                    file-id   = 4601;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+            }
+	    }
+    }
+}

--- a/src/pkcs15init/myeid_unblocking_pin.profile
+++ b/src/pkcs15init/myeid_unblocking_pin.profile
@@ -1,0 +1,238 @@
+#
+# PKCS15 r/w profile for MyEID cards
+#
+# This is a special version of the MyEID profile for creating a separate unblocking PIN.
+# In MyEID, PINs always have a directly associated PUK, but it is possible to allow unblocking PINs also using other PINs. 
+# Use this profile in case you need a PUK that can be changed after initialization.
+#
+
+cardinfo {
+	label           = "MyEID";
+	manufacturer    = "Aventra Ltd.";
+	min-pin-length	= 4;
+	max-pin-length	= 8;
+	pin-encoding	= ascii-numeric;
+   	pin-pad-char	= 0xFF;
+}
+
+#
+# The following controls some aspects of the PKCS15 we put onto
+# the card.
+#
+pkcs15 {
+    # Put certificates into the CDF itself?
+    direct-certificates = no;
+    # Put the DF length into the ODF file?
+    encode-df-length    = no;
+    # Have a lastUpdate field in the EF(TokenInfo)?
+    do-last-update	    = no;
+}
+
+option default {
+    macros {
+        #protected   = READ=NONE, UPDATE=CHV1, DELETE=CHV2;
+        #unprotected = READ=NONE, UPDATE=CHV1, DELETE=CHV1;
+		
+	unusedspace-size = 510;
+	odf-size	     = 255;
+	aodf-size	     = 255;
+	cdf-size	     = 1530;
+	cdf-trusted-size = 510;
+	prkdf-size	     = 1530;
+	pukdf-size	     = 1530;
+	skdf-size	     = 1530;
+	dodf-size	     = 1530;
+    }
+}
+
+# Define reasonable limits for PINs and PUK
+# Note that we do not set a file path or reference
+# here; that is done dynamically.
+# This version of the profile sets the unblockingPin flag to user PINs. The MyEID driver correspondingly sets the "global unblocker" flag to the PIN, which allows unblocking PINs marked with the "allow global unblocking" flag.
+PIN user-pin {
+    reference  = 1;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, needs-padding, unblockingPin;
+}
+
+PIN user-puk {
+    reference  =3;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+    flags      = needs-padding;
+}
+
+PIN so-pin {
+    reference  = 3;
+    auth-id    = FF;
+    min-length = 4;
+    max-length = 8;
+    attempts   = 3;
+    flags      = initialized, soPin, needs-padding;
+}
+
+PIN so-puk {
+    min-length = 4;
+    max-length = 8;
+    attempts   = 10;
+   flags       = needs-padding;
+}
+
+# Additional filesystem info.
+# This is added to the file system info specified in the
+# main profile.
+filesystem {
+    DF MF {
+        path  = 3F00;
+        type  = DF;
+        acl	  = CREATE=$PIN, DELETE=$SOPIN;
+
+    	# This is the DIR file
+        EF DIR {	    
+    	    file-id   = 2F00;
+            structure = transparent;
+	        size      = 128;
+	        acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+	    }
+        DF PKCS15-AppDF {
+ 	        type      = DF;
+	        file-id   = 5015;
+	        aid       = A0:00:00:00:63:50:4B:43:53:2D:31:35;
+            acl       = DELETE=$PIN, CREATE=$PIN;
+	    
+            EF PKCS15-ODF {
+        	    file-id   = 5031;
+                structure = transparent;
+        	    size      = $odf-size;
+	            acl       = READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+        	}
+
+            EF PKCS15-TokenInfo {
+        	   file-id	  = 5032;
+        	   size		  = 160;
+	           structure  = transparent;
+        	   acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-UnusedSpace {
+                file-id	  = 5033;
+                structure = transparent;
+                size	  = $unusedspace-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-AODF {
+                file-id	  = 4401;
+                structure = transparent;
+                size	  = $aodf-size;
+                acl	      = READ=NONE, UPDATE=$SOPIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PrKDF {
+                file-id	  = 4402;
+                structure = transparent;
+                size	  = $prkdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-PuKDF {
+                file-id	  = 4404;
+                structure = transparent;
+                size	  = $pukdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-SKDF {
+                file-id	  = 4407;
+                structure = transparent;
+                size	  = $skdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF {
+                file-id	  = 4403;
+                structure = transparent;
+                size	  = $cdf-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-CDF-TRUSTED {
+                file-id	  = 4405;
+                structure = transparent;
+                size	  = $cdf-trusted-size;
+                acl	      = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+
+            EF PKCS15-DODF {
+                file-id	  = 4406;
+                structure = transparent;
+                size	  = $dodf-size;
+                acl       = *=NEVER, READ=NONE, UPDATE=$PIN, DELETE=$SOPIN;
+            }
+            
+            EF template-private-key {
+                type      = internal-ef;
+                file-id   = 4B01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-secret-key {
+                type      = internal-ef;
+                file-id   = 4D01;
+                acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+            
+            EF template-public-key {
+                structure = transparent;
+                file-id	  = 5501;
+                acl	      = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+            }
+
+            EF template-certificate {
+                file-id   = 4301;
+                structure = transparent;
+                acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+            }
+
+            template key-domain {
+                # This is a dummy entry - pkcs15-init insists that
+                # this is present
+                EF private-key {
+                    file-id   = 4B01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF public-key {
+                    file-id   = 5501;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+                EF secret-key {
+                    file-id   = 4D01;
+                    type      = internal-ef;
+                    acl       = CRYPTO=$PIN, UPDATE=$PIN, DELETE=$PIN, GENERATE=$PIN;
+                }
+		
+                # Certificate template
+                EF certificate {
+                    file-id	  = 4301;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF privdata {
+                    file-id   = 4501;
+                    structure = transparent;
+                    acl       = READ=$PIN, UPDATE=$PIN, DELETE=$PIN;
+                }
+                EF data {
+                    file-id   = 4601;
+                    structure = transparent;
+                    acl       = READ=NONE, UPDATE=$PIN, DELETE=$PIN;
+                }
+            }
+	    }
+    }
+}

--- a/src/pkcs15init/pkcs15-myeid.c
+++ b/src/pkcs15init/pkcs15-myeid.c
@@ -1,7 +1,7 @@
 /*
  * MyEID specific operations for PKCS15 initialization
  *
- * Copyright (C) 2008-2009 Aventra Ltd.
+ * Copyright (C) 2008-2026 Aventra Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -354,8 +354,30 @@ myeid_create_pin(struct sc_profile *profile, struct sc_pkcs15_card *p15card,
 
 	data[18] = 0x00;
 
+	/* by default, MyEID allows unblocking PINs only with the PUK code which is included directly in the card-level PIN object,
+	and doesn't have a separate authentication object in the Authentication Object Directory File.
+	If SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN flag is set, this PIN can be used to unblock other PINs */
+
+	if ((auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN) == SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN)
+		data[18] = 0x08; /* set global unblocker flag */
+
 	data_obj.Data = data;
 	data_obj.DataLen = 19;
+
+	struct sc_pkcs15_auth_info pin_ainfo = {0};
+
+	sc_profile_get_pin_info(profile, (auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN) ? SC_PKCS15INIT_SO_PIN : SC_PKCS15INIT_USER_PIN,
+			&pin_ainfo);
+
+	/* Using a global unblocker PIN for unblocking another PIN must be explicitly allowed by setting the Allow Global Unblocking
+	flag on the user PIN. If auth_id is set in the profile for user PINs, Allow Global Unblocking flag is set on the card-level
+	PIN object and the auth_id is copied to the PKCS#15 object. The auth_id then shows, which PIN should be verified to unblock
+	this user PIN. */
+	if (pin_ainfo.auth_id.len > 0 && (!(auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_UNBLOCKING_PIN)) && (!(auth_info->attrs.pin.flags & SC_PKCS15_PIN_FLAG_SO_PIN))) {
+		sc_log(ctx, "Allow unblocking with a separate unblocking PIN.");
+		pin_obj->auth_id = pin_ainfo.auth_id;
+		data[18] |= 0x04;
+	}
 
 	r = sc_card_ctl(p15card->card, SC_CARDCTL_MYEID_PUTDATA, &data_obj);
 	LOG_TEST_RET(ctx, r, "Initialize PIN failed");


### PR DESCRIPTION
When creating a PIN to MyEID, a PUK is always created and directly attached to the PIN object. A separate PKCS#15 object is not created for the PUK. 

MyEID also supports unblocking PINs using another PIN. To enable this, the PIN being unblocked must have the "allow global unblocking" flag set and the other PIN must have the "global unblocker" flag set. This configuration is needed, in case there is a need to be able to change the unblocking PIN after initialization and finalization of the card.

This PR adds support for this configuration. 

New profiles have been added for creating the PINs. I considered using --puk-id switch to create the unblocking PIN within the same command when the PIN is created. However, this does not work with MyEID because the directly attached PUK is also created and you would need to set two different PUK values. In a practical usage scenario, the directly attached PUK could be random and stored either nowhere or in some secure location, where the unblocking PIN could be set with a known default value, to be changed later by a card management system. Therefore, the unblocking PIN is created like a normal user PIN, with a special version of the profile file.

This PR can be tested with the following commands (Starting with an empty MyEID card) :

**initialize the card**
pkcs15-init -C --pin 1111 --puk 1111 

**create user PIN 1**
pkcs15-init -P --card-profile myeid_unblock_with_other_pin -a 1 -l "Basic PIN" --pin 1111 --puk 12345678 --so-pin 12345678

**create second user PIN**
pkcs15-init -P --card-profile myeid_unblock_with_other_pin -a 2 -l "Signature PIN" --pin 2222 --puk 12345678 --so-pin 12345678

**create the unblocking PIN**
pkcs15-init -P --card-profile myeid_unblocking_pin -a 4 -l "Unblocking PIN" --pin 44444444 --puk 12345678 --so-pin 123456786

**unblock the PIN. Enter 44444444 when the PUK is requested **
pkcs15-tool -u -a 1 

or using pkcs11-tool:
pkcs11-tool --module ..\pkcs11\opensc-pkcs11.dll --unlock-pin

Testing with pkcs11-tool requires the following option in opensc.conf:

app opensc-pkcs11 {
    pkcs11 {
        # Configures SC_PKCS11_PIN_UNBLOCK_UNLOGGED_SETPIN behavior
        user_pin_unblock_style = set_pin_in_unlogged_session;
    }
}


### About testing:

- verified the the correct flags get set to MyEID native PINs with the commands above
- verified that using the default profile the PINs are initialized like before this PR (with no unblocking-related flags)
- verified that unblocking using pkcs11-tool and pkcs15-tool works both ways: with the classic MyEID configuration, using directly attached PUK, and using the separate unblocker PIN. OpenSC uses the unblocker PIN if it finds **auth-id** from the CommonObjectAttributes of the PIN being unblocked.

This change should not affect how minidriver and tokend work, at least in case the card is personalized using the default profile. I haven't tested the minidriver and don't have a MacOS system to test with.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
