### PR TITLE
setcos: Fix buffer overflow in setcos_construct_fci_44

### DIFF
--- a/src/libopensc/card-setcos.c
+++ b/src/libopensc/card-setcos.c
@@ -218,6 +218,8 @@ static int setcos_construct_fci_44(sc_card_t *card, const sc_file_t *file, u8 *o
 
 	/* Type */
 	if (file->type_attr_len) {
+		if (file->type_attr_len > sizeof(buf))
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		memcpy(buf, file->type_attr, file->type_attr_len);
 		sc_asn1_put_tag(0x82, buf, file->type_attr_len, p, *outlen - (p - out), &p);
 	} else {
@@ -271,11 +273,15 @@ static int setcos_construct_fci_44(sc_card_t *card, const sc_file_t *file, u8 *o
 	}
 
 	/* Security Attributes */
+	if (file->sec_attr_len > sizeof(buf))
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 	memcpy(buf, file->sec_attr, file->sec_attr_len);
 	sc_asn1_put_tag(0x86, buf, file->sec_attr_len, p, *outlen - (p - out), &p);
 
 	/* Life cycle status */
 	if (file->prop_attr_len) {
+		if (file->prop_attr_len > sizeof(buf))
+			LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_DATA);
 		memcpy(buf, file->prop_attr, file->prop_attr_len);
 		sc_asn1_put_tag(0x8A, buf, file->prop_attr_len, p, *outlen - (p - out), &p);
 	}


### PR DESCRIPTION
 ## Description

  `setcos_construct_fci_44()` builds the FCI for file creation by copying the file's `type_attr`, `sec_attr` and `prop_attr` into a fixed 64-byte stack buffer (`u8 buf[64]`) without validating the attribute lengths:

  ```c
  u8 buf[64];
  ...
  memcpy(buf, file->type_attr, file->type_attr_len);   /* card-setcos.c:221 */
  ...
  memcpy(buf, file->sec_attr, file->sec_attr_len);     /* card-setcos.c:274 */
  ...
  if (file->prop_attr_len) {
      memcpy(buf, file->prop_attr, file->prop_attr_len); /* card-setcos.c:279 */
  }
  ```

  If any attribute is longer than 64 bytes, this writes past the end of the stack buffer. The attribute lengths originate from the pkcs15init profile and, in part, from card responses, so corrupted or malicious data leads to a deterministic stack buffer overflow (write), reported by AddressSanitizer:

  ```
  ERROR: AddressSanitizer: stack-buffer-overflow ... WRITE of size 65
      #1 setcos_construct_fci_44 src/libopensc/card-setcos.c:279
      #2 setcos_create_file     src/libopensc/card-setcos.c:537
  SUMMARY: AddressSanitizer: stack-buffer-overflow card-setcos.c:279
  ```

  Found with the `fuzz_pkcs15init` fuzzer.

  As discussed with the maintainer, this is handled via standard bug fixing.

  ## Changes

  Return `SC_ERROR_INVALID_DATA` when any of the three attribute lengths exceeds the size of the temporary buffer. No behavior change for valid attributes (≤ 64 bytes).

  ## Testing

  - Built with the oss-fuzz toolchain (ASan + libFuzzer) and ran the reproducer from issue #60672: crash before the fix, clean exit after.
  - 50-second libFuzzer run on the patched target (~69k executions): no crashes, no regressions introduced by the new checks.
  - `make check`: 0 failures.
