### PR TITLE
minidriver: embed the ComCtl32 v6 manifest for MinGW

### DIFF
--- a/src/minidriver/versioninfo-minidriver.rc
+++ b/src/minidriver/versioninfo-minidriver.rc
@@ -13,6 +13,23 @@ IDI_SMARTCARD          ICON                    "..\\..\\win32\\DDORes.dll_14_230
 IDI_SMARTCARD          ICON                    "../../win32/DDORes.dll_14_2302.ico"
 #endif
 
+#ifdef __MINGW32__
+/* MSVC adds this via /MANIFESTDEPENDENCY (win32/Make.rules.mak); windres has no
+ * equivalent, so embed it here. Without ComCtl32 v6 the static import of
+ * TaskDialogIndirect is unresolvable and the DLL fails to load. */
+2 24
+BEGIN
+  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>\r\n"
+  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"">\r\n"
+  "  <dependency><dependentAssembly><assemblyIdentity\r\n"
+  "      type=""win32"" name=""Microsoft.Windows.Common-Controls""\r\n"
+  "      version=""6.0.0.0"" processorArchitecture=""*""\r\n"
+  "      publicKeyToken=""6595b64144ccf1df"" language=""*"" />\r\n"
+  "  </dependentAssembly></dependency>\r\n"
+  "</assembly>\r\n"
+END
+#endif
+
 VS_VERSION_INFO VERSIONINFO
 	FILEVERSION OPENSC_VERSION_MAJOR,OPENSC_VERSION_MINOR,OPENSC_VERSION_FIX,OPENSC_VERSION_REVISION
 	PRODUCTVERSION OPENSC_VERSION_MAJOR,OPENSC_VERSION_MINOR,OPENSC_VERSION_FIX,OPENSC_VERSION_REVISION


### PR DESCRIPTION
Fixes #3814

**Embeds the ComCtl32 v6 manifest in the MinGW-built minidriver, allowing the cross-compiled DLL to load.**

`minidriver.c` calls `TaskDialogIndirect`, which is exported only by ComCtl32
version 6. Reaching version 6 requires a side-by-side manifest. The MSVC build
has one via `/MANIFESTDEPENDENCY` in `win32/Make.rules.mak`, but `windres` has
no equivalent, so the autotools/MinGW build produces a DLL that binds to the
legacy comctl32 5.82 and cannot be loaded at all:

```
LoadLibrary -> Win32 error 127 "The specified procedure could not be found"
```

Inside `lsass` this presents as a card or credential problem rather than a load
failure, which makes it expensive to diagnose.

### Why the manifest is inline in the .rc

The issue proposed adding an `opensc-minidriver.manifest` file and referencing
it from the `.rc`. This PR does something a little different. fc8083444 ("Cleanup manifest
handling") instead removed the three `*.dll.manifest` files, dropped them
from `EXTRA_DIST`, and added `*.manifest` to `.gitignore`. Adding a manifest
file back would undo that.

I embedded the XML directly in `versioninfo-minidriver.rc`, which keeps that cleanup
intact. The benefits are : no new file, no `EXTRA_DIST` entry, no `.gitignore` change, and one file
touched.

The resource is guarded with `#ifdef __MINGW32__` because MSVC compiles the same
`.rc` and already embeds a manifest at link time; an unguarded resource would
collide with the linker-generated one.

`2` is `ISOLATIONAWARE_MANIFEST_RESOURCE_ID`, which is the id the loader uses for
a DLL, and matches the `;2` the old `mt -manifest -outputresource:...;2` step
used before fc8083444.

If you all would prefer a separate `opensc-minidriver.manifest` file, I am
happy to switch — I think it needs a `!` negation for the `*.manifest` line in `.gitignore` plus an
`EXTRA_DIST` entry, which is why I went this way, but either way is fine. 


### Testing

Cross-built with mingw-w64 on Debian trixie, then A/B tested on Windows 11
(10.0.26200.9168). Two DLLs from the same master commit with the same configure and
link flags, differing **only** by the embedded manifest — I diffed the import tables and
they are identical, 271 symbols, symbol for symbol.

Loaded by a bare MinGW test binary carrying **no manifest of its own**, so that its
activation context matches what `lsass` provides:

```
-- without the manifest --
LOAD FAIL   opensc-minidriver64-master-NOMANIFEST.dll
            GetLastError = 127   (ERROR_PROC_NOT_FOUND)

-- with the manifest --
LOAD OK     opensc-minidriver64-master.dll
            CardAcquireContext = found
```

Worth noting for anyone reproducing this: testing with `LoadLibrary` from PowerShell does
not reproduce the failure. `powershell.exe` has its own ComCtl32 v6 manifest, so the
process activation context supplies what the DLL lacks and both builds load.

Also verified on the resulting DLL:

- the manifest is present in `.rsrc`, 403 bytes, declared size matching the payload
  exactly, well-formed XML, no embedded NULs
- a clean rebuild with no manifest file anywhere on disk still embeds it
- `COMCTL32.dll` / `TaskDialogIndirect` remains the only ComCtl32 import

Card used for testing: `Personal Identity Verification Card` (OpenFIPS201 applet).

If a graceful `GetProcAddress` fallback is preferred as well, that is a separate
change and this one does not conflict with it — see the discussion in #3814.

##### Checklist
- [x] Windows minidriver is tested
