### PR TITLE
pkcs15-sec: zero-pad short EC digests to the field length

### DIFF
--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -762,23 +762,25 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 */
 	else if (senv.algorithm == SC_ALGORITHM_EC &&
 			(senv.algorithm_flags & SC_ALGORITHM_ECDSA_HASHES) == 0) {
+		size_t flen = BYTES4BITS(prkey->field_length);
+
 		if (inlen > flen) {
-   			inlen = flen;
-   		} else if (inlen < flen) {
-   			/* Zero-pad short digests: some applets require the input to match
-   			 * the field length exactly. Leading zeros do not change the integer
-   			 * value, so the signature still verifies. */
-   			if (flen > buflen) {
-   				r = SC_ERROR_BUFFER_TOO_SMALL;
-   				goto err;
-   			}
-   			memmove(tmp + flen - inlen, tmp, inlen);
-   			memset(tmp, 0, flen - inlen);
-   			inlen = flen;
-   		}
+			inlen = flen;
+		} else if (inlen < flen) {
+			/* Zero-pad short digests: some applets require the input to match
+			 * the field length exactly. Leading zeros do not change the integer
+			 * value, so the signature still verifies. */
+			if (flen > buflen) {
+				r = SC_ERROR_BUFFER_TOO_SMALL;
+				goto err;
+			}
+			memmove(tmp + flen - inlen, tmp, inlen);
+			memset(tmp, 0, flen - inlen);
+			inlen = flen;
+		}
 	}
 
-	
+
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);
 	LOG_TEST_GOTO_ERR(ctx, r, "use_key() failed");

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -759,6 +759,9 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 * the leftmost bits of the hash up to the length of n will be used. Any
 	 * truncation is done by the token.
 	 * But if card is going to do the hash, pass in all the data
+	 * A hash shorter than the field length is zero-padded on the left, because
+	 * some applets require the input to match the field length exactly. Leading
+	 * zeros do not change the integer value, so the signature is unaffected.
 	 */
 	else if (senv.algorithm == SC_ALGORITHM_EC &&
 			(senv.algorithm_flags & SC_ALGORITHM_ECDSA_HASHES) == 0) {
@@ -767,9 +770,6 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 		if (inlen > flen) {
 			inlen = flen;
 		} else if (inlen < flen) {
-			/* Zero-pad short digests: some applets require the input to match
-			 * the field length exactly. Leading zeros do not change the integer
-			 * value, so the signature still verifies. */
 			if (flen > buflen) {
 				r = SC_ERROR_BUFFER_TOO_SMALL;
 				goto err;

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -762,9 +762,21 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 	 */
 	else if (senv.algorithm == SC_ALGORITHM_EC &&
 			(senv.algorithm_flags & SC_ALGORITHM_ECDSA_HASHES) == 0) {
-		inlen = MIN(inlen, BYTES4BITS(prkey->field_length));
+		if (inlen > flen) {
+   			inlen = flen;
+   		} else if (inlen < flen) {
+   			/* Zero-pad short digests: some applets require the input to match
+   			 * the field length exactly. Leading zeros do not change the integer
+   			 * value, so the signature still verifies. */
+   			if (flen > buflen) {
+   				r = SC_ERROR_BUFFER_TOO_SMALL;
+   				goto err;
+   			}
+   			memmove(tmp + flen - inlen, tmp, inlen);
+   			memset(tmp, 0, flen - inlen);
+   			inlen = flen;
+   		}
 	}
-
 
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -780,7 +780,6 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
 		}
 	}
 
-
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);
 	LOG_TEST_GOTO_ERR(ctx, r, "use_key() failed");

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -778,6 +778,7 @@ int sc_pkcs15_compute_signature(struct sc_pkcs15_card *p15card,
    		}
 	}
 
+	
 	r = use_key(p15card, obj, &senv, sc_compute_signature, tmp, inlen,
 			out, outlen);
 	LOG_TEST_GOTO_ERR(ctx, r, "use_key() failed");


### PR DESCRIPTION
Fixes #3813

Windows signs a 32-byte SHA-256 digest with a P-384 key during
cached-credential (offline) logon. `sc_pkcs15_compute_signature()` truncates a
digest that is longer than the field size but forwards a shorter one unchanged,
so the applet receives 32 bytes where it expects 48.

The OpenFIPS201 applet requires the input to equal the field length and rejects
the short one with "Incorrect parameters in APDU" (-1205). Windows surfaces this
as "The domain specified is not available", which is why the cause was not
obvious.

This makes the branch symmetric by zero-padding on the left, mirroring the RSA
`SC_ALGORITHM_RSA_PAD_NONE` branch a few lines above, including its
`SC_ERROR_BUFFER_TOO_SMALL` guard.

Leading zeros do not change the integer value of the digest, so a card that
already accepts a short input produces the same signature as before. Cards that
require the exact field length now work.

### Testing

Reproduced and fixed end to end on Windows 11 24H2 with a P-384 9A key
(OpenFIPS201 applet), against a Samba AD DC: offline smart-card logon fails
before the change and succeeds after it.

P-256 is unaffected because a 32-byte digest already equals the field size.
The P-521 path is unexercised — only P-256 and P-384 available for
PIV keys, so no card was available to test it.

Note that the fix was originally developed against the 0.27.1 tarball and has
been rebased onto master for this PR; the rebased version is compiled but the
card test above was performed with the 0.27.1 build.

##### Checklist
- [ ] PKCS#11 module is tested
- [x] Windows minidriver is tested
- [ ] macOS token is tested
