### PR TITLE
piv: Support GET METADATA to discover keys without certificates

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1811,13 +1811,15 @@ piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 			(sendbuf ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_1);
 
 	sc_format_apdu(card, &apdu, cse, ins, p1, p2);
-	apdu.flags |= SC_APDU_FLAGS_CHAINING;
+	if (sendbuflen > 255) {
+		apdu.flags |= SC_APDU_FLAGS_CHAINING;
 #ifdef ENABLE_PIV_SM
-	if (card->sm_ctx.sm_mode != SM_MODE_NONE && sendbuflen > 255) {
-		/* tell apdu.c to not do the chaining, let the SM get_apdu do it */
-		apdu.flags |= SC_APDU_FLAGS_SM_CHAINING;
-	}
+		if (card->sm_ctx.sm_mode != SM_MODE_NONE) {
+			/* tell apdu.c to not do the chaining, let the SM get_apdu do it */
+			apdu.flags |= SC_APDU_FLAGS_SM_CHAINING;
+		}
 #endif
+	}
 	apdu.lc = sendbuflen;
 	apdu.datalen = sendbuflen;
 	apdu.data = sendbuf;

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -386,6 +386,16 @@ static const struct sc_card_error piv_sm_errors[] = {
 
 #define PIV_PAIRING_CODE_LEN	 8
 
+#define PIV_NUM_YK_SLOT_INFO 26
+
+typedef struct yk_slot_info_st {
+	u8 slot;
+	u8 policy;
+	u8 touch;
+	u8 algorithm;
+	struct sc_lv_data pubkey;
+} yk_slot_info_t;
+
 typedef struct piv_private_data {
 	struct sc_lv_data aid_der; /* previous aid response to compare */
 	int enumtag;
@@ -418,11 +428,7 @@ typedef struct piv_private_data {
 	unsigned int card_issues; /* card_issues flags for this card */
 	int object_test_verify; /* Can test this object to set verification state of card */
 	int yubico_version; /* 3 byte version number of NEO or Yubikey4  as integer */
-	struct {
-		u8 slot;
-		u8 policy;
-		u8 touch;
-	} yk_pin[26];
+	yk_slot_info_t yk_slot_info[PIV_NUM_YK_SLOT_INFO];
 	unsigned int ccc_flags;	    /* From  CCC indicate if CAC card */
 	unsigned int pin_policy; /* from discovery */
 	unsigned int init_flags;
@@ -1792,7 +1798,7 @@ piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 		const u8 *sendbuf, size_t sendbuflen, u8 *recvbuf,
 		size_t recvbuflen)
 {
-	int r;
+	int r, cse;
 	sc_apdu_t apdu;
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
@@ -1801,9 +1807,10 @@ piv_general_io(sc_card_t *card, int ins, int p1, int p2,
 	if (r != SC_SUCCESS)
 		LOG_FUNC_RETURN(card->ctx, r);
 
-	sc_format_apdu(card, &apdu,
-			recvbuf ? SC_APDU_CASE_4_SHORT : SC_APDU_CASE_3_SHORT,
-			ins, p1, p2);
+	cse = recvbuf ? (sendbuf ? SC_APDU_CASE_4_SHORT : SC_APDU_CASE_2_SHORT) :
+			(sendbuf ? SC_APDU_CASE_3_SHORT : SC_APDU_CASE_1);
+
+	sc_format_apdu(card, &apdu, cse, ins, p1, p2);
 	apdu.flags |= SC_APDU_FLAGS_CHAINING;
 #ifdef ENABLE_PIV_SM
 	if (card->sm_ctx.sm_mode != SM_MODE_NONE && sendbuflen > 255) {
@@ -4500,55 +4507,107 @@ piv_yk_metadata_get_policy(sc_context_t *ctx, u8 *buf, size_t buflen, u8 *pin, u
 }
 
 static int
-piv_yk_get_metadata(sc_card_t *card, u8 slot, u8 *pin_policy, u8 *touch_policy)
+piv_yk_metadata_get_pubkey_info(sc_context_t *ctx, u8 *buf, size_t buflen, yk_slot_info_t *info)
 {
-	sc_apdu_t apdu;
-	u8 resp[100];
+	size_t tag_len = 0;
+	const u8 *pk = NULL;
+
+	/*  Tag 0x01: Algorithm/type of key */
+	pk = sc_asn1_find_tag(ctx, buf, buflen, 0x01, &tag_len);
+	if (pk && tag_len == 1) {
+		info->algorithm = pk[0];
+	} else {
+		sc_log(ctx, "Yubikey algorithm not found");
+		return SC_ERROR_DATA_OBJECT_NOT_FOUND;
+	}
+
+	/*  Tag 0x04: Public key */
+	pk = sc_asn1_find_tag(ctx, buf, buflen, 0x04, &tag_len);
+	if (pk && tag_len > 0) {
+		info->pubkey.value = malloc(tag_len);
+		if (info->pubkey.value == NULL) {
+			return SC_ERROR_MEMORY_FAILURE;
+		}
+		memcpy(info->pubkey.value, pk, tag_len);
+		info->pubkey.len = tag_len;
+	} else {
+		sc_log(ctx, "Yubikey public key not found");
+		return SC_ERROR_DATA_OBJECT_NOT_FOUND;
+	}
+
+	return SC_SUCCESS;
+}
+
+static int
+piv_yk_get_metadata(sc_card_t *card, u8 slot, u8 *pin_policy, u8 *touch_policy, sc_cardctl_piv_pubkey_info_t *info)
+{
+	u8 resp[3072]; /* Should be enough to fit ML-DSA-87 key */
+	int resplen = 0;
 	size_t i;
 	piv_private_data_t *priv = PIV_DATA(card);
+	int rc;
 
 	/* initialize with the default behaviour */
 	if (pin_policy)
 		*pin_policy = 0x00;
 	if (touch_policy)
 		*touch_policy = 0x00;
+	if (info) {
+		info->algorithm = 0;
+		info->pubkey.value = NULL;
+		info->pubkey.len = 0;
+	}
 
 	if (priv->yubico_version < 0x00050300) {
 		if (priv->yubico_version != 0)
-			sc_log(card->ctx, "Yubikey's PIN and touch policy not available");
+			sc_log(card->ctx, "Yubikey's Get metadata extension not available");
 		return SC_ERROR_NOT_SUPPORTED;
 	}
 
-	for (i = 0; i < (sizeof(priv->yk_pin) / sizeof(*priv->yk_pin) - 1); i++) {
-		if (priv->yk_pin[i].slot == 0x00)
+	for (i = 0; i < (PIV_NUM_YK_SLOT_INFO - 1); i++) {
+		if (priv->yk_slot_info[i].slot == 0x00)
 			/* reached the last initialized entry */
 			break;
 
-		if (priv->yk_pin[i].slot == slot)
+		if (priv->yk_slot_info[i].slot == slot)
 			/* metadata already initialized */
 			break;
 	}
 
-	if (priv->yk_pin[i].slot == 0x00) {
+	if (priv->yk_slot_info[i].slot == 0x00) {
 		/* initialize this entry */
-		sc_format_apdu_ex(&apdu, 0x00, 0xF7, 0x00, slot, NULL, 0, resp, sizeof resp);
-		if (SC_SUCCESS == sc_transmit_apdu(card, &apdu) && SC_SUCCESS == sc_check_sw(card, apdu.sw1, apdu.sw2) && SC_SUCCESS == piv_yk_metadata_get_policy(card->ctx, resp, apdu.resplen, &priv->yk_pin[i].policy, &priv->yk_pin[i].touch)) {
-			sc_log(card->ctx, "PIN policy for slot 0x%02X: 0x%02X (touch 0x%02X)",
-					slot, priv->yk_pin[i].policy, priv->yk_pin[i].touch);
-			priv->yk_pin[i].slot = slot;
+		rc = piv_general_io(card, 0xF7, 0x00, slot, NULL, 0, resp, sizeof(resp));
+		if (rc > 2) { /* Min TLV */
+			resplen = rc;
+			rc = piv_yk_metadata_get_policy(card->ctx, resp, resplen,
+					&priv->yk_slot_info[i].policy, &priv->yk_slot_info[i].touch);
+			if (SC_SUCCESS == rc) {
+				sc_log(card->ctx, "PIN policy for slot 0x%02X: 0x%02X (touch 0x%02X)",
+						slot, priv->yk_slot_info[i].policy, priv->yk_slot_info[i].touch);
+			}
+			rc = piv_yk_metadata_get_pubkey_info(card->ctx, resp, resplen, &priv->yk_slot_info[i]);
+			if (SC_SUCCESS == rc) {
+				sc_log(card->ctx, "Public key for slot 0x%02X: present", slot);
+			}
+			priv->yk_slot_info[i].slot = slot;
 		} else {
 			sc_log(card->ctx, "Could not get Yubikey's PIN and touch policy");
 			return SC_ERROR_INVALID_DATA;
 		}
-	} else if (priv->yk_pin[i].slot != slot) {
+	} else if (priv->yk_slot_info[i].slot != slot) {
 		sc_log(card->ctx, "No free slot found");
 		return SC_ERROR_INTERNAL;
 	}
 
 	if (pin_policy)
-		*pin_policy = priv->yk_pin[i].policy;
+		*pin_policy = priv->yk_slot_info[i].policy;
 	if (touch_policy)
-		*touch_policy = priv->yk_pin[i].touch;
+		*touch_policy = priv->yk_slot_info[i].touch;
+	if (info) {
+		info->algorithm = priv->yk_slot_info[i].algorithm;
+		info->pubkey.value = priv->yk_slot_info[i].pubkey.value;
+		info->pubkey.len = priv->yk_slot_info[i].pubkey.len;
+	}
 
 	return SC_SUCCESS;
 }
@@ -4557,7 +4616,14 @@ static int
 piv_yk_pin_policy(sc_card_t *card, u8 *ptr)
 {
 	u8 slot = *ptr;
-	LOG_FUNC_RETURN(card->ctx, piv_yk_get_metadata(card, slot, ptr, NULL));
+	LOG_FUNC_RETURN(card->ctx, piv_yk_get_metadata(card, slot, ptr, NULL, NULL));
+}
+
+static int
+piv_yk_get_pubkey(sc_card_t *card, sc_cardctl_piv_pubkey_info_t *ptr)
+{
+	u8 slot = ptr->slot;
+	LOG_FUNC_RETURN(card->ctx, piv_yk_get_metadata(card, slot, NULL, NULL, ptr));
 }
 
 static int
@@ -4600,6 +4666,9 @@ piv_card_ctl(sc_card_t *card, unsigned long cmd, void *ptr)
 		break;
 	case SC_CARDCTL_PIV_YK_PIN_POLICY:
 		return piv_yk_pin_policy(card, ptr);
+		break;
+	case SC_CARDCTL_PIV_YK_GET_PUBKEY_INFO:
+		return piv_yk_get_pubkey(card, ptr);
 		break;
 	}
 
@@ -4724,7 +4793,7 @@ piv_yk_notify_touch_policy(sc_card_t *card, u8 key_ref)
 	u8 touch_policy;
 	const char *title = "Touch your Yubikey to continue";
 
-	piv_yk_get_metadata(card, key_ref, NULL, &touch_policy);
+	piv_yk_get_metadata(card, key_ref, NULL, &touch_policy, NULL);
 	switch (touch_policy) {
 	case 0x02:
 		sc_notify(title, "Touching the token is required for unlocking the key");
@@ -5491,6 +5560,9 @@ piv_finish(sc_card_t *card)
 		for (i = 0; i < PIV_OBJ_LAST_ENUM - 1; i++) {
 			piv_obj_cache_free_entry(card, i, 0);
 		}
+		for (i = 0; i < PIV_NUM_YK_SLOT_INFO; i++) {
+			free(priv->yk_slot_info[i].pubkey.value);
+		}
 #ifdef ENABLE_PIV_SM
 		piv_clear_cvc_content(&priv->sm_cvc);
 		piv_clear_cvc_content(&priv->sm_in_cvc);
@@ -5782,6 +5854,10 @@ piv_match_card_continued(sc_card_t *card)
 		if (r2 == SC_SUCCESS && apdu.resplen == 3) {
 			priv->yubico_version = (yubico_version_buf[0] << 16) | (yubico_version_buf[1] << 8) | yubico_version_buf[2];
 			sc_log(card->ctx, "Yubikey version test card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->yubico_version);
+			if (priv->yubico_version == 1) {
+				sc_log(card->ctx, "Detected Alpha/development version of yubikey. Assuming v6");
+				priv->yubico_version = 0x060000;
+			}
 		}
 		break;
 	}

--- a/src/libopensc/cardctl.h
+++ b/src/libopensc/cardctl.h
@@ -181,6 +181,7 @@ enum {
 	SC_CARDCTL_PIV_PIN_PREFERENCE,
 	SC_CARDCTL_PIV_OBJECT_PRESENT,
 	SC_CARDCTL_PIV_YK_PIN_POLICY,
+	SC_CARDCTL_PIV_YK_GET_PUBKEY_INFO,
 
 	/*
 	 * CAC specific calls
@@ -859,6 +860,12 @@ typedef struct sc_cardctl_piv_genkey_info_st {
 	size_t    ecpoint_len;    /* EC */
 
 } sc_cardctl_piv_genkey_info_t;
+
+typedef struct sc_cardctl_piv_pubkey_info_st {
+	int slot;
+	struct sc_lv_data pubkey;
+	u8 algorithm;
+} sc_cardctl_piv_pubkey_info_t;
 
 /*
  * OpenPGP

--- a/src/libopensc/pkcs15-piv.c
+++ b/src/libopensc/pkcs15-piv.c
@@ -244,6 +244,31 @@ static int piv_detect_card(sc_pkcs15_card_t *p15card)
 	return SC_SUCCESS;
 }
 
+static int
+yk_copy_pubkey_from_tag(sc_cardctl_piv_pubkey_info_t *info, struct sc_pkcs15_u8 *dst, unsigned int tag_exp)
+{
+	const unsigned char *p;
+	unsigned int cla, tag;
+	size_t tag_len;
+	int r;
+
+	p = info->pubkey.value;
+	r = sc_asn1_read_tag(&p, info->pubkey.len, &cla, &tag, &tag_len);
+	if (r != SC_SUCCESS) {
+		return SC_ERROR_ASN1_OBJECT_NOT_FOUND;
+	}
+	if ((tag | cla) != tag_exp) {
+		return SC_ERROR_INVALID_ASN1_OBJECT;
+	}
+	dst->value = malloc(tag_len);
+	if (dst->value == NULL) {
+		return SC_ERROR_OUT_OF_MEMORY;
+	}
+	memcpy(dst->value, p, tag_len);
+	dst->len = tag_len;
+
+	return SC_SUCCESS;
+}
 
 static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 {
@@ -1046,46 +1071,147 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		 *
 		 */
 		if (ckis[i].cert_found == 0 ) { /*  no cert found */
-			char * filename = NULL;
+			sc_cardctl_piv_pubkey_info_t info = {0};
 
 			sc_log(card->ctx, "No cert for this pub key i=%d",i);
 
-			/*
-			 * If we used the piv-tool to generate a key,
-			 * we would have saved the public key as a file.
-			 * This code is only used while signing a request
-			 * After the certificate is loaded on the card,
-			 * the public key is extracted from the certificate.
-			 */
+			/* First try to use yubikey extension to pull missing public key from metadata */
+			info.slot = pubkeys[i].ref;
+			r = sc_card_ctl(card, SC_CARDCTL_PIV_YK_GET_PUBKEY_INFO, &info);
+			if (r == SC_SUCCESS) {
+				struct sc_pkcs15_pubkey pubkey = {0};
+				const unsigned char *p;
+				unsigned int cla, tag;
+				size_t tag_len;
+				int r;
 
+				switch (info.algorithm) {
+				case 0x06: // RSA
+				case 0x07:
+				case 0x08:
+					p = info.pubkey.value;
+					r = sc_asn1_read_tag(&p, info.pubkey.len, &cla, &tag, &tag_len);
+					if (r != SC_SUCCESS) {
+						sc_log(card->ctx, "Failed to parse RSA modulus: %d", r);
+						continue;
+					}
+					if ((tag | cla) != 0x81) {
+						sc_log(card->ctx, "Unexpected tag %u received, expected 0x81", (tag | cla));
+						continue;
+					}
+					pubkey.u.rsa.modulus.data = malloc(tag_len);
+					if (pubkey.u.rsa.modulus.data == NULL) {
+						sc_log(card->ctx, "Out of memory");
+						continue;
+					}
+					memcpy(pubkey.u.rsa.modulus.data, p, tag_len);
+					pubkey.u.rsa.modulus.len = tag_len;
 
-			sc_log(card->ctx, "DEE look for env %s",
-					pubkeys[i].getenvname?pubkeys[i].getenvname:"NULL");
+					p += tag_len;
+					r = sc_asn1_read_tag(&p, info.pubkey.len - (p - info.pubkey.value), &cla, &tag, &tag_len);
+					if (r != SC_SUCCESS) {
+						sc_log(card->ctx, "Failed to parse RSA exponent: %d", r);
+						continue;
+					}
+					if ((tag | cla) != 0x82) {
+						sc_log(card->ctx, "Unexpected tag %u received, expected 0x82", (tag | cla));
+						continue;
+					}
+					pubkey.u.rsa.exponent.data = malloc(tag_len);
+					if (pubkey.u.rsa.exponent.data == NULL) {
+						sc_log(card->ctx, "Out of memory");
+						continue;
+					}
+					memcpy(pubkey.u.rsa.exponent.data, p, tag_len);
+					pubkey.u.rsa.exponent.len = tag_len;
 
-			if (pubkeys[i].getenvname == NULL)
-				continue;
+					pubkey.algorithm = SC_ALGORITHM_RSA;
+					break;
+				case 0x11: // ECDSA
+				case 0x14:
+					r = yk_copy_pubkey_from_tag(&info, &pubkey.u.ec.ecpointQ, 0x86);
+					if (r != SC_SUCCESS) {
+						sc_log(card->ctx, "Failed to parse ECDSA public key. %d", r);
+						continue;
+					}
+					pubkey.algorithm = SC_ALGORITHM_EC;
+					break;
+				case 0xE0: // Yubico extension: EDDSA
+					r = yk_copy_pubkey_from_tag(&info, &pubkey.u.ec.ecpointQ, 0x86);
+					if (r != SC_SUCCESS) {
+						sc_log(card->ctx, "Failed to parse EDDSA public key. %d", r);
+						continue;
+					}
+					pubkey.algorithm = SC_ALGORITHM_EDDSA;
+					break;
+				case 0xE1: // Yubico extension: XEDDSA
+					r = yk_copy_pubkey_from_tag(&info, &pubkey.u.ec.ecpointQ, 0x86);
+					if (r != SC_SUCCESS) {
+						sc_log(card->ctx, "Failed to parse XEDDSA public key. %d", r);
+						continue;
+					}
+					pubkey.algorithm = SC_ALGORITHM_XEDDSA;
+					break;
+				default:
+					sc_log(card->ctx, "Got unknown algorithm ID %d", info.algorithm);
+					continue;
+				}
 
-			filename = getenv(pubkeys[i].getenvname);
-			sc_log(card->ctx, "DEE look for file %s", filename?filename:"NULL");
-			if (filename == NULL)
-				continue;
+				r = sc_pkcs15_encode_pubkey_as_spki(card->ctx, &pubkey,
+						&pubkey_info.direct.spki.value, &pubkey_info.direct.spki.len);
+				if (r < 0) {
+					continue;
+				}
+				r = sc_pkcs15_pubkey_from_spki_sequence(card->ctx,
+						pubkey_info.direct.spki.value, pubkey_info.direct.spki.len,
+						&p15_key);
+				if (r < 0) {
+					free(p15_key);
+					continue;
+				}
+			} else {
+				char *filename = NULL;
 
-			sc_log(card->ctx, "Adding pubkey from file %s",filename);
+				sc_log(card->ctx, "Failed to get public key. Not a Yubikey? rc=%d", r);
+				/*
+				 * If we used the piv-tool or ykman to generate a key,
+				 * we would have saved the public key as a file.
+				 * This code is only used while signing a request
+				 * After the certificate is loaded on the card,
+				 * the public key is extracted from the certificate.
+				 */
 
-			r = sc_pkcs15_pubkey_from_spki_file(card->ctx,  filename, &p15_key);
-			if (r < 0) {
-				free(p15_key);
-				continue;
+				sc_log(card->ctx, "DEE look for env %s",
+						pubkeys[i].getenvname ? pubkeys[i].getenvname : "NULL");
+
+				if (pubkeys[i].getenvname == NULL)
+					continue;
+
+				filename = getenv(pubkeys[i].getenvname);
+				sc_log(card->ctx, "DEE look for file %s", filename ? filename : "NULL");
+				if (filename == NULL)
+					continue;
+
+				sc_log(card->ctx, "Adding pubkey from file %s", filename);
+
+				r = sc_pkcs15_pubkey_from_spki_file(card->ctx, filename, &p15_key);
+				if (r < 0) {
+					free(p15_key);
+					continue;
+				}
+
+				/* Lets also try another method. */
+				r = sc_pkcs15_encode_pubkey_as_spki(card->ctx, p15_key,
+						&pubkey_info.direct.spki.value, &pubkey_info.direct.spki.len);
+				LOG_TEST_GOTO_ERR(card->ctx, r, "SPKI encode public key error");
 			}
-
-			/* Lets also try another method. */
-			r = sc_pkcs15_encode_pubkey_as_spki(card->ctx, p15_key, &pubkey_info.direct.spki.value, &pubkey_info.direct.spki.len);
-			LOG_TEST_GOTO_ERR(card->ctx, r, "SPKI encode public key error");
 
 			/* Only get here if no cert, and the the above found the
 			 * pub key file (actually the SPKI version). This only
 			 * happens when trying initializing a card and have set
 			 * env PIV_9A_KEY or 9C, 9D, 9E to point at the file.
+			 * Or with Yubikey 5.3+ pulling this information from
+			 * GET METADATA instruction.
 			 *
 			 * We will cache it using the PKCS15 emulation objects
 			 */
@@ -1094,24 +1220,22 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 
 			ckis[i].key_alg = p15_key->algorithm;
 			switch (p15_key->algorithm) {
-				case SC_ALGORITHM_RSA:
-					/* save pubkey_len in pub and priv */
-					ckis[i].pubkey_len = p15_key->u.rsa.modulus.len * 8;
-					ckis[i].pubkey_found = 1;
-					ckis[i].pubkey_from_file = 1;
-					break;
-				case SC_ALGORITHM_EC:
-				case SC_ALGORITHM_EDDSA:
-				case SC_ALGORITHM_XEDDSA:
-					ckis[i].key_alg = p15_key->algorithm;
-					ckis[i].pubkey_len = p15_key->u.ec.params.field_length;
-					ckis[i].pubkey_found = 1;
-					ckis[i].pubkey_from_file = 1;
-					break;
-				default:
-					sc_log(card->ctx, "Unsupported key_alg %lu", p15_key->algorithm);
-					continue;
+			case SC_ALGORITHM_RSA:
+				/* save pubkey_len in pub and priv */
+				ckis[i].pubkey_len = p15_key->u.rsa.modulus.len * 8;
+				break;
+			case SC_ALGORITHM_EC:
+			case SC_ALGORITHM_EDDSA:
+			case SC_ALGORITHM_XEDDSA:
+				ckis[i].key_alg = p15_key->algorithm;
+				ckis[i].pubkey_len = p15_key->u.ec.params.field_length;
+				break;
+			default:
+				sc_log(card->ctx, "Unsupported key_alg %lu", p15_key->algorithm);
+				continue;
 			}
+			ckis[i].pubkey_found = 1;
+			ckis[i].pubkey_from_file = 1;
 			pubkey_obj.emulated = p15_key;
 			p15_key = NULL;
 		}
@@ -1126,49 +1250,49 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 
 		sc_log(card->ctx, "adding pubkey for %d keyalg=%lu", i, ckis[i].key_alg);
 		switch (ckis[i].key_alg) {
-			case SC_ALGORITHM_RSA:
-				if (ckis[i].cert_keyUsage_present) {
-					pubkey_info.usage =  ckis[i].pub_usage;
-				} else {
-					pubkey_info.usage = pubkeys[i].usage_rsa;
-				}
-				pubkey_info.modulus_length = ckis[i].pubkey_len;
-				strncpy(pubkey_obj.label, pubkeys[i].label, SC_PKCS15_MAX_LABEL_SIZE - 1);
+		case SC_ALGORITHM_RSA:
+			if (ckis[i].cert_keyUsage_present) {
+				pubkey_info.usage = ckis[i].pub_usage;
+			} else {
+				pubkey_info.usage = pubkeys[i].usage_rsa;
+			}
+			pubkey_info.modulus_length = ckis[i].pubkey_len;
+			strncpy(pubkey_obj.label, pubkeys[i].label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 
-				/* should not fail */
-				r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
-				LOG_TEST_GOTO_ERR(card->ctx, r, "Failed to add RSA pubkey");
+			/* should not fail */
+			r = sc_pkcs15emu_add_rsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
+			LOG_TEST_GOTO_ERR(card->ctx, r, "Failed to add RSA pubkey");
 
-				ckis[i].pubkey_found = 1;
-				break;
-			case SC_ALGORITHM_EC:
-			case SC_ALGORITHM_EDDSA:
-			case SC_ALGORITHM_XEDDSA:
-				if (ckis[i].cert_keyUsage_present) {
-					pubkey_info.usage = ckis[i].pub_usage;
-				} else {
-					pubkey_info.usage = pubkeys[i].usage_ec;
-				}
+			ckis[i].pubkey_found = 1;
+			break;
+		case SC_ALGORITHM_EC:
+		case SC_ALGORITHM_EDDSA:
+		case SC_ALGORITHM_XEDDSA:
+			if (ckis[i].cert_keyUsage_present) {
+				pubkey_info.usage = ckis[i].pub_usage;
+			} else {
+				pubkey_info.usage = pubkeys[i].usage_ec;
+			}
 
-				pubkey_info.field_length = ckis[i].pubkey_len;
-				strncpy(pubkey_obj.label, pubkeys[i].label, SC_PKCS15_MAX_LABEL_SIZE - 1);
+			pubkey_info.field_length = ckis[i].pubkey_len;
+			strncpy(pubkey_obj.label, pubkeys[i].label, SC_PKCS15_MAX_LABEL_SIZE - 1);
 
-				/* should not fail */
+			/* should not fail */
 
-				if (ckis[i].key_alg == SC_ALGORITHM_EDDSA)
-					r = sc_pkcs15emu_add_eddsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
-				else if (ckis[i].key_alg == SC_ALGORITHM_XEDDSA)
-					r = sc_pkcs15emu_add_xeddsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
-				else
-					r = sc_pkcs15emu_add_ec_pubkey(p15card, &pubkey_obj, &pubkey_info);
+			if (ckis[i].key_alg == SC_ALGORITHM_EDDSA)
+				r = sc_pkcs15emu_add_eddsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
+			else if (ckis[i].key_alg == SC_ALGORITHM_XEDDSA)
+				r = sc_pkcs15emu_add_xeddsa_pubkey(p15card, &pubkey_obj, &pubkey_info);
+			else
+				r = sc_pkcs15emu_add_ec_pubkey(p15card, &pubkey_obj, &pubkey_info);
 
-				LOG_TEST_GOTO_ERR(card->ctx, r, "Failed to add EC pubkey");
+			LOG_TEST_GOTO_ERR(card->ctx, r, "Failed to add EC pubkey");
 
-				ckis[i].pubkey_found = 1;
-				break;
-			default:
-				sc_log(card->ctx, "key_alg %lu not supported", ckis[i].key_alg);
-				continue;
+			ckis[i].pubkey_found = 1;
+			break;
+		default:
+			sc_log(card->ctx, "key_alg %lu not supported", ckis[i].key_alg);
+			continue;
 		}
 		sc_log(card->ctx, "USAGE: cert_keyUsage_present:%d usage:0x%8.8x",
 				ckis[i].cert_keyUsage_present, pubkey_info.usage);
@@ -1233,53 +1357,56 @@ static int sc_pkcs15emu_piv_init(sc_pkcs15_card_t *p15card)
 		 * normal usage would not allow it. Set SC_PKCS15_PRKEY_USAGE_SIGN
 		 * TODO if code is added to allow key generation and request
 		 * sign in the same session, similar code will be needed.
+		 * Exclude XEDDSA keys as they are not signing capable
 		 */
 
 		if (ckis[i].pubkey_from_file == 1) {
-			prkey_info.usage = SC_PKCS15_PRKEY_USAGE_SIGN;
-			sc_log(card->ctx,  "Adding SC_PKCS15_PRKEY_USAGE_SIGN");
+			switch (ckis[i].key_alg) {
+			case SC_ALGORITHM_XEDDSA:
+				break;
+			default:
+				prkey_info.usage = SC_PKCS15_PRKEY_USAGE_SIGN;
+				sc_log(card->ctx, "Adding SC_PKCS15_PRKEY_USAGE_SIGN");
+				break;
+			}
+		}
+
+		if (ckis[i].cert_keyUsage_present) {
+			prkey_info.usage |= ckis[i].priv_usage;
+			/* If retired key and non gov cert has NONREPUDIATION, treat as user_consent */
+			if (i >= 4 && (ckis[i].priv_usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)) {
+				prkey_obj.user_consent = 1;
+			}
 		}
 
 		switch (ckis[i].key_alg) {
-			case SC_ALGORITHM_RSA:
-				if(ckis[i].cert_keyUsage_present) {
-					prkey_info.usage |= ckis[i].priv_usage;
-					/* If retired key and non gov cert has NONREPUDIATION, treat as user_consent */
-					if (i >= 4 && (ckis[i].priv_usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)) {
-						prkey_obj.user_consent = 1;
-					}
-				} else {
-					prkey_info.usage |= prkeys[i].usage_rsa;
-				}
-				prkey_info.modulus_length= ckis[i].pubkey_len;
-				r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
-				break;
-			case SC_ALGORITHM_EC:
-			case SC_ALGORITHM_EDDSA:
-			case SC_ALGORITHM_XEDDSA:
-				if (ckis[i].cert_keyUsage_present) {
-					prkey_info.usage  |= ckis[i].priv_usage;
-					/* If retired key and non gov cert has NONREPUDIATION, treat as user_consent */
-					if (i >= 4 && (ckis[i].priv_usage & SC_PKCS15_PRKEY_USAGE_NONREPUDIATION)) {
-						prkey_obj.user_consent = 1;
-					}
-				} else {
-					prkey_info.usage  |= prkeys[i].usage_ec;
-				}
-				prkey_info.field_length = ckis[i].pubkey_len;
-				sc_log(card->ctx, "DEE added key_alg %2.2lx prkey_obj.flags %8.8x",
-					 ckis[i].key_alg, prkey_obj.flags);
+		case SC_ALGORITHM_RSA:
+			if (!ckis[i].cert_keyUsage_present) {
+				prkey_info.usage |= prkeys[i].usage_rsa;
+			}
+			prkey_info.modulus_length = ckis[i].pubkey_len;
+			r = sc_pkcs15emu_add_rsa_prkey(p15card, &prkey_obj, &prkey_info);
+			break;
+		case SC_ALGORITHM_EC:
+		case SC_ALGORITHM_EDDSA:
+		case SC_ALGORITHM_XEDDSA:
+			if (!ckis[i].cert_keyUsage_present) {
+				prkey_info.usage |= prkeys[i].usage_ec;
+			}
+			prkey_info.field_length = ckis[i].pubkey_len;
+			sc_log(card->ctx, "DEE added key_alg %2.2lx prkey_obj.flags %8.8x",
+					ckis[i].key_alg, prkey_obj.flags);
 
-				if (ckis[i].key_alg == SC_ALGORITHM_EDDSA)
-					r = sc_pkcs15emu_add_eddsa_prkey(p15card, &prkey_obj, &prkey_info);
-				else if (ckis[i].key_alg == SC_ALGORITHM_XEDDSA)
-					r = sc_pkcs15emu_add_xeddsa_prkey(p15card, &prkey_obj, &prkey_info);
-				else
-					r = sc_pkcs15emu_add_ec_prkey(p15card, &prkey_obj, &prkey_info);
-				break;
-			default:
-				sc_log(card->ctx, "Unsupported key_alg %lu", ckis[i].key_alg);
-				r = 0; /* we just skip this one */
+			if (ckis[i].key_alg == SC_ALGORITHM_EDDSA)
+				r = sc_pkcs15emu_add_eddsa_prkey(p15card, &prkey_obj, &prkey_info);
+			else if (ckis[i].key_alg == SC_ALGORITHM_XEDDSA)
+				r = sc_pkcs15emu_add_xeddsa_prkey(p15card, &prkey_obj, &prkey_info);
+			else
+				r = sc_pkcs15emu_add_ec_prkey(p15card, &prkey_obj, &prkey_info);
+			break;
+		default:
+			sc_log(card->ctx, "Unsupported key_alg %lu", ckis[i].key_alg);
+			r = 0; /* we just skip this one */
 		}
 		sc_log(card->ctx, "USAGE: cert_keyUsage_present:%d usage:0x%8.8x", ckis[i].cert_keyUsage_present, prkey_info.usage);
 		LOG_TEST_GOTO_ERR(card->ctx, r, "Failed to add Private key");

--- a/src/libopensc/pkcs15.h
+++ b/src/libopensc/pkcs15.h
@@ -722,6 +722,8 @@ int sc_pkcs15_pubkey_from_cert(struct sc_context *, struct sc_pkcs15_der *,
 		struct sc_pkcs15_pubkey **);
 int sc_pkcs15_pubkey_from_spki_file(struct sc_context *,
 		char *, struct sc_pkcs15_pubkey ** );
+int sc_pkcs15_pubkey_from_spki_sequence(struct sc_context *,
+		const unsigned char *, size_t, struct sc_pkcs15_pubkey **);
 int sc_pkcs15_pubkey_from_spki_fields(struct sc_context *,
 		struct sc_pkcs15_pubkey **, u8 *, size_t, int);
 int sc_pkcs15_encode_prkey(struct sc_context *,

--- a/src/pkcs11/framework-pkcs15.c
+++ b/src/pkcs11/framework-pkcs15.c
@@ -6366,9 +6366,7 @@ static CK_RV register_eddsa_mechanisms(struct sc_pkcs11_card *p11card, int flags
 	mech_info.ulMaxKeySize = max_key_size;
 
 #ifdef ENABLE_OPENSSL
-	/* TODO verification using EDDSA
 	mech_info.flags |= CKF_VERIFY;
-	*/
 #endif
 	if (flags & SC_ALGORITHM_EDDSA_RAW) {
 		mt = sc_pkcs11_new_fw_mechanism(CKM_EDDSA, &mech_info, CKK_EC_EDWARDS, NULL, NULL, NULL);

--- a/src/pkcs11/openssl.c
+++ b/src/pkcs11/openssl.c
@@ -618,6 +618,7 @@ CK_RV sc_pkcs11_verify_data(const CK_BYTE_PTR pubkey, CK_ULONG pubkey_len,
 	CK_RV rv = CKR_GENERAL_ERROR;
 	EVP_PKEY *pkey = NULL;
 	const unsigned char *pubkey_tmp = NULL;
+	EVP_MD_CTX *md_ctx = NULL;
 	int sLen;
 
 	if (mech->mechanism == CKM_GOSTR3410)
@@ -659,7 +660,7 @@ CK_RV sc_pkcs11_verify_data(const CK_BYTE_PTR pubkey, CK_ULONG pubkey_len,
 		|| mech->mechanism == CKM_ECDSA_SHA384
 		|| mech->mechanism == CKM_ECDSA_SHA512
 		)) {
-		EVP_MD_CTX *md_ctx = DIGEST_CTX(md);
+		md_ctx = DIGEST_CTX(md);
 
 		/* This does not really use the data argument, but the data
 		 * are already collected in the md_ctx
@@ -778,16 +779,42 @@ CK_RV sc_pkcs11_verify_data(const CK_BYTE_PTR pubkey, CK_ULONG pubkey_len,
 		}
 
 		res = 0;
-		r = sc_asn1_sig_value_rs_to_sequence(NULL, signat, signat_len,
-						     &signat_tmp, &signat_len_tmp);
-		ctx = sc_evp_pkey_ctx_new(context, pkey);
-		if (r == 0 && EVP_PKEY_base_id(pkey) == EVP_PKEY_EC && ctx && EVP_PKEY_verify_init(ctx) == 1)
-			res = EVP_PKEY_verify(ctx, signat_tmp, signat_len_tmp, data, data_len);
+		switch (EVP_PKEY_base_id(pkey)) {
+		case EVP_PKEY_EC:
+			ctx = sc_evp_pkey_ctx_new(context, pkey);
+			r = sc_asn1_sig_value_rs_to_sequence(NULL, signat, signat_len,
+					&signat_tmp, &signat_len_tmp);
+			if (r == 0 && ctx && EVP_PKEY_verify_init(ctx) == 1) {
+				res = EVP_PKEY_verify(ctx, signat_tmp, signat_len_tmp, data, data_len);
+			}
+			free(signat_tmp);
+			EVP_PKEY_CTX_free(ctx);
+			break;
+#ifdef EVP_PKEY_ED25519
+		case EVP_PKEY_ED25519:
+#endif
+#ifdef EVP_PKEY_ED448
+		case EVP_PKEY_ED448:
+#endif
+#if defined(EVP_PKEY_ED25519) || defined(EVP_PKEY_ED448)
+			md_ctx = EVP_MD_CTX_create();
+			if (md_ctx == NULL) {
+				EVP_PKEY_free(pkey);
+				return CKR_GENERAL_ERROR;
+			}
 
-		EVP_PKEY_CTX_free(ctx);
+			rv = EVP_DigestVerifyInit(md_ctx, NULL, NULL, NULL, pkey);
+			if (rv == 1) {
+				res = EVP_DigestVerify(md_ctx, signat, signat_len, data, data_len);
+			}
+			EVP_MD_CTX_free(md_ctx);
+			break;
+#endif /* defined(EVP_PKEY_ED25519) || defined(EVP_PKEY_ED448) */
+		default:
+			sc_log(context, "Unknown base type %u.", EVP_PKEY_base_id(pkey));
+		}
+
 		EVP_PKEY_free(pkey);
-		free(signat_tmp);
-		free(mdbuf);
 
 		if (res == 1) {
 			return CKR_OK;


### PR DESCRIPTION
The yubikeys extension GET METADATA allows pulling public keys from token without the need to have sidecar file with the SPKI and environment variable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [~] Documentation is added or updated
- [~] New files have a LGPL 2.1 license statement
- [X] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS token is tested
