### PR TITLE
tools: Check util_getpass return value in sc-hsm-tool and gids-tool

### DIFF
--- a/src/tools/gids-tool.c
+++ b/src/tools/gids-tool.c
@@ -102,7 +102,10 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 	if (so_pin == NULL) {
 		printf("Enter admin key (48 hexadecimal characters) : \n");
 		printf("Press Enter to set the admin key to 00...00\n");
-		util_getpass(&_so_pin, NULL, stdin);
+		if (util_getpass(&_so_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading admin key\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_so_pin = (char *)so_pin;
@@ -122,7 +125,10 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 
 	if (user_pin == NULL) {
 		printf("Enter initial User-PIN (4 - 16 characters) : ");
-		util_getpass(&_user_pin, NULL, stdin);
+		if (util_getpass(&_user_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading User-PIN\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_user_pin = (char *)user_pin;
@@ -131,7 +137,10 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 	if (serial == NULL) {
 		printf("Enter serial number (32 hexadecimal characters): \n");
 		printf("Press Enter to set a random serial number\n");
-		util_getpass(&_serial, NULL, stdin);
+		if (util_getpass(&_serial, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading serial number\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_serial = (char *)serial;
@@ -189,7 +198,10 @@ static int unblock(sc_card_t* card, const char *so_pin, const char *user_pin) {
 		printf("WARNING\n");
 		printf("============================================================\n");
 		printf("Enter admin key (48 hexadecimal characters) : ");
-		util_getpass(&_so_pin, NULL, stdin);
+		if (util_getpass(&_so_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading admin key\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_so_pin = (char *)so_pin;
@@ -217,7 +229,10 @@ static int unblock(sc_card_t* card, const char *so_pin, const char *user_pin) {
 
 	if (user_pin == NULL) {
 		printf("Enter User-PIN (4 - 16 characters) : ");
-		util_getpass(&_user_pin, NULL, stdin);
+		if (util_getpass(&_user_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading User-PIN\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_user_pin = (char *)user_pin;
@@ -252,7 +267,10 @@ static int changeAdminKey(sc_card_t* card, const char *so_pin, const char* new_k
 		printf("WARNING\n");
 		printf("============================================================\n");
 		printf("Enter admin key (48 hexadecimal characters) : ");
-		util_getpass(&_so_pin, NULL, stdin);
+		if (util_getpass(&_so_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading admin key\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_so_pin = (char *)so_pin;
@@ -278,7 +296,10 @@ static int changeAdminKey(sc_card_t* card, const char *so_pin, const char* new_k
 
 	if (new_key == NULL) {
 		printf("Enter new admin key (48 hexadecimal characters) : ");
-		util_getpass(&_new_key, NULL, stdin);
+		if (util_getpass(&_new_key, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading new admin key\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_new_key = (char *)new_key;

--- a/src/tools/sc-hsm-tool.c
+++ b/src/tools/sc-hsm-tool.c
@@ -594,7 +594,10 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 
 	if (so_pin == NULL) {
 		printf("Enter SO-PIN (16 hexadecimal characters) : ");
-		util_getpass(&_so_pin, NULL, stdin);
+		if (util_getpass(&_so_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading SO-PIN\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_so_pin = (char *)so_pin;
@@ -614,7 +617,10 @@ static int initialize(sc_card_t *card, const char *so_pin, const char *user_pin,
 
 	if (user_pin == NULL) {
 		printf("Enter initial User-PIN (6 - 16 characters) : ");
-		util_getpass(&_user_pin, NULL, stdin);
+		if (util_getpass(&_user_pin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading User-PIN\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		_user_pin = (char *)user_pin;
@@ -841,7 +847,10 @@ static int import_dkek_share(sc_card_t *card, const char *inf, int iter, const c
 
 		if (num_of_password_shares == -1) {
 			printf("Enter password to decrypt DKEK share : ");
-			util_getpass(&pwd, NULL, stdin);
+			if (util_getpass(&pwd, NULL, stdin) < 0) {
+				fprintf(stderr, "Error reading password\n");
+				return -1;
+			}
 			pwdlen = (int)strlen(pwd);
 			printf("\n");
 		} else {
@@ -942,7 +951,10 @@ static int print_dkek_share(sc_card_t *card, const char *inf, int iter, const ch
 
 		if (num_of_password_shares == -1) {
 			printf("Enter password to decrypt DKEK share : ");
-			util_getpass(&pwd, NULL, stdin);
+			if (util_getpass(&pwd, NULL, stdin) < 0) {
+				fprintf(stderr, "Error reading password\n");
+				return -1;
+			}
 			pwdlen = (int)strlen(pwd);
 			printf("\n");
 		} else {
@@ -1007,9 +1019,10 @@ static int print_dkek_share(sc_card_t *card, const char *inf, int iter, const ch
 	return 0;
 }
 
-static void ask_for_password(char **pwd, int *pwdlen)
+static int ask_for_password(char **pwd, int *pwdlen)
 {
 	char *refpwd = NULL;
+	int r = -1;
 
 	printf(	"\nThe DKEK share will be enciphered using a key derived from a user supplied password.\n");
 	printf(	"The security of the DKEK share relies on a well chosen and sufficiently long password.\n");
@@ -1021,14 +1034,20 @@ static void ask_for_password(char **pwd, int *pwdlen)
 
 	while (1) {
 		printf("Enter password to encrypt DKEK share : ");
-		util_getpass(pwd, NULL, stdin);
+		if (util_getpass(pwd, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading password\n");
+			goto out;
+		}
 		printf("\n");
 		if (strlen(*pwd) < 6) {
 			printf("Password way to short. Please retry.\n");
 			continue;
 		}
 		printf("Please retype password to confirm : ");
-		util_getpass(&refpwd, NULL, stdin);
+		if (util_getpass(&refpwd, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading password\n");
+			goto out;
+		}
 		printf("\n");
 		if (strcmp(*pwd, refpwd)) {
 			printf("Passwords do not match. Please retry.\n");
@@ -1038,8 +1057,13 @@ static void ask_for_password(char **pwd, int *pwdlen)
 		break;
 	}
 
-	OPENSSL_cleanse(refpwd, strlen(refpwd));
-	free(refpwd);
+	r = 0;
+out:
+	if (refpwd != NULL) {
+		OPENSSL_cleanse(refpwd, strlen(refpwd));
+		free(refpwd);
+	}
+	return r;
 }
 
 
@@ -1204,7 +1228,8 @@ static int create_dkek_share(sc_card_t *card, const char *outf, int iter, const 
 
 	if (password == NULL) {
 		if ((password_shares_threshold == -1) && (password_shares_total == -1)) {
-			ask_for_password(&pwd, &pwdlen);
+			if (ask_for_password(&pwd, &pwdlen) < 0)
+				return -1;
 		} else { // create password using threshold scheme
 			r = generate_pwd_shares(card, &pwd, &pwdlen, password_shares_threshold, password_shares_total);
 		}
@@ -1351,7 +1376,10 @@ static int wrap_key(sc_context_t *ctx, sc_card_t *card, int keyid, const char *o
 
 	if (pin == NULL) {
 		printf("Enter User PIN : ");
-		util_getpass(&lpin, NULL, stdin);
+		if (util_getpass(&lpin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading User PIN\n");
+			return -1;
+		}
 		printf("\n");
 	} else {
 		lpin = (char *)pin;
@@ -1640,7 +1668,11 @@ static int unwrap_key(sc_card_t *card, int keyid, const char *inf, const char *p
 
 	if (pin == NULL) {
 		printf("Enter User PIN : ");
-		util_getpass(&lpin, NULL, stdin);
+		if (util_getpass(&lpin, NULL, stdin) < 0) {
+			fprintf(stderr, "Error reading User PIN\n");
+			r = -1;
+			goto err;
+		}
 		printf("\n");
 	} else {
 		lpin = (char *)pin;

--- a/src/tools/util.c
+++ b/src/tools/util.c
@@ -444,12 +444,16 @@ util_getpass (char **lineptr, size_t *len, FILE *stream)
 	struct termios old, new;
 
 	fflush(stdout);
-	if (tcgetattr (fileno (stdout), &old) != 0)
+	if (tcgetattr (fileno (stdout), &old) != 0) {
+		fprintf(stderr, "\nWARNING: not prompting for input, because stdout is not a TTY\n");
 		return -1;
+	}
 	new = old;
 	new.c_lflag &= ~ECHO;
-	if (tcsetattr (fileno (stdout), TCSAFLUSH, &new) != 0)
+	if (tcsetattr (fileno (stdout), TCSAFLUSH, &new) != 0) {
+		fprintf(stderr, "\nWARNING: not prompting for input, because echo cannot be disabled\n");
 		return -1;
+	}
 #endif
 
 	buf = calloc(1, MAX_PASS_SIZE);


### PR DESCRIPTION
`util_getpass()` bails out before assigning `*lineptr`:

```c
if (tcgetattr (fileno (stdout), &old) != 0)
    return -1;
```

`tcgetattr` fails whenever stdout is not a TTY, so any redirect or pipe on
stdout makes the function return -1 with the caller's pointer untouched. Every
call site in `sc-hsm-tool.c` and `gids-tool.c` ignored the return value.

In `sc-hsm-tool` the consequence is a crash, because the pointer goes straight
into `strlen()`:

```c
char *lpin = NULL;
util_getpass(&lpin, NULL, stdin);
data.pin1.len = strlen(lpin);
```

### Reproducing

Any prompt reached without the matching command line option, with stdout
redirected:

```console
$ printf 'x\n' | sc-hsm-tool --unwrap-key blob.bin --key-reference 3 > log
Segmentation fault (core dumped)
$ echo $?
139
```

With this branch:

```console
$ printf 'x\n' | ./src/tools/sc-hsm-tool --unwrap-key blob.bin --key-reference 3 > log
$ echo $?
1
$ tail -1 log
Enter User PIN : Error reading User PIN
```

The crash happens before the PIN is sent to the card, so it consumes no retry
counter and leaves the card untouched.

### The change

Check the return value at all 15 call sites in the two files and fail with a
message. This is what `pkcs11-tool.c` and `opensc-explorer.c` already do, so the
fix follows existing practice rather than introducing a new convention. Both
files report errors with `fprintf(stderr, ...)` and a negative return
throughout, and the patch keeps to that rather than pulling in `util_fatal()`.

`ask_for_password()` was `static void` with no way to report failure, so it gains
an `int` return. It has a single caller. Its cleanup now guards `refpwd` against
NULL, which the new early-exit path can reach.

Two things deliberately left alone:

- `util_getpass()` itself is unchanged. Testing `tcgetattr` on stdout rather
  than stdin looks questionable, but changing it alters behaviour for every
  caller and does not belong in a crash fix.
- Other tools calling `util_getpass` without checking are untouched, since I
  have not reproduced a crash in them.

### Testing

Card: SmartCard-HSM version 4.1 (Nitrokey HSM 2).

- Built clean, no new warnings in either file.
- `sc-hsm-tool --unwrap-key` with redirected stdout: SIGSEGV before, exit 1 with
  a diagnostic after.
- `sc-hsm-tool --unwrap-key` with `--pin` supplied: unchanged, key imports and
  signs.
- `gids-tool` changes are the same mechanical pattern; I have no GIDS card and
  have not exercised them at runtime.

##### Checklist
<!-- Items that do not apply have been removed, per the template. This change
     adds no files, changes no documented interface, and touches neither the
     PKCS#11 module nor the Windows minidriver nor the macOS token. It is
     confined to two command line tools. -->

Nothing on the checklist applies to this change.
